### PR TITLE
chore(release): prepare v0.1.0 public preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to Raven are documented here.
+
+## v0.1.0 - Public Preview - 2026-06-30
+
+Raven is now available as an Apache-2.0 open-source project.
+
+This is the first public preview release: stable enough for developers to try,
+inspect, and build around, while the CLI surface, plugin contracts, and runtime
+internals may still evolve before v1.0.
+
+### Highlights
+
+- AI-native command line agent built for terminal-first workflows.
+- Memory-first runtime with context assembly, routing, and session management.
+- Proactive execution path for scheduled, event-driven, and background work.
+- Native TUI and bridge packages aligned under the v0.1.0 release line.
+- Skill and plugin foundations for extensible agent behavior.
+- Provider routing and fallback paths for multiple model backends.
+- Public repository hygiene: CI, commit linting, pre-commit checks, issue
+  templates, security policy, contribution guide, and Apache-2.0 licensing.
+
+### Installation
+
+```bash
+curl -fsSL http://raven.evermind.ai/install.sh | bash
+```
+
+### Release Status
+
+- Version: `0.1.0`
+- Tag: `v0.1.0`
+- Stability: public preview
+- License: Apache-2.0
+
+### Notes
+
+- Raven is not yet API stable.
+- The public install endpoint and package distribution flow should be verified
+  before publishing the GitHub Release.
+- Future releases should use semantic versioning: patch releases for fixes,
+  minor releases for new capabilities, and v1.0 once the public CLI and plugin
+  contracts are stable.

--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raven-tui",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raven-tui",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hermes/ink": "file:./packages/hermes-ink",

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raven-tui",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "description": "Raven native TUI (Ink + React). See ../docs/openspec/changes/tui-fork-hermes-import/.",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- add the initial `CHANGELOG.md` entry for `v0.1.0 - Public Preview`
- align `raven-tui` package metadata and lockfile to version `0.1.0`
- document the intended `v0.1.0` tag, public preview status, install command, and release notes

## Verification
- npm ci --ignore-scripts --no-audit --no-fund (ui-tui)
- node JSON parse for `ui-tui/package.json` and `ui-tui/package-lock.json`
- uv run pre-commit run --files CHANGELOG.md ui-tui/package.json ui-tui/package-lock.json
- npx --no-install commitlint --from origin/main --to HEAD --config commitlint.config.cjs
- PYTHONPATH=. python3 scripts/check_commit_messages.py origin/main..HEAD
- uv run pre-commit run --from-ref origin/main --to-ref HEAD
- uv run python version metadata check

## Release note draft
Release title: `Raven v0.1.0: Public Preview`

This is the first public preview release of Raven, an AI-native command line agent for terminal-first workflows. It includes the memory-first runtime, context assembly and routing, proactive execution foundations, native TUI and bridge packages, provider routing, skill/plugin foundations, and the public repository hygiene needed for an open-source launch.

Note: create the `v0.1.0` tag and GitHub Release after this PR lands on `main`.