### PR TITLE
chore: prepare open source launch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,122 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    name: pre-commit diff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: make install-deps
+
+      - name: Run pre-commit on changed files
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            BASE="$(git rev-list --max-parents=0 HEAD)"
+          fi
+          uv run pre-commit run --from-ref "$BASE" --to-ref HEAD
+
+  python:
+    name: python checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: make install-deps
+
+      - name: Focused Python lint
+        run: make lint-python
+
+      - name: Focused Python tests
+        run: make test-python
+
+  tui:
+    name: TUI checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui-tui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ui-tui
+
+      - name: Lint, type-check, and test
+        run: |
+          npm run lint
+          npm run lint:rpc
+          npm run type-check
+          npm test
+          npm run build
+        working-directory: ui-tui
+
+  bridge:
+    name: bridge checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: bridge/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: bridge
+
+      - name: Build bridge
+        run: npm run build
+        working-directory: bridge
+
+      - name: Audit bridge dependencies
+        run: npm audit --audit-level=critical
+        working-directory: bridge

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,0 +1,56 @@
+name: Commit lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: commit-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-title:
+    name: pull request title
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python3 scripts/check_pr_title.py
+
+  commit-messages:
+    name: commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install commitlint
+        run: npm install --no-save @commitlint/cli@19 @commitlint/config-conventional@19
+
+      - name: Validate commit messages
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            BASE="$(git rev-list --max-parents=0 HEAD)"
+          fi
+          npx commitlint --from "$BASE" --to HEAD --config commitlint.config.cjs
+          python3 scripts/check_commit_messages.py "$BASE..HEAD"

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Validate PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: python3 scripts/check_pr_title.py
+        run: PYTHONPATH=. python3 scripts/check_pr_title.py
 
   commit-messages:
     name: commit messages
@@ -53,4 +53,4 @@ jobs:
             BASE="$(git rev-list --max-parents=0 HEAD)"
           fi
           npx commitlint --from "$BASE" --to HEAD --config commitlint.config.cjs
-          python3 scripts/check_commit_messages.py "$BASE..HEAD"
+          PYTHONPATH=. python3 scripts/check_commit_messages.py "$BASE..HEAD"

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: 22
 
       - name: Install commitlint
-        run: npm install --no-save @commitlint/cli@19
+        run: npm ci
 
       - name: Validate commit messages
         run: |

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: 22
 
       - name: Install commitlint
-        run: npm install --no-save @commitlint/cli@19 @commitlint/config-conventional@19
+        run: npm install --no-save @commitlint/cli@19
 
       - name: Validate commit messages
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .worktrees/
 .assets
 .env
+node_modules/
+bridge/dist/
 # Generated architecture/diagram SVGs at repo root (not source)
 /*.svg
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+default_language_version:
+  python: python3.12
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+        args: [--maxkb=1024]
+      - id: check-merge-conflict
+      - id: detect-private-key
+
+  - repo: local
+    hooks:
+      - id: conventional-commit-message
+        name: conventional commit message
+        entry: python scripts/check_commit_file.py
+        language: system
+        stages: [commit-msg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,6 @@ repos:
     hooks:
       - id: conventional-commit-message
         name: conventional commit message
-        entry: python scripts/check_commit_file.py
+        entry: env PYTHONPATH=. python3 scripts/check_commit_file.py
         language: system
         stages: [commit-msg]

--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,10 @@ build-bridge:
 
 check-commits:
 	npx commitlint --from origin/main --to HEAD --config commitlint.config.cjs
-	uv run --extra dev python scripts/check_commit_messages.py $(COMMIT_RANGE)
+	PYTHONPATH=. uv run --extra dev python scripts/check_commit_messages.py $(COMMIT_RANGE)
 
 check-pr-title:
-	uv run --extra dev python scripts/check_pr_title.py
+	PYTHONPATH=. uv run --extra dev python scripts/check_pr_title.py
 
 ci: lint test build
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+.PHONY: help install install-deps lint lint-python lint-tui lint-bridge test test-python test-tui build build-tui build-bridge check-commits check-pr-title ci clean
+
+PYTHON ?= python3
+PYTHON_LINT_TARGETS ?= scripts/check_commit_file.py scripts/check_commit_messages.py scripts/check_pr_title.py scripts/commit_lint.py tests/test_commit_lint.py
+COMMIT_RANGE ?=
+
+help:
+	@echo "Targets:"
+	@echo "  install        Install Python deps, Node deps, and git hooks"
+	@echo "  install-deps   Install Python deps only (CI uses this)"
+	@echo "  lint           Run Python, TUI, and bridge lint gates"
+	@echo "  lint-python    Ruff-check the current lint target set"
+	@echo "  lint-tui       TypeScript lint + RPC drift check"
+	@echo "  lint-bridge    Bridge package build check"
+	@echo "  test           Run focused Python checks and TUI tests"
+	@echo "  check-commits  Validate Conventional Commit subjects"
+	@echo "  check-pr-title Validate the PR title in PR_TITLE"
+	@echo "  ci             Run the local CI gate"
+	@echo "  clean          Remove generated caches and build output"
+
+install-deps:
+	uv sync --frozen --extra dev --dev
+
+install: install-deps
+	uv run pre-commit install
+	uv run pre-commit install --hook-type commit-msg
+	npm ci --prefix ui-tui
+	npm ci --prefix bridge
+
+lint: lint-python lint-tui lint-bridge
+
+lint-python:
+	uv run --extra dev ruff check $(PYTHON_LINT_TARGETS)
+	uv run --extra dev ruff format --check $(PYTHON_LINT_TARGETS)
+
+lint-tui:
+	npm run lint --prefix ui-tui
+	npm run lint:rpc --prefix ui-tui
+	npm run type-check --prefix ui-tui
+
+lint-bridge:
+	npm run build --prefix bridge
+
+test: test-python test-tui
+
+test-python:
+	uv run --extra dev pytest tests/test_commit_lint.py -q
+
+test-tui:
+	npm test --prefix ui-tui
+
+build: build-tui build-bridge
+
+build-tui:
+	npm run build --prefix ui-tui
+
+build-bridge:
+	npm run build --prefix bridge
+
+check-commits:
+	uv run --extra dev python scripts/check_commit_messages.py $(COMMIT_RANGE)
+
+check-pr-title:
+	uv run --extra dev python scripts/check_pr_title.py
+
+ci: lint test build
+
+clean:
+	rm -rf .pytest_cache .ruff_cache .uv-cache .mypy_cache htmlcov dist build
+	rm -rf ui-tui/dist ui-tui/coverage ui-tui/.vitest-cache ui-tui/packages/hermes-ink/dist
+	rm -rf bridge/dist
+	find . -type d -name __pycache__ -prune -exec rm -rf {} +

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ install-deps:
 install: install-deps
 	uv run pre-commit install
 	uv run pre-commit install --hook-type commit-msg
+	npm ci
 	npm ci --prefix ui-tui
 	npm ci --prefix bridge
 
@@ -58,6 +59,7 @@ build-bridge:
 	npm run build --prefix bridge
 
 check-commits:
+	npx commitlint --from origin/main --to HEAD --config commitlint.config.cjs
 	uv run --extra dev python scripts/check_commit_messages.py $(COMMIT_RANGE)
 
 check-pr-title:

--- a/README.md
+++ b/README.md
@@ -1,399 +1,410 @@
-# Raven 🦞
+<div align="center" id="readme-top">
 
-> An agent framework designed around four pillars: **intelligent context management**, **proactivity**, **token efficiency**, and **skill self-evolution**.
+# Raven
 
-English | [简体中文](README.zh-CN.md)
+### The AI-native command line agent for people who live in the terminal.
 
-Raven is a ground-up redesign of the agent runtime — built on a battle-tested base (forked from the MIT-licensed [nanobot](https://github.com/HKUDS/nanobot) project) and extended with opinionated solutions to the four hardest problems every serious agent product eventually hits:
+<p align="center">
+  <a href="https://github.com/EverMind-AI/raven/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/EverMind-AI/raven/ci.yml?branch=main&label=CI&style=for-the-badge" alt="CI"></a>
+  <a href="https://github.com/EverMind-AI/raven/blob/main/LICENSE"><img src="https://img.shields.io/github/license/EverMind-AI/raven?style=for-the-badge" alt="License"></a>
+  <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>
+  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge" alt="HuggingFace"></a>
+</p>
 
-1. **上下文管理 · Context Management** — a *Curator* engine that autonomously decides what stays in the context window, archives the rest losslessly, and retrieves on demand.
-2. **主动性 · Proactivity** — a *Sentinel* subsystem that runs alongside the agent loop, watches events, and decides when the agent should reach out first (without being annoying).
-3. **节省 Token · Token Efficiency** — a *TokenWise* layer of cross-cutting strategies: prompt cache placement, tool-result lifecycle management, smart model routing, and real-time budget tracking.
-4. **Skill 自进化 · Skill Self-Evolution** — a *SkillForge* closed loop: auto-detect reusable patterns from conversations, version and track skill performance, and evolve skills based on execution feedback.
+[Website](https://evermind.ai) · [Documentation](https://docs.evermind.ai) · [EverOS](https://github.com/EverMind-AI/EverOS) · [中文](README.zh-CN.md)
 
----
+</div>
 
-## Status
+<br>
 
-**Pre-alpha**, under active development — APIs change without notice. The base runtime and all four feature engines have landed in code; maturity varies per engine.
+<details>
+  <summary><kbd>Table of Contents</kbd></summary>
 
-| Layer | Status |
-|------|--------|
-| Base agent runtime (forked from nanobot) | ✅ Functional — CLI, channels, tools, scheduling, providers |
-| Spine — per-turn backbone — + TUI-RPC terminal front-end | ✅ Functional |
-| Context Management — Curator engine | ✅ Implemented (`legacy` + `curator` paths) |
-| Proactivity — Sentinel + Scheduler | ✅ Implemented |
-| Token Efficiency — TokenWise strategies | ✅ Implemented (tracking + cache on by default) |
-| Skill Self-Evolution — SkillForge | ✅ Implemented |
-| Eval engine (L3 task judge) | 🚧 Partial |
+<br>
 
----
+- [Why Raven](#why-raven)
+- [Quick Start](#quick-start)
+- [What Raven Is Built For](#what-raven-is-built-for)
+- [Architecture](#architecture)
+- [Developer Workflow](#developer-workflow)
+- [Status](#status)
+- [Star Us](#star-us)
+- [EverMind Ecosystem](#evermind-ecosystem)
+- [Contributing](#contributing)
+
+<br>
+
+</details>
 
 ## Why Raven
 
-Most open-source agent frameworks stop at "LLM + tools + loop." That works until you hit production, at which point:
+Raven is a native command line agent, not a chat box wrapped around a shell.
+It is built for users who already think in terminals, repos, logs, scripts,
+sessions, and long-running workflows. The goal is simple: give your terminal an
+agent that can remember, act, use tools, manage context, and improve its own
+procedural skills over time.
 
-- Context gets fat, the window overflows, and you start losing information — so you summarize, which loses more information.
-- Every turn re-sends the same system prompt, the same skill summaries, the same tool definitions — burning tokens.
-- The agent waits passively for instructions. It never says "hey, I noticed the deploy is stuck" or "you asked me to remind you about X."
-- Skills are static markdown files. If the instructions don't match a new edge case, the skill just fails silently forever.
+Most agent CLIs stop at "LLM + tools + loop." That works for demos, but it
+breaks down when the agent becomes part of your daily environment:
 
-Raven takes each of these head-on. The four pillars are not add-ons — they are the framework.
+- Long sessions overflow context and lose important details.
+- Every turn re-sends the same system prompt, skills, and tool definitions.
+- The agent waits passively even when it can see something that needs action.
+- Useful workflows stay trapped in chat history instead of becoming reusable
+  skills.
 
----
+Raven treats those problems as the product, not edge cases.
 
-## Architecture
+<table>
+<tr>
+<th width="28%">Capability</th>
+<th width="36%">Raven</th>
+<th width="36%">Typical agent CLI</th>
+</tr>
+<tr>
+<td><strong>Native terminal product</strong></td>
+<td>Interactive TUI, CLI, gateway mode, and typed RPC between Python and React/Ink</td>
+<td>Usually a thin command wrapper around a chat loop</td>
+</tr>
+<tr>
+<td><strong>Long memory</strong></td>
+<td>EverOS-backed memory, local skills, session history, and workspace templates</td>
+<td>Usually transient context or provider-side chat history</td>
+</tr>
+<tr>
+<td><strong>Context control</strong></td>
+<td>Curator and legacy context engines with explicit token budgets and fail-safes</td>
+<td>Usually truncation, summarization, or hidden prompt heuristics</td>
+</tr>
+<tr>
+<td><strong>Proactivity</strong></td>
+<td>Sentinel, scheduler, nudge policy, and deferred decision flow</td>
+<td>Usually waits until the user types again</td>
+</tr>
+<tr>
+<td><strong>Skill evolution</strong></td>
+<td>Detects reusable procedures, materializes skills, tracks feedback, and evolves them</td>
+<td>Usually static markdown prompts or manually installed plugins</td>
+</tr>
+</table>
 
-Every turn flows through the **Spine** — a single backbone with one entry (`submit`) and one exit (`emit`), where per-conversation *lanes* are the unit of ordering and cancellation. The Spine is deliberately point-to-point, not a broadcast bus.
-
-```
-   Channels            ┌──────────────────────────────┐
-   telegram, discord,  │            Spine             │
-   slack, matrix, …    │   submit ─▶ per-conv lanes   │
-        ▲              │              └─▶ emit        │
-        │   TUI-RPC    └───────────────┬──────────────┘
-        ▼   (terminal)                 │ one turn
-   ┌──────────────┐          ┌─────────▼──────────┐
-   │ front-ends   │          │     Agent loop     │
-   └──────────────┘          │   tools · skills   │
-                             └─────────┬──────────┘
-        ┌───────────────┬─────────────┼──────────────┬───────────────┐
-   ┌────▼─────┐   ┌──────▼──────┐ ┌────▼─────┐  ┌──────▼──────┐  ┌─────▼─────┐
-   │ Context  │   │  Proactive  │ │TokenWise │  │   Memory    │  │   Eval    │
-   │ Engine   │   │  Engine     │ │strategies│  │   Engine    │  │  Engine   │
-   │ Curator/ │   │ Sentinel +  │ │cache·    │  │ SkillForge· │  │ L3 task   │
-   │ legacy   │   │ Scheduler   │ │route·track│ │ EverOS·     │  │ judge     │
-   └──────────┘   └─────────────┘ └──────────┘  │ consolidate │  └───────────┘
-                                                 └─────────────┘
-                             ┌────────────────┐
-                             │  LLM Providers │
-                             │ Anthropic/OAI/ │
-                             │  Gemini / OR … │
-                             └────────────────┘
-```
-
-**Design principle: pluggable engines behind config.** Each feature engine plugs in through config, and the novel ones default to off — a fresh install behaves like the base agent until you opt in (`context.engine = "legacy"`, `sentinel.enabled = false`, …). Engines coordinate through the Spine and explicit handoffs in the agent loop, not by importing one another.
-
-### Repo layout
-
-```
-raven/
-├── spine/              # Per-turn backbone: submit → per-conversation lanes → emit
-├── agent/              # Agent loop, tools, hooks, subagents, context builder
-├── channels/           # Platform adapters (telegram, discord, slack, matrix, whatsapp, …)
-├── tui_rpc/            # Terminal front-end protocol (Request/Response + Notification)
-├── providers/          # LLM provider adapters (Anthropic, OpenAI, Gemini, …)
-├── context_engine/     # Context layer — legacy + Curator (Fast / Slow / Fail-Safe paths)
-├── proactive_engine/   # Proactivity — Sentinel (event-driven) + Scheduler (cron / heartbeat)
-├── memory_engine/      # Memory + skills — consolidation, SkillForge, EverOS, skill_local
-├── eval_engine/        # L3 task judge / cognition coordination
-├── token_wise/         # TokenWise strategies — usage tracking, cache placement, routing
-├── routing/            # Model routing
-├── skill_hub/          # Client for the remote skill marketplace
-├── plugin/             # Plugin foundation
-├── session/            # Session management (append-only JSONL)
-├── auth/               # Authentication & authorization primitives
-├── security/           # Network access control
-├── sandbox/            # Isolated command execution (microVM / boxlite)
-├── cli/                # `raven` command-line entry point
-├── config/             # Config schema + feature blocks
-├── templates/          # Default SOUL.md / USER.md / AGENTS.md
-└── utils/              # Shared helpers
-```
-
-The repo also ships a `ui-tui/` package (the React/Ink terminal front-end that talks to `tui_rpc/`) and a `bridge/` (WhatsApp TypeScript bridge).
-
----
+<br>
 
 ## Quick Start
 
-### Requirements
+> Goal: start Raven from source, run onboarding, and open the native TUI.
 
-- Python **3.11+**
-- An API key for at least one LLM provider (Anthropic, OpenAI, OpenRouter, Gemini, DeepSeek, etc.)
+### 0. Prerequisites
 
-### Install
+- Python 3.12+
+- [uv](https://docs.astral.sh/uv/)
+- Node.js 22+ for the native TUI
+- One model provider key, or an OAuth provider configured through onboarding
+
+Raven supports OpenRouter, OpenAI, Anthropic, Gemini, DeepSeek, GitHub Copilot,
+OpenAI Codex OAuth, and custom OpenAI-compatible endpoints.
+
+### 1. Install From Source
 
 ```bash
 git clone https://github.com/EverMind-AI/raven.git
-cd Raven
-pip install -e .
+cd raven
+uv sync --extra dev --dev
 ```
 
-For channel integrations (Telegram, Discord, Slack, WhatsApp, …):
+Install the TUI dependencies:
 
 ```bash
-pip install -e ".[channels]"
+npm ci --prefix ui-tui
 ```
 
-For development (tests, linting):
+### 2. Run Onboarding
 
 ```bash
-pip install -e ".[dev]"
+uv run raven onboard
 ```
 
-### Bootstrap your workspace
+The wizard configures:
+
+- an LLM provider and default model;
+- optional sandbox execution;
+- optional chat channels;
+- optional EverOS long-term memory.
+
+### 3. Launch Raven
 
 ```bash
-raven onboard
+uv run raven
 ```
 
-This creates `~/.raven/config.json` and a workspace at `~/.raven/workspace/` with default `SOUL.md`, `USER.md`, and `AGENTS.md` templates.
-
-### Add your API key
-
-Edit `~/.raven/config.json`:
-
-```json
-{
-  "providers": {
-    "anthropic": { "api_key": "sk-ant-..." }
-  },
-  "agents": {
-    "defaults": {
-      "model": "anthropic/claude-opus-4-6"
-    }
-  }
-}
-```
-
-### Chat
+Bare `raven` opens the native TUI. For a direct one-shot turn:
 
 ```bash
-raven agent -m "Hello, who are you?"
+uv run raven agent -m "Inspect this repo and tell me what to improve first."
 ```
 
-Or interactive mode:
+For platform adapters such as Telegram, Slack, Discord, Matrix, WhatsApp, and
+WeCom:
 
 ```bash
-raven agent
+uv run raven gateway
 ```
 
-### Run as a gateway (for chat platforms)
+<br>
+<div align="right">
 
-Enable a channel in config (`channels.telegram.enabled = true`, add token), then:
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## What Raven Is Built For
+
+Raven is designed for the workflows where ordinary chat agents feel too small.
+
+### 1. Terminal-Native Daily Work
+
+Raven can run as a native TUI, a direct CLI agent, or a gateway-backed agent.
+The TUI is not a web shell: it is a React/Ink application talking to Raven's
+Python runtime through a typed RPC protocol.
+
+### 2. Memory That Becomes Useful
+
+Raven connects to EverOS for long-term user and agent memory. Sessions,
+procedures, and reusable patterns can be turned into local skill material
+instead of disappearing into old transcripts.
+
+### 3. Context That Does Not Collapse Under Pressure
+
+The context stack has a legacy path and a Curator path. Under pressure, Raven
+can archive, retrieve, and assemble context with explicit budgets instead of
+blindly clipping the oldest messages.
+
+### 4. Agents That Can Reach Out First
+
+Sentinel watches events, schedules checks, evaluates whether a nudge is useful,
+and routes proactive actions through guardrails. The point is not noisy
+notifications; the point is an agent that can notice.
+
+### 5. Skills That Improve
+
+SkillForge treats skills as procedural memory. It can detect reusable workflows,
+write skill files, track execution feedback, and evolve instructions when they
+stop working.
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## Architecture
+
+Every turn flows through the Spine: one entry (`submit`), one exit (`emit`),
+and per-conversation lanes for ordering and cancellation. Feature engines plug
+into the agent loop through explicit handoffs instead of importing each other.
+
+```text
+Channels / TUI / Gateway
+        |
+        v
+   Raven Spine
+ submit -> lanes -> emit
+        |
+        v
+   Agent Loop
+ tools · skills · providers
+        |
+        +--> Context Engine   legacy / curator
+        +--> Memory Engine    EverOS / local skills / SkillForge
+        +--> Proactive Engine Sentinel / scheduler / nudge policy
+        +--> TokenWise        usage tracking / cache placement / routing
+        +--> Eval Engine      task judgement and coordination
+```
+
+### Repo Layout
+
+```text
+raven/
+├── spine/              # Per-turn backbone: submit -> lanes -> emit
+├── agent/              # Agent loop, tools, hooks, subagents, context builder
+├── channels/           # Telegram, Discord, Slack, Matrix, WhatsApp, WeCom, ...
+├── tui_rpc/            # Python side of the native TUI protocol
+├── providers/          # LLM provider adapters
+├── context_engine/     # Context assembly and Curator path
+├── proactive_engine/   # Sentinel, scheduler, nudges, feedback
+├── memory_engine/      # EverOS memory, local skills, SkillForge
+├── token_wise/         # Usage tracking, cache placement, routing
+├── sandbox/            # Isolated command execution
+├── security/           # Trust boundaries and network checks
+├── cli/                # `raven` command line entry point
+└── config/             # Config schema and update helpers
+
+ui-tui/                 # React/Ink native terminal UI
+bridge/                 # WhatsApp TypeScript bridge
+```
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## Developer Workflow
+
+Install everything and set up hooks:
 
 ```bash
-raven gateway
+make install
 ```
 
----
-
-## Configuration
-
-Raven's config extends the base agent config with feature blocks. All novel features default to **off** — a fresh install behaves exactly like the base agent until you opt in.
-
-```json
-{
-  "agents":   { "defaults": { "model": "anthropic/claude-opus-4-6" } },
-  "channels": { "telegram": { "enabled": false } },
-  "providers": { "anthropic": { "api_key": "sk-ant-..." } },
-
-  "context": {
-    "engine": "legacy",
-    "fast_path_threshold": 0.60,
-    "curator_model": "gemini-2.5-flash"
-  },
-
-  "sentinel": {
-    "enabled": false,
-    "monitors": [],
-    "nudge_policy": {
-      "max_nudges_per_hour": 3,
-      "quiet_hours": [23, 7]
-    }
-  },
-
-  "token_wise": {
-    "enabled": true,
-    "usage_tracking": true,
-    "cache_optimization": true,
-    "smart_routing": { "enabled": false }
-  },
-
-  "skill_forge": {
-    "enabled": false,
-    "stats_tracking": true,
-    "auto_detect": false,
-    "auto_evolve": false
-  }
-}
-```
-
-See `raven/config/` for the full schema with every field documented.
-
-### Enabling skill self-evolution
-
-Completed `user → assistant` turns flow into a local extraction
-pipeline that buffers them per session and **detects task boundaries
-across turns** before distilling anything. A cheap per-turn classifier
-asks "did the user just start a new task?"; only when a boundary is
-found (or the session ends) does the buffered segment get compressed
-into an `AgentCase`. Short exchanges, pure chit-chat with no tool
-calls, or in-progress turns are dropped before any LLM call. Cases
-below the quality floor stop there; the rest go through skill
-extraction. Output lands in `<workspace>/.cache/skills.db` plus
-materialized `SKILL.md` files at `<workspace>/skills/everos/<id>/`,
-which the local BM25 pool picks up automatically. No external services
-— just SQLite + your existing LLM provider.
-
-```json
-{
-  "skill_forge": {
-    "enabled": true,
-    "evolve_model": "claude-opus-4-6",
-    "detect_model": "gemini-2.5-flash",
-    "everos": {
-      "enabled": true
-    }
-  }
-}
-```
-
-Two models drive the pipeline:
-
-- `skill_forge.evolve_model` — heavyweight LLM used to distill
-  `AgentCase`s and rewrite skills. Defaults to the active agent model
-  when unset; pin a stronger model here for higher-quality rewrites.
-- `skill_forge.detect_model` — cheap classifier for the per-turn
-  boundary detector (multi-turn task split). Runs on every accumulated
-  turn, so a small fast model (default `gemini-2.5-flash`) is
-  intentional.
-
-### Configuring media generation (image / speech / video)
-
-Three media tools call [OpenRouter](https://openrouter.ai) to generate
-media. They are **opt-in per tool**: a tool is exposed to the agent only
-when you give it a `model` or an `api_key` under `tools.media.<tool>`.
-Configuring OpenRouter as your chat provider alone does **not** enable
-them — the agent never sees image/speech/video until you ask for it.
-
-```json
-{
-  "providers": { "openrouter": { "api_key": "sk-or-..." } },
-  "tools": {
-    "media": {
-      "image":  { "model": "google/gemini-2.5-flash-image" },
-      "speech": { "model": "openai/gpt-audio-mini" },
-      "video":  { "model": "kwaivgi/kling-v3.0-std" },
-      "proxy": null,
-      "output_subdir": "generated"
-    }
-  }
-}
-```
-
-- **Key** — each configured tool defaults a missing key to
-  `providers.openrouter.api_key`, so usually you set just a `model` to
-  switch a tool on. Override per tool with `tools.media.<tool>.api_key`
-  to use a separate key.
-- `image_generate` — text-to-image (and image editing) via Nano Banana
-  (`google/gemini-2.5-flash-image`). Saves a PNG under the workspace.
-- `text_to_speech` — speech synthesis via `openai/gpt-audio-mini`.
-  Outputs WAV with zero dependencies; mp3/opus/flac require `ffmpeg` on
-  PATH and fall back to WAV when it is absent.
-- `video_generate` — text-to-video via Kling (`kwaivgi/kling-v3.0-std`),
-  an async job that takes a while and **requires postpaid billing /
-  credits on your OpenRouter account**.
-
-Generated files land in `<workspace>/<output_subdir>` (default
-`generated/`). Set `tools.media.proxy` to route media calls through an
-HTTP/SOCKS proxy.
-
----
-
-## The Four Pillars
-
-### 1. Context Management — the *Curator* engine
-
-The context layer (`context_engine/`) is pluggable, with two implementations:
-
-- **`legacy`** *(default)* — the base agent's `ContextBuilder` + Consolidation. When the prompt approaches the context window, old messages are summarized into memory notes and moved out of live context (lossy).
-- **`curator`** — an internal, bounded agent loop that manages the window. Under pressure it archives messages **losslessly** to disk, retrieves them when relevant, and uses internal tools (`curator_check_budget`, `curator_archive_messages`, `curator_retrieve_archived`, `curator_build_context`, …) to compose the final window. A two-tier design:
-  - **Fast Path** (history under the pressure threshold, default 60%): zero-LLM pass-through.
-  - **Slow Path** (under pressure): a small-model agent loop (`gemini-2.5-flash` by default) decides what stays, validated by a deterministic assembler.
-  - **Fail-Safe**: if the Slow Path errors or yields no valid plan, a deterministic Python fallback (protected + most-relevant + most-recent) produces a valid context.
-
-### 2. Proactivity — the *Sentinel* subsystem
-
-Proactivity lives in `proactive_engine/`, with two trigger paths:
-
-- **Sentinel** *(event-driven)* — an attention pipeline (attention producers → predictor → trigger policy → executor → feedback) that decides when the agent should reach out unprompted.
-- **Scheduler** *(time-driven)* — cron jobs and heartbeat.
-- **Nudge Policy** — anti-spam guardrails: `max_nudges_per_hour`, `quiet_hours`, `min_interval_seconds`, cooldown on dismiss.
-- A proactive action enters the agent loop as a turn of its own, routed as proactive context.
-
-### 3. Token Efficiency — the *TokenWise* layer
-
-TokenWise (`token_wise/`) is a set of cross-cutting `TokenStrategy` hooks, each individually enabled.
-
-| Strategy | What it does | Typical saving |
-|---------|--------------|----------------|
-| `UsageTracker` | Records every LLM call's tokens + cost | — (observability) |
-| `CacheOptimizer` | Places Anthropic `cache_control` breakpoints optimally | up to 75% input cost |
-| `SystemAndTailCacheStrategy` | Alternative cache placement (system + rolling tail), for A/B against `CacheOptimizer` | (benchmark) |
-| `SmartRouter` | Routes simple tasks to cheaper models (`haiku`, `gemini-flash`) | 40-70% per-request |
-
-### 4. Skill Self-Evolution — *SkillForge*
-
-SkillForge (`memory_engine/skill_forge/`) treats skills as procedural memory and runs a closed loop: `Detect → Create → Execute → Feedback → Evaluate → Evolve → Retire`.
-
-- Skills live at `<workspace>/skills/<id>/SKILL.md` with enriched YAML frontmatter including `version`, `stats`, and `evolution_log`.
-- **Detect**: a small-model check decides whether a conversation segment contains a reusable multi-step procedure worth saving (see *Enabling skill self-evolution* above).
-- **Draft → Active gate**: auto-created skills start as `draft` and stay out of the skills summary until they succeed at least once, preventing noise.
-- **Evolve**: when `success_rate` drops below a threshold over enough invocations, a stronger model rewrites the skill, preserving working logic; the previous version is snapshotted.
-- **Retire**: long-unused skills are deprecated, then retired to archive.
-
-A `skill_hub/` client can additionally pull skills from a remote marketplace.
-
----
-
-## Development
-
-### Run tests
+Run the local CI gate:
 
 ```bash
-uv run pytest -v
+make ci
 ```
 
-The suite spans 200+ test files covering the spine, the agent loop, channels, the feature engines, the config schema, and the CLI.
+Focused commands:
 
-### Layout conventions
+```bash
+make lint-python
+make lint-tui
+make lint-bridge
+make test-python
+make test-tui
+```
 
-- **Engines coordinate through the Spine and explicit handoffs** — feature engines don't import one another directly.
-- **Fail-safes are mandatory** — every component that calls an LLM has a deterministic fallback. No feature should crash the turn.
-- **New features default off** — anything novel ships with `enabled = false`; only cheap, well-understood strategies (cache optimization, usage tracking) are on by default.
+The repository uses:
 
-### Coding style
+- `uv` for Python dependency management;
+- `ruff` and `pre-commit` for Python and repository hygiene;
+- `commitlint` plus a Python checker for Conventional Commit subjects and
+  ASCII-only public history;
+- `eslint`, `tsc`, `vitest`, and RPC drift checks for the TUI;
+- `npm ci`, `tsc`, and `npm audit --audit-level=critical` for the bridge.
 
-- Python 3.11+, `from __future__ import annotations` where helpful
-- `uv` is the only package manager (`uv add`, `uv run`, `uv sync`)
-- Ruff for linting; type hints throughout (`Literal`, `Protocol` where appropriate)
-- Tests use `pytest` with `pytest-asyncio` (asyncio mode `auto`)
+`CLAUDE.md` contains the full collaboration rules for branch naming, commit
+format, dependency updates, testing, and PR hygiene.
 
-See `CLAUDE.md` for the full contribution constraints (branch naming, commit format, dependency and test rules).
+<br>
+<div align="right">
 
----
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
 
-## Credits & License
+</div>
 
-Raven is MIT-licensed. The base agent runtime (under `raven/agent/`, `raven/channels/`, `raven/cli/`, `raven/config/`, `raven/providers/`, `raven/routing/`, `raven/session/`, `raven/templates/`, `raven/utils/`) originated from the MIT-licensed [nanobot](https://github.com/HKUDS/nanobot) project by HKUDS. See `LICENSE` and `NOTICES.md` for details.
+## Status
 
-The feature engines (`context_engine/`, `proactive_engine/`, `token_wise/`, `memory_engine/`, `eval_engine/`, `spine/`, plus config extensions) are new to Raven.
+Raven is pre-alpha and moving quickly. APIs can change without notice, but the
+core product surfaces are already in the repository.
 
-Inspiration from the broader ecosystem — including [hermes-agent](https://github.com/NousResearch/hermes-agent) (Nous Research), [Letta / MemGPT](https://github.com/letta-ai/letta), and [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) — informed the design.
+| Layer | Status |
+| --- | --- |
+| Native TUI + CLI | Functional |
+| Spine runtime | Functional |
+| Base agent loop, tools, providers | Functional |
+| Context engine | Implemented, still evolving |
+| Sentinel proactivity | Implemented, still evolving |
+| TokenWise strategies | Implemented |
+| SkillForge | Implemented |
+| Eval engine | Partial |
 
----
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## Star Us
+
+If Raven is the kind of command line agent you want to exist, star the repo.
+It helps more terminal-native builders discover the project and gives the
+EverMind ecosystem a stronger signal to keep investing in open agents.
+
+### Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=EverMind-AI/raven&type=Date)](https://www.star-history.com/#EverMind-AI/raven&Date)
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## EverMind Ecosystem
+
+EverMind is an open-source ecosystem for long-term memory, self-evolving
+agents, AI-native interfaces, and memory evaluation.
+
+<table>
+<tr>
+<th colspan="2">EverMind Open-Source Ecosystem</th>
+</tr>
+<tr>
+<td><strong>Memory Runtime</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> - the local memory operating system and research-backed runtime for agent and user memory.</td>
+</tr>
+<tr>
+<td><strong>AI-Native CLI Agent</strong></td>
+<td><a href="https://github.com/EverMind-AI/raven">Raven</a> - the native command line agent that brings memory, proactivity, context control, and skill evolution into the terminal.</td>
+</tr>
+<tr>
+<td><strong>Algorithm Engine</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a> - stateless extraction, ranking, parsing, and memory operators that power EverOS.</td>
+</tr>
+<tr>
+<td><strong>Hypergraph Memory</strong></td>
+<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> - hypergraph memory for long-term conversations, with benchmark-backed topic -> episode -> fact retrieval.</td>
+</tr>
+<tr>
+<td><strong>Benchmarks</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a> - evaluation suites for conversational memory and agent self-evolution.</td>
+</tr>
+<tr>
+<td><strong>Long-Context Research</strong></td>
+<td><a href="https://github.com/EverMind-AI/MSA">MSA</a> - Memory Sparse Attention for scalable latent memory and 100M-token contexts.</td>
+</tr>
+<tr>
+<td><strong>Personal Memory Layer</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> - CLI and agent plugin suite for cross-device, cross-agent personal memory.</td>
+</tr>
+<tr>
+<td><strong>Developer Integrations</strong></td>
+<td><a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a> - plugins, skills, and migration tooling for AI coding agents.</td>
+</tr>
+</table>
+
+Together, these repositories form EverMind's research-to-runtime stack: memory
+methods, reusable algorithms, benchmark evidence, native agent products, and
+practical developer integrations.
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 ## Contributing
 
-Raven is in pre-alpha. APIs will change. If you're interested in contributing:
+Raven is early, and useful contributions are welcome across runtime
+architecture, TUI polish, provider support, memory workflows, proactivity,
+benchmarks, documentation, and issue reports.
 
-1. Open an issue before starting work so we can align on direction.
-2. Read `CLAUDE.md` and match the layout conventions above.
-3. Add tests alongside your change.
-4. Document your module's contract in its docstring and update the relevant section of this README.
+Before opening a PR:
 
----
+1. Read `CLAUDE.md`.
+2. Keep the change scoped.
+3. Add or update tests for behavior changes.
+4. Run the relevant `make` targets.
+5. Use a Conventional Commit title.
 
-*Raven is built by EverMind.*
+### License
+
+Raven is MIT-licensed. The base agent runtime originated from the
+MIT-licensed [nanobot](https://github.com/HKUDS/nanobot) project by HKUDS.
+See [LICENSE](LICENSE), [NOTICES.md](NOTICES.md), and [LICENSES/](LICENSES/)
+for details.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center" id="readme-top">
 
+<img src="https://github.com/user-attachments/assets/224c1623-2705-4a48-8a60-fd5681ca0cb2" alt="Raven banner" width="100%">
+
 # Raven
 
 ### The AI-native command line agent for people who live in the terminal.

--- a/README.md
+++ b/README.md
@@ -2,18 +2,14 @@
 
 <img src="https://github.com/user-attachments/assets/224c1623-2705-4a48-8a60-fd5681ca0cb2" alt="Raven banner" width="100%">
 
-# Raven
-
-### The AI-native command line agent for people who live in the terminal.
-
 <p align="center">
-  <a href="https://github.com/EverMind-AI/raven/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/EverMind-AI/raven/ci.yml?branch=main&label=CI&style=for-the-badge" alt="CI"></a>
-  <a href="https://github.com/EverMind-AI/raven/blob/main/LICENSE"><img src="https://img.shields.io/github/license/EverMind-AI/raven?style=for-the-badge" alt="License"></a>
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>
-  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge" alt="HuggingFace"></a>
+  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/🤗_HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge" alt="HuggingFace"></a>
+  <a href="https://discord.gg/gYep5nQRZJ"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FgYep5nQRZJ%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&label=Discord&color=404EED&labelColor=gray&style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_社区-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
 </p>
 
-[Website](https://evermind.ai) · [Documentation](https://docs.evermind.ai) · [EverOS](https://github.com/EverMind-AI/EverOS) · [中文](README.zh-CN.md)
+[Website](https://raven.evermind.ai) · [EverOS](https://github.com/EverMind-AI/EverOS) · [中文](README.zh-CN.md)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 <br>
 
 - [Why Raven](#why-raven)
-- [Quick Start](#quick-start)
+- [Quick Install](#quick-install)
+- [Getting Started](#getting-started)
 - [What Raven Is Built For](#what-raven-is-built-for)
 - [Architecture](#architecture)
 - [Developer Workflow](#developer-workflow)
@@ -88,65 +89,44 @@ Raven treats those problems as the product, not edge cases.
 
 <br>
 
-## Quick Start
+## Quick Install
 
-> Goal: start Raven from source, run onboarding, and open the native TUI.
+```bash
+curl -fsSL http://raven.evermind.ai/install.sh | bash
+```
 
-### 0. Prerequisites
+After installation, reload your shell and run the setup wizard:
 
-- Python 3.12+
-- [uv](https://docs.astral.sh/uv/)
-- Node.js 22+ for the native TUI
-- One model provider key, or an OAuth provider configured through onboarding
+```bash
+source ~/.bashrc    # or: source ~/.zshrc
+raven onboard
+```
 
 Raven supports OpenRouter, OpenAI, Anthropic, Gemini, DeepSeek, GitHub Copilot,
 OpenAI Codex OAuth, and custom OpenAI-compatible endpoints.
 
-### 1. Install From Source
+## Getting Started
 
 ```bash
-git clone https://github.com/EverMind-AI/raven.git
-cd raven
-uv sync --extra dev --dev
+raven                  # Native TUI - start a conversation
+raven tui              # Explicitly launch the native TUI
+raven tui --check      # Verify the TUI runtime before launching
+raven onboard          # Configure provider, sandbox, channels, and memory
+raven agent -m "..."   # Run a one-shot task from the shell
+raven provider list    # Review LLM providers and model configuration
+raven channels list    # List available messaging channels
+raven gateway          # Start the messaging gateway
+raven sessions list    # List, resume, fork, export, or delete sessions
+raven cron list        # Inspect scheduled jobs and automations
+raven skill list       # Browse SkillForge skills
+raven sentinel status  # Inspect proactive memory and nudge state
+raven plugins          # List installed plugins and the active memory backend
+raven sandbox list     # Inspect sandbox VMs when sandbox debugging is enabled
+raven status           # Show local config and runtime status
+raven doctor           # Diagnose config, routing, and LLM readiness
 ```
 
-Install the TUI dependencies:
-
-```bash
-npm ci --prefix ui-tui
-```
-
-### 2. Run Onboarding
-
-```bash
-uv run raven onboard
-```
-
-The wizard configures:
-
-- an LLM provider and default model;
-- optional sandbox execution;
-- optional chat channels;
-- optional EverOS long-term memory.
-
-### 3. Launch Raven
-
-```bash
-uv run raven
-```
-
-Bare `raven` opens the native TUI. For a direct one-shot turn:
-
-```bash
-uv run raven agent -m "Inspect this repo and tell me what to improve first."
-```
-
-For platform adapters such as Telegram, Slack, Discord, Matrix, WhatsApp, and
-WeCom:
-
-```bash
-uv run raven gateway
-```
+For source-based development, use the [Developer Workflow](#developer-workflow).
 
 <br>
 <div align="right">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,414 +1,398 @@
-# Raven 🦞
+<div align="center" id="readme-top">
 
-> 围绕四大支柱设计的 Agent 框架:**智能上下文管理**、**主动性**、**Token 效率**、**Skill 自进化**。
+# Raven
 
-[English](README.md) | 简体中文
+### 为终端重度用户打造的 AI-native Command Line Agent。
 
-Raven 是对 Agent 运行时的一次自底向上的重新设计 —— 基于经过实战验证的基座(Fork 自 MIT 协议的 [nanobot](https://github.com/HKUDS/nanobot) 项目),针对每个严肃 Agent 产品最终都会撞上的四大难题,给出有明确主张的解决方案:
+<p align="center">
+  <a href="https://github.com/EverMind-AI/raven/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/EverMind-AI/raven/ci.yml?branch=main&label=CI&style=for-the-badge" alt="CI"></a>
+  <a href="https://github.com/EverMind-AI/raven/blob/main/LICENSE"><img src="https://img.shields.io/github/license/EverMind-AI/raven?style=for-the-badge" alt="License"></a>
+  <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>
+  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge" alt="HuggingFace"></a>
+</p>
 
-1. **上下文管理 · Context Management** —— *Curator* 引擎自主决定哪些消息留在上下文窗口,其余无损归档,按需检索。
-2. **主动性 · Proactivity** —— *Sentinel* 子系统与主 Agent 循环并行运行,监听事件,决定何时由 Agent 主动开口(且不惹人烦)。
-3. **节省 Token · Token Efficiency** —— *TokenWise* 层的一组跨切面策略:Prompt 缓存优化、工具结果生命周期管理、智能模型路由、实时预算追踪。
-4. **Skill 自进化 · Skill Self-Evolution** —— *SkillForge* 闭环:从对话中自动识别可复用模式,为 Skill 做版本管理与性能追踪,并基于执行反馈持续进化。
+[Website](https://evermind.ai) · [Documentation](https://docs.evermind.ai) · [EverOS](https://github.com/EverMind-AI/EverOS) · [English](README.md)
 
----
+</div>
 
-## 当前状态
+<br>
 
-**Pre-alpha**,活跃开发中。
+<details>
+  <summary><kbd>目录</kbd></summary>
 
-| 层级 | 状态 |
-|------|------|
-| 基础 Agent 运行时(Fork 自 nanobot) | ✅ 可用 —— CLI、Channels、Tools、Cron、Providers |
-| 核心抽象(`raven/core/`) | ✅ Tier 1 完成 —— 接口、事件总线、配置 |
-| 特性支柱:Curator 上下文引擎 | 🚧 已设计,尚未实现 |
-| 特性支柱:Sentinel 主动性 | 🚧 已设计,尚未实现 |
-| 特性支柱:TokenWise 效率 | 🚧 已设计,部分实现 |
-| 特性支柱:SkillForge 自进化 | 🚧 已设计,部分实现 |
+<br>
 
-实施计划见下文 [Roadmap](#roadmap)。
+- [为什么是 Raven](#为什么是-raven)
+- [快速开始](#快速开始)
+- [Raven 适合什么](#raven-适合什么)
+- [架构](#架构)
+- [开发工作流](#开发工作流)
+- [当前状态](#当前状态)
+- [Star 支持](#star-支持)
+- [EverMind 生态](#evermind-生态)
+- [参与贡献](#参与贡献)
 
----
+<br>
+
+</details>
 
 ## 为什么是 Raven
 
-大多数开源 Agent 框架都止步于 "LLM + 工具 + 循环"。这套在生产前够用,但一到生产就会遇到:
+Raven 是一个原生 Command Line Agent，不是给 shell 套了一层聊天框。
+它面向已经生活在终端、仓库、日志、脚本、会话和长流程里的用户。
+目标很直接：让你的终端拥有一个会记忆、会行动、会使用工具、会管理
+上下文，并且能持续沉淀自身技能的 Agent。
 
-- 上下文越来越臃肿,窗口溢出,信息开始丢失 —— 于是做摘要,信息进一步丢失。
-- 每一轮都在重复发送同样的 System Prompt、同样的 Skill 摘要、同样的工具定义 —— 烧 Token。
-- Agent 只会被动等指令,从不说 "嘿,我发现部署卡住了" 或 "你让我提醒你的 X 来了"。
-- Skill 是静态 Markdown 文件,遇到新的边缘 case 匹配不上,就永远静默失败。
+大多数 Agent CLI 只做到 "LLM + tools + loop"。Demo 阶段够用，但一旦进入
+真实日常工作就会遇到这些问题：
 
-Raven 针对这四个问题各给出正面解法。**四大支柱不是可有可无的附加项,它们就是这个框架本身。**
+- 长会话撑爆上下文，重要信息开始丢失。
+- 每轮都重复发送 system prompt、skills 和工具定义，Token 成本失控。
+- Agent 永远被动等待输入，即使它已经看到有事需要处理。
+- 有用的工作流留在聊天记录里，没有变成可复用技能。
 
----
+Raven 把这些问题当成产品本身，而不是边缘 case。
 
-## 架构
+<table>
+<tr>
+<th width="28%">能力</th>
+<th width="36%">Raven</th>
+<th width="36%">常见 Agent CLI</th>
+</tr>
+<tr>
+<td><strong>原生终端产品</strong></td>
+<td>交互式 TUI、CLI、Gateway 模式，以及 Python 与 React/Ink 之间的 typed RPC</td>
+<td>通常只是聊天循环外面的一层命令包装</td>
+</tr>
+<tr>
+<td><strong>长期记忆</strong></td>
+<td>EverOS-backed memory、本地 skills、session history 和 workspace templates</td>
+<td>通常是临时上下文或 provider 侧聊天历史</td>
+</tr>
+<tr>
+<td><strong>上下文控制</strong></td>
+<td>Curator 与 legacy context engines，显式 token budgets 和 fail-safes</td>
+<td>通常是截断、摘要或隐藏 prompt heuristic</td>
+</tr>
+<tr>
+<td><strong>主动性</strong></td>
+<td>Sentinel、scheduler、nudge policy 和 deferred decision flow</td>
+<td>通常等用户再次输入</td>
+</tr>
+<tr>
+<td><strong>Skill 进化</strong></td>
+<td>识别可复用流程，生成 skill，追踪反馈，并在失效时进化</td>
+<td>通常是静态 markdown prompt 或手动安装插件</td>
+</tr>
+</table>
 
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                            Event Bus                              │
-│  (inbound, outbound, generic pub/sub for BusEvent / TriggerEvent) │
-└─────┬───────────┬───────────┬──────────┬──────────┬───────────────┘
-      │           │           │          │          │
-┌─────▼─────┐┌────▼────┐┌─────▼────┐┌────▼────┐┌────▼─────┐
-│  Channels ││  Agent  ││ Sentinel ││TokenWise││SkillForge│
-│   Layer   ││  Loop   ││(proactive)││(token  ││(evolving)│
-│           ││         ││          ││ hooks) ││          │
-│ telegram  ││ tools   ││ monitors ││ cache  ││  stats   │
-│ discord   ││ session ││ evaluator││ routing││  evolve  │
-│ slack …   ││ memory  ││ nudges   ││ tracker││  detect  │
-└───────────┘└────┬────┘└──────────┘└────────┘└──────────┘
-                  │
-         ┌────────▼─────────┐
-         │  ContextEngine   │  ← 可插拔
-         │                  │      legacy = 基线
-         │   [legacy]       │      curator = 自主
-         │   [curator]      │
-         └────────┬─────────┘
-                  │
-         ┌────────▼─────────┐
-         │   LLM Providers  │
-         │ Anthropic / OAI  │
-         │  Gemini / OR …   │
-         └──────────────────┘
-```
-
-**设计原则:通过接口解耦。** 每个特性支柱都在 `raven/core/interfaces.py` 中以抽象基类形式定义,实现通过配置挂载。你完全可以设 `context.engine = "legacy"`、`sentinel.enabled = false`,此时 Raven 就等价于基础 Agent —— 也可以逐个开启支柱。
-
-### 仓库结构
-
-```
-raven/
-├── core/               # 抽象接口 + 通用事件总线
-│   ├── events.py       # BusEvent, EventType, TriggerEvent
-│   ├── event_bus.py    # EventBus (inbound/outbound + pub/sub)
-│   └── interfaces.py   # ContextEngine, Monitor, SkillHandler, TokenStrategy
-│
-├── context/            # Curator —— 智能上下文管理
-├── sentinel/           # Sentinel —— 主动监听器与 Nudge
-├── token_wise/         # TokenWise —— 缓存、路由、裁剪、预算
-├── skill_forge/        # SkillForge —— Skill 自动识别、进化、退役
-│
-├── agent/              # 基础 Agent 循环、工具、Skill、记忆
-├── bus/                # 基础 MessageBus (InboundMessage / OutboundMessage)
-├── channels/           # 平台集成(telegram, discord, slack, …)
-├── cli/                # `raven` 命令行入口
-├── config/             # 配置 schema(基础)+ Raven 特性块
-├── cron/               # 定时任务
-├── memory/             # 双层记忆(MEMORY.md + HISTORY.md)
-├── providers/          # LLM Provider 适配
-├── routing/            # 基于 PinchBench 基准的模型路由
-├── session/            # 会话管理(append-only JSONL)
-├── skills/             # 内置 Skill
-├── templates/          # 默认 SOUL.md / USER.md / AGENTS.md
-└── utils/              # 共享工具
-```
-
----
+<br>
 
 ## 快速开始
 
-### 环境要求
+> 目标：从源码启动 Raven，完成 onboarding，然后进入原生 TUI。
 
-- Python **3.11+**
-- 至少一个 LLM Provider 的 API Key(Anthropic、OpenAI、OpenRouter、Gemini、DeepSeek 等)
+### 0. 前置条件
 
-### 安装
+- Python 3.12+
+- [uv](https://docs.astral.sh/uv/)
+- Node.js 22+，用于原生 TUI
+- 一个模型 provider key，或通过 onboarding 配置 OAuth provider
+
+Raven 支持 OpenRouter、OpenAI、Anthropic、Gemini、DeepSeek、GitHub Copilot、
+OpenAI Codex OAuth，以及自定义 OpenAI-compatible endpoint。
+
+### 1. 从源码安装
 
 ```bash
 git clone https://github.com/EverMind-AI/raven.git
-cd Raven
-pip install -e .
+cd raven
+uv sync --extra dev --dev
 ```
 
-需要 Channel 集成(Telegram、Discord、Slack、WhatsApp 等):
+安装 TUI 依赖：
 
 ```bash
-pip install -e ".[channels]"
+npm ci --prefix ui-tui
 ```
 
-开发环境(测试、Lint):
+### 2. 运行 Onboarding
 
 ```bash
-pip install -e ".[dev]"
+uv run raven onboard
 ```
 
-### 初始化工作空间
+Wizard 会配置：
+
+- LLM provider 和默认模型；
+- 可选 sandbox 执行环境；
+- 可选聊天 channel；
+- 可选 EverOS 长期记忆。
+
+### 3. 启动 Raven
 
 ```bash
-raven onboard
+uv run raven
 ```
 
-会创建 `~/.raven/config.json`,并在 `~/.raven/workspace/` 下生成默认的 `SOUL.md`、`USER.md`、`AGENTS.md` 模板。
-
-### 配置 API Key
-
-编辑 `~/.raven/config.json`:
-
-```json
-{
-  "providers": {
-    "anthropic": { "api_key": "sk-ant-..." }
-  },
-  "agents": {
-    "defaults": {
-      "model": "anthropic/claude-opus-4-6"
-    }
-  }
-}
-```
-
-### 开始对话
+裸 `raven` 会打开原生 TUI。也可以直接执行一次任务：
 
 ```bash
-raven agent -m "你好,你是谁?"
+uv run raven agent -m "Inspect this repo and tell me what to improve first."
 ```
 
-或交互模式:
+对接 Telegram、Slack、Discord、Matrix、WhatsApp、WeCom 等平台时：
 
 ```bash
-raven agent
+uv run raven gateway
 ```
 
-### 作为网关运行(对接聊天平台)
+<br>
+<div align="right">
 
-在配置中启用 Channel(例如 `channels.telegram.enabled = true` 并填入 token),然后:
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## Raven 适合什么
+
+Raven 面向那些普通聊天 Agent 显得太轻、太浅、太短的工作流。
+
+### 1. 终端原生日常工作
+
+Raven 可以作为 native TUI、直接 CLI agent 或 gateway-backed agent 运行。
+TUI 不是网页 shell，而是一个 React/Ink 应用，通过 typed RPC 与 Python
+runtime 通信。
+
+### 2. 会变得有用的记忆
+
+Raven 连接 EverOS 作为长期用户记忆与 Agent 记忆层。Sessions、procedures
+和可复用模式可以转成本地 skill 材料，而不是消失在旧 transcript 里。
+
+### 3. 不会在压力下崩掉的上下文
+
+Context stack 有 legacy path 和 Curator path。在 token 压力下，Raven 可以
+归档、检索并组装上下文，而不是盲目裁掉最旧消息。
+
+### 4. 会主动开口的 Agent
+
+Sentinel 监听事件、调度检查、判断 nudge 是否有用，并通过 guardrails 路由
+主动动作。目标不是制造通知噪音，而是让 Agent 真的能 notice。
+
+### 5. 会进化的 Skills
+
+SkillForge 把 skills 当成 procedural memory。它可以识别可复用工作流、写入
+skill 文件、追踪执行反馈，并在 instruction 失效时进化它。
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## 架构
+
+每个 turn 都流经 Spine：一个入口 `submit`，一个出口 `emit`，并用
+per-conversation lanes 处理顺序与取消。各个 feature engine 通过显式 handoff
+接入 Agent loop，而不是互相 import。
+
+```text
+Channels / TUI / Gateway
+        |
+        v
+   Raven Spine
+ submit -> lanes -> emit
+        |
+        v
+   Agent Loop
+ tools · skills · providers
+        |
+        +--> Context Engine   legacy / curator
+        +--> Memory Engine    EverOS / local skills / SkillForge
+        +--> Proactive Engine Sentinel / scheduler / nudge policy
+        +--> TokenWise        usage tracking / cache placement / routing
+        +--> Eval Engine      task judgement and coordination
+```
+
+### 仓库结构
+
+```text
+raven/
+├── spine/              # Per-turn backbone: submit -> lanes -> emit
+├── agent/              # Agent loop, tools, hooks, subagents, context builder
+├── channels/           # Telegram, Discord, Slack, Matrix, WhatsApp, WeCom, ...
+├── tui_rpc/            # Native TUI protocol 的 Python 侧
+├── providers/          # LLM provider adapters
+├── context_engine/     # Context assembly 与 Curator path
+├── proactive_engine/   # Sentinel, scheduler, nudges, feedback
+├── memory_engine/      # EverOS memory, local skills, SkillForge
+├── token_wise/         # Usage tracking, cache placement, routing
+├── sandbox/            # Isolated command execution
+├── security/           # Trust boundaries and network checks
+├── cli/                # `raven` command line entry point
+└── config/             # Config schema and update helpers
+
+ui-tui/                 # React/Ink 原生终端 UI
+bridge/                 # WhatsApp TypeScript bridge
+```
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## 开发工作流
+
+安装依赖并设置 hooks：
 
 ```bash
-raven gateway
+make install
 ```
 
----
-
-## 配置
-
-Raven 的配置在基础 Agent 配置之上增加了四个特性块。**所有新特性默认关闭** —— 新装 Raven 的行为与基础 Agent 完全一致,直到你主动启用。
-
-```json
-{
-  "agents":   { "defaults": { "model": "anthropic/claude-opus-4-6" } },
-  "channels": { "telegram": { "enabled": false } },
-  "providers": { "anthropic": { "api_key": "sk-ant-..." } },
-
-  "context": {
-    "engine": "legacy",
-    "fast_path_threshold": 0.60,
-    "curator_model": "gemini-2.5-flash"
-  },
-
-  "sentinel": {
-    "enabled": false,
-    "monitors": [],
-    "nudge_policy": {
-      "max_nudges_per_hour": 3,
-      "quiet_hours": [23, 7]
-    }
-  },
-
-  "token_wise": {
-    "enabled": true,
-    "usage_tracking": true,
-    "cache_optimization": true,
-    "smart_routing": { "enabled": false }
-  },
-
-  "skill_forge": {
-    "enabled": false,
-    "stats_tracking": true,
-    "auto_detect": false,
-    "auto_evolve": false
-  }
-}
-```
-
-完整字段定义见 `raven/config/raven.py`。
-
-### 启用 Skill 自进化
-
-完成的 `user → assistant` 轮次会以 session 为单位攒在本地抽取 pipeline 的
-缓冲里,**先做跨轮的任务边界检测,再决定要不要蒸馏**。每一轮都会触发一次
-轻量分类器,问一句"用户是不是刚开了个新任务";只有检测到边界(或 session
-结束)时,缓冲里的这一段才会被压成 `AgentCase`。太短的对话、没有工具调用
-的纯聊天、还没结束的轮次,会在任何 LLM 调用之前直接丢掉。低于质量门槛的
-case 停在这里,通过的继续进 skill 抽取。结果落到
-`<workspace>/.cache/skills.db`,物化的 `SKILL.md` 写到
-`<workspace>/skills/everos/<id>/`,本地 BM25 池自动 pickup。无需外部
-服务,只用 SQLite + 现有 LLM provider。
-
-```json
-{
-  "skill_forge": {
-    "enabled": true,
-    "evolve_model": "claude-opus-4-6",
-    "detect_model": "gemini-2.5-flash",
-    "everos": {
-      "enabled": true
-    }
-  }
-}
-```
-
-Pipeline 用到两个模型:
-
-- `skill_forge.evolve_model` —— 重量级 LLM,负责把 `AgentCase` 蒸馏成
-  skill、以及对已有 skill 做重写。不设置时回落到当前 agent model;想要
-  更高质量的重写就在这里钉一个更强的模型。
-- `skill_forge.detect_model` —— 每轮 boundary detector(多轮任务切分)
-  用的轻量分类器。因为它会在每个累计轮次上运行,默认 `gemini-2.5-flash`
-  这种小而快的模型是有意为之。
-
-### 配置媒体生成(图片 / 语音 / 视频)
-
-三个媒体工具通过 [OpenRouter](https://openrouter.ai) 生成媒体,**按工具
-逐个 opt-in**:只有当你在 `tools.media.<tool>` 下给某个工具配了 `model`
-或 `api_key`,它才会暴露给 agent。**仅把 OpenRouter 配成 chat provider
-并不会启用它们** —— 不主动配置,agent 永远看不到图片/语音/视频工具。
-
-```json
-{
-  "providers": { "openrouter": { "api_key": "sk-or-..." } },
-  "tools": {
-    "media": {
-      "image":  { "model": "google/gemini-2.5-flash-image" },
-      "speech": { "model": "openai/gpt-audio-mini" },
-      "video":  { "model": "kwaivgi/kling-v3.0-std" },
-      "proxy": null,
-      "output_subdir": "generated"
-    }
-  }
-}
-```
-
-- **Key** —— 已配置的工具若没单独设 key,会回落到
-  `providers.openrouter.api_key`,所以通常只需配一个 `model` 就能开启某个
-  工具。想用独立的 key,就在 `tools.media.<tool>.api_key` 单独覆盖。
-- `image_generate` —— 文生图(及图片编辑),用 Nano Banana
-  (`google/gemini-2.5-flash-image`)。在 workspace 下保存 PNG。
-- `text_to_speech` —— 语音合成,用 `openai/gpt-audio-mini`。零依赖输出
-  WAV;mp3/opus/flac 需要 PATH 上有 `ffmpeg`,没有时回退 WAV。
-- `video_generate` —— 文生视频,用 Kling(`kwaivgi/kling-v3.0-std`),
-  异步任务、耗时较长,且**需要 OpenRouter 账户开通后付费 / credits**。
-
-生成的文件落在 `<workspace>/<output_subdir>`(默认 `generated/`)。设置
-`tools.media.proxy` 可让媒体调用走 HTTP/SOCKS 代理。
-
----
-
-## 四大支柱详解
-
-### 1. 上下文管理 —— *Curator* 引擎
-
-`ContextEngine` 抽象基类定义了可插拔的上下文层。规划了两个实现:
-
-- **`legacy`** *(默认)* —— 基础 Agent 的 `ContextBuilder` + Consolidator。当 Prompt 接近上下文窗口上限时,老消息会被摘要并移出活跃上下文。
-- **`curator`** *(进行中)* —— 一个自主管理自身上下文的 Agent。在压力下,它会将消息无损归档到磁盘、需要时再检索回来,并通过 11 个内部工具(`curator_check_budget`、`curator_archive_messages`、`curator_retrieve_archived`、`curator_build_context` 等)组装最终窗口。采用快慢双路设计:
-  - **Fast Path**(历史 < 60% 预算):零 LLM 直通,仅注入工作态。
-  - **Slow Path**(压力态):运行一个小模型 Agent 循环(默认 `gemini-2.5-flash`)决定保留什么。
-  - **Fail-Safe**:若 Slow Path 的 LLM 失败或超时,一个确定性 Python 降级方案会产出有效上下文。
-
-设计文档给出的基准目标:
-- **PinchBench 连续评测,16K 窗口**:Legacy 86% → Curator 96% 整体成功率。
-- **DeepResearch-Bench-II,32K 窗口,10 项研究任务**:Legacy 43% → Curator 50% 整体成功率。
-
-### 2. 主动性 —— *Sentinel* 子系统
-
-Sentinel **与主 Agent 循环并行**运行,订阅事件总线,决定 Agent 何时无需提示即可主动发声。关键组件:
-
-- **Monitors**(`Monitor` ABC)—— 订阅事件类型,条件触发时产出 `TriggerEvent`。规划中的监听器:`IdleMonitor`、`CronMonitor`、`WorkspaceMonitor`、`MemoryMonitor`、`FollowUpMonitor`、`TaskMonitor`。
-- **Evaluator** —— 双层决策。规则层以零成本处理高确定性 case;可选的 LLM Evaluator 用小模型(`gemini-2.5-flash`,3 秒超时)判定模糊场景。
-- **Nudge Policy** —— 反骚扰护栏:`max_nudges_per_hour`、`quiet_hours`、`min_interval_seconds`、被 Dismiss 后的冷却。
-- **注入** —— Nudge 通过事件总线以普通 `InboundMessage`(`sender_id="sentinel"`)进入 Agent 循环,被路由为主动式上下文。
-
-### 3. Token 效率 —— *TokenWise* 层
-
-TokenWise 是一组跨切面的 `TokenStrategy` 钩子,而非单一模块。每个策略都可独立开关。
-
-| 策略 | 作用 | 典型节省 |
-|------|------|----------|
-| `UsageTracker` | 记录每次 LLM 调用的 tokens 和成本 | —(可观测性) |
-| `CacheOptimizer` | 在 Anthropic 请求中合理放置 `cache_control` 断点 | input 成本最多降 75% |
-| `ToolResultLifecycle` | 三阶段裁剪:保留最近 / 摘要中段 / 归档远端 | 30-60% 历史 tokens |
-| `SmartRouter` | 简单任务路由到廉价模型(`haiku`、`gemini-flash`) | 单请求降 40-70% |
-| `SkillLazyLoader` | 只注入与当前消息相关的 Skill 摘要 | 10-30% system prompt |
-| `BudgetAlerter` | 按会话/按天的可配置支出上限告警或阻断 | —(护栏) |
-
-### 4. Skill 自进化 —— *SkillForge*
-
-SkillForge 是一个闭环:`Detect → Create → Execute → Feedback → Evaluate → Evolve → Retire`。
-
-- Skill 存放在 `~/.raven/skills/<skill-name>/SKILL.md`,YAML frontmatter 扩展了 `version`、`stats`、`evolution_log`。
-- **Detect**:会话结束时,小模型判断该对话是否包含值得保存的可复用多步流程。
-- **Draft → Active 门槛**:自动创建的 Skill 以 `draft` 状态起步,直到至少成功一次才进入 Skill 摘要,避免噪声。
-- **Execute 追踪**:每次 Skill 调用都记录 `turns_used`、`tokens_consumed`、`outcome` 和 `user_feedback`(显式或隐式)。
-- **Evolve**:当 `success_rate` 在 `>= 10` 次调用内跌破阈值(默认 0.70),由强模型(`claude-opus-4-6`)重写该 Skill —— 保留可用逻辑并追加改进;版本递增,旧版本快照保留。
-- **Retire**:闲置 `retirement_idle_days` 天(默认 90)的 Skill 被标为 `deprecated`;再闲置 30 天 → `retired`(移入归档)。
-
----
-
-## Roadmap
-
-Raven 分六个 Tier 构建,按依赖关系与风险排序:
-
-| Tier | 范围 | 状态 |
-|------|------|------|
-| **1** | 骨架:仓库 Fork、核心接口、事件总线、配置 | ✅ 完成 |
-| **2** | 低风险高价值:使用量追踪、缓存优化、预算告警、Skill 统计 | 🚧 进行中 |
-| **3** | Curator Fast Path + Archive + 11 内部工具 + Slow Path | 规划中 |
-| **4** | TokenWise 高阶:工具结果生命周期、智能路由(规则层)、Skill 懒加载 | 规划中 |
-| **5** | SkillForge 闭环:识别、自动创建、执行追踪、进化、退役 | 规划中 |
-| **6** | Sentinel:Monitors、Evaluator、Nudge Policy、注入 | 规划中 |
-
-每个 Tier 的实施细节详见 [development docs](docs/)(补充中)。
-
----
-
-## 开发
-
-### 运行测试
+运行本地 CI gate：
 
 ```bash
-cd Raven
-PYTHONPATH=. pytest -v
+make ci
 ```
 
-Tier 1 提供 24 个测试,覆盖包骨架、事件总线 pub/sub 契约、四个抽象接口、配置 schema。
+常用命令：
 
-### 布局约定
+```bash
+make lint-python
+make lint-tui
+make lint-bridge
+make test-python
+make test-tui
+```
 
-- **`core/interfaces.py` 不放任何运行时逻辑** —— 只保留 ABC、dataclass、类型别名。避免循环导入。
-- **特性模块之间不直接互相 import** —— 通过事件总线或 Agent 循环中的显式交接通信。
-- **Fail-safe 是强制要求** —— 每个调用 LLM 的组件都必须有确定性降级。任何特性都不得导致主 Agent 循环崩溃。
-- **新特性默认关闭** —— 任何新增能力都以 `enabled = false` 发布;仅低成本、成熟的策略(缓存优化、使用量追踪)默认开启。
+仓库使用：
 
-### 代码风格
+- `uv` 管理 Python 依赖；
+- `ruff` 和 `pre-commit` 做 Python 与 repo hygiene；
+- `commitlint` 加 Python checker 校验 Conventional Commit subjects 和
+  ASCII-only public history；
+- `eslint`、`tsc`、`vitest` 和 RPC drift check 校验 TUI；
+- `npm ci`、`tsc` 和 `npm audit --audit-level=critical` 校验 bridge。
 
-- Python 3.11+,合适处使用 `from __future__ import annotations`
-- Ruff Lint(`ruff check raven tests`)
-- 全量类型标注(`Literal`、`Protocol` 按需使用)
-- 测试使用 `pytest` 搭配 `pytest-asyncio`(asyncio mode `auto`)
+`CLAUDE.md` 包含 branch naming、commit format、dependency update、testing 和
+PR hygiene 的完整协作规则。
 
----
+<br>
+<div align="right">
 
-## 致谢与许可
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
 
-Raven 采用 MIT 许可。基础 Agent 运行时(涉及 `raven/agent/`、`raven/bus/`、`raven/channels/`、`raven/cli/`、`raven/config/{loader,paths,schema}.py`、`raven/cron/`、`raven/memory/`、`raven/providers/`、`raven/routing/`、`raven/session/`、`raven/skills/`、`raven/templates/`、`raven/utils/`)来自 HKUDS 的 MIT 许可项目 [nanobot](https://github.com/HKUDS/nanobot),完整许可见 `LICENSE`。
+</div>
 
-四大特性支柱(`context/`、`sentinel/`、`token_wise/`、`skill_forge/`,以及 `core/` 接口与配置扩展)是 Raven 的新增内容。
+## 当前状态
 
-接口设计参考了生态内若干项目 —— [hermes-agent](https://github.com/NousResearch/hermes-agent)(Nous Research)、[Letta / MemGPT](https://github.com/letta-ai/letta)、[Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) 等。
+Raven 仍处于 pre-alpha，变化会很快。API 可能调整，但核心产品面已经在仓库里。
 
----
+| 层级 | 状态 |
+| --- | --- |
+| Native TUI + CLI | 可用 |
+| Spine runtime | 可用 |
+| Base agent loop, tools, providers | 可用 |
+| Context engine | 已实现，持续演进 |
+| Sentinel proactivity | 已实现，持续演进 |
+| TokenWise strategies | 已实现 |
+| SkillForge | 已实现 |
+| Eval engine | 部分完成 |
 
-## 贡献
+<br>
+<div align="right">
 
-Raven 处于 pre-alpha 阶段,API 会持续演进。如果你有兴趣贡献:
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
 
-1. 动手前先开 Issue,我们对齐一下方向。
-2. 遵循上面的布局约定。
-3. 补测试 —— Tier 1 的 `tests/test_tier1_skeleton.py` 是模板。
-4. 在模块 docstring 中说明其契约,并同步更新 README 对应章节。
+</div>
 
----
+## Star 支持
 
-*Raven 由 EverMind 打造。*
+如果 Raven 是你希望存在的 Command Line Agent，请 Star 这个仓库。它会帮助更多
+terminal-native builders 发现项目，也会给 EverMind 生态一个更强的信号，继续
+投入开源 Agent。
+
+### Star 趋势
+
+[![Star History Chart](https://api.star-history.com/svg?repos=EverMind-AI/raven&type=Date)](https://www.star-history.com/#EverMind-AI/raven&Date)
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## EverMind 生态
+
+EverMind 是一个面向长期记忆、自进化 Agent、AI-native interfaces 和记忆评测的开源生态。
+
+<table>
+<tr>
+<th colspan="2">EverMind Open-Source Ecosystem</th>
+</tr>
+<tr>
+<td><strong>Memory Runtime</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> - 本地记忆操作系统，以及有研究支撑的 Agent 和用户记忆 runtime。</td>
+</tr>
+<tr>
+<td><strong>AI-Native CLI Agent</strong></td>
+<td><a href="https://github.com/EverMind-AI/raven">Raven</a> - 把记忆、主动性、上下文控制和 skill evolution 带进终端的 native command line agent。</td>
+</tr>
+<tr>
+<td><strong>Algorithm Engine</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a> - stateless extraction、ranking、parsing 和 memory operators，为 EverOS 提供算法能力。</td>
+</tr>
+<tr>
+<td><strong>Hypergraph Memory</strong></td>
+<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> - 面向长期对话的 hypergraph memory，拥有 benchmark-backed topic -> episode -> fact retrieval。</td>
+</tr>
+<tr>
+<td><strong>Benchmarks</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a> - conversational memory 和 Agent self-evolution 的评测套件。</td>
+</tr>
+<tr>
+<td><strong>Long-Context Research</strong></td>
+<td><a href="https://github.com/EverMind-AI/MSA">MSA</a> - Memory Sparse Attention，用于可扩展 latent memory 和 100M-token contexts。</td>
+</tr>
+<tr>
+<td><strong>Personal Memory Layer</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> - CLI 和 Agent plugin suite，用于跨设备、跨 Agent 的个人记忆。</td>
+</tr>
+<tr>
+<td><strong>Developer Integrations</strong></td>
+<td><a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a> - AI coding agents 的 plugins、skills 和 migration tooling。</td>
+</tr>
+</table>
+
+这些仓库共同构成 EverMind 的 research-to-runtime stack：记忆方法、可复用算法、
+benchmark evidence、native agent products 和开发者集成。
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## 参与贡献
+
+Raven 还很早。欢迎在 runtime architecture、TUI polish、provider support、
+memory workflows、proactivity、benchmarks、documentation 和 issue reports 上贡献。
+
+提交 PR 前：
+
+1. 阅读 `CLAUDE.md`。
+2. 保持改动范围清晰。
+3. 行为变化需要添加或更新测试。
+4. 运行相关 `make` targets。
+5. 使用 Conventional Commit 标题。
+
+### 许可证
+
+Raven 使用 MIT License。基础 agent runtime 来自 HKUDS 的 MIT 协议项目
+[nanobot](https://github.com/HKUDS/nanobot)。第三方归属说明见
+[LICENSE](LICENSE)、[NOTICES.md](NOTICES.md) 和 [LICENSES/](LICENSES/)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,7 +21,8 @@
 <br>
 
 - [为什么是 Raven](#为什么是-raven)
-- [快速开始](#快速开始)
+- [快速安装](#快速安装)
+- [开始使用](#开始使用)
 - [Raven 适合什么](#raven-适合什么)
 - [架构](#架构)
 - [开发工作流](#开发工作流)
@@ -86,64 +87,44 @@ Raven 把这些问题当成产品本身，而不是边缘 case。
 
 <br>
 
-## 快速开始
+## 快速安装
 
-> 目标：从源码启动 Raven，完成 onboarding，然后进入原生 TUI。
+```bash
+curl -fsSL http://raven.evermind.ai/install.sh | bash
+```
 
-### 0. 前置条件
+安装后重新加载 shell，并运行 setup wizard：
 
-- Python 3.12+
-- [uv](https://docs.astral.sh/uv/)
-- Node.js 22+，用于原生 TUI
-- 一个模型 provider key，或通过 onboarding 配置 OAuth provider
+```bash
+source ~/.bashrc    # 或：source ~/.zshrc
+raven onboard
+```
 
 Raven 支持 OpenRouter、OpenAI、Anthropic、Gemini、DeepSeek、GitHub Copilot、
 OpenAI Codex OAuth，以及自定义 OpenAI-compatible endpoint。
 
-### 1. 从源码安装
+## 开始使用
 
 ```bash
-git clone https://github.com/EverMind-AI/raven.git
-cd raven
-uv sync --extra dev --dev
+raven                  # 原生 TUI，开始一段对话
+raven tui              # 显式启动原生 TUI
+raven tui --check      # 启动前检查 TUI runtime
+raven onboard          # 配置 provider、sandbox、channels 和 memory
+raven agent -m "..."   # 从 shell 里执行一次性任务
+raven provider list    # 查看 LLM providers 与模型配置
+raven channels list    # 列出可用消息渠道
+raven gateway          # 启动 messaging gateway
+raven sessions list    # 列出、恢复、fork、导出或删除 sessions
+raven cron list        # 查看 scheduled jobs 与 automations
+raven skill list       # 浏览 SkillForge skills
+raven sentinel status  # 查看主动记忆与 nudge 状态
+raven plugins          # 列出已安装插件和当前 memory backend
+raven sandbox list     # sandbox debug 开启时查看 sandbox VMs
+raven status           # 查看本地配置与运行状态
+raven doctor           # 诊断 config、routing 和 LLM readiness
 ```
 
-安装 TUI 依赖：
-
-```bash
-npm ci --prefix ui-tui
-```
-
-### 2. 运行 Onboarding
-
-```bash
-uv run raven onboard
-```
-
-Wizard 会配置：
-
-- LLM provider 和默认模型；
-- 可选 sandbox 执行环境；
-- 可选聊天 channel；
-- 可选 EverOS 长期记忆。
-
-### 3. 启动 Raven
-
-```bash
-uv run raven
-```
-
-裸 `raven` 会打开原生 TUI。也可以直接执行一次任务：
-
-```bash
-uv run raven agent -m "Inspect this repo and tell me what to improve first."
-```
-
-对接 Telegram、Slack、Discord、Matrix、WhatsApp、WeCom 等平台时：
-
-```bash
-uv run raven gateway
-```
+源码开发请看 [开发工作流](#开发工作流)。
 
 <br>
 <div align="right">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,7 @@
 <div align="center" id="readme-top">
 
+<img src="https://github.com/user-attachments/assets/224c1623-2705-4a48-8a60-fd5681ca0cb2" alt="Raven banner" width="100%">
+
 # Raven
 
 ### 为终端重度用户打造的 AI-native Command Line Agent。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,18 +2,14 @@
 
 <img src="https://github.com/user-attachments/assets/224c1623-2705-4a48-8a60-fd5681ca0cb2" alt="Raven banner" width="100%">
 
-# Raven
-
-### 为终端重度用户打造的 AI-native Command Line Agent。
-
 <p align="center">
-  <a href="https://github.com/EverMind-AI/raven/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/EverMind-AI/raven/ci.yml?branch=main&label=CI&style=for-the-badge" alt="CI"></a>
-  <a href="https://github.com/EverMind-AI/raven/blob/main/LICENSE"><img src="https://img.shields.io/github/license/EverMind-AI/raven?style=for-the-badge" alt="License"></a>
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>
-  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge" alt="HuggingFace"></a>
+  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/🤗_HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge" alt="HuggingFace"></a>
+  <a href="https://discord.gg/gYep5nQRZJ"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FgYep5nQRZJ%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&label=Discord&color=404EED&labelColor=gray&style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_社区-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
 </p>
 
-[Website](https://evermind.ai) · [Documentation](https://docs.evermind.ai) · [EverOS](https://github.com/EverMind-AI/EverOS) · [English](README.md)
+[官网](https://raven.evermind.ai) · [EverOS](https://github.com/EverMind-AI/EverOS) · [English](README.md)
 
 </div>
 

--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -1,0 +1,1368 @@
+{
+  "name": "raven-whatsapp-bridge",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "raven-whatsapp-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "@whiskeysockets/baileys": "7.0.0-rc13",
+        "pino": "^9.0.0",
+        "qrcode-terminal": "^0.12.0",
+        "ws": "^8.17.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "@types/ws": "^8.5.10",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.5.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/node-cache": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@cacheable/node-cache/-/node-cache-1.7.6.tgz",
+      "integrity": "sha512-6Omk2SgNnjtxB5f/E6bTIWIt5xhdpx39fGNRQgU9lojvRxU68v+qY+SXXLsp3ZGukqoPjsK21wZ6XABFr/Ge3A==",
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.3.1",
+        "hookified": "^1.14.0",
+        "keyv": "^5.5.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "license": "MIT"
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@whiskeysockets/baileys": {
+      "version": "7.0.0-rc13",
+      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc13.tgz",
+      "integrity": "sha512-8JPc8gaaCRykkjW2jxLGQ7/RZGrc7awO7WU+QJocf58eSUI9jAdcuYLynzhAbyU4UWvJJsHImZ+5E/JaZj5ypA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/node-cache": "^1.4.0",
+        "@hapi/boom": "^9.1.3",
+        "async-mutex": "^0.5.0",
+        "libsignal": "^6.0.0",
+        "lru-cache": "^11.1.0",
+        "music-metadata": "^11.12.3",
+        "p-queue": "^9.0.0",
+        "pino": "^9.6",
+        "protobufjs": "^7.5.6",
+        "whatsapp-rust-bridge": "0.5.4",
+        "ws": "^8.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "audio-decode": "^2.1.3",
+        "jimp": "^1.6.1",
+        "link-preview-js": "^3.0.0",
+        "sharp": "*"
+      },
+      "peerDependenciesMeta": {
+        "audio-decode": {
+          "optional": true
+        },
+        "jimp": {
+          "optional": true
+        },
+        "link-preview-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/curve25519-js": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/curve25519-js/-/curve25519-js-0.0.4.tgz",
+      "integrity": "sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/libsignal": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/libsignal/-/libsignal-6.0.0.tgz",
+      "integrity": "sha512-d/5V3YFtDljbFMufz4ncyUYGYhJl+vzAe+c2EFFBQ6bz1h8Q3IOMEGXYMzlibU60I+e8GagMMpji18iez3P1hA==",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "curve25519-js": "^0.0.4",
+        "protobufjs": "^7.5.5"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-2.0.0.tgz",
+      "integrity": "sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/music-metadata": {
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.13.0.tgz",
+      "integrity": "sha512-uXRaov9dfjSpQufXIU7sMxVZnh+FilCQv2mXn+K5EJ/decP3dTWrgvPYa5r6MtRbieNSCE708Da4J0u1UGfQIw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Borewit"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/borewit"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.2",
+        "@tokenizer/token": "^0.3.0",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "file-type": "^21.3.4",
+        "media-typer": "^2.0.0",
+        "strtok3": "^10.3.5",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0",
+        "win-guid": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/whatsapp-rust-bridge": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.5.4.tgz",
+      "integrity": "sha512-yYO1qSs0Fe7tGtnxOFHomocUD6IZtoAgmA4oDFyGIRZ67D3QZk3w7swA6XXFXNQngiyrg2k7tul6IrM3eUFh7A==",
+      "license": "MIT"
+    },
+    "node_modules/win-guid": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
+      "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -10,7 +10,7 @@
     "dev": "tsc && node dist/index.js"
   },
   "dependencies": {
-    "@whiskeysockets/baileys": "7.0.0-rc.9",
+    "@whiskeysockets/baileys": "7.0.0-rc13",
     "ws": "^8.17.1",
     "qrcode-terminal": "^0.12.0",
     "pino": "^9.0.0"

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,25 @@
+const TYPES = [
+  "build",
+  "chore",
+  "ci",
+  "docs",
+  "feat",
+  "fix",
+  "perf",
+  "refactor",
+  "revert",
+  "test",
+];
+
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "header-max-length": [2, "always", 100],
+    "subject-case": [2, "always", ["lower-case"]],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "type-case": [2, "always", "lower-case"],
+    "type-empty": [2, "never"],
+    "type-enum": [2, "always", TYPES],
+  },
+};

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -12,7 +12,6 @@ const TYPES = [
 ];
 
 module.exports = {
-  extends: ["@commitlint/config-conventional"],
   rules: {
     "header-max-length": [2, "always", 100],
     "subject-case": [2, "always", ["lower-case"]],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1230 @@
+{
+  "name": "raven-repo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "raven-repo",
+      "license": "MIT",
+      "devDependencies": {
+        "@commitlint/cli": "^19.8.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@commitlint/cli": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.1.tgz",
+      "integrity": "sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/format": "^19.8.1",
+        "@commitlint/lint": "^19.8.1",
+        "@commitlint/load": "^19.8.1",
+        "@commitlint/read": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
+        "tinyexec": "^1.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-validator": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.1.tgz",
+      "integrity": "sha512-0jvJ4u+eqGPBIzzSdqKNX1rvdbSU1lPNYlfQQRIFnBgLy26BtC0cFnr7c/AyuzExMxWsMOte6MkTi9I3SQ3iGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "ajv": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.1.tgz",
+      "integrity": "sha512-mXDnlJdvDzSObafjYrOSvZBwkD01cqB4gbnnFuVyNpGUM5ijwU/r/6uqUmBXAAOKRfyEjpkGVZxaDsCVnHAgyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "lodash.upperfirst": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/execute-rule": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.1.tgz",
+      "integrity": "sha512-YfJyIqIKWI64Mgvn/sE7FXvVMQER/Cd+s3hZke6cI1xgNT/f6ZAz5heND0QtffH+KbcqAwXDEE1/5niYayYaQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/format": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.1.tgz",
+      "integrity": "sha512-kSJj34Rp10ItP+Eh9oCItiuN/HwGQMXBnIRk69jdOwEW9llW9FlyqcWYbHPSGofmjsqeoxa38UaEA5tsbm2JWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/is-ignored": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.1.tgz",
+      "integrity": "sha512-AceOhEhekBUQ5dzrVhDDsbMaY5LqtN8s1mqSnT2Kz1ERvVZkNihrs3Sfk1Je/rxRNbXYFzKZSHaPsEJJDJV8dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.1.tgz",
+      "integrity": "sha512-52PFbsl+1EvMuokZXLRlOsdcLHf10isTPlWwoY1FQIidTsTvjKXVXYb7AvtpWkDzRO2ZsqIgPK7bI98x8LRUEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/is-ignored": "^19.8.1",
+        "@commitlint/parse": "^19.8.1",
+        "@commitlint/rules": "^19.8.1",
+        "@commitlint/types": "^19.8.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/load": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.1.tgz",
+      "integrity": "sha512-9V99EKG3u7z+FEoe4ikgq7YGRCSukAcvmKQuTtUyiYPnOd9a2/H9Ak1J9nJA1HChRQp9OA/sIKPugGS+FK/k1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^19.8.1",
+        "@commitlint/execute-rule": "^19.8.1",
+        "@commitlint/resolve-extends": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
+        "chalk": "^5.3.0",
+        "cosmiconfig": "^9.0.0",
+        "cosmiconfig-typescript-loader": "^6.1.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/message": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.1.tgz",
+      "integrity": "sha512-+PMLQvjRXiU+Ae0Wc+p99EoGEutzSXFVwQfa3jRNUZLNW5odZAyseb92OSBTKCu+9gGZiJASt76Cj3dLTtcTdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/parse": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.1.tgz",
+      "integrity": "sha512-mmAHYcMBmAgJDKWdkjIGq50X4yB0pSGpxyOODwYmoexxxiUCy5JJT99t1+PEMK7KtsCtzuWYIAXYAiKR+k+/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "conventional-changelog-angular": "^7.0.0",
+        "conventional-commits-parser": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/read": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.8.1.tgz",
+      "integrity": "sha512-03Jbjb1MqluaVXKHKRuGhcKWtSgh3Jizqy2lJCRbRrnWpcM06MYm8th59Xcns8EqBYvo0Xqb+2DoZFlga97uXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/top-level": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
+        "git-raw-commits": "^4.0.0",
+        "minimist": "^1.2.8",
+        "tinyexec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.1.tgz",
+      "integrity": "sha512-GM0mAhFk49I+T/5UCYns5ayGStkTt4XFFrjjf0L4S26xoMTSkdCf9ZRO8en1kuopC4isDFuEm7ZOm/WRVeElVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
+        "global-directory": "^4.0.1",
+        "import-meta-resolve": "^4.0.0",
+        "lodash.mergewith": "^4.6.2",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.1.tgz",
+      "integrity": "sha512-Hnlhd9DyvGiGwjfjfToMi1dsnw1EXKGJNLTcsuGORHz6SS9swRgkBsou33MQ2n51/boIDrbsg4tIBbRpEWK2kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/ensure": "^19.8.1",
+        "@commitlint/message": "^19.8.1",
+        "@commitlint/to-lines": "^19.8.1",
+        "@commitlint/types": "^19.8.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/to-lines": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.1.tgz",
+      "integrity": "sha512-98Mm5inzbWTKuZQr2aW4SReY6WUukdWXuZhrqf1QdKPZBCCsXuG87c+iP0bwtD6DBnmVVQjgp4whoHRVixyPBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/top-level": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.1.tgz",
+      "integrity": "sha512-Ph8IN1IOHPSDhURCSXBz44+CIu+60duFwRsg6HqaISFHQHbmBtxVw4ZrFNIYUzEP7WwrNPxa2/5qJ//NK1FGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/types": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.1.tgz",
+      "integrity": "sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@types/conventional-commits-parser": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.2.tgz",
+      "integrity": "sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/conventional-changelog-angular": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
+      "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-text-path": "^2.0.0",
+        "JSONStream": "^1.3.5",
+        "meow": "^12.0.1",
+        "split2": "^4.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jiti": "2.6.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/dargs": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
+      "integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/find-up": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
+      "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.2.0",
+        "path-exists": "^5.0.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/git-raw-commits": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
+      "integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
+      "deprecated": "Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dargs": "^8.0.0",
+        "meow": "^12.0.1",
+        "split2": "^4.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-text-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+      "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "text-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/meow": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-extensions": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
+      "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "raven-repo",
+  "private": true,
+  "description": "Repository-level tooling for Raven.",
+  "license": "MIT",
+  "scripts": {
+    "commitlint": "commitlint --config commitlint.config.cjs"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^19.8.1"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "raven"
 version = "0.1.0"
-description = "Raven — Agent framework with intelligent context management, proactivity, token efficiency, and skill self-evolution"
+description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "MIT"
 license-files = ["LICENSE", "LICENSES/*.txt", "NOTICES.md"]
 authors = [
     {name = "EverMind"}
 ]
-keywords = ["ai", "agent", "context-management", "skill-evolution"]
+keywords = ["ai", "agent", "cli", "terminal", "context-management", "skill-evolution"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -169,8 +169,10 @@ dev = [
     "oauth-cli-kit>=0.1.3",
     "pexpect>=4.9",
     "pip-audit>=2.10.0",
+    "pre-commit>=4.5.0",
     "pyte>=0.8",
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.1.0",
+    "ruff>=0.15.0",
 ]

--- a/scripts/check_commit_file.py
+++ b/scripts/check_commit_file.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from scripts.commit_lint import check_commit_message
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        print("Usage: check_commit_file.py <commit-msg-file>", file=sys.stderr)
+        return 2
+
+    message = Path(args[0]).read_text()
+    result = check_commit_message(message)
+    if result.ok:
+        return 0
+
+    print("Invalid commit message:", file=sys.stderr)
+    for error in result.errors:
+        print(f"- {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_commit_file.py
+++ b/scripts/check_commit_file.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 
@@ -12,7 +13,21 @@ def main(argv: list[str] | None = None) -> int:
         print("Usage: check_commit_file.py <commit-msg-file>", file=sys.stderr)
         return 2
 
-    message = Path(args[0]).read_text()
+    path = Path(args[0])
+    subprocess.run(
+        [
+            "npx",
+            "--no-install",
+            "commitlint",
+            "--edit",
+            str(path),
+            "--config",
+            "commitlint.config.cjs",
+        ],
+        check=True,
+    )
+
+    message = path.read_text()
     result = check_commit_message(message)
     if result.ok:
         return 0

--- a/scripts/check_commit_messages.py
+++ b/scripts/check_commit_messages.py
@@ -49,7 +49,7 @@ def _commit_messages(revision_range: str) -> list[tuple[str, str]]:
         text=True,
     )
     chunks = output.rstrip("\0").split("\0")
-    return list(zip(chunks[0::2], chunks[1::2], strict=False))
+    return list(zip(chunks[0::2], chunks[1::2]))
 
 
 if __name__ == "__main__":

--- a/scripts/check_commit_messages.py
+++ b/scripts/check_commit_messages.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from scripts.commit_lint import check_commit_message
+
+ZERO_SHA = "0" * 40
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    revision_range = args[0] if args else _default_range()
+    if not revision_range:
+        print("No commit range detected; skipping commit message lint")
+        return 0
+
+    messages = _commit_messages(revision_range)
+    failed = False
+    for sha, message in messages:
+        result = check_commit_message(message)
+        if result.ok:
+            continue
+        failed = True
+        header = message.strip().splitlines()[0] if message.strip() else "<empty>"
+        print(f"Invalid commit message {sha}: {header}", file=sys.stderr)
+        for error in result.errors:
+            print(f"- {error}", file=sys.stderr)
+
+    return 1 if failed else 0
+
+
+def _default_range() -> str | None:
+    pr_base = os.environ.get("GITHUB_PR_BASE_SHA", "").strip()
+    if pr_base:
+        return f"{pr_base}..HEAD"
+
+    before = os.environ.get("GITHUB_EVENT_BEFORE", "").strip()
+    if before and before != ZERO_SHA:
+        return f"{before}..HEAD"
+
+    return os.environ.get("RANGE", "").strip() or None
+
+
+def _commit_messages(revision_range: str) -> list[tuple[str, str]]:
+    output = subprocess.check_output(
+        ["git", "log", "--format=%H%x00%B%x00", revision_range],
+        text=True,
+    )
+    chunks = output.rstrip("\0").split("\0")
+    return list(zip(chunks[0::2], chunks[1::2], strict=False))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_pr_title.py
+++ b/scripts/check_pr_title.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import os
+import sys
+
+from scripts.commit_lint import check_pr_title
+
+
+def main() -> int:
+    title = os.environ.get("PR_TITLE", "").strip()
+    if not title:
+        print("PR_TITLE is required", file=sys.stderr)
+        return 2
+
+    result = check_pr_title(title)
+    if result.ok:
+        return 0
+
+    print(f"Invalid PR title: {title}", file=sys.stderr)
+    for error in result.errors:
+        print(f"- {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/commit_lint.py
+++ b/scripts/commit_lint.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+ALLOWED_TYPES = {
+    "feat",
+    "fix",
+    "docs",
+    "refactor",
+    "perf",
+    "test",
+    "build",
+    "ci",
+    "chore",
+    "revert",
+}
+
+HEADER_RE = re.compile(r"^(?P<type>[a-z]+)(?:\((?P<scope>[a-z0-9_*.-]+)\))?: (?P<subject>.+)$")
+
+
+@dataclass(frozen=True)
+class CommitLintConfig:
+    subject_limit: int = 72
+    pr_title_subject_limit: int = 90
+
+
+@dataclass(frozen=True)
+class LintResult:
+    errors: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def check_commit_message(message: str, config: CommitLintConfig | None = None) -> LintResult:
+    return _check_message(message, subject_limit=(config or CommitLintConfig()).subject_limit)
+
+
+def check_pr_title(title: str, config: CommitLintConfig | None = None) -> LintResult:
+    return _check_message(
+        title, subject_limit=(config or CommitLintConfig()).pr_title_subject_limit
+    )
+
+
+def _check_message(message: str, *, subject_limit: int) -> LintResult:
+    errors: list[str] = []
+    text = message.strip()
+    header = text.splitlines()[0] if text else ""
+
+    if header.startswith(("fixup!", "squash!")):
+        errors.append("fixup/squash commits are not allowed")
+        return LintResult(errors)
+
+    if header.startswith("Merge "):
+        errors.append("merge commits are not allowed in PR ranges")
+        return LintResult(errors)
+
+    if not _is_ascii(text):
+        errors.append("must be ASCII-only English")
+
+    match = HEADER_RE.match(header)
+    if not match:
+        errors.append("must match <type>(<scope>): <subject>")
+        return LintResult(errors)
+
+    commit_type = match.group("type")
+    subject = match.group("subject")
+
+    if commit_type not in ALLOWED_TYPES:
+        errors.append(f"type must be one of: {', '.join(sorted(ALLOWED_TYPES))}")
+
+    if len(subject) > subject_limit:
+        errors.append(f"subject must be {subject_limit} characters or fewer")
+
+    first_alpha = next((ch for ch in subject if ch.isalpha()), "")
+    if first_alpha and not first_alpha.islower():
+        errors.append("subject must start lowercase")
+
+    if subject.endswith((".", "!", "?")):
+        errors.append("subject must not end with punctuation")
+
+    return LintResult(errors)
+
+
+def _is_ascii(text: str) -> bool:
+    try:
+        text.encode("ascii")
+    except UnicodeEncodeError:
+        return False
+    return True

--- a/tests/test_commit_lint.py
+++ b/tests/test_commit_lint.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from scripts.commit_lint import (
+    CommitLintConfig,
+    check_commit_message,
+    check_pr_title,
+)
+
+
+def test_accepts_valid_conventional_commit_with_scope() -> None:
+    result = check_commit_message("docs(readme): sharpen launch positioning")
+
+    assert result.ok
+    assert result.errors == []
+
+
+def test_rejects_missing_conventional_commit_type() -> None:
+    result = check_commit_message("update README")
+
+    assert not result.ok
+    assert "must match <type>(<scope>): <subject>" in result.errors[0]
+
+
+def test_rejects_cjk_and_full_width_punctuation() -> None:
+    result = check_commit_message("docs: 更新 README。")
+
+    assert not result.ok
+    assert "must be ASCII-only English" in result.errors
+
+
+def test_rejects_uppercase_subject_and_trailing_period() -> None:
+    result = check_commit_message("docs: Update README.")
+
+    assert not result.ok
+    assert "subject must start lowercase" in result.errors
+    assert "subject must not end with punctuation" in result.errors
+
+
+def test_rejects_subject_over_commit_limit() -> None:
+    subject = "a" * 73
+    result = check_commit_message(f"docs: {subject}")
+
+    assert not result.ok
+    assert "subject must be 72 characters or fewer" in result.errors
+
+
+def test_rejects_fixup_and_merge_subjects() -> None:
+    fixup = check_commit_message("fixup! docs: sharpen launch positioning")
+    merge = check_commit_message("Merge branch 'main' into feature")
+
+    assert not fixup.ok
+    assert not merge.ok
+    assert "fixup/squash commits are not allowed" in fixup.errors
+    assert "merge commits are not allowed in PR ranges" in merge.errors
+
+
+def test_pr_title_allows_longer_subject_limit() -> None:
+    subject = "add launch-ready readme and contributor checks"
+    result = check_pr_title(f"docs: {subject}", CommitLintConfig(pr_title_subject_limit=90))
+
+    assert result.ok
+
+
+def test_pr_title_rejects_subject_over_pr_limit() -> None:
+    subject = "a" * 91
+    result = check_pr_title(f"docs: {subject}", CommitLintConfig(pr_title_subject_limit=90))
+
+    assert not result.ok
+    assert "subject must be 90 characters or fewer" in result.errors

--- a/tests/test_commit_lint.py
+++ b/tests/test_commit_lint.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
+from scripts import check_commit_file
 from scripts.commit_lint import (
     CommitLintConfig,
     check_commit_message,
@@ -67,3 +71,28 @@ def test_pr_title_rejects_subject_over_pr_limit() -> None:
 
     assert not result.ok
     assert "subject must be 90 characters or fewer" in result.errors
+
+
+def test_commit_msg_hook_runs_commitlint_before_python_checker(monkeypatch, tmp_path: Path) -> None:
+    message_file = tmp_path / "COMMIT_EDITMSG"
+    message_file.write_text("docs: add launch notes\n")
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], check: bool) -> subprocess.CompletedProcess:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(check_commit_file.subprocess, "run", fake_run)
+
+    assert check_commit_file.main([str(message_file)]) == 0
+    assert calls == [
+        [
+            "npx",
+            "--no-install",
+            "commitlint",
+            "--edit",
+            str(message_file),
+            "--config",
+            "commitlint.config.cjs",
+        ]
+    ]

--- a/ui-tui/eslint.config.js
+++ b/ui-tui/eslint.config.js
@@ -1,0 +1,48 @@
+import js from "@eslint/js";
+import tsParser from "@typescript-eslint/parser";
+import reactHooks from "eslint-plugin-react-hooks";
+import globals from "globals";
+
+export default [
+  {
+    ignores: ["**/dist/**", "**/coverage/**", "**/.vitest-cache/**"],
+    linterOptions: {
+      reportUnusedDisableDirectives: "off",
+    },
+  },
+  js.configs.recommended,
+  {
+    files: ["src/**/*.{ts,tsx}", "packages/**/*.{ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      globals: {
+        ...globals.es2024,
+        ...globals.node,
+      },
+      parser: tsParser,
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+        sourceType: "module",
+      },
+    },
+    plugins: {
+      "react-hooks": reactHooks,
+    },
+    rules: {
+      "no-undef": "off",
+      "no-unused-vars": "off",
+      "react-hooks/exhaustive-deps": "warn",
+      "react-hooks/rules-of-hooks": "error",
+    },
+  },
+  {
+    files: ["packages/hermes-ink/src/**/*.{ts,tsx}"],
+    rules: {
+      "no-empty": "off",
+      "no-fallthrough": "off",
+      "no-redeclare": "off",
+    },
+  },
+];

--- a/ui-tui/eslint.config.js
+++ b/ui-tui/eslint.config.js
@@ -6,6 +6,8 @@ import globals from "globals";
 export default [
   {
     ignores: ["**/dist/**", "**/coverage/**", "**/.vitest-cache/**"],
+  },
+  {
     linterOptions: {
       reportUnusedDisableDirectives: "off",
     },

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -19,6 +19,7 @@
     "lint:fix": "eslint src/ packages/ --fix",
     "fmt": "prettier --write 'src/**/*.{ts,tsx}' 'packages/**/*.{ts,tsx}'",
     "fix": "npm run lint:fix && npm run fmt",
+    "pretest": "npm run build --prefix packages/hermes-ink",
     "test": "vitest run",
     "test:watch": "vitest",
     "gen:rpc": "node scripts/gen-rpc-types.mjs",

--- a/ui-tui/src/__tests__/modelPicker.test.tsx
+++ b/ui-tui/src/__tests__/modelPicker.test.tsx
@@ -14,6 +14,14 @@ import { DEFAULT_THEME } from '../theme.js'
 
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
+const waitForFrame = async (h: Pick<Harness, 'frame'>, text: string) => {
+  for (let i = 0; i < 20; i++) {
+    if (h.frame().includes(text)) return
+    await delay(30)
+  }
+  expect(h.frame()).toContain(text)
+}
+
 const ESC_RE = new RegExp(String.fromCharCode(27), 'g')
 
 // ink emits cursor-forward moves (CSI nC) in place of spaces for alignment, so
@@ -192,7 +200,7 @@ describe('ModelPicker', () => {
 
     // Enter the authenticated anthropic provider's model stage.
     await h.type(ENTER)
-    expect(h.frame()).toContain('step 2/2')
+    await waitForFrame(h, 'step 2/2')
 
     // 'a' opens the add-model sub-input.
     await h.type('a')
@@ -221,6 +229,7 @@ describe('ModelPicker', () => {
     await delay(60)
 
     await h.type(ENTER)
+    await waitForFrame(h, 'step 2/2')
     expect(h.frame()).toContain('claude-sonnet-4-6')
 
     // Delete the highlighted (first) model.

--- a/uv.lock
+++ b/uv.lock
@@ -388,6 +388,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "chardet"
 version = "7.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -785,6 +794,15 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/44/102dede3f371277598df6aa9725b82e3add068c729333c7a5dbc12764579/dingtalk_stream-0.24.3-py3-none-any.whl", hash = "sha256:2160403656985962878bf60cdf5adf41619f21067348e06f07a7c7eebf5943ad", size = 27813, upload-time = "2025-10-24T09:36:57.497Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
 ]
 
 [[package]]
@@ -1339,6 +1357,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -2051,6 +2078,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2477,6 +2513,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2884,6 +2936,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/1a/cbbaf13b730abb0a16b964d984e19f2fe520c21a4dc664051359a3f5a9e7/python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690", size = 70277, upload-time = "2026-06-11T16:10:42.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500", size = 33886, upload-time = "2026-06-11T16:10:41.192Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3168,10 +3233,12 @@ dev = [
     { name = "oauth-cli-kit" },
     { name = "pexpect" },
     { name = "pip-audit" },
+    { name = "pre-commit" },
     { name = "pyte" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -3242,10 +3309,12 @@ dev = [
     { name = "oauth-cli-kit", specifier = ">=0.1.3" },
     { name = "pexpect", specifier = ">=4.9" },
     { name = "pip-audit", specifier = ">=2.10.0" },
+    { name = "pre-commit", specifier = ">=4.5.0" },
     { name = "pyte", specifier = ">=0.8" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "ruff", specifier = ">=0.15.0" },
 ]
 
 [[package]]
@@ -4090,6 +4159,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783", size = 4558820, upload-time = "2026-06-16T16:23:56.963Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Change description

Prepare Raven for the open-source launch by turning the repository from an internal technical drop into a public-facing project with quality gates.

This PR:
- rewrites `README.md` and `README.zh-CN.md` in the EverOS launch-page style, positioning Raven as an AI-native command line agent for terminal-native users;
- adds Raven to the EverMind ecosystem table as the AI-native CLI Agent surface;
- adds GitHub Actions for pre-commit diff checks, Python checks, TUI checks, bridge build/audit, PR title linting, and commit message linting;
- adds `Makefile`, `.pre-commit-config.yaml`, `commitlint.config.cjs`, and tested Python commit/PR title validators;
- adds a TUI ESLint flat config and stabilizes the asynchronous model picker tests exposed by CI;
- upgrades the WhatsApp bridge Baileys dependency to a non-advisory release and commits `bridge/package-lock.json` for reproducible CI installs.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Document
- [x] Others

## Related issues (if there is)

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary

## Verification

```text
make ci
uv run pre-commit run --from-ref origin/main --to-ref HEAD
uv run --extra dev python scripts/check_commit_messages.py origin/main..HEAD
npx --yes -p @commitlint/cli@19 commitlint --from origin/main --to HEAD --config commitlint.config.cjs
npm audit --audit-level=critical  # in bridge/
```

Notes:
- `make ci` exits 0. TUI ESLint currently reports 5 existing `react-hooks/exhaustive-deps` warnings but no errors.
- Vitest exits 0 with 74 passed files, 1 skipped file, 867 passed tests, and 3 skipped tests. It still prints an existing `raven_cli` probe traceback from `slashParity.test.ts`; the test suite passes.
