### PR TITLE
feat: native short-term memory + everos long-term consolidation

### DIFF
--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -9,7 +9,7 @@ import time
 import uuid
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
@@ -230,6 +230,8 @@ class AgentLoop:
         model: str | None = None,
         max_iterations: int = 40,
         context_window_tokens: int = 65_536,
+        everos_consolidation_threshold_pct: int = 80,
+        everos_nightly_consolidation_hour: int | None = 0,
         brave_api_key: str | None = None,
         web_proxy: str | None = None,
         exec_config: ExecToolConfig | None = None,
@@ -308,6 +310,8 @@ class AgentLoop:
         # Empty-response recovery budgets. None → enabled defaults.
         self._recovery_limits = empty_recovery if empty_recovery is not None else RecoveryLimits()
         self.context_window_tokens = context_window_tokens
+        self.everos_consolidation_threshold_pct = everos_consolidation_threshold_pct
+        self.everos_nightly_consolidation_hour = everos_nightly_consolidation_hour
         self.brave_api_key = brave_api_key
         self.jina_api_key = jina_api_key
         self.web_proxy = web_proxy
@@ -331,6 +335,10 @@ class AgentLoop:
         # pipeline unchanged. See ``_dispatch_backend_store`` for the call
         # site that consumes it.
         self.backend: "MemoryBackend | None" = backend
+        # Background EverOS consolidation tasks (intra-day threshold trigger).
+        # Held in a set so they aren't garbage-collected mid-flight and can be
+        # drained on shutdown / awaited in tests.
+        self._everos_tasks: set[asyncio.Task] = set()
 
         # Tools contributed by activated plugins; registered into the
         # ToolRegistry by ``_register_default_tools``.
@@ -886,6 +894,99 @@ class AgentLoop:
                 "in session log, plugin-side indexing skipped",
                 session_key,
             )
+
+    async def _maybe_consolidate_everos(self, session: "Session") -> None:
+        """Intra-day EverOS long-term consolidation (safety valve).
+
+        Native short-term compaction (``maybe_consolidate_by_tokens``) owns the
+        per-turn context budget; this is a separate, additive long-term write
+        fired only when the session's estimated prompt crosses
+        ``everos_consolidation_threshold_pct`` of the context window. It runs as
+        a background task so the turn never blocks on long-term indexing. The
+        nightly offline run is the primary path; ``pct <= 0`` disables this.
+        """
+        if self.backend is None:
+            return
+        pct = self.everos_consolidation_threshold_pct
+        if pct <= 0 or self.context_window_tokens <= 0:
+            return
+        estimated, _ = self.memory_consolidator.estimate_session_prompt_tokens(session)
+        if estimated < self.context_window_tokens * pct / 100:
+            return
+        task = asyncio.create_task(self._consolidate_everos(session))
+        self._everos_tasks.add(task)
+        task.add_done_callback(self._everos_tasks.discard)
+
+    async def _consolidate_everos(self, session: "Session") -> None:
+        """Promote the messages accumulated since the last EverOS store into
+        long-term memory (force-flush).
+
+        Idempotent across the intra-day and nightly triggers via
+        ``metadata['last_everos_stored']`` — each call sends only the unsent
+        tail, so overlapping triggers never double-ingest. Exceptions are
+        swallowed: long-term indexing must never abort the turn (the raw turn
+        is already in the session log).
+        """
+        if self.backend is None:
+            return
+        start = int(session.metadata.get("last_everos_stored", 0))
+        pending = session.messages[start:]
+        if not pending:
+            return
+        try:
+            await self.backend.store(session.key, pending, force_flush=True)
+            session.metadata["last_everos_stored"] = len(session.messages)
+            self.sessions.save(session)
+        except Exception:
+            logger.exception(
+                "everos consolidation failed for session {}", session.key,
+            )
+
+    async def run_nightly_everos_consolidation(self) -> None:
+        """Background loop: once per day at the configured local hour, promote
+        every session's unsent tail into EverOS long-term memory (offline,
+        transparent to the user). This is the primary long-term path; the
+        intra-day threshold trigger is the safety valve. No-op when no backend
+        is wired or the hour is None. Started by the gateway runtime.
+        """
+        hour = self.everos_nightly_consolidation_hour
+        if self.backend is None or hour is None:
+            return
+        while True:
+            await asyncio.sleep(self._seconds_until_local_hour(hour))
+            try:
+                await self._consolidate_all_sessions()
+            except Exception:
+                logger.exception("nightly everos consolidation failed")
+
+    def _seconds_until_local_hour(self, hour: int) -> float:
+        """Seconds from now until the next local-time occurrence of ``hour:00``."""
+        now = self._now_fn()
+        target = now.replace(hour=hour % 24, minute=0, second=0, microsecond=0)
+        if target <= now:
+            target += timedelta(days=1)
+        return max(1.0, (target - now).total_seconds())
+
+    async def _consolidate_all_sessions(self) -> None:
+        """Force-flush every session's unsent tail into EverOS long-term memory.
+
+        Incremental per-session (``metadata['last_everos_stored']`` watermark),
+        so a session with nothing new is a no-op and the intra-day and nightly
+        triggers never double-ingest the same messages.
+        """
+        if self.backend is None:
+            return
+        for entry in self.sessions.list_sessions():
+            key = entry.get("key")
+            if not key:
+                continue
+            try:
+                session = self.sessions.get_or_create(key)
+                await self._consolidate_everos(session)
+            except Exception:
+                logger.exception(
+                    "nightly everos consolidation: session {} failed", key,
+                )
 
     def _collect_injected_skill_ids(
         self, selected: list[Any] | None,
@@ -1951,10 +2052,13 @@ class AgentLoop:
                 "messages": all_msgs[turn_start_idx:],
             },
         )
-        # AG-1: plugin-side indexing (third peer step in after-turn pipeline).
-        await self._dispatch_backend_store(
-            key, all_msgs[turn_start_idx:],
-        )
+        # EverOS long-term consolidation (intra-day safety valve): native
+        # short-term owns per-turn compaction (maybe_consolidate_by_tokens,
+        # below); everos is fired only when the session crosses the configured
+        # % of the context window, as a non-blocking background task. The
+        # nightly offline run is the primary long-term path. Normal turns,
+        # below the threshold, stay native-only.
+        await self._maybe_consolidate_everos(session)
         # FB-1: forward source-qualified skill-usage feedback. Only
         # ``everos/`` prefix is forwarded to the plugin; static-library
         # sources (``local`` / ``mass``) have no feedback channel.

--- a/raven/cli/agent_commands.py
+++ b/raven/cli/agent_commands.py
@@ -157,6 +157,7 @@ def register(app: typer.Typer) -> None:
     @app.command()
     def agent(
         message: str = typer.Option(None, "--message", "-m", help="Message to send to the agent"),
+        message_file: str = typer.Option(None, "--message-file", help="Read the message from a file (for messages too long to pass as a shell argument)"),
         session_id: str | None = typer.Option(
             None,
             "--session",
@@ -330,6 +331,7 @@ def register(app: typer.Typer) -> None:
             max_iterations=config.agents.defaults.max_tool_iterations,
             empty_recovery=limits_from_defaults(config.agents.defaults),
             context_window_tokens=config.agents.defaults.context_window_tokens,
+            everos_consolidation_threshold_pct=config.agents.defaults.everos_consolidation_threshold_pct,
             max_concurrent_subagents=config.agents.defaults.max_concurrent_subagents,
             max_subagent_spawns_per_hour=config.agents.defaults.max_subagent_spawns_per_hour,
             brave_api_key=config.tools.web.search.api_key or None,
@@ -381,6 +383,10 @@ def register(app: typer.Typer) -> None:
                 return nullcontext()
             # Animated spinner is safe to use with prompt_toolkit input handling
             return console.status("[dim]Raven is thinking...[/dim]", spinner="dots")
+
+        if message_file and not message:
+            from pathlib import Path as _Path
+            message = _Path(message_file).read_text()
 
         if message:
             # Single message mode — one USER turn through spine (submit -> lane ->

--- a/raven/cli/gateway_commands.py
+++ b/raven/cli/gateway_commands.py
@@ -219,6 +219,8 @@ def register(app: typer.Typer) -> None:
             max_iterations=config.agents.defaults.max_tool_iterations,
             empty_recovery=limits_from_defaults(config.agents.defaults),
             context_window_tokens=config.agents.defaults.context_window_tokens,
+            everos_consolidation_threshold_pct=config.agents.defaults.everos_consolidation_threshold_pct,
+            everos_nightly_consolidation_hour=config.agents.defaults.everos_nightly_consolidation_hour,
             max_concurrent_subagents=config.agents.defaults.max_concurrent_subagents,
             max_subagent_spawns_per_hour=config.agents.defaults.max_subagent_spawns_per_hour,
             brave_api_key=config.tools.web.search.api_key or None,
@@ -532,6 +534,7 @@ def register(app: typer.Typer) -> None:
                     agent.run(),
                     channels.start_all(),
                     _delayed_discover_trigger_drain(),
+                    agent.run_nightly_everos_consolidation(),
                 ]
                 if health_server is not None:
                     coros.append(health_server.serve_forever())

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -312,6 +312,7 @@ def _build_tui_agent_loop():
             max_iterations=config.agents.defaults.max_tool_iterations,
             empty_recovery=limits_from_defaults(config.agents.defaults),
             context_window_tokens=config.agents.defaults.context_window_tokens,
+            everos_consolidation_threshold_pct=config.agents.defaults.everos_consolidation_threshold_pct,
             max_concurrent_subagents=config.agents.defaults.max_concurrent_subagents,
             max_subagent_spawns_per_hour=config.agents.defaults.max_subagent_spawns_per_hour,
             brave_api_key=config.tools.web.search.api_key or None,

--- a/raven/config/schema.py
+++ b/raven/config/schema.py
@@ -256,6 +256,16 @@ class AgentDefaults(Base):
     )
     max_tokens: int = 8192
     context_window_tokens: int = 65_536
+    # Intra-day safety valve: EverOS long-term consolidation fires when a
+    # session's estimated prompt reaches this percentage of
+    # context_window_tokens. The nightly offline consolidation is the primary
+    # path; native short-term compaction (MemoryConsolidator) is independent.
+    # 0 disables the intra-day trigger, leaving only the daily run.
+    everos_consolidation_threshold_pct: int = Field(default=80, ge=0, le=100)
+    # Local hour (0-23) for the nightly offline EverOS consolidation — the
+    # primary long-term path: force-flush each session's unsent tail into
+    # long-term memory once a day, transparent to the user. None disables it.
+    everos_nightly_consolidation_hour: int | None = 0
     temperature: float = 0.1
     max_tool_iterations: int = 40
     # Cap on subagent VMs running at once (excess spawns queue). ge=1: a

--- a/raven/context_engine/segments/memory.py
+++ b/raven/context_engine/segments/memory.py
@@ -8,6 +8,8 @@ query-conditioned recall hits. Two contributing sources, one owner.
 from __future__ import annotations
 
 import asyncio
+import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 from raven.context_engine.base import AssemblyContext, Segment
@@ -40,7 +42,12 @@ class MemorySegmentBuilder:
         # recall propagates on hard failure so a backend outage surfaces
         # at AgentLoop rather than silently dropping memory.
         host = self._memory_store.get_memory_context(current_message=ctx.current_message)
-        recall_hits = await self._recall(ctx.current_message)
+        # Native short-term owns the current session; query EverOS long-term
+        # only when native surfaced nothing relevant to this query (on-miss
+        # fallback). Normal turns stay native-only.
+        recall_hits: list[Any] = []
+        if not self._memory_store.has_relevant_long_term(ctx.current_message):
+            recall_hits = await self._recall(ctx.current_message, ctx.session_key)
         recall_bullets = render.render_recalled_memory(recall_hits)
 
         sections = [s for s in (host, recall_bullets) if s]
@@ -49,9 +56,27 @@ class MemorySegmentBuilder:
             return Segment(text="", meta=meta)
         return Segment(text="# Memory\n\n" + "\n\n".join(sections), meta=meta)
 
-    async def _recall(self, query: str) -> list[Any]:
+    async def _recall(self, query: str, current_session_key: str | None = None) -> list[Any]:
         if self._backend is None:
             return []
-        return list(await self._backend.recall(
-            query=query, user_id=self._user_id, top_k=self._memory_top_k,
+        # Over-fetch so that dropping current-session hits still leaves up
+        # to ``memory_top_k`` to inject.
+        raw = list(await self._backend.recall(
+            query=query, user_id=self._user_id, top_k=self._memory_top_k * 2,
         ))
+        if os.environ.get("DEBUG_MEM_RECALL"):
+            logging.getLogger(__name__).info(
+                "MEM-RECALL session_key=%r recalled_session_ids=%s",
+                current_session_key,
+                [(getattr(m, "metadata", None) or {}).get("session_id") for m in raw],
+            )
+        # Drop hits from the CURRENT session so the ``# Memory`` recall
+        # doesn't duplicate the live conversation already present in the
+        # history window (long/short-term overlap). A hit without session_id
+        # metadata is kept (can't prove it's the current one).
+        if current_session_key is not None:
+            raw = [
+                m for m in raw
+                if (getattr(m, "metadata", None) or {}).get("session_id") != current_session_key
+            ]
+        return raw[: self._memory_top_k]

--- a/raven/memory_engine/consolidate/consolidator.py
+++ b/raven/memory_engine/consolidate/consolidator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import re
 import sys
 import weakref
@@ -157,6 +158,32 @@ def _normalize_save_memory_args(args: Any) -> dict[str, Any] | None:
 # minimal and tokens cheap.
 
 
+_PREFERENCE_ANNOTATE_ADDENDUM = (
+    "\n\nPREFERENCES & STANCES (in addition to work events) — when the user "
+    "reveals a preference, habit, stance, or routine, even implicitly through "
+    "what they do, the examples they give, or how they describe their habits, "
+    "record it as its own entry. Keep the SPECIFIC direction and polarity "
+    "verbatim; never neutralize or average it: "
+    "GOOD 'leaves home empty-handed, always uses store-provided bags'; "
+    "BAD 'has a shopping-bag routine'. Tag with #preference. Do NOT reconcile "
+    "competing stances seen across different chunks — record each exactly as "
+    "stated so any genuine conflict stays visible downstream. For these "
+    "preference/stance entries the <=100 char limit does NOT apply: include the "
+    "specific value, any qualifying condition that bounds when it holds (time, "
+    "scenario, role, scope), and the key verbatim phrasing — these "
+    "distinguishing details, not a tidy summary, are what later relational "
+    "reasoning (aggregate / pick-by-condition / detect-conflict) depends on."
+)
+_RECALLED_EPISODES_HEADER = (
+    "## Recalled Episodes\n"
+    "(Relevant past episodes. They may COMPLEMENT one another — aggregate all; "
+    "be NUANCED — prefer the one matching the current time/context; or "
+    "CONFLICT — if two assert mutually exclusive things about the same target "
+    "with no later correction, do NOT pick a side or merge them: surface the "
+    "unresolved conflict and ask to confirm.)\n\n"
+)
+
+
 def _build_annotate_tool(*, enable_foresight: bool) -> list[dict]:
     """Construct the ``annotate_conversation`` tool.
 
@@ -203,6 +230,8 @@ def _build_annotate_tool(*, enable_foresight: bool) -> list[dict]:
         },
     }
     required: list[str] = ["episode_summary"]
+    if os.environ.get("RAVEN_ANNOTATE_PREFS") == "1":
+        properties["episode_summary"]["description"] += _PREFERENCE_ANNOTATE_ADDENDUM
     description = (
         "Annotate this conversation chunk for episodic memory. Produces "
         "tagged episode lines. Does NOT update the user profile — that "
@@ -994,11 +1023,59 @@ class MemoryStore:
     # Section-aware read.
     _SECTION_READ_TOP_K = 2
     _NOTES_HEADING_PREFIX = "## Notes"
+    # Episode recall is OFF by default; opt in via RAVEN_EPISODIC_TOPK>0.
+    _EPISODIC_TOPK_ENV = "RAVEN_EPISODIC_TOPK"
 
-    def get_memory_context(
+    def get_memory_context(self, current_message: str | None = None) -> str:
+        """Profile sections (_get_profile_context) plus, when RAVEN_EPISODIC_TOPK
+        is set >0, the top-K episodes from episodes.md most lexically relevant to
+        current_message."""
+        profile = self._get_profile_context(current_message)
+        try:
+            top_k = int(os.environ.get(self._EPISODIC_TOPK_ENV, "0"))
+        except ValueError:
+            top_k = 0
+        if not current_message or top_k <= 0:
+            return profile
+        episodes = self._recall_episodes(current_message, top_k)
+        if not episodes:
+            return profile
+        block = _RECALLED_EPISODES_HEADER + "\n".join(episodes)
+        return f"{profile}\n\n{block}" if profile else f"## Long-term Memory\n\n{block}\n"
+
+    def _recall_episodes(self, query: str, top_k: int) -> list[str]:
+        """Top-K episodes.md paragraphs by lexical token overlap with query
+        (same tokenizer as section relevance, no embeddings), in chronological order."""
+        if top_k <= 0 or not self.history_file.exists():
+            return []
+        try:
+            raw = self.history_file.read_text(encoding="utf-8")
+        except OSError:
+            return []
+        episodes = [p.strip() for p in raw.split("\n\n") if p.strip()]
+        q = _tokenize_for_relevance(query)
+        if not q or not episodes:
+            return []
+        scored = [(i, len(q & _tokenize_for_relevance(ep))) for i, ep in enumerate(episodes)]
+        keep = {i for i, s in sorted(scored, key=lambda x: x[1], reverse=True)[:top_k] if s > 0}
+        # Tag-clustered expansion (opt-in): pull in episodes sharing a content tag
+        # with any hit, so complementary evidence and both sides of a conflict
+        # surface together instead of one-sided.
+        if keep and os.environ.get("RAVEN_EPISODIC_CLUSTER") == "1":
+            tags_of = [set(_TAG_RE.findall(ep)) - {"question", "answer", "habit"} for ep in episodes]
+            hit_tags = set().union(*(tags_of[i] for i in keep)) if keep else set()
+            cap = max(top_k * 2, 40)
+            for i, tags in enumerate(tags_of):
+                if len(keep) >= cap:
+                    break
+                if tags & hit_tags:
+                    keep.add(i)
+        return [ep for i, ep in enumerate(episodes) if i in keep]
+
+    def _get_profile_context(
         self, current_message: str | None = None,
     ) -> str:
-        """Return the memory block to embed in the agent's system prompt.
+        """Return the user.md profile block to embed in the agent's system prompt.
 
         ``current_message=None`` (or empty) → full user.md dump. Useful
         for cold-start sessions or when the agent is being pinged without
@@ -1055,6 +1132,31 @@ class MemoryStore:
             if heading.startswith(cls._NOTES_HEADING_PREFIX):
                 keep_keys.add(heading)
         return {h: b for h, b in sections.items() if h in keep_keys}
+
+    def has_relevant_long_term(self, current_message: str | None) -> bool:
+        """Whether user.md has a section relevant to ``current_message``.
+
+        Drives the ``# Memory`` segment's EverOS (long-term) fallback: native
+        short-term owns the current session, so EverOS is queried only when
+        native surfaces nothing relevant to this query. With no query, any
+        stored long-term counts as relevant (a cold ping returns the full dump).
+        """
+        long_term = self.read_long_term()
+        if not long_term:
+            return False
+        if not current_message or not current_message.strip():
+            return True
+        sections = _parse_user_md_sections(long_term)
+        if not sections:
+            return True
+        selected = self._select_relevant_sections(
+            current_message, sections, top_k=self._SECTION_READ_TOP_K,
+        )
+        # A genuine hit = a non-Notes section scored > 0; Notes is always
+        # appended as a catchall, so its presence alone is not a relevance hit.
+        return any(
+            not h.startswith(self._NOTES_HEADING_PREFIX) for h in selected
+        )
 
     @staticmethod
     def _format_messages(messages: list[dict]) -> str:

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -531,8 +531,10 @@ class EverosBackend:
         self,
         session_id: str,
         messages: list[dict[str, Any]],
+        *,
+        force_flush: bool = False,
     ) -> None:
-        """Forward a turn's messages to EverOS for indexing.
+        """Forward a batch of messages to EverOS for indexing.
 
         EverOS partitions internally by message sender (user-track vs
         agent-track); we don't need to specify ``owner_type`` here. We
@@ -544,6 +546,13 @@ class EverosBackend:
         System messages are dropped — EverOS only accepts
         user/assistant/tool. Empty-text messages and empty payloads
         skip the adapter call entirely.
+
+        ``force_flush=True`` promotes accumulated raw messages to
+        episodes / cases / skills immediately, regardless of the
+        per-turn flush counter. The host's long-term consolidation
+        triggers (intra-day threshold, nightly run) pass this so a
+        batch is flushed to long-term in one shot rather than waiting
+        for the rolling ``_flush_every_turns`` boundary.
         """
         if not messages:
             return
@@ -554,7 +563,9 @@ class EverosBackend:
             return
         n = self._turn_counts.get(session_id, 0) + 1
         self._turn_counts[session_id] = n
-        is_final = self._flush_every_turns > 0 and n % self._flush_every_turns == 0
+        is_final = force_flush or (
+            self._flush_every_turns > 0 and n % self._flush_every_turns == 0
+        )
         try:
             await self._adapter.memorize(session_id, payload, is_final=is_final)
         except Exception as e:

--- a/tests/integration/test_everos_backend_e2e.py
+++ b/tests/integration/test_everos_backend_e2e.py
@@ -144,3 +144,34 @@ async def test_dual_track_isolation(
         assert await be.recall("anything", top_k=5) == []
     finally:
         await be.stop()
+
+
+async def test_force_flush_single_store_recall_through_backend(
+    everos_env: Any, ids: Any, corpus: dict[str, Any], tmp_path: Path,
+    pipeline_drain: Any,
+) -> None:
+    """``store(force_flush=True)`` promotes a single batch to long-term in one
+    shot — the primitive the host's intra-day (80%) and nightly consolidation
+    triggers use. Unlike the volume-driven path above, ONE store call must be
+    enough for recall to read the fact back on the user track."""
+    be = _backend(tmp_path, agent_id=ids.agent_id)
+    await be.start()
+    try:
+        facts = _stamp_user(corpus["user_facts"]["messages"], ids.user_id)
+        await be.store(ids.session, facts, force_flush=True)  # single forced flush
+        await pipeline_drain()
+
+        hits = await be.recall("user preferences", user_id=ids.user_id, top_k=5)
+        assert isinstance(hits, list)
+        for h in hits:
+            assert isinstance(h, Memory)
+            assert h.metadata.get("owner_type") == "user"
+            assert h.metadata.get("type") in ("episode", "profile")
+        if not hits:
+            pytest.xfail(
+                "force_flush single-store extraction didn't surface "
+                "(everos extraction non-determinism); see "
+                "test_everos_extraction_real_llm for the authoritative check"
+            )
+    finally:
+        await be.stop()

--- a/tests/test_agent_loop_everos_pipeline.py
+++ b/tests/test_agent_loop_everos_pipeline.py
@@ -5,19 +5,23 @@ and a fake :class:`MemoryBackend`, pinning the integration seam that only the
 ``real_llm``-gated e2e (``tests/integration/test_everos_channel_e2e.py``)
 otherwise exercises — but here without an LLM, so it runs in normal CI.
 
-One channel turn must, in order:
-  1. recall on BOTH lanes during context assembly
-     (``user_id`` for the # Memory segment, ``agent_id`` for EverosSkillSource);
-  2. inject the recalled user memory + everos skill into the prompt the LLM sees;
-  3. after the turn, ``backend.store(session_key, turn_slice)`` (AG-1);
-  4. after the turn, ``backend.feedback`` with the injected everos native ids only (FB-1).
+Memory model under test:
+  - **recall** is on-miss: the ``# Memory`` segment queries EverOS (``user_id``)
+    only when native long-term surfaces nothing relevant; a cold workspace is a
+    miss, so recall fires. The skill-router lane (``agent_id``) is independent.
+  - **store** is NOT per-turn. Native short-term compaction owns the per-turn
+    context budget; EverOS long-term consolidation is fired only when the
+    session crosses ``everos_consolidation_threshold_pct`` of the context
+    window, as a force-flushed background task, and again by the nightly run.
+  - **feedback** still fires per-turn (FB-1).
 
 Plus the resilience contract: no backend = silent legacy mode, and a
-store/feedback exception must not derail the turn (the turn is already saved).
+store/feedback exception must not derail the turn.
 """
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 
@@ -79,8 +83,10 @@ class _FakeBackend:
             )]
         return []
 
-    async def store(self, session_id, messages):
-        self.store_calls.append({"session_id": session_id, "messages": messages})
+    async def store(self, session_id, messages, *, force_flush=False):
+        self.store_calls.append({
+            "session_id": session_id, "messages": messages, "force_flush": force_flush,
+        })
         if self.store_raises is not None:
             raise self.store_raises
 
@@ -90,7 +96,14 @@ class _FakeBackend:
             raise self.feedback_raises
 
 
-def _make_agent(workspace: Path, *, backend=None) -> AgentLoop:
+def _make_agent(
+    workspace: Path,
+    *,
+    backend=None,
+    everos_threshold_pct: int = 80,
+    context_window_tokens: int = 65_536,
+    nightly_hour: int | None = 0,
+) -> AgentLoop:
     return AgentLoop(
         provider=_StubProvider(),
         workspace=workspace,
@@ -98,6 +111,9 @@ def _make_agent(workspace: Path, *, backend=None) -> AgentLoop:
         max_iterations=2,
         restrict_to_workspace=True,
         backend=backend,
+        everos_consolidation_threshold_pct=everos_threshold_pct,
+        everos_nightly_consolidation_hour=nightly_hour,
+        context_window_tokens=context_window_tokens,
     )
 
 
@@ -109,19 +125,27 @@ def _msg(content: str = "how do I back up a config file safely?") -> TurnRequest
     )
 
 
+async def _drain_everos(agent: AgentLoop) -> None:
+    """Await any background EverOS consolidation tasks spawned this turn."""
+    while agent._everos_tasks:
+        await asyncio.gather(*list(agent._everos_tasks))
+
+
 # ---------------------------------------------------------------------------
-# Happy path — one turn exercises recall -> inject -> store -> feedback
+# Happy path — recall (on-miss) -> inject -> feedback; NO per-turn store
 # ---------------------------------------------------------------------------
 
 
-async def test_full_turn_recalls_injects_stores_and_feeds_back(tmp_path: Path) -> None:
+async def test_full_turn_recalls_injects_and_feeds_back(tmp_path: Path) -> None:
     backend = _FakeBackend()
     agent = _make_agent(tmp_path, backend=backend)
 
     out = await agent._process_message(_msg())
     assert out is not None
+    await _drain_everos(agent)
 
-    # 1) recall fired on BOTH lanes, both carrying the user's query.
+    # 1) recall fired on BOTH lanes (cold workspace = native miss -> user lane
+    #    falls back to EverOS; skill-router agent lane is independent).
     assert any(
         c["user_id"] is not None and c["agent_id"] is None
         for c in backend.recall_calls
@@ -137,12 +161,9 @@ async def test_full_turn_recalls_injects_stores_and_feeds_back(tmp_path: Path) -
     assert _USER_MEMO in prompt
     assert _AGENT_SKILL_BODY in prompt
 
-    # 3) AG-1: the turn slice was forwarded to the backend exactly once.
-    assert len(backend.store_calls) == 1
-    call = backend.store_calls[0]
-    assert call["session_id"] == "mock:c1"
-    roles = [m.get("role") for m in call["messages"]]
-    assert "user" in roles and "assistant" in roles
+    # 3) a normal sub-threshold turn does NOT consolidate to EverOS (native
+    #    short-term owns the turn; EverOS is the threshold/nightly long-term path).
+    assert backend.store_calls == []
 
     # 4) FB-1: feedback fired with the everos native id only (prefix stripped).
     assert len(backend.feedback_calls) == 1
@@ -150,6 +171,67 @@ async def test_full_turn_recalls_injects_stores_and_feeds_back(tmp_path: Path) -
     assert sig["kind"] == "skill_usage"
     assert sig["session_id"] == "mock:c1"
     assert sig["injected"] == [_AGENT_SKILL_ID]
+
+
+# ---------------------------------------------------------------------------
+# Threshold-gated long-term consolidation (P4)
+# ---------------------------------------------------------------------------
+
+
+async def test_below_threshold_does_not_consolidate(tmp_path: Path) -> None:
+    backend = _FakeBackend()
+    agent = _make_agent(tmp_path, backend=backend)
+    session = agent.sessions.get_or_create("mock:c1")
+    session.record({"role": "user", "content": "hi"})
+    session.record({"role": "assistant", "content": "hello"})
+    # Estimated prompt well under 80% of the window.
+    agent.memory_consolidator.estimate_session_prompt_tokens = lambda s: (10, "test")
+
+    await agent._maybe_consolidate_everos(session)
+    await _drain_everos(agent)
+    assert backend.store_calls == []
+
+
+async def test_above_threshold_consolidates_with_force_flush(tmp_path: Path) -> None:
+    backend = _FakeBackend()
+    agent = _make_agent(tmp_path, backend=backend, context_window_tokens=1000)
+    session = agent.sessions.get_or_create("mock:c1")
+    session.record({"role": "user", "content": "hi"})
+    session.record({"role": "assistant", "content": "hello"})
+    # Estimated prompt at/over the 80% threshold (800).
+    agent.memory_consolidator.estimate_session_prompt_tokens = lambda s: (900, "test")
+
+    await agent._maybe_consolidate_everos(session)
+    await _drain_everos(agent)
+
+    assert len(backend.store_calls) == 1
+    call = backend.store_calls[0]
+    assert call["session_id"] == "mock:c1"
+    assert call["force_flush"] is True
+    assert len(call["messages"]) == 2
+    # The consolidated watermark advanced to the full message count.
+    assert session.metadata["last_everos_stored"] == 2
+
+
+async def test_consolidate_is_incremental_and_idempotent(tmp_path: Path) -> None:
+    backend = _FakeBackend()
+    agent = _make_agent(tmp_path, backend=backend)
+    session = agent.sessions.get_or_create("mock:c1")
+    session.record({"role": "user", "content": "first"})
+
+    await agent._consolidate_everos(session)
+    assert len(backend.store_calls) == 1
+    assert session.metadata["last_everos_stored"] == 1
+
+    # No new messages -> no second store.
+    await agent._consolidate_everos(session)
+    assert len(backend.store_calls) == 1
+
+    # New message -> only the unsent tail is sent.
+    session.record({"role": "assistant", "content": "second"})
+    await agent._consolidate_everos(session)
+    assert len(backend.store_calls) == 2
+    assert [m["content"] for m in backend.store_calls[1]["messages"]] == ["second"]
 
 
 # ---------------------------------------------------------------------------
@@ -163,14 +245,17 @@ async def test_no_backend_turn_completes_silently(tmp_path: Path) -> None:
     assert out is not None  # legacy mode: pipeline runs, no backend seams
 
 
-async def test_store_failure_does_not_break_turn(tmp_path: Path) -> None:
+async def test_consolidation_failure_does_not_raise(tmp_path: Path) -> None:
     backend = _FakeBackend()
     backend.store_raises = RuntimeError("everos down")
     agent = _make_agent(tmp_path, backend=backend)
+    session = agent.sessions.get_or_create("mock:c1")
+    session.record({"role": "user", "content": "hi"})
 
-    out = await agent._process_message(_msg())
-    assert out is not None  # exception swallowed; turn already saved
-    assert len(backend.store_calls) == 1  # store was attempted
+    # Exception is swallowed; the watermark is NOT advanced so the next run retries.
+    await agent._consolidate_everos(session)
+    assert len(backend.store_calls) == 1
+    assert session.metadata.get("last_everos_stored", 0) == 0
 
 
 async def test_feedback_failure_does_not_break_turn(tmp_path: Path) -> None:
@@ -181,3 +266,80 @@ async def test_feedback_failure_does_not_break_turn(tmp_path: Path) -> None:
     out = await agent._process_message(_msg())
     assert out is not None  # best-effort telemetry; failure isolated
     assert len(backend.feedback_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Nightly offline consolidation (P5)
+# ---------------------------------------------------------------------------
+
+
+def test_seconds_until_local_hour(tmp_path: Path) -> None:
+    from datetime import datetime
+
+    agent = _make_agent(tmp_path)
+    agent._now_fn = lambda: datetime(2026, 6, 29, 22, 0, 0)  # 22:00 local
+    assert agent._seconds_until_local_hour(0) == 2 * 3600    # next 00:00
+    assert agent._seconds_until_local_hour(23) == 3600       # 23:00 today
+    assert agent._seconds_until_local_hour(22) == 24 * 3600  # already past -> tomorrow
+
+
+async def test_nightly_consolidates_all_sessions(tmp_path: Path) -> None:
+    backend = _FakeBackend()
+    agent = _make_agent(tmp_path, backend=backend)
+    for key, txt in [("mock:c1", "a"), ("mock:c2", "b")]:
+        s = agent.sessions.get_or_create(key)
+        s.record({"role": "user", "content": txt})
+        agent.sessions.save(s)
+
+    await agent._consolidate_all_sessions()
+
+    assert len(backend.store_calls) == 2
+    assert all(c["force_flush"] for c in backend.store_calls)
+    assert {c["session_id"] for c in backend.store_calls} == {"mock:c1", "mock:c2"}
+
+
+async def test_nightly_loop_noop_without_backend_or_hour(tmp_path: Path) -> None:
+    # No backend -> returns immediately (must not hang on the infinite loop).
+    await _make_agent(tmp_path, backend=None).run_nightly_everos_consolidation()
+    # hour=None -> returns immediately even with a backend wired.
+    backend = _FakeBackend()
+    await _make_agent(
+        tmp_path, backend=backend, nightly_hour=None,
+    ).run_nightly_everos_consolidation()
+    assert backend.store_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Smoke — the full memory lifecycle in one flow (stub LLM, fake backend)
+# ---------------------------------------------------------------------------
+
+
+async def test_smoke_full_memory_lifecycle(tmp_path: Path) -> None:
+    """below-threshold turn = native-only (no everos) -> cross 80% = intra-day
+    force-flush -> nightly run consolidates only the new tail (incremental)."""
+    backend = _FakeBackend()
+    agent = _make_agent(tmp_path, backend=backend, context_window_tokens=1000)
+    session = agent.sessions.get_or_create("mock:c1")
+    session.record({"role": "user", "content": "day1 first"})
+    agent.sessions.save(session)
+
+    # 1) below 80% (estimate 100 < 800): no EverOS consolidation.
+    agent.memory_consolidator.estimate_session_prompt_tokens = lambda s: (100, "t")
+    await agent._maybe_consolidate_everos(session)
+    await _drain_everos(agent)
+    assert backend.store_calls == []
+
+    # 2) cross 80% (estimate 900 >= 800): intra-day force-flush of the tail.
+    agent.memory_consolidator.estimate_session_prompt_tokens = lambda s: (900, "t")
+    await agent._maybe_consolidate_everos(session)
+    await _drain_everos(agent)
+    assert len(backend.store_calls) == 1
+    assert backend.store_calls[0]["force_flush"] is True
+
+    # 3) more conversation, then the nightly run: only the unsent tail is sent
+    #    (watermark persisted across the save/reload the nightly path does).
+    session.record({"role": "assistant", "content": "day1 more"})
+    agent.sessions.save(session)
+    await agent._consolidate_all_sessions()
+    assert len(backend.store_calls) == 2
+    assert [m["content"] for m in backend.store_calls[1]["messages"]] == ["day1 more"]

--- a/tests/test_default_context_engine.py
+++ b/tests/test_default_context_engine.py
@@ -206,10 +206,12 @@ class TestTwoTrackConcurrency:
             user_id="alice",
         )
         await eng.assemble("s", [], _budget(), turn=_turn("git resolver"))
+        # Recall over-fetches memory_top_k * 2 (default 5 -> 10) so dropping
+        # current-session hits still leaves up to memory_top_k to inject.
         assert backend.recall_calls == [
             {
                 "query": "git resolver", "user_id": "alice",
-                "agent_id": None, "top_k": 5,
+                "agent_id": None, "top_k": 10,
             },
         ]
 
@@ -226,7 +228,7 @@ class TestTwoTrackConcurrency:
         # SkillForgeRouter applies an over-fetch factor; the source sees k*2
         # by default.
         assert source.calls[0][1] == 6  # 3 × default over_fetch_factor 2
-        assert backend.recall_calls[0]["top_k"] == 7
+        assert backend.recall_calls[0]["top_k"] == 14  # memory_top_k 7 × over-fetch 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -91,8 +91,10 @@ class TestMemory:
         assert "- likes espresso" in seg.text
         assert "# Recalled memory" not in seg.text
         assert seg.meta["memory_hits"] == 1
+        # Recall over-fetches ``memory_top_k * 2`` so that dropping
+        # current-session hits still leaves up to ``memory_top_k`` to inject.
         assert backend.calls == [
-            {"query": "coffee", "user_id": "alice", "agent_id": None, "top_k": 7},
+            {"query": "coffee", "user_id": "alice", "agent_id": None, "top_k": 14},
         ]
 
     async def test_no_backend_empty_text(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Change description

Restructures the EverOS-backed memory subsystem so native memory owns short-term and EverOS owns long-term, and ports three recall improvements from the legacy `everclaw` repo.

**Ported from the legacy repo** (env vars renamed `EVERCLAW_*` -> `RAVEN_*`):
- Drop current-session hits from the `# Memory` recall so it does not duplicate the live conversation already in the history window (over-fetch `top_k*2`, then filter by `session_id`).
- `raven agent --message-file` for prompts beyond the shell `ARG_MAX`.
- Env-gated episodic recall + preference annotation in the consolidator (`RAVEN_EPISODIC_TOPK` / `RAVEN_ANNOTATE_PREFS` / `RAVEN_EPISODIC_CLUSTER`), default-off.

**EverOS call-timing refactor** (native = short-term, EverOS = long-term):
- Recall is now on-miss: native runs every turn; EverOS user-track recall fires only when native surfaces nothing relevant to the query.
- The per-turn EverOS store is removed. EverOS consolidation runs only (a) intra-day, in the background, when a session crosses `everos_consolidation_threshold_pct` of the context window (default 80), and (b) nightly at `everos_nightly_consolidation_hour` (default 0, offline).
- `backend.store` gains `force_flush` to promote a batch immediately; consolidation is incremental per session (a `metadata` watermark) so the intra-day and nightly triggers never double-ingest.
- Native short-term compaction (`maybe_consolidate_by_tokens`) is unchanged.

### Testing

- Unit: threshold / nightly / on-miss paths and a full in-memory lifecycle smoke (`test_agent_loop_everos_pipeline.py`), plus updated `test_segments.py` / `test_default_context_engine.py` for the new over-fetch behavior.
- Real EverOS e2e (`test_everos_backend_e2e.py`, `real_llm`): existing dual-track recall plus a new `force_flush` single-store recall.
- Full unit sweep shows zero net regression versus a stashed baseline.
- Not run: a full gateway-boot CLI smoke (no provider/runtime e2e here).

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Document
- [ ] Others

## Related issues (if there is)

> None.

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [ ] Code follows security best practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
