### PR TITLE
docs: add repository section guides

### DIFF
--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,0 +1,15 @@
+# Third-Party License Notices
+
+This directory keeps license texts for upstream projects and libraries whose
+notices Raven preserves.
+
+Raven itself is licensed under Apache-2.0. Some imported code, references, and
+design influences originated from MIT-licensed projects; those notices remain
+here so downstream users can audit attribution without searching through the
+history.
+
+## Files
+
+- `MIT-hermes-agent.txt` - Hermes Agent license notice.
+- `MIT-ink.txt` - Ink license notice.
+- `MIT-nanobot.txt` - Nanobot license notice.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,6 +4,10 @@ This directory holds **evaluation harnesses** that are deliberately decoupled
 from the runtime package. They are not imported by `raven/` and are
 excluded from the wheel build — keep it that way.
 
+Use this area for reproducible evaluation work: capability suites, agent
+comparisons, context stress tests, and proactivity runs that should not ship as
+part of the end-user CLI package.
+
 ## Layout
 
 ```

--- a/demos/README.md
+++ b/demos/README.md
@@ -3,6 +3,10 @@
 Each subdirectory is one self-contained showcase: an inputs-+-runner-+-output
 bundle that should be reproducible from a fresh checkout.
 
+Keep demos focused on user-visible behavior. A good demo should explain what it
+proves, how to run it, and what a successful output looks like without relying
+on private EverMind infrastructure.
+
 | Demo | What it shows |
 |------|---------------|
 | [skill_retrieval/](skill_retrieval/) | An agent reads a SKILL.md, follows it, and generates an image via Nano Banana on OpenRouter. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Raven Documentation
+
+This directory holds design notes, implementation plans, architecture diagrams,
+and developer references that are too detailed for the main README.
+
+For first-time users, start at the root `README.md`. Use this directory when you
+need to understand the internal architecture or extend a subsystem.
+
+## Index
+
+- `dev.md` - local development notes.
+- `Raven-vs-OpenClaw-Hermes.md` - product and architecture comparison notes.
+- `memory-plugin-architecture.md` - memory/plugin architecture details.
+- `everos-memory-e2e-test-plan.md` - end-to-end memory validation plan.
+- `sandbox/` - BoxLite sandbox usage and debugging notes.
+- `architecture/` - architecture diagrams used by design docs.
+- `Proactivity-*.md` - planning, implementation, and cost notes for proactive
+  behavior.
+- `skill-hub-integration-design.md` - Skill Hub integration design.

--- a/raven/README.md
+++ b/raven/README.md
@@ -1,0 +1,20 @@
+# Raven Runtime Package
+
+`raven/` contains the Python runtime for the Raven command line agent. The
+package is intentionally split by responsibility so CLI commands, provider
+adapters, memory, routing, channels, and proactive execution can evolve without
+coupling everything through one agent loop.
+
+## Key Areas
+
+- `cli/` - Typer command surface and terminal workflows.
+- `agent/` and `spine/` - turn execution, scheduling, and message delivery.
+- `context_engine/` and `routing/` - context assembly and model/tool routing.
+- `memory_engine/` - memory backend contracts and consolidation paths.
+- `providers/` - model provider adapters and fallback behavior.
+- `channels/` - gateway/channel integrations.
+- `plugin/` and `skill_hub/` - plugin discovery and skill retrieval.
+- `sandbox/` and `security/` - execution isolation and trust boundaries.
+- `templates/` - workspace templates materialized by Raven.
+
+Runtime code should not import from `benchmarks/`, `demos/`, or `tests/`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,23 @@
+# Raven Test Suite
+
+The test suite covers the CLI, provider routing, context assembly, memory,
+channels, sandbox behavior, TUI RPC contracts, and proactive engine flows.
+
+## Running Tests
+
+Run the default suite from the repository root:
+
+```bash
+uv run pytest
+```
+
+For focused work, target the relevant file or marker:
+
+```bash
+uv run pytest tests/test_cli_doctor_commands.py
+uv run pytest -m "not real_llm"
+```
+
+Tests should avoid live network calls by default. When a test needs external
+services or a real model, guard it behind an explicit marker or environment
+variable so CI and local contributors get deterministic results.


### PR DESCRIPTION
## Summary
- add lightweight overview files for top-level repository sections that still displayed old non-conventional commit messages
- update existing benchmark and demo READMEs with public-facing guidance
- make the GitHub directory listing show a clean conventional commit message after merge without rewriting main history

## Verification
- uv run pre-commit run --files LICENSES/README.md benchmarks/README.md demos/README.md docs/README.md raven/README.md tests/README.md
- npx --no-install commitlint --from origin/main --to HEAD --config commitlint.config.cjs
- PYTHONPATH=. python3 scripts/check_commit_messages.py origin/main..HEAD
- uv run pre-commit run --from-ref origin/main --to-ref HEAD

## Note
A normal pull request cannot rename historical commits already merged into main. This PR instead updates the affected directories with useful public-facing overview docs so GitHub displays the new conventional commit as the latest directory change.