### PR TITLE
feat(install): one-line zero-friction install + packaged tui bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+# Release build — DRAFT.
+#
+# Goal: produce a wheel that ships a fresh, self-contained TUI bundle
+# (ui-tui/dist/entry.js) so `pip`/`uv tool install` yields a working
+# `raven tui` with no source checkout and no npm build on the user's machine.
+#
+# This is the "self-maintaining" piece: every tagged release rebuilds
+# entry.js from the current ui-tui/ source, so the packaged TUI can never drift
+# behind the Python code. Do NOT commit dist/entry.js to git — it is a build
+# artifact produced here.
+#
+# Trigger: push a version tag (v1.2.3) or run manually.
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch: {}
+
+jobs:
+  build-wheel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # 1) Node toolchain to build the TUI bundle.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # 2) Build the self-contained bundle into ui-tui/dist/entry.js.
+      #    esbuild bundles react/ink in — no node_modules ships in the wheel.
+      - name: Build TUI bundle
+        working-directory: ui-tui
+        run: |
+          npm ci
+          npm run build
+          test -f dist/entry.js  # fail fast if the bundle didn't land
+
+      # 3) uv builds the wheel; pyproject force-includes ui-tui/dist -> raven/ui-tui/dist.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build wheel + sdist
+        run: uv build
+
+      # 4) Sanity gate: the wheel MUST contain the bundle and MUST NOT carry
+      #    node_modules or src (keeps the wheel lean and the smoke honest).
+      - name: Verify wheel contents
+        run: |
+          python3 - <<'PY'
+          import glob, sys, zipfile
+          whl = sorted(glob.glob("dist/*.whl"))[-1]
+          names = zipfile.ZipFile(whl).namelist()
+          assert "raven/ui-tui/dist/entry.js" in names, "entry.js missing from wheel"
+          assert not any("node_modules" in n for n in names), "node_modules leaked into wheel"
+          # The only ui-tui/ entry must be the bundle — no TS source, no stray files.
+          ui = [n for n in names if "ui-tui/" in n]
+          assert ui == ["raven/ui-tui/dist/entry.js"], f"unexpected ui-tui entries: {ui}"
+          assert not any(n.endswith(".tsx") or n.endswith(".ts") for n in names), "TS source leaked into wheel"
+          print(f"OK: {whl} ships only entry.js under ui-tui/, no node_modules/src")
+          PY
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+      # 5) (Optional, wire up when ready) publish to PyPI on tag:
+      # - name: Publish to PyPI
+      #   if: startsWith(github.ref, 'refs/tags/v')
+      #   run: uv publish
+      #   env:
+      #     UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,39 @@
+"""Custom Hatchling build hook: conditionally package the prebuilt TUI bundle.
+
+The TUI ships as a single self-contained esbuild bundle at ``ui-tui/dist/entry.js``.
+We want a wheel to carry it so `pip`/`uv tool install` yields a working
+`raven tui` with no source checkout. But ``dist/`` is a build artifact and is
+NOT committed (see .gitignore), so a clean checkout legitimately lacks it.
+
+A static ``[tool.hatch.build.targets.wheel.force-include]`` entry would make
+hatchling hard-fail with "Forced include not found" whenever ``dist/`` is
+absent — which would break the ordinary developer flow (`git clone && uv sync`
+with no prior `npm run build`). So instead we add the bundle to the wheel's
+force-include map *only when it exists*, and emit a warning otherwise.
+
+Release builds run ``npm ci && npm run build`` first (see
+.github/workflows/release.yml), so the published wheel always carries the
+bundle; dev builds without it simply fall back to the source tree at runtime
+(see resolve_dist_entry() in raven/cli/tui_commands.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self, version: str, build_data: dict) -> None:
+        dist = Path(self.root) / "ui-tui" / "dist"
+        if dist.is_dir() and (dist / "entry.js").is_file():
+            # Map source -> path inside the wheel's `raven` package.
+            build_data.setdefault("force_include", {})[str(dist)] = "raven/ui-tui/dist"
+        else:
+            self.app.display_warning(
+                "ui-tui/dist/entry.js not found — building WITHOUT the bundled TUI. "
+                "`raven tui` from this wheel will not work; run "
+                "`npm --prefix ui-tui ci && npm --prefix ui-tui run build` before "
+                "building a release wheel."
+            )

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,201 @@
+#!/bin/sh
+# Raven one-line installer (macOS / Linux).
+#
+#   Remote (website):   curl -fsSL https://raven.evermind.ai/install.sh | sh
+#   Local (dev clone):  git clone … && cd raven && ./install.sh
+#
+# Goal: a clean machine ends up able to run `raven` / `raven tui` from any
+# directory with no manual steps. The script is idempotent — it detects what
+# is already present and only fills the gaps:
+#   1. uv            (Python toolchain + package manager)
+#   2. Node.js >= 22 (TUI runtime; installed privately if the system lacks it)
+#   3. raven         (installed as a global uv tool -> ~/.local/bin/raven)
+#
+# POSIX sh on purpose (runs under dash/ash, not just bash).
+set -eu
+
+# --- config ---------------------------------------------------------------
+REPO_URL="${RAVEN_REPO_URL:-git+https://github.com/EverMind-AI/raven.git}"
+MIN_NODE_MAJOR=22
+RAVEN_HOME="${RAVEN_HOME:-${HOME:?需要 HOME 环境变量，或显式设置 RAVEN_HOME}/.raven}"
+NODE_RUNTIME_DIR="$RAVEN_HOME/runtime"
+
+# --- pretty output ---------------------------------------------------------
+info()  { printf '\033[1;34m▶\033[0m %s\n' "$1"; }
+ok()    { printf '\033[1;32m✓\033[0m %s\n' "$1"; }
+warn()  { printf '\033[1;33m!\033[0m %s\n' "$1" >&2; }
+die()   { printf '\033[1;31m✗\033[0m %s\n' "$1" >&2; exit 1; }
+have()  { command -v "$1" >/dev/null 2>&1; }
+
+# --- 0. platform detection -------------------------------------------------
+detect_platform() {
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "$os" in
+    Darwin) NODE_OS="darwin" ;;
+    Linux)  NODE_OS="linux" ;;
+    *) die "不支持的操作系统：$os（仅支持 macOS / Linux；Windows 请用 install.ps1）" ;;
+  esac
+  case "$arch" in
+    arm64|aarch64) NODE_ARCH="arm64" ;;
+    x86_64|amd64)  NODE_ARCH="x64" ;;
+    *) die "不支持的架构：$arch" ;;
+  esac
+}
+
+# --- 1. ensure uv ----------------------------------------------------------
+ensure_uv() {
+  if have uv; then
+    ok "uv 已安装（$(uv --version)）"
+    return
+  fi
+  info "未找到 uv，正在安装…"
+  curl -fsSL https://astral.sh/uv/install.sh | sh
+  # uv installs to ~/.local/bin (or $XDG_BIN_HOME) — make it visible for the
+  # rest of this script even before the shell profile is re-sourced.
+  export PATH="$HOME/.local/bin:$PATH"
+  have uv || die "uv 安装后仍不可用，请检查 PATH（期望在 ~/.local/bin）"
+  ok "uv 安装完成"
+}
+
+# --- 2. ensure Node >= 22 --------------------------------------------------
+# Returns 0 if a usable system node is found.
+system_node_ok() {
+  have node || return 1
+  v="$(node --version 2>/dev/null | sed 's/^v//; s/\..*//')"
+  [ -n "$v" ] && [ "$v" -ge "$MIN_NODE_MAJOR" ] 2>/dev/null
+}
+
+# Resolve the latest v22 LTS version string (e.g. v22.20.0) from nodejs.org,
+# without requiring jq/python. Falls back to a pinned version if the index
+# can't be reached.
+latest_node_v22() {
+  idx="$(curl -fsSL https://nodejs.org/dist/index.json 2>/dev/null || true)"
+  ver="$(printf '%s' "$idx" | tr ',' '\n' | grep -o '"version":"v22\.[0-9.]*"' \
+         | head -n1 | sed 's/.*"v/v/; s/"$//')"
+  [ -n "$ver" ] && printf '%s' "$ver" || printf 'v22.20.0'
+}
+
+# Print the path to a Raven-provisioned private node binary (first match), or
+# return non-zero if none. Iterating the glob avoids passing multiple words to
+# `[ -x ... ]` (which errors) when several versioned dirs linger.
+private_node_bin() {
+  for n in "$NODE_RUNTIME_DIR"/node-v22*/bin/node; do
+    [ -x "$n" ] || continue
+    # Actually run it — a half-extracted / corrupt binary is +x but won't run,
+    # and must NOT be mistaken for a ready runtime (else we'd never re-download).
+    "$n" --version >/dev/null 2>&1 && { printf '%s' "$n"; return 0; }
+  done
+  return 1
+}
+
+ensure_node() {
+  if system_node_ok; then
+    ok "Node.js 已满足要求（$(node --version)）"
+    return
+  fi
+  # Already provisioned privately by a previous run?
+  if pn="$(private_node_bin)"; then
+    ok "已存在 Raven 私有 Node（$pn）"
+    return
+  fi
+
+  info "未找到 Node.js >= $MIN_NODE_MAJOR，正在下载私有运行时（不污染系统）…"
+  ver="$(latest_node_v22)"
+  pkg="node-${ver}-${NODE_OS}-${NODE_ARCH}"
+  url="https://nodejs.org/dist/${ver}/${pkg}.tar.gz"
+  mkdir -p "$NODE_RUNTIME_DIR"
+  tmp="$(mktemp -d)"
+  info "  $url"
+  curl -fsSL "$url" -o "$tmp/node.tar.gz" || die "Node 下载失败：$url"
+
+  # Supply-chain integrity: verify the tarball against the official
+  # SHASUMS256.txt before extracting/executing it. Node publishes this file
+  # next to every release.
+  if curl -fsSL "https://nodejs.org/dist/${ver}/SHASUMS256.txt" -o "$tmp/SHASUMS256.txt" 2>/dev/null; then
+    expected="$(awk -v f="${pkg}.tar.gz" '$2==f {print $1}' "$tmp/SHASUMS256.txt")"
+    if [ -n "$expected" ]; then
+      if have shasum; then
+        actual="$(shasum -a 256 "$tmp/node.tar.gz" | awk '{print $1}')"
+      elif have sha256sum; then
+        actual="$(sha256sum "$tmp/node.tar.gz" | awk '{print $1}')"
+      else
+        actual=""; warn "未找到 shasum/sha256sum，跳过校验"
+      fi
+      if [ -n "$actual" ] && [ "$actual" != "$expected" ]; then
+        rm -rf "$tmp"
+        die "Node 校验失败：SHA256 不匹配（期望 $expected，实际 $actual）"
+      fi
+      [ -n "$actual" ] && ok "Node tarball SHA256 校验通过"
+    else
+      warn "SHASUMS256.txt 未列出 ${pkg}.tar.gz，跳过校验"
+    fi
+  else
+    warn "无法获取 SHASUMS256.txt，跳过完整性校验"
+  fi
+
+  tar -xzf "$tmp/node.tar.gz" -C "$NODE_RUNTIME_DIR"
+  rm -rf "$tmp"
+  [ -x "$NODE_RUNTIME_DIR/$pkg/bin/node" ] || die "Node 解压后未找到可执行文件"
+  # Run it once now: catches a libc mismatch (e.g. glibc tarball on Alpine/musl)
+  # at install time instead of letting `raven tui` fail later on the user's box.
+  "$NODE_RUNTIME_DIR/$pkg/bin/node" --version >/dev/null 2>&1 \
+    || die "下载的 Node 无法在本机运行（可能 libc 不匹配，如 Alpine/musl）。请改用系统包管理器安装 Node >= ${MIN_NODE_MAJOR}。"
+  ok "Node 私有运行时就绪：$NODE_RUNTIME_DIR/$pkg"
+  # raven's find_node() globs ~/.raven/runtime/node-*/bin/node automatically,
+  # so no PATH change is needed for `raven tui` to find it.
+}
+
+# --- 3. install raven ------------------------------------------------------
+install_raven() {
+  # Local mode: run from a raven source checkout -> editable install of the
+  # working tree (what a developer wants). Otherwise install from git.
+  script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+  if [ -f "$script_dir/pyproject.toml" ] && grep -q '^name = "raven"' "$script_dir/pyproject.toml" 2>/dev/null; then
+    info "检测到本地 raven 源码，使用 editable 安装：$script_dir"
+    # The TUI bundle must exist before first run. In a dev checkout it isn't
+    # committed, so build it now if Node is available.
+    if [ ! -f "$script_dir/ui-tui/dist/entry.js" ]; then
+      node_bin="$(command -v node || true)"
+      [ -n "$node_bin" ] || node_bin="$(private_node_bin || true)"
+      if [ -n "$node_bin" ] && [ -x "$node_bin" ]; then
+        node_dir="$(dirname "$node_bin")"
+        # npm ships alongside node, but verify explicitly before relying on it.
+        if PATH="$node_dir:$PATH" command -v npm >/dev/null 2>&1; then
+          info "构建 TUI 产物（ui-tui/dist/entry.js）…"
+          ( cd "$script_dir/ui-tui" && PATH="$node_dir:$PATH" npm ci && PATH="$node_dir:$PATH" npm run build )
+        else
+          warn "找到 node 但未找到 npm，跳过 TUI 产物构建；raven tui 可能不可用"
+        fi
+      else
+        warn "未找到可用 node，跳过 TUI 产物构建；raven tui 可能不可用"
+      fi
+    fi
+    uv tool install --force -e "$script_dir"
+  else
+    info "从 GitHub 安装 raven：$REPO_URL"
+    uv tool install --force "$REPO_URL"
+  fi
+  # Ensure ~/.local/bin (uv tool bin dir) is on PATH for future shells.
+  uv tool update-shell || true
+  ok "raven 安装完成"
+}
+
+# --- main ------------------------------------------------------------------
+main() {
+  have curl || die "需要 curl，请先安装"
+  detect_platform
+  ensure_uv
+  ensure_node
+  install_raven
+
+  printf '\n'
+  ok "全部就绪！打开一个新终端（或 source 你的 shell 配置），然后运行："
+  printf '\n    \033[1mraven\033[0m            # 进入 TUI\n'
+  printf '    \033[1mraven agent\033[0m -m "你好"\n\n'
+  if ! printf '%s' "$PATH" | grep -q "$HOME/.local/bin"; then
+    warn "当前 shell 的 PATH 还没包含 ~/.local/bin —— 重开终端或运行：export PATH=\"\$HOME/.local/bin:\$PATH\""
+  fi
+}
+
+main "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,16 @@ packages = ["raven"]
 [tool.hatch.build.targets.wheel.force-include]
 "bridge" = "raven/bridge"
 
+# The prebuilt, self-contained TUI bundle (ui-tui/dist/entry.js) is packaged
+# into the wheel as raven/ui-tui/dist so `pip`/`uv tool install` yields a
+# working `raven tui` with no source checkout. It is added *conditionally* by
+# the custom build hook below (hatch_build.py) — a static force-include would
+# hard-fail when dist/ is absent (it's gitignored), breaking `git clone && uv
+# sync`. CI builds the bundle before building the release wheel
+# (see .github/workflows/release.yml).
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
+
 [tool.hatch.build]
 include = [
     "raven/**/*.py",
@@ -136,6 +146,7 @@ include = [
 include = [
     "raven/",
     "bridge/",
+    "hatch_build.py",
     "README.md",
     "LICENSE",
 ]

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -31,10 +31,35 @@ from raven.cli._log_file import redirect_loguru_to_file
 
 tui_app = typer.Typer(name="tui", help="Launch Raven native TUI (Ink+React).")
 
-# Path to ui-tui/ relative to this file: raven/cli/tui_commands.py -> ../../ui-tui/
+# Path to the ui-tui/ source tree, relative to this file:
+# raven/cli/tui_commands.py -> ../../../ui-tui/. Only the `--dev` path (tsx from
+# source) needs this; it requires src/ + node_modules and is absent from wheels.
 _UI_TUI_DIR = Path(__file__).resolve().parent.parent.parent / "ui-tui"
 
+# Packaged location of the prebuilt, self-contained bundle inside an installed
+# wheel: raven/cli/tui_commands.py -> ../ui-tui/dist/entry.js (i.e.
+# raven/ui-tui/dist/entry.js). pyproject force-includes ui-tui/dist here so a
+# `pip`/`uv tool install` ships the TUI without a source checkout.
+_PACKAGED_DIST_ENTRY = Path(__file__).resolve().parent.parent / "ui-tui" / "dist" / "entry.js"
+
 _MIN_NODE_VERSION = (22, 0, 0)
+
+
+def resolve_dist_entry() -> Optional[Path]:
+    """Locate the prebuilt ``entry.js`` bundle for production (non-dev) launch.
+
+    Tries, in order:
+      1. The packaged copy inside the installed wheel (``raven/ui-tui/dist``).
+      2. The source-tree copy a developer built locally (``ui-tui/dist``).
+
+    The bundle is self-contained (esbuild ``bundle: true``), so no sibling
+    ``node_modules`` is needed — only a Node runtime. Returns the first path
+    that exists, or ``None`` if neither does.
+    """
+    for candidate in (_PACKAGED_DIST_ENTRY, _UI_TUI_DIR / "dist" / "entry.js"):
+        if candidate.exists():
+            return candidate
+    return None
 
 
 def _stdout_isatty() -> bool:
@@ -63,6 +88,18 @@ def find_node() -> Tuple[Optional[str], Optional[Tuple[int, int, int]]]:
         # Priority 3: PATH
         if path_node := shutil.which("node"):
             candidates.append(path_node)
+
+        # Priority 4: Raven-managed private runtime installed by install.sh
+        # into ~/.raven/runtime/. This is the zero-config fallback so a user
+        # who has no system Node still gets a working `raven tui` after the
+        # one-line installer provisioned a private Node here. Glob to tolerate
+        # the versioned dir name (e.g. node-v22.x.y-darwin-arm64/bin/node).
+        runtime_root = Path(os.environ.get("RAVEN_HOME", Path.home() / ".raven")) / "runtime"
+        if runtime_root.is_dir():
+            direct = runtime_root / "node" / "bin" / "node"
+            if direct.exists():
+                candidates.append(str(direct))
+            candidates.extend(str(p) for p in sorted(runtime_root.glob("node-*/bin/node")))
 
     for node_path in candidates:
         if not Path(node_path).exists():
@@ -287,8 +324,8 @@ def _build_tui_agent_loop():
         from raven.agent.loop import AgentLoop
         from raven.agent.loop.recovery import limits_from_defaults
         from raven.cli._helpers import load_runtime_config, make_provider
-        from raven.config.raven import load_raven_config
         from raven.config.paths import get_cron_dir
+        from raven.config.raven import load_raven_config
         from raven.proactive_engine.schedulers.cron.service import CronService
         from raven.proactive_engine.schedulers.cron.tool import CronTool
         from raven.session.manager import SessionManager
@@ -389,7 +426,6 @@ async def _run_rpc_server_until_done(
     # Lazy import: keeps tui_commands importable without pulling tui_rpc on
     # users who never touch the TUI (e.g. CLI-only workflows).
     from raven.tui_rpc.confirm_broker import ConfirmBroker
-    from raven.tui_rpc.question_broker import QuestionBroker
     from raven.tui_rpc.dispatcher import Dispatcher
     from raven.tui_rpc.methods import register_aligned_methods_except_system
     from raven.tui_rpc.methods.system import (
@@ -399,6 +435,7 @@ async def _run_rpc_server_until_done(
         system_ping,
         system_version,
     )
+    from raven.tui_rpc.question_broker import QuestionBroker
     from raven.tui_rpc.server import RpcServer
     from raven.tui_rpc.spine import build_tui
     from raven.tui_rpc.subscriptions import SubscriptionEmitter
@@ -804,12 +841,12 @@ def _print_node_help(out=None) -> None:
     typer.echo(msg, file=out)
 
 
-def _diagnose_crash(node_path: str, dist_entry: Path) -> None:
+def _diagnose_crash(node_path: str, dist_entry: Path, cwd: Path) -> None:
     """When `tui` child exits non-zero, re-run capturing stderr for diagnosis."""
     try:
         proc = subprocess.run(
             [node_path, str(dist_entry)],
-            cwd=str(_UI_TUI_DIR),
+            cwd=str(cwd),
             capture_output=True,
             text=True,
             timeout=5,
@@ -864,8 +901,8 @@ def tui(
     # no-TTY diagnostic spawns (--check / --print-colors / --preview-colors).
     if not (check or print_colors or preview_colors) and _stdout_isatty():
         from raven.cli.onboard_commands import (
-            ensure_configured_or_onboard,
             _is_config_populated,
+            ensure_configured_or_onboard,
         )
 
         if not _is_config_populated():
@@ -883,8 +920,12 @@ def tui(
         )
         raise typer.Exit(code=1)
 
-    if not _UI_TUI_DIR.exists():
-        print(f"✗ TUI 资源缺失：{_UI_TUI_DIR}", file=sys.stderr)
+    # `--dev` runs tsx from the source tree, so it requires the ui-tui/ checkout.
+    # The production path resolves a packaged or source-built bundle separately
+    # (see resolve_dist_entry), so it must NOT hard-require the source tree —
+    # a wheel install legitimately has no ui-tui/ source directory.
+    if dev and not _UI_TUI_DIR.exists():
+        print(f"✗ TUI 源码缺失（--dev 需要源码树）：{_UI_TUI_DIR}", file=sys.stderr)
         raise typer.Exit(code=2)
 
     # Color override flows to the child via env (entry.tsx -> colorTier.ts).
@@ -956,23 +997,32 @@ def tui(
         else:
             exit_code = run_subprocess_with_rpc(npx, tsx_args, cwd=_UI_TUI_DIR)
     else:
-        dist_entry = _UI_TUI_DIR / "dist" / "entry.js"
-        if not dist_entry.exists() and not check:
+        dist_entry = resolve_dist_entry()
+        if dist_entry is None and not check:
             print(
-                f"✗ TUI 构建产物缺失：{dist_entry}\n"
-                f"  请先运行：cd {_UI_TUI_DIR} && npm install && npm run build\n",
+                f"✗ TUI 构建产物缺失：{_PACKAGED_DIST_ENTRY}（或源码树 {_UI_TUI_DIR / 'dist' / 'entry.js'}）\n"
+                f"  开发者请运行：cd {_UI_TUI_DIR} && npm install && npm run build\n"
+                f"  用户请重新安装：curl -fsSL https://raven.evermind.ai/install.sh | sh\n",
                 file=sys.stderr,
             )
             raise typer.Exit(code=2)
+        # On the `--check` smoke path a missing bundle is tolerated (the test
+        # only proves Node was found and a child can spawn). Use the expected
+        # packaged path as the spawn target so the command stays well-formed.
+        if dist_entry is None:
+            dist_entry = _PACKAGED_DIST_ENTRY
+        # The self-contained bundle needs no node_modules; run it from its own
+        # directory so any relative resource resolution stays well-defined.
+        dist_cwd = dist_entry.parent
         # `--check` smoke path keeps the simple stdio-only spawn so the
         # bootstrap-era tests (which don't speak JSON-RPC) still pass; the
         # interactive run path opens the RPC pipes and enforces handshake.
         if no_rpc:
-            exit_code = run_subprocess(node_path, [str(dist_entry)], cwd=_UI_TUI_DIR)
+            exit_code = run_subprocess(node_path, [str(dist_entry)], cwd=dist_cwd)
         else:
-            exit_code = run_subprocess_with_rpc(node_path, [str(dist_entry)], cwd=_UI_TUI_DIR)
+            exit_code = run_subprocess_with_rpc(node_path, [str(dist_entry)], cwd=dist_cwd)
         if exit_code != 0 and exit_code != 130 and exit_code != _RPC_HANDSHAKE_EXIT_CODE:
-            _diagnose_crash(node_path, dist_entry)
+            _diagnose_crash(node_path, dist_entry, dist_cwd)
 
     if check:
         # --check passes when Node was found and child process spawned,


### PR DESCRIPTION
## Change description

Make `raven` / `raven tui` runnable from any directory after a single install — no manual cd / uv run / npm build / Node setup.

- **pyproject.toml + hatch_build.py**: a custom build hook conditionally packages `ui-tui/dist` into the wheel as `raven/ui-tui/dist` when the bundle exists. A static force-include would hard-fail when `dist/` is absent (it's gitignored), breaking `git clone && uv sync`; the hook degrades gracefully with a warning instead.
- **raven/cli/tui_commands.py**: `resolve_dist_entry()` locates `entry.js` packaged-first then source-tree; `find_node()` adds a Priority-4 fallback to a Raven-managed private Node under `~/.raven/runtime`; `--dev` still requires the source tree, production no longer does.
- **install.sh** (new): POSIX one-line installer — ensures uv, ensures Node>=22 (downloads a private runtime if missing), installs raven as a global uv tool. Hardened: verifies the Node tarball against `SHASUMS256.txt`, self-tests the downloaded node (glibc/musl), validates a cached node before reuse, guards unset `HOME`.
- **.github/workflows/release.yml** (new, DRAFT): on tag, build `entry.js` then the wheel, asserting the bundle ships and `node_modules`/`src` do not.

## Verification
- wheel contains exactly `raven/ui-tui/dist/entry.js` (no node_modules/src)
- clean-venv install + `raven tui --check` exits 0 from an unrelated dir
- private-Node download + `find_node` Priority-4 discovery confirmed
- conditional hook verified both ways (with dist → packaged; without dist → builds + warns, no crash)

## Type of change
- [x] Bug fix
- [x] New feature
- [x] Others (packaging / tooling)

## Checklists
### Development
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass
### Security
- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
### Code review
- [x] Pull request has a descriptive title and context useful to a reviewer
- [ ] Pull request linked to JIRA ticket when applicable
