### PR TITLE
docs(glossary): add Consolidator term + fix Profile file casing

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -22,7 +22,7 @@ A full glossary↔code gap scan (2026-06-28) is under team review. Key open item
 - **Bus → Spine** — the `CONTEXT.md` "Bus" cluster (Message Bus / Event Bus) is being
   rewritten as a **Spine** term; `raven/bus/` was replaced by `raven/spine/`.
 - **Proposed missing Runtime terms** — Spine, Agent Loop, Turn Runner, Plugin, Skill Hub,
-  Agent Hook, Subagent, Routing Profile, Consolidator.
+  Agent Hook, Subagent, Routing Profile. (**Consolidator** landed — now defined in `CONTEXT.md` → Memory.)
 - **TUI side** — one correction (StatusRulePane → Status Bar) + candidate additions
   (Turn Cycle, Streaming Segment, RPC Client, Composer, Slash Command System, …).
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -184,13 +184,21 @@ retained; it is now a live module under the Memory Engine, not the old top-level
 A distilled event note the Consolidation step writes to `episodes.md`.
 
 **Profile**:
-The user-profile sections in `USER.md`, refreshed when their tags run hot.
+The user-profile sections in `user.md`, refreshed when their tags run hot.
 
 **Foresight**:
 A prediction the Memory Engine derives about the user's likely future behavior
 (each carries prediction / time-window / confidence), written by the consolidator.
 _Avoid_: conflating with the Proactive Engine's Predictor — Foresight is the stored
 memory artifact; the Predictor is the live proactive stage.
+
+**Consolidator** (`memory_engine/consolidate/`):
+The Memory Engine component (`MemoryConsolidator`) that performs Consolidation —
+under session-token pressure it annotates evicted message chunks into Episodes,
+refreshes hot Profile sections, and (opt-in) emits Foresight. The agent loop skips
+it when the Curator Context Engine is active.
+_Avoid_: conflating with the Curator — the Curator builds the context window
+losslessly; the Consolidator is the legacy lossy path that writes long-term memory.
 
 ### Security & Access
 


### PR DESCRIPTION
Owner review of @zhao.wang's assigned terms (proactive_engine/ + memory_engine/consolidate/) against refactor/EverClaw tip 50ad392a.

- Add **Consolidator** (memory_engine/consolidate/) to CONTEXT.md Memory: the MemoryConsolidator that performs Consolidation — annotates evicted message chunks into Episodes, refreshes hot Profile sections, opt-in emits Foresight; the agent loop skips it when the Curator Context Engine is active. Cross-refs the existing Consolidation/Curator terms.
- Fix Profile: backing file is `user.md` (user_memory/profile/user.md), not `USER.md`.
- Drop Consolidator from CONTEXT-MAP "proposed missing" list (now landed).

Foresight / Predictor / Episode / Sentinel verified against code and left unchanged.

## Change description

> Description here

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Document
- [ ] Others

## Related issues (if there is)

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows security best practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
