### PR TITLE
feat(onboard): bilingual wizard, unified EverOS model setup, back-nav

### DIFF
--- a/raven/agent/context/builder.py
+++ b/raven/agent/context/builder.py
@@ -9,8 +9,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 from raven.memory_engine.consolidate.consolidator import MemoryStore
-from raven.memory_engine.skill_local.types import SkillMeta
 from raven.memory_engine.skill_forge import LocalSkillCatalog
+from raven.memory_engine.skill_local.types import SkillMeta
 from raven.security.trust import wrap_untrusted
 from raven.utils.helpers import build_assistant_message, detect_image_mime
 
@@ -88,7 +88,8 @@ class ContextBuilder:
             cfg = getattr(self.skills, "_config", None)
             always_max = getattr(cfg, "always_max", 5) or 5
             always_content = self.skills.load_skills_for_context(
-                always_skills, max_inject=always_max,
+                always_skills,
+                max_inject=always_max,
             )
             if always_content:
                 parts.append(f"# Active Skills\n\n{always_content}")
@@ -118,27 +119,37 @@ class ContextBuilder:
             # (used by claweval / PinchBench A/B to attribute scores to
             # specific skills the agent saw inline).
             try:
-                import json as _json, time as _time
+                import json as _json
+                import time as _time
+
                 injected_meta = []
-                for _m in (only[:inject_max] if inject_max else only):
-                    injected_meta.append({
-                        "name": getattr(_m, "name", None),
-                        "id": str(getattr(_m, "id", "")),
-                        "source": getattr(_m, "source", None),
-                        "body_len": len(getattr(_m, "content", "") or ""),
-                    })
+                for _m in only[:inject_max] if inject_max else only:
+                    injected_meta.append(
+                        {
+                            "name": getattr(_m, "name", None),
+                            "id": str(getattr(_m, "id", "")),
+                            "source": getattr(_m, "source", None),
+                            "body_len": len(getattr(_m, "content", "") or ""),
+                        }
+                    )
                 _path = self.workspace / "skill_injections.jsonl"
                 with open(_path, "a") as _f:
-                    _f.write(_json.dumps({
-                        "ts": _time.time(),
-                        "mode": "full_body",
-                        "inject_max": inject_max,
-                        "skills": injected_meta,
-                    }) + "\n")
+                    _f.write(
+                        _json.dumps(
+                            {
+                                "ts": _time.time(),
+                                "mode": "full_body",
+                                "inject_max": inject_max,
+                                "skills": injected_meta,
+                            }
+                        )
+                        + "\n"
+                    )
             except Exception:
                 pass  # never break agent on telemetry failure
             ctx = self.skills.load_skills_for_context(
-                only, max_inject=inject_max,
+                only,
+                max_inject=inject_max,
             )
             if ctx:
                 parts.append(f"""# Skills
@@ -182,7 +193,7 @@ Skills with available="false" need dependencies installed first - you can try in
 - Use file tools when they are simpler or more reliable than shell commands.
 """
 
-        return f"""# Raven 🦞
+        return f"""# Raven 🐦‍⬛
 
 You are Raven, a helpful AI assistant.
 
@@ -253,9 +264,13 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
             merged = [{"type": "text", "text": runtime_ctx}] + user_content
 
         return [
-            {"role": "system", "content": self.build_system_prompt(
-                selected_skills, current_message=current_message,
-            )},
+            {
+                "role": "system",
+                "content": self.build_system_prompt(
+                    selected_skills,
+                    current_message=current_message,
+                ),
+            },
             *history,
             {"role": "user", "content": merged},
         ]
@@ -283,8 +298,11 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         return images + [{"type": "text", "text": text}]
 
     def add_tool_result(
-        self, messages: list[dict[str, Any]],
-        tool_call_id: str, tool_name: str, result: str,
+        self,
+        messages: list[dict[str, Any]],
+        tool_call_id: str,
+        tool_name: str,
+        result: str,
     ) -> list[dict[str, Any]]:
         """Add a tool result to the message list.
 
@@ -293,21 +311,26 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         reaches the model — every tool result funnels through here.
         """
         content = wrap_untrusted(result, source=tool_name)
-        messages.append({"role": "tool", "tool_call_id": tool_call_id, "name": tool_name, "content": content})
+        messages.append(
+            {"role": "tool", "tool_call_id": tool_call_id, "name": tool_name, "content": content}
+        )
         return messages
 
     def add_assistant_message(
-        self, messages: list[dict[str, Any]],
+        self,
+        messages: list[dict[str, Any]],
         content: str | None,
         tool_calls: list[dict[str, Any]] | None = None,
         reasoning_content: str | None = None,
         thinking_blocks: list[dict] | None = None,
     ) -> list[dict[str, Any]]:
         """Add an assistant message to the message list."""
-        messages.append(build_assistant_message(
-            content,
-            tool_calls=tool_calls,
-            reasoning_content=reasoning_content,
-            thinking_blocks=thinking_blocks,
-        ))
+        messages.append(
+            build_assistant_message(
+                content,
+                tool_calls=tool_calls,
+                reasoning_content=reasoning_content,
+                thinking_blocks=thinking_blocks,
+            )
+        )
         return messages

--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -6,7 +6,6 @@ import asyncio
 import json
 import re
 import time
-import uuid
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -23,22 +22,22 @@ from raven.agent.loop.recovery import (
     classify_empty_response,
 )
 from raven.agent.subagent import SubagentManager
+from raven.agent.tools.ask_user import AskUserTool
+from raven.agent.tools.file_search import FindTool, GrepTool
 from raven.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from raven.agent.tools.media_gen import (
     ImageGenerateTool,
     SpeechGenerateTool,
     VideoGenerateTool,
 )
-from raven.agent.tools.ask_user import AskUserTool
 from raven.agent.tools.message import MessageTool
 from raven.agent.tools.registry import ToolRegistry
-from raven.agent.tools.file_search import FindTool, GrepTool
 from raven.agent.tools.shell import ExecTool
 from raven.agent.tools.spawn import SpawnTool
 from raven.agent.tools.web import WebFetchTool, WebSearchTool
 from raven.memory_engine.base import TokenBudget
 from raven.memory_engine.consolidate.consolidator import MemoryConsolidator, MemoryStore
-from raven.providers.base import LLMProvider, LLMResponse, StreamDelta, ToolCallRequest
+from raven.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 from raven.sandbox import SandboxConfig, SandboxExecutor, SandboxInitError, build_executor
 from raven.session.manager import Session, SessionManager
 from raven.spine.turn import Origin
@@ -63,15 +62,15 @@ if TYPE_CHECKING:
         SkillForgeRouterConfig,
     )
     from raven.config.schema import ChannelsConfig, ExecToolConfig
-    from raven.context_engine import ContextEngine, TurnContext
+    from raven.context_engine import ContextEngine
     from raven.memory_engine.backend import MemoryBackend
-    from raven.skill_hub import SkillHubClient
-    from raven.token_wise.base import UsageSnapshot
     from raven.proactive_engine.schedulers.cron.service import CronService
     from raven.routing.router import ModelRouter
     from raven.sandbox.debug_server import SandboxDebugServer
+    from raven.skill_hub import SkillHubClient
     from raven.spine.runner import Drain, Emit, TurnOutcome
     from raven.spine.turn import TurnRequest
+    from raven.token_wise.base import UsageSnapshot
     from raven.token_wise.registry import StrategyRegistry
 
 
@@ -111,7 +110,7 @@ def _filter_qualified_ids(
         if not isinstance(qid, str):
             continue
         if qid.startswith(needle):
-            native = qid[len(needle):]
+            native = qid[len(needle) :]
             if native:
                 out.append(native)
     return out
@@ -157,7 +156,13 @@ _SKIP_AFTER_SEND_ORIGINS = frozenset({Origin.SENTINEL, Origin.SUBAGENT})
 # Failure markers a plain retry would likely clear — these must NOT count toward
 # the tool-failure-loop streak (nudging on a 429 that self-heals is just noise).
 _TRANSIENT_FAILURE_MARKERS = (
-    "429", "rate limit", "timed out", "timeout", "no healthy upstream", "502", "503",
+    "429",
+    "rate limit",
+    "timed out",
+    "timeout",
+    "no healthy upstream",
+    "502",
+    "503",
 )
 # Successful-but-empty results: the tool ran fine and just found nothing. A
 # repeated empty search is legitimate exploration, not a stuck dead call, so it
@@ -282,6 +287,7 @@ class AgentLoop:
         )
         from raven.config.schema import ExecToolConfig
         from raven.token_wise.registry import StrategyRegistry
+
         # Optional transform applied to the final assistant content right
         # before outbound delivery. Signature: (session_key, content) -> content.
         # Used by Sentinel's NudgeInjector to piggyback on the agent's reply,
@@ -312,6 +318,7 @@ class AgentLoop:
         self.jina_api_key = jina_api_key
         self.web_proxy = web_proxy
         from raven.config.schema import MediaGenConfig
+
         self.media_config = media_config or MediaGenConfig()
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
@@ -367,8 +374,10 @@ class AgentLoop:
         # the import cycle with ``raven.agent.__init__``.
         if context_config is None:
             from raven.config.raven import ContextConfig
+
             context_config = ContextConfig()
         from raven.context_engine import build_context_engine
+
         self.context_config = context_config
 
         # Skill Hub client — built once and shared by the HubSkillSource
@@ -379,7 +388,8 @@ class AgentLoop:
         # Hub endpoint is configured — read_skill is then not registered and
         # use_skill serves local/everos only.
         self._skill_hub_client = self._build_skill_hub_client(
-            workspace, skill_forge_router_config,
+            workspace,
+            skill_forge_router_config,
         )
 
         self.context_engine: "ContextEngine" = build_context_engine(
@@ -405,15 +415,18 @@ class AgentLoop:
         # the gate is closed the loop is byte-identical to baseline.
         if runtime_config is None:
             from raven.config.raven import RuntimeConfig
+
             runtime_config = RuntimeConfig()
         self.runtime_config = runtime_config
         self.interactive = interactive
         self._checkpoint = None
         if self._checkpoint_active(runtime_config.checkpoint.policy, interactive):
             from raven.agent.loop.checkpoint import CheckpointService
+
             try:
                 self._checkpoint = CheckpointService(
-                    workspace, shadow_dir=runtime_config.checkpoint.shadow_dir,
+                    workspace,
+                    shadow_dir=runtime_config.checkpoint.shadow_dir,
                 )
             except ValueError as exc:
                 # Bad shadow_dir (e.g. ``../escape`` or absolute path) →
@@ -548,13 +561,15 @@ class AgentLoop:
         allowed_dir = self.workspace if self.restrict_to_workspace else None
         for cls in (ReadFileTool, WriteFileTool, EditFileTool, ListDirTool, GrepTool, FindTool):
             self.tools.register(cls(workspace=self.workspace, allowed_dir=allowed_dir))
-        self.tools.register(ExecTool(
-            working_dir=str(self.workspace),
-            timeout=self.exec_config.timeout,
-            restrict_to_workspace=self.restrict_to_workspace,
-            path_append=self.exec_config.path_append,
-            executor=self._executor,
-        ))
+        self.tools.register(
+            ExecTool(
+                working_dir=str(self.workspace),
+                timeout=self.exec_config.timeout,
+                restrict_to_workspace=self.restrict_to_workspace,
+                path_append=self.exec_config.path_append,
+                executor=self._executor,
+            )
+        )
         self.tools.register(WebSearchTool(api_key=self.brave_api_key, proxy=self.web_proxy))
         self.tools.register(WebFetchTool(api_key=self.jina_api_key, proxy=self.web_proxy))
         # Media tools (image/speech/video) are opt-in: a tool is registered only
@@ -569,10 +584,14 @@ class AgentLoop:
         )
         for cls, tool_cfg in media_tools:
             if tool_cfg.api_key or tool_cfg.model:
-                self.tools.register(cls(
-                    tool_cfg, workspace=self.workspace,
-                    proxy=media.proxy, output_subdir=media.output_subdir,
-                ))
+                self.tools.register(
+                    cls(
+                        tool_cfg,
+                        workspace=self.workspace,
+                        proxy=media.proxy,
+                        output_subdir=media.output_subdir,
+                    )
+                )
         self.tools.register(MessageTool())
         self.tools.register(SpawnTool(manager=self.subagents))
         # The QuestionBroker is a per-transport singleton, late-bound via
@@ -600,7 +619,9 @@ class AgentLoop:
         # bodies (local/everos bodies already ride in context), so it
         # registers only when a Hub endpoint is configured.
         skill_registry = getattr(
-            getattr(self.context, "skills", None), "registry", None,
+            getattr(self.context, "skills", None),
+            "registry",
+            None,
         )
         if skill_registry is not None or self._skill_hub_client is not None:
             from raven.agent.tools.skill_hub import ReadSkillTool, UseSkillTool
@@ -611,7 +632,8 @@ class AgentLoop:
             if self._skill_hub_client is not None:
                 self.tools.register(
                     ReadSkillTool(
-                        client=self._skill_hub_client, registry=skill_registry,
+                        client=self._skill_hub_client,
+                        registry=skill_registry,
                     ),
                 )
 
@@ -656,9 +678,7 @@ class AgentLoop:
         )
         tool_tokens = estimate_prompt_tokens([], self.tools.get_definitions())
         system_prompt = self.context.build_system_prompt(selected_skills)
-        system_tokens = estimate_prompt_tokens(
-            [{"role": "system", "content": system_prompt}]
-        )
+        system_tokens = estimate_prompt_tokens([{"role": "system", "content": system_prompt}])
         available_history = max(
             0,
             self.context_window_tokens - reserved_output - tool_tokens - system_tokens,
@@ -709,6 +729,7 @@ class AgentLoop:
     ) -> list[dict[str, Any]]:
         """Ask the active context engine for the main-agent message window."""
         from raven.context_engine import TurnContext  # deferred — see module note
+
         # Phase A / Phase C tidy: reset the metadata stash BEFORE calling
         # the engine. If ``engine.assemble`` raises partway, the next
         # caller falls back to the legacy ``_collect_injected_skill_ids``
@@ -888,7 +909,8 @@ class AgentLoop:
             )
 
     def _collect_injected_skill_ids(
-        self, selected: list[Any] | None,
+        self,
+        selected: list[Any] | None,
     ) -> list[str]:
         """Combine selector top-K + always-skills into a deduplicated id list.
 
@@ -940,7 +962,7 @@ class AgentLoop:
             for qid in self._last_injected_skill_ids:
                 _add_raw_id(qid)
         else:
-            for meta in (selected or []):
+            for meta in selected or []:
                 _add(meta)
         try:
             always = skills_svc.get_always_skills()
@@ -979,9 +1001,8 @@ class AgentLoop:
         try:
             from raven.config.paths import get_data_dir
             from raven.sandbox.debug_server import SandboxDebugServer
-            socket_path = SandboxDebugServer.resolve_socket_path(
-                cfg.debug.socket, get_data_dir()
-            )
+
+            socket_path = SandboxDebugServer.resolve_socket_path(cfg.debug.socket, get_data_dir())
             server = SandboxDebugServer(
                 socket_path=socket_path,
                 owned_ids=self._owned_ids,
@@ -1027,10 +1048,13 @@ class AgentLoop:
         try:
             await self._start_executor()  # ensure executor is live before MCP servers connect
             from raven.agent.tools.mcp import connect_mcp_servers
+
             self._mcp_stack = AsyncExitStack()
             await self._mcp_stack.__aenter__()
             await connect_mcp_servers(
-                self._mcp_servers, self.tools, self._mcp_stack,
+                self._mcp_servers,
+                self.tools,
+                self._mcp_stack,
                 executor=self._executor,
             )
             # Re-apply blacklist: MCP servers may register tool names that
@@ -1066,12 +1090,14 @@ class AgentLoop:
     @staticmethod
     def _tool_hint(tool_calls: list) -> str:
         """Format tool calls as concise hint, e.g. 'web_search("query")'."""
+
         def _fmt(tc):
             args = (tc.arguments[0] if isinstance(tc.arguments, list) else tc.arguments) or {}
             val = next(iter(args.values()), None) if isinstance(args, dict) else None
             if not isinstance(val, str):
                 return tc.name
             return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'
+
         return ", ".join(_fmt(tc) for tc in tool_calls)
 
     @staticmethod
@@ -1143,7 +1169,9 @@ class AgentLoop:
         final_usage: dict[str, Any] | None = None
 
         async for delta in self.provider.chat_stream(
-            messages=messages, tools=tools, model=model,
+            messages=messages,
+            tools=tools,
+            model=model,
         ):
             reasoning_delta = getattr(delta, "reasoning_content", None)
             if reasoning_delta:
@@ -1156,7 +1184,8 @@ class AgentLoop:
                     await on_token_delta(delta.content)
             if delta.tool_call_delta:
                 _merge_tool_call_fragments(
-                    tool_call_slots, delta.tool_call_delta,
+                    tool_call_slots,
+                    delta.tool_call_delta,
                 )
             if delta.usage is not None:
                 final_usage = delta.usage
@@ -1221,9 +1250,7 @@ class AgentLoop:
         run_turn boundary only emits a closing ``Text`` when nothing streamed,
         so a non-streamed wrap-up after an already-streamed turn gets dropped.
         """
-        synth_messages = messages + [
-            {"role": "user", "content": _MAX_ITER_SYNTHESIS_PROMPT}
-        ]
+        synth_messages = messages + [{"role": "user", "content": _MAX_ITER_SYNTHESIS_PROMPT}]
         try:
             if on_token_delta is not None or on_reasoning_delta is not None:
                 response = await self._llm_call_stream(
@@ -1313,7 +1340,10 @@ class AgentLoop:
         while iteration < self.max_iterations:
             iteration += 1
             logger.info(
-                "Iteration {}/{} model={}", iteration, self.max_iterations, effective_model,
+                "Iteration {}/{} model={}",
+                iteration,
+                self.max_iterations,
+                effective_model,
             )
 
             # Merge any INJECT-ed user messages (BusyPolicy.INJECT) before this
@@ -1325,7 +1355,9 @@ class AgentLoop:
                     inj_paths = [m.path for m in inj.media]
                     if inj_paths:
                         prefix = inj_text + "\n" if inj_text else ""
-                        inj_text = f"{prefix}[injected message; attached files: {', '.join(inj_paths)}]"
+                        inj_text = (
+                            f"{prefix}[injected message; attached files: {', '.join(inj_paths)}]"
+                        )
                     if inj_text:
                         messages.append({"role": "user", "content": inj_text})
                         logger.info("inject: merged a mid-turn user message")
@@ -1335,7 +1367,9 @@ class AgentLoop:
             # TokenWise before-hook: strategies may rewrite messages, tools,
             # or model (e.g. CacheOptimizer marks cache_control blocks).
             call_messages, call_tools, call_model = await self.strategies.before_llm_call(
-                messages, tool_defs, effective_model,
+                messages,
+                tool_defs,
+                effective_model,
             )
             if on_token_delta is not None or on_reasoning_delta is not None:
                 response = await self._llm_call_stream(
@@ -1356,7 +1390,11 @@ class AgentLoop:
             # usage tracking, budget enforcement, etc. Errors are swallowed.
             usage_snapshot = self._build_usage_snapshot(response, call_model, session_key)
             await self.strategies.after_llm_call(
-                {"content": response.content, "finish_reason": response.finish_reason, "usage": response.usage},
+                {
+                    "content": response.content,
+                    "finish_reason": response.finish_reason,
+                    "usage": response.usage,
+                },
                 usage_snapshot,
             )
             # tui-chat L2-A wire: stream caller (turn.* handler) may want the
@@ -1400,7 +1438,9 @@ class AgentLoop:
                     iteration -= 1  # the overflowed call did no work; don't bill it
                     logger.warning(
                         "Context overflow; elided {} old tool result(s), retrying ({}/{})",
-                        elided, compress_retries, self._MAX_COMPRESS_RETRIES,
+                        elided,
+                        compress_retries,
+                        self._MAX_COMPRESS_RETRIES,
                     )
                     continue
 
@@ -1411,12 +1451,11 @@ class AgentLoop:
                         await on_progress(thought)
                     await on_progress(self._tool_hint(response.tool_calls), tool_hint=True)
 
-                tool_call_dicts = [
-                    tc.to_openai_tool_call()
-                    for tc in response.tool_calls
-                ]
+                tool_call_dicts = [tc.to_openai_tool_call() for tc in response.tool_calls]
                 messages = self.context.add_assistant_message(
-                    messages, response.content, tool_call_dicts,
+                    messages,
+                    response.content,
+                    tool_call_dicts,
                     reasoning_content=response.reasoning_content,
                     thinking_blocks=response.thinking_blocks,
                 )
@@ -1429,11 +1468,14 @@ class AgentLoop:
                     # second emit here would double it.
                     emit_tool_event = on_tool_event is not None and tool_call.name != "message"
                     if emit_tool_event:
-                        await on_tool_event("start", {
-                            "tool_call_id": tool_call.id,
-                            "name": tool_call.name,
-                            "arguments": tool_call.arguments,
-                        })
+                        await on_tool_event(
+                            "start",
+                            {
+                                "tool_call_id": tool_call.id,
+                                "name": tool_call.name,
+                                "arguments": tool_call.arguments,
+                            },
+                        )
                     tool_t0 = time.monotonic()
                     result = await self.tools.execute(tool_call.name, tool_call.arguments)
                     duration_ms = int((time.monotonic() - tool_t0) * 1000)
@@ -1441,14 +1483,19 @@ class AgentLoop:
                     preview = result_str.replace("\n", " ")[:200]
                     logger.info(
                         "Tool result: {} duration={}ms result={}",
-                        tool_call.name, duration_ms, preview,
+                        tool_call.name,
+                        duration_ms,
+                        preview,
                     )
                     if emit_tool_event:
-                        await on_tool_event("complete", {
-                            "tool_call_id": tool_call.id,
-                            "result_preview": preview,
-                            "truncated": len(result_str) > 200,
-                        })
+                        await on_tool_event(
+                            "complete",
+                            {
+                                "tool_call_id": tool_call.id,
+                                "result_preview": preview,
+                                "truncated": len(result_str) > 200,
+                            },
+                        )
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
                     )
@@ -1468,12 +1515,14 @@ class AgentLoop:
                 if (
                     loop_fail_streak >= self._LOOP_BREAK_THRESHOLD
                     and loop_nudges < self._LOOP_BREAK_MAX
-                    and messages and messages[-1].get("role") == "tool"
+                    and messages
+                    and messages[-1].get("role") == "tool"
                 ):
                     loop_nudges += 1
                     messages[-1]["content"] = (
                         str(messages[-1].get("content", ""))
-                        + "\n\n" + _loop_break_nudge(loop_fail_tool, loop_fail_streak)
+                        + "\n\n"
+                        + _loop_break_nudge(loop_fail_tool, loop_fail_streak)
                     )
                     loop_fail_streak = 0  # fire once per fresh streak
                 prev_had_tool_calls = True
@@ -1493,7 +1542,8 @@ class AgentLoop:
                 # marked ``_recovery_synthetic`` and stripped before persistence
                 # / extraction so it can't poison future context.
                 action = classify_empty_response(
-                    response, clean,
+                    response,
+                    clean,
                     prev_had_tool_calls=prev_had_tool_calls,
                     nudges_done=post_tool_nudges,
                     prefill_retries=prefill_retries,
@@ -1504,14 +1554,16 @@ class AgentLoop:
                     prefill_retries += 1
                     logger.warning(
                         "empty-recovery: thinking-only prefill {}/{}",
-                        prefill_retries, self._recovery_limits.thinking_prefill_max_retries,
+                        prefill_retries,
+                        self._recovery_limits.thinking_prefill_max_retries,
                     )
                     # Re-feed the model its own reasoning (not stripped) so it
                     # continues into the body. Marked synthetic → dropped before
                     # persistence/extraction; the reasoning fields are stripped
                     # from the wire request by the provider's key allowlist.
                     messages = self.context.add_assistant_message(
-                        messages, response.content,
+                        messages,
+                        response.content,
                         reasoning_content=response.reasoning_content,
                         thinking_blocks=response.thinking_blocks,
                     )
@@ -1534,20 +1586,25 @@ class AgentLoop:
                     empty_retries += 1
                     logger.warning(
                         "empty-recovery: plain empty retry {}/{}",
-                        empty_retries, self._recovery_limits.empty_content_max_retries,
+                        empty_retries,
+                        self._recovery_limits.empty_content_max_retries,
                     )
                     prev_had_tool_calls = False
                     continue
 
                 messages = self.context.add_assistant_message(
-                    messages, clean, reasoning_content=response.reasoning_content,
+                    messages,
+                    clean,
+                    reasoning_content=response.reasoning_content,
                     thinking_blocks=response.thinking_blocks,
                 )
                 final_content = clean
                 break
 
         if final_content is None and iteration >= self.max_iterations:
-            logger.warning("Max iterations ({}) reached; synthesizing final answer", self.max_iterations)
+            logger.warning(
+                "Max iterations ({}) reached; synthesizing final answer", self.max_iterations
+            )
             # Exhaustion is two orthogonal facts, not an either/or:
             #   1. The turn did NOT complete — tag it ``interrupted`` so the
             #      shadow-git checkpoint commit is labelled and the next turn's
@@ -1559,7 +1616,9 @@ class AgentLoop:
             #      internally if the call fails, so the turn is never silent.
             status = "interrupted"
             final_content = await self._synthesize_final_on_exhaustion(
-                messages, effective_model, fallback_models,
+                messages,
+                effective_model,
+                fallback_models,
                 on_token_delta=on_token_delta,
                 on_reasoning_delta=on_reasoning_delta,
             )
@@ -1668,9 +1727,9 @@ class AgentLoop:
             except (RuntimeError, BaseExceptionGroup):
                 pass  # MCP SDK cancel scope cleanup is noisy but harmless
             self._mcp_stack = None
-        self._mcp_connected = False   # reset so _connect_mcp() can reconnect after close
+        self._mcp_connected = False  # reset so _connect_mcp() can reconnect after close
         self._mcp_connecting = False  # reset so a concurrent caller isn't permanently blocked
-        await self.close_executor()   # always runs, even when no MCP servers are configured
+        await self.close_executor()  # always runs, even when no MCP servers are configured
 
     def stop(self) -> None:
         """Stop the agent loop."""
@@ -1761,7 +1820,7 @@ class AgentLoop:
             return ("New session started.", [])
         if cmd == "/help":
             lines = [
-                "🦞 Raven commands:",
+                "🐦‍⬛ Raven commands:",
                 "/new — Start a new conversation",
                 "/stop — Stop the current task",
                 "/restart — Restart the bot",
@@ -1781,6 +1840,7 @@ class AgentLoop:
             from datetime import datetime as _dt
 
             from raven.agent.personalizer import Personalizer
+
             _personalizer = Personalizer(MemoryStore(self.workspace), self.provider, self.model)
 
             # ── Step 2 completion: user is answering a pending clarification ──
@@ -1799,7 +1859,9 @@ class AgentLoop:
                     # User started a new request; discard the old pending state and re-classify.
                     session.pending_clarification = None
                     self.sessions.save(session)
-                    logger.info("Personalization: new request detected, discarding old pending_clarification")
+                    logger.info(
+                        "Personalization: new request detected, discarding old pending_clarification"
+                    )
 
                     _question = await _personalizer.generate_question(
                         content,
@@ -1807,15 +1869,20 @@ class AgentLoop:
                     )
                     if _question:
                         _ts = _dt.now().isoformat()
-                        session.record({"role": "user",      "content": content, "timestamp": _ts})
-                        session.record({"role": "assistant", "content": _question,   "timestamp": _ts})
+                        session.record({"role": "user", "content": content, "timestamp": _ts})
+                        session.record(
+                            {"role": "assistant", "content": _question, "timestamp": _ts}
+                        )
                         session.pending_clarification = {
                             "original_message": content,
-                            "question":         _question,
-                            "domain":           _recheck.get("domain", ""),
+                            "question": _question,
+                            "domain": _recheck.get("domain", ""),
                         }
                         self.sessions.save(session)
-                        logger.info("Personalization: asked clarification for new request, session {}", session.key)
+                        logger.info(
+                            "Personalization: asked clarification for new request, session {}",
+                            session.key,
+                        )
                         return (_question, [])
                     # Clear pending state and proceed normally when question generation fails.
                     session.pending_clarification = None
@@ -1831,6 +1898,7 @@ class AgentLoop:
                             question=_pending["question"],
                             answer=content,
                         )
+
                     _t = asyncio.create_task(_extract())
                     self._consolidation_tasks.add(_t)
                     _t.add_done_callback(self._consolidation_tasks.discard)
@@ -1851,18 +1919,22 @@ class AgentLoop:
                     if _question:
                         # Write the original request and the clarifying question into history to keep the conversation coherent.
                         _ts = _dt.now().isoformat()
-                        session.record({"role": "user",      "content": content, "timestamp": _ts})
-                        session.record({"role": "assistant", "content": _question,   "timestamp": _ts})
+                        session.record({"role": "user", "content": content, "timestamp": _ts})
+                        session.record(
+                            {"role": "assistant", "content": _question, "timestamp": _ts}
+                        )
 
                         # Save the pending state so the next message can resume it.
                         session.pending_clarification = {
                             "original_message": content,
-                            "question":         _question,
-                            "domain":           _classification.get("domain", ""),
+                            "question": _question,
+                            "domain": _classification.get("domain", ""),
                         }
                         self.sessions.save(session)
 
-                        logger.info("Personalization: asked clarification for session {}", session.key)
+                        logger.info(
+                            "Personalization: asked clarification for session {}", session.key
+                        )
                         return (_question, [])
                     # generate_question failed: skip silently and proceed
         # ── End personalization flow ─────────────────────────────────────────
@@ -1882,7 +1954,8 @@ class AgentLoop:
         # Phase B-3: routed via ``_select_skills_for_turn`` so the new
         # ``default`` engine short-circuits selection here.
         selected_skills = await self._select_skills_for_turn(
-            content, context_messages,
+            content,
+            context_messages,
         )
         initial_messages = await self._assemble_context_messages(
             session=session,
@@ -1953,13 +2026,15 @@ class AgentLoop:
         )
         # AG-1: plugin-side indexing (third peer step in after-turn pipeline).
         await self._dispatch_backend_store(
-            key, all_msgs[turn_start_idx:],
+            key,
+            all_msgs[turn_start_idx:],
         )
         # FB-1: forward source-qualified skill-usage feedback. Only
         # ``everos/`` prefix is forwarded to the plugin; static-library
         # sources (``local`` / ``mass``) have no feedback channel.
         await self._dispatch_backend_feedback(
-            key, self._collect_injected_skill_ids(selected_skills),
+            key,
+            self._collect_injected_skill_ids(selected_skills),
         )
         if not self.context_engine.owns_compaction:
             await self.memory_consolidator.maybe_consolidate_by_tokens(session)
@@ -1969,6 +2044,7 @@ class AgentLoop:
         # its content is a system-generated announce, not user input to learn from.
         if self.enable_personalization and origin is not Origin.SUBAGENT:
             from raven.agent.personalizer import Personalizer
+
             _p4 = Personalizer(MemoryStore(self.workspace), self.provider, self.model)
 
             async def _post_learn():
@@ -1986,12 +2062,12 @@ class AgentLoop:
             # the would-be response so future investigations have a trail
             # parallel to "Response to ..." below.
             if final_content:
-                preview = (
-                    final_content[:120] + "..." if len(final_content) > 120 else final_content
-                )
+                preview = final_content[:120] + "..." if len(final_content) > 120 else final_content
                 logger.info(
                     "MessageTool sent in turn for {}:{}: {}",
-                    channel, sender_id, preview,
+                    channel,
+                    sender_id,
+                    preview,
                 )
             return None
 
@@ -2008,10 +2084,16 @@ class AgentLoop:
                 continue  # #1a synthetic recovery nudge — never persist scaffolding
             if role == "assistant" and not content and not entry.get("tool_calls"):
                 continue  # skip empty assistant messages — they poison session context
-            if role == "tool" and isinstance(content, str) and len(content) > self._TOOL_RESULT_MAX_CHARS:
-                entry["content"] = content[:self._TOOL_RESULT_MAX_CHARS] + "\n... (truncated)"
+            if (
+                role == "tool"
+                and isinstance(content, str)
+                and len(content) > self._TOOL_RESULT_MAX_CHARS
+            ):
+                entry["content"] = content[: self._TOOL_RESULT_MAX_CHARS] + "\n... (truncated)"
             elif role == "user":
-                if isinstance(content, str) and content.startswith(ContextBuilder._RUNTIME_CONTEXT_TAG):
+                if isinstance(content, str) and content.startswith(
+                    ContextBuilder._RUNTIME_CONTEXT_TAG
+                ):
                     # Strip the runtime-context prefix, keep only the user text.
                     parts = content.split("\n\n", 1)
                     if len(parts) > 1 and parts[1].strip():
@@ -2021,10 +2103,15 @@ class AgentLoop:
                 if isinstance(content, list):
                     filtered = []
                     for c in content:
-                        if c.get("type") == "text" and isinstance(c.get("text"), str) and c["text"].startswith(ContextBuilder._RUNTIME_CONTEXT_TAG):
+                        if (
+                            c.get("type") == "text"
+                            and isinstance(c.get("text"), str)
+                            and c["text"].startswith(ContextBuilder._RUNTIME_CONTEXT_TAG)
+                        ):
                             continue  # Strip runtime context from multimodal messages
-                        if (c.get("type") == "image_url"
-                                and c.get("image_url", {}).get("url", "").startswith("data:image/")):
+                        if c.get("type") == "image_url" and c.get("image_url", {}).get(
+                            "url", ""
+                        ).startswith("data:image/"):
                             filtered.append({"type": "text", "text": "[image]"})
                         else:
                             filtered.append(c)
@@ -2078,6 +2165,7 @@ class AgentLoop:
         ``drain`` pulls user messages injected mid-turn (BusyPolicy.INJECT); it
         is threaded into the agent loop and consumed at the top of each iteration.
         """
+        from raven.proactive_engine.schedulers.cron.tool import CronTool
         from raven.spine.events import (
             MediaOut,
             Notice,
@@ -2089,7 +2177,6 @@ class AgentLoop:
             ToolPhase,
             Usage,
         )
-        from raven.proactive_engine.schedulers.cron.tool import CronTool
         from raven.spine.message import Media
         from raven.spine.runner import TurnOutcome
 
@@ -2145,8 +2232,7 @@ class AgentLoop:
             await emit(
                 MediaOut(
                     media=tuple(
-                        Media(path=p, mime="application/octet-stream", kind="file")
-                        for p in paths
+                        Media(path=p, mime="application/octet-stream", kind="file") for p in paths
                     )
                 )
             )
@@ -2275,9 +2361,11 @@ def _finalize_tool_calls(slots: list[dict[str, Any]]) -> list[ToolCallRequest]:
             args = json.loads(args_text) if args_text else {}
         except json.JSONDecodeError:
             args = {"_raw_arguments": args_text}
-        result.append(ToolCallRequest(
-            id=slot["id"] or "",
-            name=name,
-            arguments=args,
-        ))
+        result.append(
+            ToolCallRequest(
+                id=slot["id"] or "",
+                name=name,
+                arguments=args,
+            )
+        )
     return result

--- a/raven/channels/adapters/telegram/channel.py
+++ b/raven/channels/adapters/telegram/channel.py
@@ -31,14 +31,25 @@ _ALBUM_WINDOW_S = 0.6
 
 # Telegram media APIs keyed by the kind we resolve from a file extension.
 _EXT_KIND = {
-    "jpg": "photo", "jpeg": "photo", "png": "photo", "gif": "photo", "webp": "photo",
+    "jpg": "photo",
+    "jpeg": "photo",
+    "png": "photo",
+    "gif": "photo",
+    "webp": "photo",
     "ogg": "voice",
-    "mp3": "audio", "m4a": "audio", "wav": "audio", "aac": "audio",
+    "mp3": "audio",
+    "m4a": "audio",
+    "wav": "audio",
+    "aac": "audio",
 }
 # Inbound: map a Telegram media object kind to the saved-file extension.
 _INBOUND_MIME_EXT = {
-    "image/jpeg": ".jpg", "image/png": ".png", "image/gif": ".gif",
-    "audio/ogg": ".ogg", "audio/mpeg": ".mp3", "audio/mp4": ".m4a",
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "audio/ogg": ".ogg",
+    "audio/mpeg": ".mp3",
+    "audio/mp4": ".m4a",
 }
 _INBOUND_KIND_EXT = {"image": ".jpg", "voice": ".ogg", "audio": ".mp3"}
 
@@ -208,7 +219,7 @@ class TelegramChannel(ChannelBase):
             logger.error("Telegram bot token not configured")
             return
         self._running = True
-        self._stop_event = asyncio.Event()   # fresh per start (restart-safe)
+        self._stop_event = asyncio.Event()  # fresh per start (restart-safe)
 
         request = HTTPXRequest(
             connection_pool_size=16,
@@ -231,7 +242,13 @@ class TelegramChannel(ChannelBase):
             self._app.add_handler(CommandHandler(cmd, self._on_command))
         self._app.add_handler(
             MessageHandler(
-                (filters.TEXT | filters.PHOTO | filters.VOICE | filters.AUDIO | filters.Document.ALL)
+                (
+                    filters.TEXT
+                    | filters.PHOTO
+                    | filters.VOICE
+                    | filters.AUDIO
+                    | filters.Document.ALL
+                )
                 & ~filters.COMMAND,
                 self._on_message,
             )
@@ -332,7 +349,9 @@ class TelegramChannel(ChannelBase):
         try:
             step = max(len(text) // 8, 40)
             for cut in range(step, len(text), step):
-                await self._app.bot.send_message_draft(chat_id=chat_id, draft_id=draft_id, text=text[:cut])
+                await self._app.bot.send_message_draft(
+                    chat_id=chat_id, draft_id=draft_id, text=text[:cut]
+                )
                 await asyncio.sleep(0.04)
             await self._app.bot.send_message_draft(chat_id=chat_id, draft_id=draft_id, text=text)
             await asyncio.sleep(0.15)
@@ -353,7 +372,7 @@ class TelegramChannel(ChannelBase):
     async def _on_help(self, update: Update, _ctx: ContextTypes.DEFAULT_TYPE) -> None:
         if update.message:
             await update.message.reply_text(
-                "🦞 Raven commands:\n"
+                "🐦‍⬛ Raven commands:\n"
                 "/new — Start a new conversation\n"
                 "/stop — Stop the current task\n"
                 "/help — Show available commands"
@@ -381,7 +400,7 @@ class TelegramChannel(ChannelBase):
         self._remember_thread(message)
         if not await self._addressed_to_bot(message):
             return
-        if not self.is_allowed(self._sender_id(user)):   # reject before media download / typing
+        if not self.is_allowed(self._sender_id(user)):  # reject before media download / typing
             return
 
         parts: list[str] = []
@@ -399,7 +418,9 @@ class TelegramChannel(ChannelBase):
             else:
                 media_paths.append(saved)
                 if kind in ("voice", "audio"):
-                    text = await transcribe_audio(saved, self.transcription_api_key, channel=self.name)
+                    text = await transcribe_audio(
+                        saved, self.transcription_api_key, channel=self.name
+                    )
                     parts.append(f"[transcription: {text}]" if text else f"[{kind}: {saved}]")
                 else:
                     parts.append(f"[{kind}: {saved}]")
@@ -503,7 +524,9 @@ class TelegramChannel(ChannelBase):
         if self._bot_username:
             if self._mentions_bot(message.text or "", getattr(message, "entities", None)):
                 return True
-            if self._mentions_bot(message.caption or "", getattr(message, "caption_entities", None)):
+            if self._mentions_bot(
+                message.caption or "", getattr(message, "caption_entities", None)
+            ):
                 return True
         replied = getattr(getattr(message, "reply_to_message", None), "from_user", None)
         return bool(self._bot_id and replied and replied.id == self._bot_id)
@@ -518,7 +541,11 @@ class TelegramChannel(ChannelBase):
                     return True
             elif etype == "mention":
                 off, length = getattr(entity, "offset", None), getattr(entity, "length", None)
-                if off is not None and length is not None and text[off : off + length].lower() == handle:
+                if (
+                    off is not None
+                    and length is not None
+                    and text[off : off + length].lower() == handle
+                ):
                     return True
         return handle in text.lower()
 

--- a/raven/channels/adapters/whatsapp/bridge.py
+++ b/raven/channels/adapters/whatsapp/bridge.py
@@ -57,7 +57,14 @@ def ensure_bridge_dir() -> Path:
         raise RuntimeError("npm not found. Please install Node.js >= 18.")
 
     here = Path(__file__).resolve()
-    candidates = [here.parent.parent.parent / "bridge", here.parent.parent.parent.parent / "bridge"]
+    # here = raven/channels/adapters/whatsapp/bridge.py. The bridge source lives
+    # at <package>/bridge in a built wheel (parents[3]) but at the repo root's
+    # ./bridge when running from an editable / source checkout (parents[4]).
+    candidates = [
+        here.parents[2] / "bridge",  # raven/channels/bridge (legacy)
+        here.parents[3] / "bridge",  # raven/bridge (packaged wheel)
+        here.parents[4] / "bridge",  # <repo-root>/bridge (editable / source)
+    ]
     source = next((c for c in candidates if (c / "package.json").exists()), None)
     if not source:
         raise RuntimeError(

--- a/raven/cli/_repl_spine.py
+++ b/raven/cli/_repl_spine.py
@@ -38,7 +38,7 @@ class CliOutlet:
 
     ``render_marker`` is opt-in: a Text whose ``source.extras._sentinel_origin``
     is set renders this proactive marker before its content (the interactive
-    REPL passes the 🦞 marker the old bus consumer printed). Left None elsewhere,
+    REPL passes the 🐦‍⬛ marker the old bus consumer printed). Left None elsewhere,
     so a normal turn reply renders unchanged."""
 
     def __init__(
@@ -153,7 +153,9 @@ async def run_repl_loop(
             handle = submit(
                 TurnRequest(
                     origin=Origin.USER,
-                    source=Source(channel=channel, chat_id=chat_id, sender_id="user", chat_type=ChatType.DM),
+                    source=Source(
+                        channel=channel, chat_id=chat_id, sender_id="user", chat_type=ChatType.DM
+                    ),
                     text=user_input,
                     conversation=f"{channel}:{chat_id}",
                 )

--- a/raven/cli/_styles.py
+++ b/raven/cli/_styles.py
@@ -13,16 +13,31 @@ from questionary import Style
 
 RAVEN_STYLE = Style(
     [
-        ("qmark", "fg:cyan bold"),
+        # Leading "?" glyph + the question text.
+        ("qmark", "fg:#fbe23f bold"),
         ("question", "bold"),
-        ("answer", "fg:cyan"),
-        ("pointer", "fg:cyan bold"),
-        ("highlighted", "fg:cyan bold"),
-        ("selected", "fg:#5fafff"),
-        ("separator", "fg:#3a3a3a"),
-        ("instruction", "fg:#808080"),
-        ("disabled", "fg:#5f5f5f italic"),
-        ("validation-toolbar", "fg:#d75f5f bold"),
+        # The committed answer echoed after a prompt resolves.
+        ("answer", "fg:#fbe23f bold"),
+        # The "❯" pointer and the row it sits on (hover state).
+        ("pointer", "fg:#fbe23f bold"),
+        # Active row: same text color as the other rows, only bold — the yellow
+        # "❯" pointer is the sole selection cue, so every option reads in one
+        # consistent color. noreverse: prompt_toolkit's base style reverse-
+        # highlights the active row, which would otherwise paint a solid block.
+        ("highlighted", "fg:#FFF5EA bold noreverse"),
+        # A previously selected value (e.g. checkbox); noreverse for the same
+        # reason — show selection via the gold color, not a background block.
+        ("selected", "fg:#c8a900 noreverse"),
+        # Faint rule between option groups.
+        ("separator", "fg:#444444"),
+        # The "(Use arrow keys)" style hint after the question.
+        ("instruction", "fg:#6c6c6c italic"),
+        # Non-selectable rows.
+        ("disabled", "fg:#585858 italic"),
+        # Inline validation error toolbar.
+        ("validation-toolbar", "fg:#ff5f5f bold"),
+        # Free-text input the user is typing.
+        ("text", "fg:#FFF5EA"),
     ]
 )
 

--- a/raven/cli/agent_commands.py
+++ b/raven/cli/agent_commands.py
@@ -63,6 +63,7 @@ _SAVED_TERM_ATTRS = None  # original termios settings, restored on exit
 # Helpers (private to this module)
 # ---------------------------------------------------------------------------
 
+
 def _stdout_isatty() -> bool:
     """Whether stdout is an interactive TTY (seam for the onboarding gate test;
     CliRunner swaps ``sys.stdout`` for a non-TTY buffer)."""
@@ -120,10 +121,6 @@ def _is_exit_command(command: str) -> bool:
     return command.lower() in EXIT_COMMANDS
 
 
-
-
-
-
 async def _read_interactive_input_async() -> str:
     """Read user input using prompt_toolkit (handles paste, history, display).
 
@@ -154,6 +151,7 @@ async def _read_interactive_input_async() -> str:
 
 def register(app: typer.Typer) -> None:
     """Attach the ``agent`` command to ``app``."""
+
     @app.command()
     def agent(
         message: str = typer.Option(None, "--message", "-m", help="Message to send to the agent"),
@@ -167,8 +165,12 @@ def register(app: typer.Typer) -> None:
                 "'direct' session remains reachable via --resume direct."
             ),
         ),
-        continue_: bool = typer.Option(False, "--continue", "-c", help="Continue the most recent cli session"),
-        resume: str | None = typer.Option(None, "--resume", "-r", help="Resume session by bare id or unique prefix"),
+        continue_: bool = typer.Option(
+            False, "--continue", "-c", help="Continue the most recent cli session"
+        ),
+        resume: str | None = typer.Option(
+            None, "--resume", "-r", help="Resume session by bare id or unique prefix"
+        ),
         workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
         config: str | None = typer.Option(None, "--config", help="Config file path"),
         markdown: bool = typer.Option(
@@ -219,9 +221,7 @@ def register(app: typer.Typer) -> None:
     ):
         """Interact with the agent directly."""
         if sum((session_id is not None, continue_, resume is not None)) > 1:
-            raise typer.BadParameter(
-                "--session, --continue and --resume are mutually exclusive"
-            )
+            raise typer.BadParameter("--session, --continue and --resume are mutually exclusive")
 
         # Startup gate: when the required config (a provider key + default
         # model) is missing, run the onboarding wizard first. Only on an
@@ -244,8 +244,8 @@ def register(app: typer.Typer) -> None:
             attach_sentinel_spawn,
             build_sentinel_stack,
         )
-        from raven.config.raven import load_raven_config
         from raven.config.paths import get_cron_dir
+        from raven.config.raven import load_raven_config
         from raven.proactive_engine.schedulers.cron.service import CronService
         from raven.session.manager import SessionManager, new_chat_id
 
@@ -266,6 +266,7 @@ def register(app: typer.Typer) -> None:
         # New-session-by-default: independent one-shots don't bleed into each other.
         if resume is not None:
             from raven.cli.session_commands import resolve_session
+
             session_id = resolve_session(session_manager, resume)
         elif continue_:
             recent = session_manager.find_most_recent_chat_id("cli")
@@ -277,6 +278,7 @@ def register(app: typer.Typer) -> None:
             session_id = f"cli:{new_chat_id()}"
         else:
             from raven.cli.session_commands import resolve_session_cross_channel
+
             session_id = resolve_session_cross_channel(session_manager, session_id)
 
         # Create cron service (callback set below once the agent exists).
@@ -285,7 +287,8 @@ def register(app: typer.Typer) -> None:
         # gateway which has the real channel adapters wired up.
         cron_store_path = get_cron_dir() / "jobs.json"
         cron = CronService(
-            cron_store_path, allowed_channels={"cli"},
+            cron_store_path,
+            allowed_channels={"cli"},
             now_fn=parse_fake_now(fake_now),
         )
 
@@ -294,10 +297,15 @@ def register(app: typer.Typer) -> None:
         # triggers are dispatcher-side: only the gateway has real channel
         # adapters, so REPL must NOT drain them or feishu/slack triggers get
         # consumed without delivery.
-        sentinel_runner, sentinel_response_modifier, sentinel_on_user_inbound = build_sentinel_stack(
-            config, sentinel_cfg, session_manager, provider,
-            now_fn=parse_fake_now(fake_now),
-            include_discover_triggers=False,
+        sentinel_runner, sentinel_response_modifier, sentinel_on_user_inbound = (
+            build_sentinel_stack(
+                config,
+                sentinel_cfg,
+                session_manager,
+                provider,
+                now_fn=parse_fake_now(fake_now),
+                include_discover_triggers=False,
+            )
         )
 
         if logs:
@@ -316,10 +324,14 @@ def register(app: typer.Typer) -> None:
         # runs a single time.
         plugin_registry = build_plugin_registry(ec_config)
         backend = maybe_build_memory_backend(
-            config.workspace_path, ec_config, registry=plugin_registry,
+            config.workspace_path,
+            ec_config,
+            registry=plugin_registry,
         )
         plugin_tools = build_plugin_tools(
-            config.workspace_path, ec_config, registry=plugin_registry,
+            config.workspace_path,
+            ec_config,
+            registry=plugin_registry,
         )
 
         agent_loop = AgentLoop(
@@ -367,6 +379,7 @@ def register(app: typer.Typer) -> None:
         # shim goes to the sentinel runner so anticipatory (sentinel:direct)
         # nudges resolve to the terminal instead of being dropped.
         from types import SimpleNamespace
+
         cli_shim = SimpleNamespace(enabled_channels=["cli"])
         if sentinel_runner is not None:
             sentinel_runner.set_channel_manager(cli_shim)
@@ -399,8 +412,7 @@ def register(app: typer.Typer) -> None:
                         await backend.start()
                     except Exception:
                         logger.exception(
-                            "memory backend start failed; continuing with "
-                            "legacy memory path",
+                            "memory backend start failed; continuing with legacy memory path",
                         )
                 try:
                     # Build inside the running loop: Scheduler pins its home loop in
@@ -509,13 +521,13 @@ def register(app: typer.Typer) -> None:
                         await backend.start()
                     except Exception:
                         logger.exception(
-                            "memory backend start failed; continuing with "
-                            "legacy memory path",
+                            "memory backend start failed; continuing with legacy memory path",
                         )
                 # agent_loop.run() is now a lifecycle keep-alive (executor /
                 # debug server / MCP up, then idle); all turns go through the
                 # spine. Gathered on teardown.
                 runtime_task = asyncio.create_task(agent_loop.run())
+
                 # Build the spine before starting cron: cron jobs submit CRON
                 # turns through this scheduler, and on_job must be wired
                 # before cron.start() so an immediately-firing job has its
@@ -523,7 +535,7 @@ def register(app: typer.Typer) -> None:
                 # async) — it must not move to the sync prologue.
                 def _render_nudge_marker() -> None:
                     console.print()
-                    console.print("[bold magenta]🦞 [主动][/bold magenta]")
+                    console.print("[bold magenta]🐦‍⬛ [主动][/bold magenta]")
 
                 scheduler, hub, teardown = build_repl(
                     agent_loop,
@@ -538,7 +550,8 @@ def register(app: typer.Typer) -> None:
                 # legacy bus path). readback_texts/system_events stay unset: the
                 # REPL has no heartbeat, so the handler no-ops them.
                 cron.on_job = make_on_cron_job(
-                    agent_loop, hub,
+                    agent_loop,
+                    hub,
                     submit=scheduler.submit,
                     channel_manager=cli_shim,
                     session_manager=session_manager,
@@ -553,7 +566,7 @@ def register(app: typer.Typer) -> None:
                 # never started its tick loop, so jobs just sat in jobs.json.
                 await cron.start()
                 # Start Sentinel if enabled so anticipatory nudges reach the REPL.
-                # Nudges ride the spine hub -> CliOutlet (which renders the 🦞
+                # Nudges ride the spine hub -> CliOutlet (which renders the 🐦‍⬛
                 # proactive marker for _sentinel_origin); no bus consumer here.
                 if sentinel_runner is not None:
                     await sentinel_runner.start()
@@ -584,7 +597,9 @@ def register(app: typer.Typer) -> None:
                         await sentinel_runner.stop()
                     cron.stop()
                     agent_loop.stop()
-                    await teardown()  # scheduler.shutdown + hub.aclose (honors the shutdown contract)
+                    await (
+                        teardown()
+                    )  # scheduler.shutdown + hub.aclose (honors the shutdown contract)
                     await asyncio.gather(runtime_task, return_exceptions=True)
                     if wait_skill_extract or flush_skill_buffer:
                         # ``exit`` is not a natural boundary; without a
@@ -596,8 +611,7 @@ def register(app: typer.Typer) -> None:
                         # resulting (and any other in-flight) task.
                         await agent_loop.await_pending_extractions(
                             flush_session_id=(
-                                f"{cli_channel}:{cli_chat_id}"
-                                if flush_skill_buffer else None
+                                f"{cli_channel}:{cli_chat_id}" if flush_skill_buffer else None
                             ),
                             wait=wait_skill_extract,
                         )

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -47,6 +47,24 @@ _TOTAL_STEPS = 4
 # screen; ``None`` from a picker means Ctrl+C (exit).
 _BACK = object()
 
+# Unified prompt chrome (display-only): no leading question glyph (drops
+# questionary's default "?"). A single-space qmark is rendered as one blank,
+# which — with questionary's own leading space — puts every prompt line on the
+# same 2-space column as our printed help/status lines, so the left edge stays
+# flush instead of jittering between 1- and 2-space indents. Pointer is a
+# calmer "❯" than questionary's default "»".
+_QMARK = " "
+_POINTER = "❯"
+
+# UI language, chosen on the wizard's first screen. ``_t`` returns the English
+# or Chinese variant so every later prompt / message stays bilingual.
+_LANG = "en"
+
+
+def _t(en: str, zh: str) -> str:
+    """Return ``zh`` when the user picked Chinese, else ``en``."""
+    return zh if _LANG == "zh" else en
+
 
 # ---------------------------------------------------------------------------
 # Curated provider catalogue surfaced in Step 1's picker.
@@ -54,22 +72,73 @@ _BACK = object()
 
 
 _CURATED_PROVIDERS: list[dict[str, Any]] = [
-    {"name": "openrouter", "label": "OpenRouter (recommended, multi-provider)", "is_oauth": False},
-    {"name": "openai", "label": "OpenAI", "is_oauth": False},
-    {"name": "anthropic", "label": "Anthropic", "is_oauth": False},
-    {"name": "gemini", "label": "Gemini", "is_oauth": False},
-    {"name": "deepseek", "label": "DeepSeek", "is_oauth": False},
-    {"name": "github_copilot", "label": "GitHub Copilot (OAuth)", "is_oauth": True},
-    {"name": "openai_codex", "label": "Codex (OAuth)", "is_oauth": True},
-    {"name": "custom", "label": "Other (OpenAI-compatible endpoint)", "is_oauth": False},
+    {
+        "name": "openrouter",
+        "label": "OpenRouter (recommended — one key, many models)",
+        "label_zh": "OpenRouter(推荐 · 一个 Key 调用多家模型)",
+        "is_oauth": False,
+    },
+    {"name": "openai", "label": "OpenAI", "label_zh": "OpenAI", "is_oauth": False},
+    {"name": "anthropic", "label": "Anthropic", "label_zh": "Anthropic", "is_oauth": False},
+    {"name": "gemini", "label": "Gemini", "label_zh": "Gemini", "is_oauth": False},
+    {"name": "deepseek", "label": "DeepSeek", "label_zh": "DeepSeek", "is_oauth": False},
+    {
+        "name": "github_copilot",
+        "label": "GitHub Copilot (OAuth)",
+        "label_zh": "GitHub Copilot(OAuth 登录)",
+        "is_oauth": True,
+    },
+    {
+        "name": "openai_codex",
+        "label": "Codex (OAuth)",
+        "label_zh": "Codex(OAuth 登录)",
+        "is_oauth": True,
+    },
+    {
+        "name": "custom",
+        "label": "Other (OpenAI-compatible endpoint)",
+        "label_zh": "其他(OpenAI 兼容端点)",
+        "is_oauth": False,
+    },
 ]
 
 _QUESTIONARY_INSTALL_HINT = (
-    "[red]Missing dependency:[/red] [cyan]questionary[/cyan] is required for "
+    "[red]Missing dependency:[/red] [#fbe23f]questionary[/#fbe23f] is required for "
     "interactive onboarding.\n"
-    "Install it with: [cyan]uv add 'questionary>=2.0,<3.0'[/cyan]\n"
-    "Or re-run with [cyan]--non-interactive[/cyan] plus the relevant flags."
+    "Install it with: [#fbe23f]uv add 'questionary>=2.0,<3.0'[/#fbe23f]\n"
+    "Or re-run with [#fbe23f]--non-interactive[/#fbe23f] plus the relevant flags."
 )
+
+
+_PROMPT_THEMED = False
+
+
+def _theme_questionary(questionary: Any) -> None:
+    """Give every ``select`` a consistent pointer and drop questionary's own
+    "(Use arrow keys)" hint — the step header already prints the controls.
+
+    Display-only and applied once: we wrap ``questionary.select`` so callers
+    that don't pass ``pointer`` / ``instruction`` inherit the unified look,
+    while any explicit value still wins (``setdefault``).
+    """
+    global _PROMPT_THEMED
+    if _PROMPT_THEMED:
+        return
+    import functools
+
+    _orig_select = questionary.select
+
+    @functools.wraps(_orig_select)
+    def _themed_select(*args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("pointer", _POINTER)
+        # questionary shows "(Use arrow keys)" when instruction is falsy; a
+        # single space is truthy yet visually blank, so it hides that hint
+        # (the step header already prints the controls).
+        kwargs.setdefault("instruction", " ")
+        return _orig_select(*args, **kwargs)
+
+    questionary.select = _themed_select
+    _PROMPT_THEMED = True
 
 
 def _require_questionary() -> Any:
@@ -79,7 +148,59 @@ def _require_questionary() -> Any:
     except ModuleNotFoundError:
         console.print(_QUESTIONARY_INSTALL_HINT)
         raise typer.Exit(1)
+    _theme_questionary(questionary)
     return questionary
+
+
+def _config_language() -> str:
+    """Read the saved UI language from the on-disk config ('en' / 'zh').
+
+    Tolerant of a missing / unreadable config (fresh install) → defaults to 'en'.
+    """
+    data = _load_raw_config()
+    lang = data.get("language")
+    return lang if lang in ("en", "zh") else "en"
+
+
+def _pick_language() -> None:
+    """First screen: choose the wizard's language. Updates module-level ``_LANG``.
+
+    Persistence happens later (after bootstrap created the config file), via
+    ``set_language`` in :func:`_run_wizard_body`.
+    """
+    global _LANG
+    questionary = _require_questionary()
+    from raven.cli._styles import RAVEN_STYLE
+
+    # Framed like the other screens (bilingual, since no language is chosen yet)
+    # so it reads as the wizard's first step, not a bare floating list.
+    console.print()
+    console.print(
+        Panel(
+            "[bold white]Let's set up Raven — first, choose your language.[/bold white]\n"
+            "[dim]开始配置 Raven — 请先选择语言。[/dim]",
+            title="[bold #fbe23f]Raven setup[/bold #fbe23f]",
+            title_align="left",
+            border_style="#c8a900",
+            padding=(1, 2),
+        )
+    )
+    console.print("  [dim]↑↓ select · Enter confirm · Ctrl+C quit[/dim]")
+    console.print()
+
+    picked = questionary.select(
+        "Language / 语言",
+        choices=[
+            questionary.Choice("English", value="en"),
+            questionary.Choice("中文(简体)", value="zh"),
+        ],
+        default=_LANG,  # preselect the saved language on a re-run
+        style=RAVEN_STYLE,
+        qmark=_QMARK,
+    ).ask()
+    if picked is None:
+        raise typer.Exit(1)
+    _LANG = picked
 
 
 # ---------------------------------------------------------------------------
@@ -88,11 +209,24 @@ def _require_questionary() -> Any:
 
 
 def _step_header(n: int, title: str) -> None:
-    console.print()
-    console.print(Panel(f"[bold]Step {n}/{_TOTAL_STEPS}[/bold] · {title}", border_style="cyan"))
-    console.print(
-        "[dim]↑↓ select · Enter confirm · 0 back · Ctrl+C quit[/dim]"
+    # Progress dots: filled for done/current steps, hollow for upcoming ones.
+    dots = " ".join(
+        "[#fbe23f]●[/#fbe23f]" if i <= n else "[grey37]○[/grey37]"
+        for i in range(1, _TOTAL_STEPS + 1)
     )
+    console.print()
+    console.print(
+        Panel(
+            f"[bold white]{title}[/bold white]",
+            title=f"[bold #fbe23f]{_t('Step', '步骤')} {n}/{_TOTAL_STEPS}[/bold #fbe23f]",
+            title_align="left",
+            subtitle=dots,
+            subtitle_align="right",
+            border_style="#c8a900",
+            padding=(0, 2),
+        )
+    )
+    console.print()  # breathing room between the header and the step's prompts
 
 
 def _check_tty_or_die(non_interactive: bool) -> None:
@@ -103,7 +237,7 @@ def _check_tty_or_die(non_interactive: bool) -> None:
         console.print(
             "[red]Non-interactive terminal detected.[/red]\n"
             "Re-run with: "
-            "[cyan]raven onboard --non-interactive --provider <name> --api-key <key>[/cyan]"
+            "[#fbe23f]raven onboard --non-interactive --provider <name> --api-key <key>[/#fbe23f]"
         )
         raise typer.Exit(2)
 
@@ -125,11 +259,7 @@ def _configured_providers() -> list[str]:
     """Names of providers that currently have an api_key set on disk."""
     data = _load_raw_config()
     providers = data.get("providers") or {}
-    return [
-        name
-        for name, p in providers.items()
-        if isinstance(p, dict) and p.get("apiKey")
-    ]
+    return [name for name, p in providers.items() if isinstance(p, dict) and p.get("apiKey")]
 
 
 def _is_config_populated() -> bool:
@@ -141,15 +271,21 @@ def _is_config_populated() -> bool:
     """
     data = _load_raw_config()
     providers = data.get("providers") or {}
-    has_provider = any(
-        isinstance(p, dict) and p.get("apiKey") for p in providers.values()
-    )
+    has_provider = any(isinstance(p, dict) and p.get("apiKey") for p in providers.values())
     model = (data.get("agents", {}) or {}).get("defaults", {}).get("model")
     return bool(has_provider and model)
 
 
 def _handle_existing_config(*, reset: bool, yes: bool, non_interactive: bool) -> None:
-    """Ask the user what to do when a populated config already exists."""
+    """Guard against silently overwriting an existing config in non-interactive
+    runs.
+
+    Interactive runs always fall through into the structured wizard: every step
+    defaults to "Keep current" for already-set values, so pressing Enter all the
+    way through is equivalent to skipping, and changing any value reconfigures
+    just that one. No separate skip/redo/quit screen — it would drop the wizard's
+    welcome banner and step framing.
+    """
     if reset:
         return
     if not _is_config_populated():
@@ -162,32 +298,13 @@ def _handle_existing_config(*, reset: bool, yes: bool, non_interactive: bool) ->
             )
             return
         console.print(
-            "[red]Existing config detected.[/red] Pass [cyan]--reset[/cyan] (or "
-            "[cyan]--yes[/cyan]) to overwrite, or edit in place with "
-            "[cyan]raven provider set[/cyan] / [cyan]raven channels enable[/cyan]."
+            "[red]Existing config detected.[/red] Pass [#fbe23f]--reset[/#fbe23f] (or "
+            "[#fbe23f]--yes[/#fbe23f]) to overwrite, or edit in place with "
+            "[#fbe23f]raven provider set[/#fbe23f] / [#fbe23f]raven channels enable[/#fbe23f]."
         )
         raise typer.Exit(2)
-
-    questionary = _require_questionary()
-    from raven.cli._styles import RAVEN_STYLE
-
-    action = questionary.select(
-        "An Raven config already exists. What would you like to do?",
-        choices=[
-            questionary.Choice("Skip onboarding — keep existing config", value="skip"),
-            questionary.Choice("Re-run the wizard — overwrite", value="redo"),
-            questionary.Choice("Quit", value="quit"),
-        ],
-        style=RAVEN_STYLE,
-    ).ask()
-    if action in (None, "quit"):
-        raise typer.Exit(1)
-    if action == "skip":
-        console.print(
-            "[green]✓[/green] Keeping existing config. Run "
-            "[cyan]raven provider list[/cyan] to review."
-        )
-        raise typer.Exit(0)
+    # Interactive: fall through to the wizard (per-step "Keep current" handles
+    # the existing config gracefully).
 
 
 def _bootstrap_empty_config() -> None:
@@ -230,7 +347,7 @@ def _provider_label(name: str) -> str:
     """Display label for a provider, falling back to the registry's display_name."""
     for entry in _CURATED_PROVIDERS:
         if entry["name"] == name:
-            return entry["label"]
+            return _t(entry["label"], entry.get("label_zh", entry["label"]))
     try:
         from raven.providers.registry import find_by_name
 
@@ -252,6 +369,44 @@ def _validate_provider_name(name: str) -> str:
     return candidate
 
 
+def _back_placeholder(allow_back: bool) -> Any:
+    """A faint in-field placeholder telling the user an empty submit rewinds.
+
+    Rendered greyed inside the input (via prompt_toolkit's ``placeholder``),
+    it disappears the moment they type and leaves nothing behind once the
+    prompt is answered. Returns ``None`` when back isn't offered.
+    """
+    if not allow_back:
+        return None
+    return [("fg:#6c6c6c italic", _t("empty ↵ to go back", "留空回车返回上一步"))]
+
+
+def _collect_fields(prompts: list[Callable[[], Any]]) -> Optional[list[Any]]:
+    """Run text-prompt callables in order with empty-submit = back.
+
+    Each callable prompts one field and returns its value, or ``_BACK`` (an
+    empty submit) to rewind one field. Backing out of the first field returns
+    ``None`` so the caller can rewind to the preceding screen. Returns the list
+    of collected values on success.
+    """
+    values: list[Any] = []
+    i = 0
+    while i < len(prompts):
+        value = prompts[i]()
+        if value is _BACK:
+            if i == 0:
+                return None
+            values.pop()
+            i -= 1
+            continue
+        if i < len(values):
+            values[i] = value
+        else:
+            values.append(value)
+        i += 1
+    return values
+
+
 def _select_provider() -> Optional[str]:
     """Interactive provider picker built from the curated catalogue.
 
@@ -261,88 +416,187 @@ def _select_provider() -> Optional[str]:
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
 
-    choices: list[Any] = []
-    last_was_oauth_boundary = False
-    for entry in _CURATED_PROVIDERS:
-        if entry["is_oauth"] and not last_was_oauth_boundary:
-            choices.append(questionary.Separator())
-            last_was_oauth_boundary = True
-        if not entry["is_oauth"] and last_was_oauth_boundary:
-            choices.append(questionary.Separator())
-            last_was_oauth_boundary = False
-        choices.append(questionary.Choice(entry["label"], value=entry["name"]))
+    choices: list[Any] = [
+        questionary.Choice(
+            _t(entry["label"], entry.get("label_zh", entry["label"])),
+            value=entry["name"],
+        )
+        for entry in _CURATED_PROVIDERS
+    ]
     choices.append(questionary.Separator())
-    choices.append(questionary.Choice("0) Back", value=_BACK))
+    choices.append(questionary.Choice(_t("Back", "返回"), value=_BACK))
 
     picked = questionary.select(
-        "Provider:",
+        _t("Provider:", "服务商:"),
         choices=choices,
         style=RAVEN_STYLE,
+        qmark=_QMARK,
     ).ask()
     return picked  # None on Ctrl+C
 
 
-def _prompt_api_key(provider: str) -> str:
-    """Ask for an API key (hidden input)."""
+def _prompt_api_key(provider: str, *, allow_back: bool = False) -> Any:
+    """Ask for an API key (hidden input). Returns ``_BACK`` on empty submit
+    when ``allow_back`` is set, else the key string."""
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
 
+    def _validate(v: str) -> Any:
+        if allow_back and v == "":
+            return True  # empty is the back signal, not an error
+        return (
+            True
+            if len(v) >= 8
+            else _t(
+                "API key looks off (empty or too short) — please re-enter (≥ 8 chars).",
+                "API Key 看起来不对(过短或为空),请重新输入(至少 8 位)。",
+            )
+        )
+
     key = questionary.password(
-        f"API key for {provider}:",
-        validate=lambda v: True if len(v) >= 8 else "Key looks too short (≥ 8 chars).",
+        _t("Paste your API key:", "粘贴你的 API Key:"),
+        validate=_validate,
+        placeholder=_back_placeholder(allow_back),
         style=RAVEN_STYLE,
+        qmark=_QMARK,
     ).ask()
+    if key is None:
+        raise typer.Exit(1)
+    if allow_back and key == "":
+        return _BACK
     if not key:
         raise typer.Exit(1)
     return key
 
 
-def _prompt_base_url(default: str = "https://") -> str:
-    """Ask for an OpenAI-compatible base URL (used by the 'custom' provider)."""
+def _prompt_base_url(default: str = "https://", *, allow_back: bool = False) -> Any:
+    """Ask for an OpenAI-compatible base URL (used by the 'custom' provider).
+    Returns ``_BACK`` on empty submit when ``allow_back`` is set."""
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
 
+    # With back enabled, don't seed a default — an empty field must be reachable
+    # so the user can submit nothing to rewind.
+    seed = "" if allow_back else default
+
+    def _validate(v: str) -> Any:
+        if allow_back and v == "":
+            return True
+        return (
+            True
+            if v.startswith(("http://", "https://"))
+            else _t("URL must start with http:// or https://", "地址需以 http:// 或 https:// 开头")
+        )
+
     url = questionary.text(
-        "Base URL (must include /v1):",
-        default=default,
-        validate=lambda v: True if v.startswith(("http://", "https://")) else "URL must start with http:// or https://",
+        _t("Base URL (must include /v1):", "Base URL(需包含 /v1):"),
+        default=seed,
+        validate=_validate,
+        placeholder=_back_placeholder(allow_back),
         style=RAVEN_STYLE,
+        qmark=_QMARK,
     ).ask()
+    if url is None:
+        raise typer.Exit(1)
+    if allow_back and url == "":
+        return _BACK
     if not url:
         raise typer.Exit(1)
     return url
 
 
-def _prompt_custom_model() -> str:
-    """Ask for the model name when using a custom OpenAI-compatible endpoint."""
+def _prompt_custom_model(*, allow_back: bool = False) -> Any:
+    """Ask for the model name when using a custom OpenAI-compatible endpoint.
+    Returns ``_BACK`` on empty submit when ``allow_back`` is set."""
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
 
+    def _validate(v: str) -> Any:
+        if allow_back and v.strip() == "":
+            return True
+        return (
+            True
+            if v.strip()
+            else _t("Model id is required for custom endpoints.", "自定义端点必须指定模型 id。")
+        )
+
     model = questionary.text(
-        "Default model id (e.g. 'gpt-3.5-turbo' or 'qwen-max'):",
-        validate=lambda v: True if v.strip() else "Model id is required for custom endpoints.",
+        _t(
+            "Default model id (e.g. 'gpt-3.5-turbo' or 'qwen-max'):",
+            "默认模型 id(如 'gpt-3.5-turbo' 或 'qwen-max'):",
+        ),
+        validate=_validate,
+        placeholder=_back_placeholder(allow_back),
         style=RAVEN_STYLE,
+        qmark=_QMARK,
     ).ask()
+    if model is None:
+        raise typer.Exit(1)
+    if allow_back and model.strip() == "":
+        return _BACK
     if not model:
         raise typer.Exit(1)
     return model.strip()
 
 
-def _run_oauth_login(provider: str) -> None:
-    """Dispatch the OAuth login handler registered by ``provider_commands``."""
+def _run_oauth_login(provider: str) -> bool:
+    """Dispatch the OAuth login handler registered by ``provider_commands``.
+
+    Returns ``True`` on success. A login that fails (the handler raises
+    ``typer.Exit`` or any error) returns ``False`` so the caller can offer a
+    retry / back menu instead of tearing the whole wizard down. A genuine
+    Ctrl+C (``KeyboardInterrupt``) is left to propagate as a quit.
+    """
     from raven.cli.provider_commands import _LOGIN_HANDLERS
     from raven.providers.registry import find_by_name
 
     spec = find_by_name(provider)
     if not spec or not spec.is_oauth:
-        console.print(f"[red]✗ {provider} is not an OAuth provider.[/red]")
+        console.print(
+            _t(
+                f"  [red]✗ {provider} is not an OAuth provider.[/red]",
+                f"  [red]✗ {provider} 不是 OAuth 服务商。[/red]",
+            )
+        )
         raise typer.Exit(1)
     handler = _LOGIN_HANDLERS.get(spec.name)
     if not handler:
-        console.print(f"[red]✗ No login handler registered for {provider}.[/red]")
+        console.print(
+            _t(
+                f"  [red]✗ No login handler registered for {provider}.[/red]",
+                f"  [red]✗ 未为 {provider} 注册登录处理器。[/red]",
+            )
+        )
         raise typer.Exit(1)
-    console.print(f"[cyan]Starting OAuth login for {spec.label}...[/cyan]\n")
-    handler()
+    console.print(
+        _t(
+            f"  [#fbe23f]Starting OAuth login for {spec.label}…[/#fbe23f]\n",
+            f"  [#fbe23f]正在为 {spec.label} 启动 OAuth 登录…[/#fbe23f]\n",
+        )
+    )
+    console.print(
+        _t(
+            "  [dim]A browser window / link will open — finish the sign-in there, "
+            "then come back here. This waits until you're done.[/dim]\n",
+            "  [dim]会打开浏览器窗口 / 链接 — 在那里完成登录后回到这里;"
+            "这里会一直等到你完成。[/dim]\n",
+        )
+    )
+    try:
+        handler()
+    except typer.Exit as exc:
+        # Handlers signal a failed login with Exit(1); Exit(0) (if any) is success.
+        if exc.exit_code:
+            return False
+    except Exception as exc:  # network / browser / token errors — recoverable
+        console.print(
+            _t(
+                f"  [yellow]✗ Login didn't complete: {exc}[/yellow]",
+                f"  [yellow]✗ 登录未完成:{exc}[/yellow]",
+            )
+        )
+        return False
+    return True
 
 
 def _verify_provider(provider: str) -> tuple[bool, str, Optional[list[str]]]:
@@ -354,23 +608,56 @@ def _verify_provider(provider: str) -> tuple[bool, str, Optional[list[str]]]:
     """
     from raven.config.update_providers import test_provider as probe
 
-    console.print("  [dim]⏳ Verifying via GET /v1/models ...[/dim]")
+    console.print(
+        _t("  [dim]⏳ Verifying your API key…[/dim]", "  [dim]⏳ 正在验证 API Key…[/dim]")
+    )
     result = probe(provider)
     if result["ok"]:
         models = result.get("models_count")
-        suffix = f" ({models} models available)" if models else ""
-        console.print(f"  [green]✓ Connected!{suffix}[/green]")
+        suffix = _t(f" ({models} models available)", f"(共 {models} 个可用模型)") if models else ""
+        console.print(
+            _t(f"  [green]✓ Connected!{suffix}[/green]", f"  [green]✓ 连接成功!{suffix}[/green]")
+        )
         return True, "valid", result.get("model_ids")
 
     status = result.get("status", "unknown")
+    # Some direct providers (openai / anthropic / deepseek / gemini) ship no
+    # base URL and rely on the SDK's built-in endpoint, so there's nothing to
+    # hit for a GET /v1/models pre-check — the probe reports "not_configured"
+    # because api_base is empty. That's NOT a real auth failure: skip the pre-
+    # check (the test message sent later exercises real connectivity via
+    # litellm) instead of dumping the user into the failure submenu.
+    if status == "not_configured" and "api_base" in (result.get("error") or ""):
+        console.print(
+            _t(
+                "  [dim]Skipping the model-list pre-check (this provider has no public /models endpoint); the test message below will confirm connectivity.[/dim]",
+                "  [dim]跳过模型列表预检(该服务商无公开 /models 端点);稍后的测试消息会验证连通。[/dim]",
+            )
+        )
+        return True, "skipped", None
     hint_map = {
-        "invalid_key": "Auth failed: the API key is invalid — check for typos / stray spaces.",
-        "no_credits": "Account out of credits or not provisioned — top up and retry.",
-        "rate_limited": "Rate limited — wait a bit and retry, or switch provider.",
-        "network_error": "Network error reaching the provider — check network / proxy / VPN.",
-        "oauth_token_missing": f"Run: raven provider login {provider.replace('_', '-')}",
+        "invalid_key": _t(
+            "Auth failed: the API key is invalid — check for typos / stray spaces.",
+            "鉴权失败:API Key 无效 — 检查有无拼写错误或多余空格。",
+        ),
+        "no_credits": _t(
+            "Account out of credits or not provisioned — top up and retry.",
+            "账户余额不足或未开通 — 充值后重试。",
+        ),
+        "rate_limited": _t(
+            "Rate limited — wait a bit and retry, or switch provider.",
+            "触发限流 — 稍等后重试,或更换服务商。",
+        ),
+        "network_error": _t(
+            "Network error reaching the provider — check network / proxy / VPN.",
+            "连接服务商时网络出错 — 检查网络 / 代理 / VPN。",
+        ),
+        "oauth_token_missing": _t(
+            f"Run: raven provider login {provider.replace('_', '-')}",
+            f"请运行:raven provider login {provider.replace('_', '-')}",
+        ),
     }
-    msg = hint_map.get(status, f"Verification failed: {status}")
+    msg = hint_map.get(status, _t(f"Verification failed: {status}", f"验证失败:{status}"))
     console.print(
         f"  [yellow]✗ {msg}[/yellow]"
         + (f"  [dim]{result['error']}[/dim]" if result.get("error") else "")
@@ -446,29 +733,45 @@ def _pick_model(
         choices = [_format_model_for_provider(spec, mid) for mid in model_ids]
         if default_value and default_value not in choices:
             choices.insert(0, default_value)
-        prompt_label = (
-            f"Default model ({len(choices)} available — type to filter, Tab to complete):"
+        prompt_label = _t(
+            f"Default model ({len(choices)} available — type to filter, Tab to complete):",
+            f"默认模型(共 {len(choices)} 个 — 输入可筛选,Tab 补全):",
         )
         chosen = questionary.autocomplete(
             prompt_label,
             choices=choices,
             default=default_value,
             style=RAVEN_STYLE,
+            qmark=_QMARK,
             ignore_case=True,
             match_middle=True,
         ).ask()
-    elif default_value:
-        chosen = questionary.text(
-            f"Default model (press Enter for [{default_value}]):",
-            default=default_value,
-            style=RAVEN_STYLE,
-        ).ask()
     else:
-        chosen = questionary.text(
-            f"Default model id for {spec.name}:",
-            validate=lambda v: True if v.strip() else "Model id is required.",
-            style=RAVEN_STYLE,
-        ).ask()
+        console.print(
+            _t(
+                "  [dim]Couldn't fetch the model list — enter the model id by hand.[/dim]",
+                "  [dim]未能拉取模型列表,请手动输入模型 id。[/dim]",
+            )
+        )
+        if default_value:
+            chosen = questionary.text(
+                _t(
+                    f"Default model (press Enter for [{default_value}]):",
+                    f"默认模型(回车使用 [{default_value}]):",
+                ),
+                default=default_value,
+                style=RAVEN_STYLE,
+                qmark=_QMARK,
+            ).ask()
+        else:
+            chosen = questionary.text(
+                _t(f"Default model id for {spec.name}:", f"{spec.name} 的默认模型 id:"),
+                validate=lambda v: (
+                    True if v.strip() else _t("Model id is required.", "必须指定模型 id。")
+                ),
+                style=RAVEN_STYLE,
+                qmark=_QMARK,
+            ).ask()
 
     if not chosen:
         raise typer.Exit(1)
@@ -484,13 +787,15 @@ def _write_provider_fields(provider: str, fields: dict[str, Any]) -> None:
     try:
         set_provider_fields(provider, fields)
     except KeyError as exc:
-        console.print(f"[red]✗[/red] {exc}")
+        console.print(f"  [red]✗[/red] {exc}")
         raise typer.Exit(1)
     except RuntimeError as exc:
-        console.print(f"[red]✗[/red] {exc}")
+        console.print(f"  [red]✗[/red] {exc}")
         raise typer.Exit(1)
     except ValidationError as exc:
-        console.print(f"[red]✗ Validation failed:[/red]\n{exc}")
+        console.print(
+            _t(f"  [red]✗ Validation failed:[/red]\n{exc}", f"  [red]✗ 校验失败:[/red]\n{exc}")
+        )
         raise typer.Exit(1)
 
 
@@ -521,9 +826,10 @@ def _failure_choice(options: list[tuple[str, str]], *, non_interactive: bool) ->
     from raven.cli._styles import RAVEN_STYLE
 
     chosen = questionary.select(
-        "What next?",
+        _t("What would you like to do?", "想做什么?"),
         choices=[questionary.Choice(label, value=value) for label, value in options],
         style=RAVEN_STYLE,
+        qmark=_QMARK,
     ).ask()
     if chosen is None:
         raise typer.Exit(1)
@@ -536,21 +842,29 @@ def _run_test_probe(provider: str, *, non_interactive: bool, warnings: list[str]
     Returns one of ``"ok"`` / ``"continue"`` / ``"repick"``. ``"repick"`` asks
     the caller to re-run the model picker.
     """
-    console.print(f'  [dim]Sending test message: "{DEFAULT_PROBE_MESSAGE}"[/dim]')
+    console.print(
+        _t(
+            f'  [dim]Sending test message: "{DEFAULT_PROBE_MESSAGE}"[/dim]',
+            f'  [dim]正在发送测试消息:"{DEFAULT_PROBE_MESSAGE}"[/dim]',
+        )
+    )
     try:
         text, tokens, elapsed = send_probe()
     except Exception as exc:
-        console.print(f"  [red]✗ Test failed:[/red] {exc}")
+        console.print(_t(f"  [red]✗ Test failed:[/red] {exc}", f"  [red]✗ 测试失败:[/red] {exc}"))
         console.print(
-            "  [dim]Run 'raven provider test' to re-check, or confirm the model is "
-            "served by this provider.[/dim]"
+            _t(
+                "  [dim]Run 'raven provider test' to re-check, or confirm the model is "
+                "served by this provider.[/dim]",
+                "  [dim]可运行 'raven provider test' 复查,或确认该模型确由此服务商提供。[/dim]",
+            )
         )
         print_probe_troubleshooting(provider)
         choice = _failure_choice(
             [
-                ("1) Retry", "retry"),
-                ("2) Re-pick model", "repick"),
-                ("3) Continue anyway", "continue"),
+                (_t("Retry", "重试"), "retry"),
+                (_t("Re-pick model", "重新选模型"), "repick"),
+                (_t("Continue anyway", "仍然继续"), "continue"),
             ],
             non_interactive=non_interactive,
         )
@@ -612,7 +926,15 @@ def _configure_one_provider(
         spec = find_by_name(provider)
         is_oauth = bool(spec and spec.is_oauth)
         is_custom = provider == "custom"
-        console.print(f"  [dim]Provider:[/dim] [cyan]{_provider_label(provider)}[/cyan]")
+        # The interactive picker already echoes the chosen provider; only print
+        # an explicit confirmation when it came from --provider (no echo then).
+        if flag_provider:
+            console.print(
+                _t(
+                    f"  [dim]Provider:[/dim] [#fbe23f]{_provider_label(provider)}[/#fbe23f]",
+                    f"  [dim]服务商:[/dim] [#fbe23f]{_provider_label(provider)}[/#fbe23f]",
+                )
+            )
 
         custom_model = _collect_credentials(
             provider,
@@ -623,6 +945,11 @@ def _configure_one_provider(
             model=model,
             non_interactive=non_interactive,
         )
+        if custom_model is _BACK:
+            # User backed out of the first credential field — rewind to the
+            # provider picker (drop any flag so the picker actually shows).
+            flag_provider = None
+            continue
 
         chosen_model = _resolve_model_with_test(
             spec,
@@ -650,42 +977,76 @@ def _collect_credentials(
     base_url: Optional[str],
     model: Optional[str],
     non_interactive: bool,
-) -> Optional[str]:
+) -> Any:
     """Auth setup: OAuth browser flow or api_key write. Returns the custom
-    model id when the provider is ``custom`` (locked in here), else ``None``."""
+    model id when the provider is ``custom`` (locked in here), ``None`` for a
+    non-custom provider, or ``_BACK`` if the user backed out of the first
+    interactive credential field (caller should rewind to the picker)."""
     if is_oauth:
         if non_interactive:
             console.print(
                 "[red]OAuth providers require an interactive browser flow.[/red]\n"
-                "Run [cyan]raven provider login "
-                f"{provider.replace('_', '-')}[/cyan] separately, then re-run "
+                "Run [#fbe23f]raven provider login "
+                f"{provider.replace('_', '-')}[/#fbe23f] separately, then re-run "
                 "onboard."
             )
             raise typer.Exit(2)
-        _run_oauth_login(provider)
-        return None
+        # Loop so a failed login offers retry / back instead of crashing out.
+        while True:
+            if _run_oauth_login(provider):
+                return None
+            choice = _failure_choice(
+                [
+                    (_t("Retry", "重试"), "retry"),
+                    (_t("Back (pick another provider)", "返回(改选服务商)"), "back"),
+                ],
+                non_interactive=non_interactive,
+            )
+            if choice == "retry":
+                continue
+            return _BACK
 
-    if not api_key:
-        if non_interactive:
-            raise typer.BadParameter("--api-key is required in non-interactive mode")
-        api_key = _prompt_api_key(provider)
+    # Pure interactive path (no creds came from flags): prompt field-by-field
+    # with empty-submit = back; backing out of the first field rewinds to the
+    # provider picker.
+    pure_interactive = (
+        not non_interactive and not api_key and (not is_custom or (not base_url and not model))
+    )
+    if pure_interactive:
+        prompts: list[Callable[[], Any]] = [lambda: _prompt_api_key(provider, allow_back=True)]
+        if is_custom:
+            prompts.append(lambda: _prompt_base_url(allow_back=True))
+            prompts.append(lambda: _prompt_custom_model(allow_back=True))
+        collected = _collect_fields(prompts)
+        if collected is None:
+            return _BACK
+        api_key = collected[0]
+        if is_custom:
+            base_url = collected[1]
+            model = collected[2]
+    else:
+        if not api_key:
+            if non_interactive:
+                raise typer.BadParameter("--api-key is required in non-interactive mode")
+            api_key = _prompt_api_key(provider)
+        if is_custom:
+            if not base_url:
+                if non_interactive:
+                    raise typer.BadParameter(
+                        "--base-url is required when --provider=custom in non-interactive mode"
+                    )
+                base_url = _prompt_base_url()
+            if not model:
+                if non_interactive:
+                    raise typer.BadParameter(
+                        "--model is required when --provider=custom in non-interactive mode"
+                    )
+                model = _prompt_custom_model()
 
     fields: dict[str, Any] = {"api_key": api_key}
     custom_model: Optional[str] = None
     if is_custom:
-        if not base_url:
-            if non_interactive:
-                raise typer.BadParameter(
-                    "--base-url is required when --provider=custom in non-interactive mode"
-                )
-            base_url = _prompt_base_url()
         fields["api_base"] = base_url
-        if not model:
-            if non_interactive:
-                raise typer.BadParameter(
-                    "--model is required when --provider=custom in non-interactive mode"
-                )
-            model = _prompt_custom_model()
         custom_model = model
     elif base_url:
         fields["api_base"] = base_url
@@ -713,12 +1074,12 @@ def _resolve_model_with_test(
         ok, status, model_ids = _verify_provider(spec.name)
         if not ok:
             options = (
-                [("1) Retry", "retry"), ("2) Continue anyway", "continue")]
+                [(_t("Retry", "重试"), "retry"), (_t("Continue anyway", "仍然继续"), "continue")]
                 if status == "network_error"
                 else [
-                    ("1) Re-enter key", "rekey"),
-                    ("2) Switch provider", "switch"),
-                    ("3) Continue anyway", "continue"),
+                    (_t("Re-enter key", "重新填 Key"), "rekey"),
+                    (_t("Switch provider", "更换服务商"), "switch"),
+                    (_t("Continue anyway", "仍然继续"), "continue"),
                 ]
             )
             choice = _failure_choice(options, non_interactive=non_interactive)
@@ -769,44 +1130,73 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
         if not configured:
             return
         choices = [questionary.Choice(_provider_label(n), value=n) for n in configured]
-        choices.append(questionary.Choice("0) Back", value=_BACK))
+        choices.append(questionary.Choice(_t("Back", "返回"), value=_BACK))
         target = questionary.select(
-            "Pick a provider to manage:", choices=choices, style=RAVEN_STYLE
+            _t("Pick a provider to manage:", "选择要管理的服务商:"),
+            choices=choices,
+            style=RAVEN_STYLE,
+            qmark=_QMARK,
         ).ask()
         if target is None or target is _BACK:
             return
 
         action = questionary.select(
-            f"What would you like to do with {_provider_label(target)}?",
+            _t(
+                f"What would you like to do with {_provider_label(target)}?",
+                f"对 {_provider_label(target)} 想做什么?",
+            ),
             choices=[
-                questionary.Choice("1) Update API key", value="update"),
-                questionary.Choice("2) Remove (clear this provider's key)", value="remove"),
-                questionary.Choice("0) Back", value=_BACK),
+                questionary.Choice(_t("Update API key", "更新 API Key"), value="update"),
+                questionary.Choice(
+                    _t("Remove (clear this provider's key)", "移除(清除该服务商的 Key)"),
+                    value="remove",
+                ),
+                questionary.Choice(_t("Back", "返回"), value=_BACK),
             ],
             style=RAVEN_STYLE,
+            qmark=_QMARK,
         ).ask()
         if action is None or action is _BACK:
             continue
         if action == "update":
             _write_provider_fields(target, {"api_key": _prompt_api_key(target)})
-            console.print(f"  [green]✓ Updated {_provider_label(target)}.[/green]")
+            console.print(
+                _t(
+                    f"  [green]✓ Updated {_provider_label(target)}.[/green]",
+                    f"  [green]✓ 已更新 {_provider_label(target)}。[/green]",
+                )
+            )
         elif action == "remove":
             current = _load_current_default_model()
             from raven.providers.registry import find_by_name
 
             spec = find_by_name(target)
-            if current and spec and _model_routes_to_provider(current, spec):
+            was_default_source = bool(current and spec and _model_routes_to_provider(current, spec))
+            if was_default_source:
                 confirm = questionary.confirm(
-                    f"The current default model comes from {_provider_label(target)}; "
-                    "removing it means you'll need to pick a new default. Remove anyway?",
+                    _t(
+                        f"The current default model comes from {_provider_label(target)}; "
+                        "removing it means you'll need to pick a new default. Remove anyway?",
+                        f"当前默认模型来自 {_provider_label(target)};移除后需要重新选择默认模型。仍要移除吗?",
+                    ),
                     default=False,
                     style=RAVEN_STYLE,
+                    qmark=_QMARK,
                 ).ask()
                 if not confirm:
                     continue
             _write_provider_fields(target, {"api_key": ""})
+            if was_default_source:
+                # Clear the now-dangling default so step 1's guard forces a
+                # re-pick instead of leaving a model whose provider has no key.
+                from raven.config.update import set_default_model
+
+                set_default_model("")
             console.print(
-                f"  [green]✓ Removed {_provider_label(target)}'s configuration.[/green]"
+                _t(
+                    f"  [green]✓ Removed {_provider_label(target)}'s configuration.[/green]",
+                    f"  [green]✓ 已移除 {_provider_label(target)} 的配置。[/green]",
+                )
             )
 
 
@@ -821,7 +1211,13 @@ def _step1_provider(
 ) -> object:
     """Step 1 screen. Returns ``_BACK`` only when the user backs out of the
     first-run picker on the welcome screen (handled by the runner)."""
-    _step_header(1, "Choose your LLM provider")
+    _step_header(1, _t("Choose your LLM provider", "选择 LLM 服务商"))
+    console.print(
+        _t(
+            "  [dim]Raven's chat and reasoning are all driven by it.[/dim]",
+            "  [dim]Raven 的对话与思考都由它驱动。[/dim]",
+        )
+    )
 
     configured = _configured_providers()
     if non_interactive or not configured:
@@ -841,22 +1237,30 @@ def _step1_provider(
     from raven.cli._styles import RAVEN_STYLE
 
     while True:
-        names = ", ".join(_provider_label(n) for n in _configured_providers())
-        console.print(f"  [dim]Configured:[/dim] {names}")
+        names = ", ".join(_provider_label(n).split(" (")[0] for n in _configured_providers())
         action = questionary.select(
-            "LLM providers:",
+            _t(
+                f"LLM provider already configured: {names}. What would you like to do?",
+                f"LLM 服务商已配置:{names}。想做什么?",
+            ),
             choices=[
-                questionary.Choice("1) Done — continue", value="done"),
-                questionary.Choice("2) Add another provider", value="add"),
-                questionary.Choice("3) Edit / remove a provider", value="edit"),
+                questionary.Choice(_t("Done, continue", "完成,继续"), value="done"),
+                questionary.Choice(_t("Add another provider", "新增一个服务商"), value="add"),
+                questionary.Choice(
+                    _t("Edit / remove a provider", "编辑 / 移除服务商"), value="edit"
+                ),
             ],
             style=RAVEN_STYLE,
+            qmark=_QMARK,
         ).ask()
         if action in (None, "done"):
             # Re-pick a default model if the prior one was removed.
             if not _load_current_default_model() and _configured_providers():
                 console.print(
-                    "[yellow]No default model set — add or re-pick a provider.[/yellow]"
+                    _t(
+                        "  [yellow]No default model set — add or re-pick a provider.[/yellow]",
+                        "  [yellow]尚未设置默认模型 — 请新增或重新选择一个服务商。[/yellow]",
+                    )
                 )
                 continue
             return None
@@ -897,7 +1301,9 @@ def _probe_boxlite() -> tuple[bool, str]:
     ``reason`` ∈ ``"ok"`` / ``"missing"`` / ``"error"``. The runtime import is
     the same availability gate ``build_executor`` uses for the boxlite backend.
     """
-    console.print("  [dim]⏳ Probing sandbox availability...[/dim]")
+    console.print(
+        _t("  [dim]⏳ Checking sandbox availability…[/dim]", "  [dim]⏳ 正在检测沙箱可用性…[/dim]")
+    )
     try:
         import boxlite  # noqa: F401
     except ImportError:
@@ -909,10 +1315,17 @@ def _probe_boxlite() -> tuple[bool, str]:
 
 def _step2_sandbox(*, skip: bool, non_interactive: bool) -> object:
     """Step 2 — choose run location (host / boxlite sandbox)."""
-    _step_header(2, "Choose where Raven runs code / commands")
+    _step_header(
+        2, _t("Choose where Raven runs code / commands", "选择 Raven 运行代码 / 命令的位置")
+    )
 
     if skip or non_interactive:
-        console.print("  [dim]Keeping run location: host (direct).[/dim]")
+        console.print(
+            _t(
+                "  [dim]Keeping run location: host (direct).[/dim]",
+                "  [dim]保持运行位置:本机直接运行。[/dim]",
+            )
+        )
         return None
 
     questionary = _require_questionary()
@@ -921,16 +1334,34 @@ def _step2_sandbox(*, skip: bool, non_interactive: bool) -> object:
     current = _current_sandbox_backend()
     choices: list[Any] = []
     if current != "none":
-        choices.append(questionary.Choice("Keep current: sandbox (boxlite)", value="keep"))
+        choices.append(
+            questionary.Choice(
+                _t("Keep current: sandbox (boxlite)", "沿用当前:沙箱(boxlite)"), value="keep"
+            )
+        )
     choices.extend(
         [
-            questionary.Choice("1) Host (direct) — simplest, runs on your machine", value="none"),
-            questionary.Choice("2) Sandbox isolation (boxlite) — safer microVM", value="boxlite"),
-            questionary.Choice("0) Back", value=_BACK),
+            questionary.Choice(
+                _t(
+                    "Host (direct) — simplest, runs right on your machine",
+                    "本机直接运行 — 最简单,直接在你的电脑上执行",
+                ),
+                value="none",
+            ),
+            questionary.Choice(
+                _t(
+                    "Sandbox isolation (boxlite) — isolated in a lightweight VM, safer (needs platform support)",
+                    "沙箱隔离(boxlite)— 用轻量虚拟机隔离,更安全,需环境支持",
+                ),
+                value="boxlite",
+            ),
+            questionary.Choice(_t("Back", "返回"), value=_BACK),
         ]
     )
 
-    picked = questionary.select("Run location:", choices=choices, style=RAVEN_STYLE).ask()
+    picked = questionary.select(
+        _t("Run location:", "运行位置:"), choices=choices, style=RAVEN_STYLE, qmark=_QMARK
+    ).ask()
     if picked is None:
         raise typer.Exit(1)
     if picked is _BACK:
@@ -939,7 +1370,12 @@ def _step2_sandbox(*, skip: bool, non_interactive: bool) -> object:
         return None
     if picked == "none":
         _persist_sandbox_backend("none")
-        console.print("  [green]✓ Running directly on the host.[/green]")
+        console.print(
+            _t(
+                "  [green]✓ Running directly on the host.[/green]",
+                "  [green]✓ 将在本机直接运行。[/green]",
+            )
+        )
         return None
 
     # boxlite — probe before committing.
@@ -948,19 +1384,41 @@ def _step2_sandbox(*, skip: bool, non_interactive: bool) -> object:
         if ok:
             _persist_sandbox_backend("boxlite")
             console.print(
-                "  [green]✓ Sandbox available. Using default resources "
-                "(2 CPU / 2 GB / network); tune in the config file if needed.[/green]"
+                _t(
+                    "  [green]✓ Sandbox available. Using default resources "
+                    "(2 CPU / 2 GB / network); tune in the config file if needed.[/green]",
+                    "  [green]✓ 沙箱可用。将使用默认资源"
+                    "(2 CPU / 2 GB / 联网);如需调整可改配置文件。[/green]",
+                )
             )
             return None
-        console.print(
-            "  [yellow]✗ Sandbox runtime (boxlite) not detected; install the "
-            "dependency first.[/yellow]"
-        )
+        if reason == "missing":
+            console.print(
+                _t(
+                    "  [yellow]✗ Sandbox runtime (boxlite) isn't installed.[/yellow]\n"
+                    "  [dim]Install it, then choose “Retry after install”:  "
+                    "pip install 'raven\\[sandbox]'[/dim]",
+                    "  [yellow]✗ 未安装沙箱运行时(boxlite)。[/yellow]\n"
+                    "  [dim]先安装,再选「安装后重试」:  "
+                    "pip install 'raven\\[sandbox]'[/dim]",
+                )
+            )
+        else:  # reason == "error": importable but failed to initialize
+            console.print(
+                _t(
+                    "  [yellow]✗ Sandbox runtime (boxlite) is installed but failed to "
+                    "start.[/yellow]\n"
+                    "  [dim]Your machine may lack the required virtualization support. "
+                    "Fall back to host, or check the boxlite setup docs.[/dim]",
+                    "  [yellow]✗ 沙箱运行时(boxlite)已安装,但启动失败。[/yellow]\n"
+                    "  [dim]可能本机缺少所需的虚拟化支持。可退回本机运行,或查阅 boxlite 安装文档。[/dim]",
+                )
+            )
         choice = _failure_choice(
             [
-                ("1) Fall back to host", "host"),
-                ("2) Retry after install", "retry"),
-                ("0) Skip", "skip"),
+                (_t("Fall back to host", "退回本机运行"), "host"),
+                (_t("Retry after install", "安装后重试"), "retry"),
+                (_t("Skip", "跳过"), "skip"),
             ],
             non_interactive=non_interactive,
         )
@@ -968,7 +1426,12 @@ def _step2_sandbox(*, skip: bool, non_interactive: bool) -> object:
             continue
         if choice == "host":
             _persist_sandbox_backend("none")
-            console.print("  [green]✓ Running directly on the host.[/green]")
+            console.print(
+                _t(
+                    "  [green]✓ Running directly on the host.[/green]",
+                    "  [green]✓ 将在本机直接运行。[/green]",
+                )
+            )
         return None
 
 
@@ -981,20 +1444,81 @@ def _enabled_channels() -> list[str]:
     """Names of channels currently enabled on disk."""
     data = _load_raw_config()
     channels = data.get("channels") or {}
-    return [
-        name
-        for name, c in channels.items()
-        if isinstance(c, dict) and c.get("enabled")
-    ]
+    return [name for name, c in channels.items() if isinstance(c, dict) and c.get("enabled")]
 
 
 # Curated channel order: China-domestic first, then overseas. Channels not
 # listed (e.g. a newly added adapter) fall to the end in alphabetical order so
 # the picker never silently hides one.
+# Display order: US/global-common → China-common → US/global-uncommon →
+# China-uncommon. (Email is a universal but less-common-as-IM channel, so it
+# sits in the uncommon tail.)
 _CHANNEL_ORDER = (
-    "weixin", "feishu", "dingtalk", "wecom", "qq", "mochat",
-    "telegram", "discord", "whatsapp", "slack", "matrix", "email",
+    # US / global, common
+    "telegram",
+    "discord",
+    "slack",
+    "whatsapp",
+    # China, common
+    "weixin",
+    "wecom",
+    "feishu",
+    "dingtalk",
+    "qq",
+    # US / global, less common
+    "matrix",
+    "email",
+    # China, niche
+    "mochat",
 )
+
+
+# Where to obtain each channel's credentials — shown (dim) before the field
+# prompts so the user knows where to fetch the token / keys.
+_CHANNEL_CRED_HELP: dict[str, tuple[str, str]] = {
+    "telegram": (
+        "Create a bot with @BotFather in Telegram (send /newbot) — it replies with the token.",
+        "在 Telegram 里找 @BotFather 发 /newbot 创建机器人,它会回复 token。",
+    ),
+    "discord": (
+        "Discord Developer Portal → your app → Bot → Reset Token to copy it.",
+        "Discord 开发者门户 → 你的应用 → Bot → Reset Token 复制。",
+    ),
+    "slack": (
+        "api.slack.com/apps → OAuth & Permissions gives bot_token (xoxb-…); "
+        "Basic Information → App-Level Tokens gives app_token (xapp-…).",
+        "api.slack.com/apps → OAuth & Permissions 拿 bot_token(xoxb-…);"
+        "Basic Information → App-Level Tokens 拿 app_token(xapp-…)。",
+    ),
+    "feishu": (
+        "Feishu / Lark Open Platform → your app → Credentials for App ID & App Secret.",
+        "飞书开放平台 → 你的应用 → 凭证与基础信息 拿 App ID / App Secret。",
+    ),
+    "wecom": (
+        "WeCom admin console → your bot / app for its ID and secret.",
+        "企业微信管理后台 → 机器人 / 应用 拿 ID 和 secret。",
+    ),
+    "dingtalk": (
+        "DingTalk Open Platform → your app for Client ID & Client Secret.",
+        "钉钉开放平台 → 你的应用 拿 Client ID / Client Secret。",
+    ),
+    "qq": (
+        "QQ Open Platform → your bot for App ID & secret.",
+        "QQ 开放平台 → 你的机器人 拿 App ID 和 secret。",
+    ),
+    "email": (
+        "Use your mail provider's IMAP / SMTP settings; for Gmail / Outlook create an app password.",
+        "用你邮箱服务商的 IMAP / SMTP 设置;Gmail / Outlook 需创建应用专用密码。",
+    ),
+    "matrix": (
+        "From your Matrix account: an access token and your full user id (@you:server).",
+        "从你的 Matrix 账号获取 access token 和完整用户 id(@you:server)。",
+    ),
+    "mochat": (
+        "Get the claw token and agent user id from your Mochat workspace.",
+        "从你的 Mochat 工作区获取 claw token 和 agent user id。",
+    ),
+}
 
 
 def _ordered_channel_names() -> list[str]:
@@ -1011,12 +1535,14 @@ def _select_channel() -> Optional[str]:
 
     names = _ordered_channel_names()
     choices = [questionary.Choice(n, value=n) for n in names]
-    choices.append(questionary.Choice("0) Back", value=_BACK))
-    picked = questionary.select("Channel:", choices=choices, style=RAVEN_STYLE).ask()
+    choices.append(questionary.Choice(_t("Back", "返回"), value=_BACK))
+    picked = questionary.select(
+        _t("Channel:", "渠道:"), choices=choices, style=RAVEN_STYLE, qmark=_QMARK
+    ).ask()
     return picked
 
 
-def _prompt_channel_fields(channel: str) -> dict[str, Any]:
+def _prompt_channel_fields(channel: str) -> Any:
     """Reflect a channel's Pydantic schema and prompt for credential-like fields."""
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
@@ -1025,26 +1551,66 @@ def _prompt_channel_fields(channel: str) -> dict[str, Any]:
     try:
         specs = channel_field_specs(channel)
     except KeyError as exc:
-        console.print(f"[red]✗[/red] {exc}")
+        console.print(f"  [red]✗[/red] {exc}")
         raise typer.Exit(1)
 
+    # Pre-scan which credential fields we'll ask for, so we can tell the user
+    # up front what's being configured (and handle the zero-field case).
+    promptable = [
+        (path, spec)
+        for path, spec in specs.items()
+        if path != "enabled" and spec.get("type", "") == "str" and spec.get("default") in ("", None)
+    ]
+    if promptable:
+        names = ", ".join(path for path, _ in promptable)
+        console.print(
+            _t(
+                f"  [dim]Configuring {channel} — fill in:[/dim] {names}",
+                f"  [dim]正在配置 {channel} — 请填写:[/dim] {names}",
+            )
+        )
+        help_text = _CHANNEL_CRED_HELP.get(channel)
+        if help_text:
+            console.print(
+                _t(
+                    f"  [dim]Where to get it: {help_text[0]}[/dim]",
+                    f"  [dim]去哪拿:{help_text[1]}[/dim]",
+                )
+            )
+    else:
+        console.print(
+            _t(
+                f"  [dim]{channel} needs no credentials; enabling.[/dim]",
+                f"  [dim]{channel} 无需填写凭证,正在启用。[/dim]",
+            )
+        )
+
     fields: dict[str, Any] = {}
-    for path, spec in specs.items():
-        if path == "enabled":
-            continue
-        if spec.get("type", "") != "str":
-            continue
-        default = spec.get("default")
-        if default not in ("", None):
-            continue
+    for idx, (path, spec) in enumerate(promptable):
         description = spec.get("description", "")
         prompt_label = f"{path}" + (f" — {description}" if description else "") + ":"
+        # First field: an empty submit rewinds to the channel picker. Later
+        # fields keep the "empty = skip this optional field" semantics, so the
+        # back hint only shows on the first one.
+        allow_back = idx == 0
         if spec.get("is_secret"):
-            value = questionary.password(prompt_label, style=RAVEN_STYLE).ask()
+            value = questionary.password(
+                prompt_label,
+                placeholder=_back_placeholder(allow_back),
+                style=RAVEN_STYLE,
+                qmark=_QMARK,
+            ).ask()
         else:
-            value = questionary.text(prompt_label, style=RAVEN_STYLE).ask()
+            value = questionary.text(
+                prompt_label,
+                placeholder=_back_placeholder(allow_back),
+                style=RAVEN_STYLE,
+                qmark=_QMARK,
+            ).ask()
         if value is None:
             raise typer.Exit(1)
+        if allow_back and value == "":
+            return _BACK
         if value:
             fields[path] = value
     return fields
@@ -1059,10 +1625,12 @@ def _enable_channel(channel: str, fields: dict[str, Any]) -> None:
     try:
         enable_channel(channel, fields)
     except KeyError as exc:
-        console.print(f"[red]✗[/red] {exc}")
+        console.print(f"  [red]✗[/red] {exc}")
         raise typer.Exit(1)
     except ValidationError as exc:
-        console.print(f"[red]✗ Validation failed:[/red]\n{exc}")
+        console.print(
+            _t(f"  [red]✗ Validation failed:[/red]\n{exc}", f"  [red]✗ 校验失败:[/red]\n{exc}")
+        )
         raise typer.Exit(1)
 
 
@@ -1103,13 +1671,17 @@ def _handle_missing_node(channel: str) -> str:
     intentionally absent — there's no bridge to render a QR without Node.
     """
     console.print(
-        f"  [yellow]✗ Node.js / npm not found (the {channel} bridge needs it). "
-        "Install Node.js, then retry.[/yellow]"
+        _t(
+            f"  [yellow]✗ Node.js / npm not found (the {channel} bridge needs it). "
+            "Install Node.js, then retry.[/yellow]",
+            f"  [yellow]✗ 未找到 Node.js / npm({channel} 的桥接需要它)。"
+            "请先安装 Node.js,再重试。[/yellow]",
+        )
     )
     choice = _failure_choice(
         [
-            ("1) Retry after install", "retry"),
-            ("0) Skip", "skip"),
+            (_t("Retry after install", "安装后重试"), "retry"),
+            (_t("Skip", "跳过"), "skip"),
         ],
         non_interactive=False,
     )
@@ -1123,22 +1695,26 @@ def _scancode_login(channel: str) -> None:
     persists, build the adapter via its spec factory, then drive
     ``await channel.login()`` (which for WhatsApp builds the bridge, displays
     the QR, and waits). A failed / timed-out login drops into a numbered
-    submenu (re-show QR / skip / continue). Node-bridge channels missing
-    Node/npm get a dedicated install-then-retry menu instead (a "re-show QR"
-    choice is meaningless with no bridge).
+    submenu (retry / skip). Node-bridge channels missing Node/npm get a
+    dedicated install-then-retry menu instead.
     """
     import asyncio
 
     from raven.channels.registry import discover_specs
+    from raven.config.update_channels import disable_channel
 
-    # Enable first so the config section exists for the factory to read and so
-    # the channel is wired even if the user later finishes login out-of-band.
+    # Enable first so the config section exists for the factory to read while we
+    # attempt login. We REVERT this (disable) on any path that doesn't complete
+    # login, so a cancelled / skipped scan never shows up as "connected".
     _enable_channel(channel, {})
 
     specs = discover_specs()
     spec = specs.get(channel)
     if spec is None:
-        console.print(f"[red]✗ Unknown channel: {channel}[/red]")
+        disable_channel(channel)
+        console.print(
+            _t(f"  [red]✗ Unknown channel: {channel}[/red]", f"  [red]✗ 未知渠道:{channel}[/red]")
+        )
         return
 
     while True:
@@ -1147,9 +1723,14 @@ def _scancode_login(channel: str) -> None:
         if _node_runtime_missing(channel):
             if _handle_missing_node(channel) == "retry":
                 continue
+            disable_channel(channel)  # not logged in → don't leave it "connected"
             console.print(
-                f"  [dim]Skipped {channel}; install Node.js then run "
-                f"raven channels login {channel}.[/dim]"
+                _t(
+                    f"  [dim]Skipped {channel}; install Node.js then run "
+                    f"raven channels login {channel}.[/dim]",
+                    f"  [dim]已跳过 {channel};装好 Node.js 后运行 "
+                    f"raven channels login {channel}。[/dim]",
+                )
             )
             return
 
@@ -1157,49 +1738,106 @@ def _scancode_login(channel: str) -> None:
 
         channel_cfg = getattr(load_config().channels, channel, None)
         if channel_cfg is None:
-            console.print(f"[red]✗ No config section for channel: {channel}[/red]")
+            disable_channel(channel)
+            console.print(
+                _t(
+                    f"  [red]✗ No config section for channel: {channel}[/red]",
+                    f"  [red]✗ 渠道 {channel} 没有配置段。[/red]",
+                )
+            )
             return
         adapter = spec.factory(channel_cfg)
-        console.print(f"  [dim]Starting {spec.display_name} QR login...[/dim]")
+        if channel == "whatsapp":
+            console.print(
+                _t(
+                    "  [dim]Building the WhatsApp bridge — the first run can take 30–120s…[/dim]",
+                    "  [dim]正在构建 WhatsApp 桥接,首次约需 30–120 秒…[/dim]",
+                )
+            )
+        console.print(
+            _t(
+                f"  [dim]Starting {spec.display_name} QR login…[/dim]",
+                f"  [dim]正在启动 {spec.display_name} 扫码登录…[/dim]",
+            )
+        )
+        console.print(
+            _t(
+                f"  [dim]A login link / QR code will appear below — scan it with "
+                f"{spec.display_name} (or open the link on a phone signed in to "
+                f"{spec.display_name}) to connect. This waits until you finish.[/dim]",
+                f"  [dim]下方会出现登录链接 / 二维码 — 用 {spec.display_name} 扫码"
+                f"(或在已登录 {spec.display_name} 的手机上打开该链接)即可接入;"
+                f"这里会一直等到你完成。[/dim]",
+            )
+        )
+        from loguru import logger as _wiz_logger
+
+        # The wizard silences raven logs for a clean UI, but a scancode login
+        # emits its QR / link / progress / failure reason through loguru. Re-
+        # enable ONLY this channel's adapter subtree for the login attempt (not
+        # all of raven, which would dump unrelated noise), then restore quiet.
+        _login_log_scope = f"raven.channels.adapters.{channel}"
         try:
+            _wiz_logger.enable(_login_log_scope)
             ok = asyncio.run(adapter.login(force=True))
         except Exception as exc:
-            console.print(f"  [yellow]✗ Login failed: {exc}[/yellow]")
+            console.print(
+                _t(
+                    f"  [yellow]✗ Login failed: {exc}[/yellow]",
+                    f"  [yellow]✗ 登录失败:{exc}[/yellow]",
+                )
+            )
             ok = False
+        finally:
+            _wiz_logger.disable(_login_log_scope)
         if ok:
-            console.print(f"  [green]✓ Logged in; {channel} connected.[/green]")
+            console.print(
+                _t(
+                    f"  [green]✓ Logged in; {channel} connected.[/green]",
+                    f"  [green]✓ 已登录;{channel} 已接入。[/green]",
+                )
+            )
             return
         choice = _failure_choice(
             [
-                ("1) Re-show QR code", "retry"),
-                ("2) Skip this channel", "skip"),
-                ("3) Continue", "continue"),
+                (_t("Retry", "重试"), "retry"),
+                (_t("Skip this channel", "跳过此渠道"), "skip"),
             ],
             non_interactive=False,
         )
         if choice == "retry":
             continue
-        if choice == "skip":
-            # Leave the channel enabled but unauthenticated — the user can run
-            # `raven channels login <name>` later to finish pairing.
-            console.print(
-                f"  [dim]Skipped scan; finish later with "
-                f"raven channels login {channel}.[/dim]"
+        # Not completed (skip) → revert the enable so the channel isn't shown as
+        # connected. The config section is kept, so the user can finish
+        # out-of-band with `raven channels login <name>`.
+        disable_channel(channel)
+        console.print(
+            _t(
+                f"  [dim]{channel} not connected — finish later with "
+                f"raven channels login {channel}.[/dim]",
+                f"  [dim]{channel} 未接入 — 之后用 raven channels login {channel} 完成。[/dim]",
             )
+        )
         return
 
 
 def _add_one_channel() -> None:
     """Pick + (scancode login | reflect-prompt) + enable one channel."""
-    channel = _select_channel()
-    if channel is None or channel is _BACK:
+    while True:
+        channel = _select_channel()
+        if channel is None or channel is _BACK:
+            return
+        if _channel_uses_interactive_login(channel):
+            _scancode_login(channel)
+            return
+        fields = _prompt_channel_fields(channel)
+        if fields is _BACK:
+            continue  # backed out of the first field — re-pick a channel
+        _enable_channel(channel, fields)
+        console.print(
+            _t(f"  [green]✓ {channel} enabled.[/green]", f"  [green]✓ {channel} 已启用。[/green]")
+        )
         return
-    if _channel_uses_interactive_login(channel):
-        _scancode_login(channel)
-        return
-    fields = _prompt_channel_fields(channel)
-    _enable_channel(channel, fields)
-    console.print(f"  [green]✓ {channel} enabled.[/green]")
 
 
 def _manage_existing_channels() -> None:
@@ -1213,42 +1851,72 @@ def _manage_existing_channels() -> None:
         if not enabled:
             return
         choices = [questionary.Choice(n, value=n) for n in enabled]
-        choices.append(questionary.Choice("0) Back", value=_BACK))
+        choices.append(questionary.Choice(_t("Back", "返回"), value=_BACK))
         target = questionary.select(
-            "Pick a channel to manage:", choices=choices, style=RAVEN_STYLE
+            _t("Pick a channel to manage:", "选择要管理的渠道:"),
+            choices=choices,
+            style=RAVEN_STYLE,
+            qmark=_QMARK,
         ).ask()
         if target is None or target is _BACK:
             return
         action = questionary.select(
-            f"What would you like to do with {target}?",
+            _t(f"What would you like to do with {target}?", f"对 {target} 想做什么?"),
             choices=[
-                questionary.Choice("1) Edit config (re-enter fields)", value="edit"),
-                questionary.Choice("2) Disable (keep credentials)", value="disable"),
-                questionary.Choice("0) Back", value=_BACK),
+                questionary.Choice(
+                    _t("Edit config (re-enter fields)", "编辑配置(重填字段)"), value="edit"
+                ),
+                questionary.Choice(
+                    _t("Disable (keep credentials)", "停用(保留凭证)"), value="disable"
+                ),
+                questionary.Choice(_t("Back", "返回"), value=_BACK),
             ],
             style=RAVEN_STYLE,
+            qmark=_QMARK,
         ).ask()
         if action is None or action is _BACK:
             continue
         if action == "edit":
             fields = _prompt_channel_fields(target)
+            if fields is _BACK:
+                continue  # backed out — return to the manage menu
             if fields:
                 set_channel_fields(target, fields)
-            console.print(f"  [green]✓ {target} config updated.[/green]")
+            console.print(
+                _t(
+                    f"  [green]✓ {target} config updated.[/green]",
+                    f"  [green]✓ {target} 配置已更新。[/green]",
+                )
+            )
         elif action == "disable":
             disable_channel(target)
             console.print(
-                f"  [green]✓ Disabled {target} (credentials kept; re-enable later "
-                f"with raven channels enable {target}).[/green]"
+                _t(
+                    f"  [green]✓ Disabled {target} (credentials kept; re-enable later "
+                    f"with raven channels enable {target}).[/green]",
+                    f"  [green]✓ 已停用 {target}(凭证保留;之后用 "
+                    f"raven channels enable {target} 重新启用)。[/green]",
+                )
             )
 
 
 def _step3_channel(*, channel: Optional[str], skip: bool, non_interactive: bool) -> object:
     """Step 3 — optionally enable chat channel(s)."""
-    _step_header(3, "(Optional) Connect a chat tool so you can talk to Raven in an IM")
+    _step_header(
+        3,
+        _t(
+            "(Optional) Connect a messaging app so you can chat with Raven there",
+            "(可选)接入即时通讯软件,直接在里面和 Raven 聊天",
+        ),
+    )
 
     if skip:
-        console.print("  [dim]Skipped via --skip-channel.[/dim]")
+        console.print(
+            _t(
+                "  [dim]Skipped via --skip-channel.[/dim]",
+                "  [dim]已通过 --skip-channel 跳过。[/dim]",
+            )
+        )
         return None
 
     if non_interactive:
@@ -1256,11 +1924,16 @@ def _step3_channel(*, channel: Optional[str], skip: bool, non_interactive: bool)
             console.print(
                 f"[red]--channel {channel} given but non-interactive mode can't "
                 "prompt for credential fields.[/red]\n"
-                f"Run [cyan]raven channels enable {channel} --<field> <value> ...[/cyan] "
+                f"Run [#fbe23f]raven channels enable {channel} --<field> <value> ...[/#fbe23f] "
                 "after onboard finishes."
             )
             raise typer.Exit(2)
-        console.print("  [dim]Skipped (non-interactive, --channel not given).[/dim]")
+        console.print(
+            _t(
+                "  [dim]Skipped (non-interactive, --channel not given).[/dim]",
+                "  [dim]已跳过(非交互且未提供 --channel)。[/dim]",
+            )
+        )
         return None
 
     questionary = _require_questionary()
@@ -1271,36 +1944,54 @@ def _step3_channel(*, channel: Optional[str], skip: bool, non_interactive: bool)
             _scancode_login(channel)
         else:
             fields = _prompt_channel_fields(channel)
+            if fields is _BACK:
+                console.print(_t("  [dim]Skipped.[/dim]", "  [dim]已跳过。[/dim]"))
+                return None
             _enable_channel(channel, fields)
-            console.print(f"  [green]✓ {channel} enabled.[/green]")
+            console.print(
+                _t(
+                    f"  [green]✓ {channel} enabled.[/green]",
+                    f"  [green]✓ {channel} 已启用。[/green]",
+                )
+            )
         return None
 
     while True:
         enabled = _enabled_channels()
         if not enabled:
             action = questionary.select(
-                "Connect a chat channel?",
+                _t("Connect a chat channel?", "接入一个聊天渠道吗?"),
                 choices=[
-                    questionary.Choice("1) Add a channel", value="add"),
-                    questionary.Choice("0) Skip (add later with raven channels enable)", value="skip"),
+                    questionary.Choice(_t("Add a channel", "新增一个渠道"), value="add"),
+                    questionary.Choice(
+                        _t(
+                            "Skip (add later with raven channels enable)",
+                            "跳过(之后用 raven channels enable 添加)",
+                        ),
+                        value="skip",
+                    ),
                 ],
                 style=RAVEN_STYLE,
+                qmark=_QMARK,
             ).ask()
             if action in (None, "skip"):
-                console.print("  [dim]Skipped.[/dim]")
+                console.print(_t("  [dim]Skipped.[/dim]", "  [dim]已跳过。[/dim]"))
                 return None
             _add_one_channel()
             continue
 
-        console.print(f"  [dim]Enabled:[/dim] {', '.join(enabled)}")
         action = questionary.select(
-            "Chat channels:",
+            _t(
+                f"Chat channel already connected: {', '.join(enabled)}. What would you like to do?",
+                f"聊天渠道已接入:{', '.join(enabled)}。想做什么?",
+            ),
             choices=[
-                questionary.Choice("0) Done — next step", value="done"),
-                questionary.Choice("1) Add a channel", value="add"),
-                questionary.Choice("2) Edit / remove a channel", value="edit"),
+                questionary.Choice(_t("Done, next step", "完成,下一步"), value="done"),
+                questionary.Choice(_t("Add a channel", "新增一个渠道"), value="add"),
+                questionary.Choice(_t("Edit / remove a channel", "编辑 / 移除渠道"), value="edit"),
             ],
             style=RAVEN_STYLE,
+            qmark=_QMARK,
         ).ask()
         if action in (None, "done"):
             return None
@@ -1363,6 +2054,7 @@ _OPENAI_COMPATIBLE_PROVIDERS = {"openrouter", "openai", "deepseek", "custom"}
 _PROVIDER_BASE_URL_FALLBACK = {
     "openai": "https://api.openai.com/v1",
     "deepseek": "https://api.deepseek.com/v1",
+    "openrouter": "https://openrouter.ai/api/v1",
 }
 
 
@@ -1449,17 +2141,29 @@ def _resolve_reuse_llm_creds(main_model: str) -> dict[str, Optional[str]]:
     }
 
 
-def _prompt_text(label: str, *, secret: bool = False, default: str = "") -> str:
+def _prompt_text(
+    label: str, *, secret: bool = False, default: str = "", allow_back: bool = False
+) -> Any:
+    """Prompt for free text. With ``allow_back``, an empty submit returns
+    ``_BACK`` (and a hint is shown); otherwise returns the stripped string."""
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
 
+    placeholder = _back_placeholder(allow_back)
     if secret:
-        value = questionary.password(label, style=RAVEN_STYLE).ask()
+        value = questionary.password(
+            label, placeholder=placeholder, style=RAVEN_STYLE, qmark=_QMARK
+        ).ask()
     else:
-        value = questionary.text(label, default=default, style=RAVEN_STYLE).ask()
+        value = questionary.text(
+            label, default=default, placeholder=placeholder, style=RAVEN_STYLE, qmark=_QMARK
+        ).ask()
     if value is None:
         raise typer.Exit(1)
-    return value.strip()
+    value = value.strip()
+    if allow_back and value == "":
+        return _BACK
+    return value
 
 
 def _probe_everos_endpoint(
@@ -1493,274 +2197,465 @@ def _verify_everos_model(
     base_url: Optional[str],
     non_interactive: bool,
     warnings: list[str],
+    continue_hint: Optional[tuple[str, str]] = None,
 ) -> bool:
     """Probe one EverOS model endpoint, offering retry/continue on failure.
 
     Returns ``True`` if the caller should keep the just-written config, or
     ``False`` to re-prompt (the "Re-enter" branch). Failures that the user
     chooses to ignore are recorded in ``warnings`` for the screen-5 summary.
+    ``continue_hint`` (en, zh) spells out the consequence of continuing anyway.
     """
-    console.print(f"  [dim]⏳ Verifying {label}...[/dim]")
-    ok, detail = _probe_everos_endpoint(
-        label, model=model, api_key=api_key, base_url=base_url
-    )
+    console.print(_t(f"  [dim]⏳ Verifying {label}…[/dim]", f"  [dim]⏳ 正在验证 {label}…[/dim]"))
+    ok, detail = _probe_everos_endpoint(label, model=model, api_key=api_key, base_url=base_url)
     if ok:
-        console.print(f"  [green]✓ {label} connected.[/green]")
+        console.print(
+            _t(f"  [green]✓ {label} connected.[/green]", f"  [green]✓ {label} 连接成功。[/green]")
+        )
         return True
-    console.print(f"  [yellow]✗ Couldn't reach {label}: {detail}[/yellow]")
+    console.print(
+        _t(
+            f"  [yellow]✗ Couldn't reach {label}: {detail}[/yellow]",
+            f"  [yellow]✗ 连不上 {label}:{detail}[/yellow]",
+        )
+    )
+    if continue_hint:
+        cont_label = _t(f"Continue anyway ({continue_hint[0]})", f"仍然继续({continue_hint[1]})")
+    else:
+        cont_label = _t("Continue anyway", "仍然继续")
     choice = _failure_choice(
         [
-            ("1) Re-enter", "rekey"),
-            ("2) Continue anyway", "continue"),
+            (_t("Re-enter", "重新填写"), "rekey"),
+            (cont_label, "continue"),
         ],
         non_interactive=non_interactive,
     )
     if choice == "rekey":
         return False
-    warnings.append(f"memory {label}")
+    warnings.append(label)
     return True
 
 
-def _config_memory_llm(*, main_model: Optional[str], non_interactive: bool, warnings: list[str]) -> None:
-    """4.1 — memory LLM (required once memory is enabled)."""
+# Curated OpenAI-compatible endpoints for EverOS memory models. Picking one
+# pre-fills its base_url (mirrors the main provider step); everything else is
+# reachable via "reuse an existing endpoint" or "custom" (type a base_url).
+# These are the providers' documented OpenAI-compatible /v1 endpoints.
+_EVEROS_PROVIDERS: list[dict[str, str]] = [
+    {
+        "name": "openai",
+        "label": "OpenAI",
+        "label_zh": "OpenAI",
+        "base_url": "https://api.openai.com/v1",
+    },
+    {
+        "name": "openrouter",
+        "label": "OpenRouter",
+        "label_zh": "OpenRouter",
+        "base_url": "https://openrouter.ai/api/v1",
+    },
+    {
+        "name": "deepseek",
+        "label": "DeepSeek",
+        "label_zh": "DeepSeek",
+        "base_url": "https://api.deepseek.com/v1",
+    },
+    {
+        "name": "siliconflow",
+        "label": "SiliconFlow",
+        "label_zh": "硅基流动 SiliconFlow",
+        "base_url": "https://api.siliconflow.cn/v1",
+    },
+    {
+        "name": "dashscope",
+        "label": "DashScope (Alibaba)",
+        "label_zh": "阿里百炼 DashScope",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    },
+]
+
+# Per-role config: menu/verify label, model-id example, whether optional, and
+# whether to run a connectivity probe after configuring (rerank/multimodal use
+# non-chat endpoints whose /models probe isn't a reliable health check).
+_EVEROS_ROLES: dict[str, dict[str, Any]] = {
+    "llm": {
+        "label": ("Memory LLM", "记忆 LLM"),
+        "example": "gpt-4o-mini",
+        "optional": False,
+        "verify": True,
+        "purpose": (
+            "reads each conversation to judge what matters and extract the key points",
+            "从对话中判断信息边界、抽取要点",
+        ),
+        "continue_hint": ("memory extraction may fail", "记忆抽取可能失败"),
+    },
+    "embedding": {
+        "label": ("Memory embedding", "记忆 embedding"),
+        "example": "text-embedding-3-small",
+        "optional": False,
+        "verify": True,
+        "purpose": (
+            "turns text into vectors so memories are stored and retrieved by meaning, not just keywords",
+            "把文字转成向量,存入记忆库并在检索时按「意思」匹配,而不只是关键词",
+        ),
+        "continue_hint": ("semantic recall will be unavailable", "语义召回将不可用"),
+    },
+    "rerank": {
+        "label": ("Memory rerank", "记忆 rerank"),
+        "example": "BAAI/bge-reranker-v2-m3",
+        "optional": True,
+        "verify": False,
+        "purpose": (
+            "re-ranks the candidates from semantic search so the best match comes first (slightly slower); "
+            "memory works fine without it, just with slightly weaker ordering",
+            "在语义召回一批候选后再精排一遍,让结果更准,会略增延迟;不配也能正常用记忆,只是排序略逊",
+        ),
+        "skip_note": (
+            "Skipped reranking; memory retrieval still works.",
+            "已跳过 rerank,记忆检索仍可用。",
+        ),
+    },
+    "multimodal": {
+        "label": ("Memory multimodal", "记忆多模态"),
+        "example": "gpt-4o",
+        "optional": True,
+        "verify": False,
+        "purpose": (
+            "lets Raven store and recall images / PDFs / audio as memory — only needed if you actually want "
+            "multimodal content remembered, not merely because such files exist",
+            "让 Raven 把图片 / PDF / 音频也作为记忆来理解和检索;仅当你确有把多模态内容纳入记忆的需求时才配,有这类文件并不等于需要",
+        ),
+        "skip_note": (
+            "Skipped; everything else is unaffected — configure it later if you come to need multimodal memory.",
+            "已跳过;其余功能不受影响,日后确有把多模态内容纳入记忆的需求时再配即可。",
+        ),
+    },
+}
+
+
+def _fetch_everos_models(base_url: Optional[str], api_key: Optional[str]) -> Optional[list[str]]:
+    """GET ``{base_url}/models`` → sorted model-id list, or ``None`` when the
+    endpoint is unreachable / unauthorized / returns nothing. Never raises."""
+    import httpx
+
+    if not base_url:
+        return None
+    url = base_url.rstrip("/") + ("/models" if "/v1" in base_url else "/v1/models")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    try:
+        with httpx.Client(timeout=10) as client:
+            resp = client.get(url, headers=headers)
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+    items = data.get("data") if isinstance(data, dict) else None
+    if not isinstance(items, list):
+        return None
+    ids = [m.get("id") for m in items if isinstance(m, dict) and m.get("id")]
+    return sorted(ids) or None
+
+
+def _everos_pick_model(
+    *, base_url: Optional[str], api_key: Optional[str], example: str, allow_back: bool
+) -> Any:
+    """Pick a model id for an EverOS endpoint: fetch ``/models`` for a
+    fuzzy-searchable list, else fall back to free text. Empty submit = back."""
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
-    from raven.config.update_everos import set_everos_section
 
-    current = _everos_section("llm").get("model")
-    reuse_ok = _model_is_openai_compatible(main_model)
-
-    if current:
-        choices = [questionary.Choice(f"Keep current: {current}", value="keep")]
-        if reuse_ok:
-            choices.append(questionary.Choice("Reuse main chat model", value="reuse"))
-        choices.append(questionary.Choice("Configure separately", value="separate"))
-        action = questionary.select("Memory LLM:", choices=choices, style=RAVEN_STYLE).ask()
-        if action is None:
-            raise typer.Exit(1)
-        if action == "keep":
-            return
-    elif reuse_ok:
-        action = questionary.select(
-            "Configure the memory LLM:",
-            choices=[
-                questionary.Choice(f"Reuse main chat model ({main_model})", value="reuse"),
-                questionary.Choice("Configure separately", value="separate"),
-            ],
+    console.print(_t("  [dim]⏳ Loading models…[/dim]", "  [dim]⏳ 正在拉取模型列表…[/dim]"))
+    models = _fetch_everos_models(base_url, api_key)
+    if models:
+        chosen = questionary.autocomplete(
+            _t(
+                f"Model ({len(models)} available — type to filter, e.g. {example}):",
+                f"模型(共 {len(models)} 个 — 输入可筛选,如 {example}):",
+            ),
+            choices=models,
+            ignore_case=True,
+            match_middle=True,
+            placeholder=_back_placeholder(allow_back),
             style=RAVEN_STYLE,
+            qmark=_QMARK,
         ).ask()
-        if action is None:
-            raise typer.Exit(1)
     else:
         console.print(
-            "  [dim]Your main model isn't OpenAI-compatible; the memory LLM needs a "
-            "separate OpenAI-compatible endpoint.[/dim]"
+            _t(
+                "  [dim]Couldn't list models from this endpoint — type the id manually.[/dim]",
+                "  [dim]该端点拉不到模型列表 — 请手动输入模型 id。[/dim]",
+            )
         )
-        action = "separate"
-
-    if action == "reuse":
-        # Reuse the main provider's credentials: strip the litellm prefix to
-        # the bare model id and resolve the provider's real base_url/key so
-        # EverOS's bare OpenAI client can call it.
-        creds = _resolve_reuse_llm_creds(main_model or "")
-        set_everos_section("llm", creds)
-        _verify_everos_model(
-            "memory LLM",
-            model=creds["model"],
-            api_key=creds["api_key"],
-            base_url=creds["base_url"],
-            non_interactive=non_interactive,
-            warnings=warnings,
-        )
-        return
-
-    while True:
-        model = _prompt_text("Memory LLM model id:")
-        api_key = _prompt_text("API key (hidden):", secret=True)
-        base_url = _prompt_text("base_url (must include /v1):")
-        set_everos_section("llm", {"model": model, "api_key": api_key, "base_url": base_url})
-        if _verify_everos_model(
-            "memory LLM",
-            model=model,
-            api_key=api_key,
-            base_url=base_url,
-            non_interactive=non_interactive,
-            warnings=warnings,
-        ):
-            return
-
-
-def _config_memory_embedding(*, non_interactive: bool, warnings: list[str]) -> None:
-    """4.2 — embedding (required once memory is enabled)."""
-    questionary = _require_questionary()
-    from raven.cli._styles import RAVEN_STYLE
-    from raven.config.update_everos import set_everos_section
-
-    current = _everos_section("embedding").get("model")
-    if current:
-        action = questionary.select(
-            "Memory embedding:",
-            choices=[
-                questionary.Choice(f"Keep current: {current}", value="keep"),
-                questionary.Choice("Reconfigure", value="redo"),
-            ],
+        chosen = questionary.text(
+            _t(f"Model id (e.g. {example}):", f"模型 id(如 {example}):"),
+            placeholder=_back_placeholder(allow_back),
             style=RAVEN_STYLE,
+            qmark=_QMARK,
         ).ask()
-        if action is None:
-            raise typer.Exit(1)
-        if action == "keep":
-            return
-
-    while True:
-        model = _prompt_text("Embedding model id:")
-        api_key = _prompt_text("API key (hidden):", secret=True)
-        base_url = _prompt_text("base_url:")
-        set_everos_section(
-            "embedding", {"model": model, "api_key": api_key, "base_url": base_url}
-        )
-        if _verify_everos_model(
-            "embedding",
-            model=model,
-            api_key=api_key,
-            base_url=base_url,
-            non_interactive=non_interactive,
-            warnings=warnings,
-        ):
-            return
+    if chosen is None:
+        raise typer.Exit(1)
+    chosen = chosen.strip()
+    if allow_back and chosen == "":
+        return _BACK
+    if not chosen:
+        raise typer.Exit(1)
+    return chosen
 
 
-def _maybe_reuse_memory_llm_creds() -> tuple[Optional[str], Optional[str]]:
-    """Offer to reuse the memory LLM's key/base_url; return ``(api_key, base_url)``.
-
-    Default is to reuse (spec §617①). Returns ``(None, None)`` when the user
-    opts to enter fresh credentials.
-    """
+def _everos_pick_creds_and_model(
+    *, section: str, example: str, main_model: Optional[str], non_interactive: bool
+) -> Any:
+    """Mirror the main provider step for one EverOS model: pick a source
+    (reuse / curated provider / custom) → API key → model. Returns a dict with
+    ``model`` / ``api_key`` / ``base_url`` (plus ``provider`` for rerank), or
+    ``_BACK`` when the user backs out of the source picker. Empty submit on any
+    field rewinds one step."""
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
 
     llm = _everos_section("llm")
-    if not (llm.get("api_key") and llm.get("base_url")):
-        return None, None
-    reuse = questionary.confirm(
-        "Reuse the memory LLM's api_key / base_url?",
-        default=True,
-        style=RAVEN_STYLE,
-    ).ask()
-    if reuse is None:
-        raise typer.Exit(1)
-    if reuse:
-        return llm.get("api_key"), llm.get("base_url")
-    return None, None
+    reuse_llm_ok = section != "llm" and bool(llm.get("api_key") and llm.get("base_url"))
+    reuse_main_ok = section == "llm" and _model_is_openai_compatible(main_model)
+
+    while True:  # source picker — a field-level back rewinds here
+        choices: list[Any] = []
+        if reuse_main_ok:
+            choices.append(
+                questionary.Choice(
+                    _t(
+                        f"↺ Reuse main chat model ({main_model})", f"↺ 复用主对话模型({main_model})"
+                    ),
+                    value=("reuse_main",),
+                )
+            )
+        if reuse_llm_ok:
+            choices.append(
+                questionary.Choice(
+                    _t(
+                        f"↺ Reuse memory LLM endpoint ({llm.get('base_url')})",
+                        f"↺ 复用记忆 LLM 端点({llm.get('base_url')})",
+                    ),
+                    value=("reuse_llm",),
+                )
+            )
+        for prov in _EVEROS_PROVIDERS:
+            choices.append(
+                questionary.Choice(_t(prov["label"], prov["label_zh"]), value=("provider", prov))
+            )
+        choices.append(
+            questionary.Choice(
+                _t("Other (custom OpenAI-compatible endpoint)", "其他(自定义 OpenAI 兼容端点)"),
+                value=("custom",),
+            )
+        )
+        choices.append(questionary.Separator())
+        choices.append(questionary.Choice(_t("Back", "返回"), value=_BACK))
+
+        src = questionary.select(
+            _t("Pick a provider (or reuse / custom):", "选择服务商(或复用 / 自定义):"),
+            choices=choices,
+            style=RAVEN_STYLE,
+            qmark=_QMARK,
+        ).ask()
+        if src is None:
+            raise typer.Exit(1)
+        if src is _BACK:
+            return _BACK
+        kind = src[0]
+
+        # Reuse main chat model: model id + credentials all come along — done.
+        if kind == "reuse_main":
+            creds = _resolve_reuse_llm_creds(main_model or "")
+            if creds.get("model") and creds.get("api_key") and creds.get("base_url"):
+                return {
+                    "model": creds["model"],
+                    "api_key": creds["api_key"],
+                    "base_url": creds["base_url"],
+                }
+            console.print(
+                _t(
+                    "  [yellow]✗ Couldn't resolve the main model's key / endpoint — pick a source below.[/yellow]",
+                    "  [yellow]✗ 无法解析主模型的 Key / 端点 — 请在下面另选来源。[/yellow]",
+                )
+            )
+            continue
+
+        # Resolve (api_key, base_url) from the chosen source.
+        if kind == "reuse_llm":
+            api_key = llm.get("api_key")
+            base_url = llm.get("base_url")
+        elif kind == "provider":
+            base_url = src[1]["base_url"]
+            api_key = _prompt_api_key(src[1]["name"], allow_back=True)
+            if api_key is _BACK:
+                continue
+        else:  # custom
+            base_url = _prompt_text(
+                _t("Base URL (must include /v1):", "Base URL(需包含 /v1):"), allow_back=True
+            )
+            if base_url is _BACK:
+                continue
+            api_key = _prompt_text(
+                _t("API key (hidden):", "API Key(隐藏输入):"), secret=True, allow_back=True
+            )
+            if api_key is _BACK:
+                continue
+
+        # Guard against a source that resolved to an empty key / endpoint —
+        # set_everos_section drops None values, which would otherwise persist a
+        # section with a model but no usable endpoint.
+        if not (api_key and base_url):
+            console.print(
+                _t(
+                    "  [yellow]✗ Missing API key or Base URL for this source — pick another.[/yellow]",
+                    "  [yellow]✗ 该来源缺少 API Key 或 Base URL — 请换一个。[/yellow]",
+                )
+            )
+            continue
+
+        # rerank carries a service-type field EverOS needs.
+        rerank_provider: Optional[str] = None
+        if section == "rerank":
+            rerank_provider = questionary.select(
+                _t("Rerank service type:", "rerank 服务类型:"),
+                choices=[
+                    questionary.Choice("deepinfra", value="deepinfra"),
+                    questionary.Choice("vllm", value="vllm"),
+                    questionary.Choice(_t("Back", "返回"), value=_BACK),
+                ],
+                style=RAVEN_STYLE,
+                qmark=_QMARK,
+            ).ask()
+            if rerank_provider is None:
+                raise typer.Exit(1)
+            if rerank_provider is _BACK:
+                continue
+
+        model = _everos_pick_model(
+            base_url=base_url, api_key=api_key, example=example, allow_back=True
+        )
+        if model is _BACK:
+            continue
+
+        result: dict[str, Any] = {"model": model, "api_key": api_key, "base_url": base_url}
+        if rerank_provider:
+            result["provider"] = rerank_provider
+        return result
 
 
-def _config_memory_rerank(*, non_interactive: bool) -> None:
-    """4.3 — rerank (optional)."""
+def _config_everos_role(
+    *, section: str, main_model: Optional[str], non_interactive: bool, warnings: list[str]
+) -> None:
+    """Configure one EverOS memory role (llm / embedding / rerank / multimodal)
+    with the unified provider→key→model flow, reuse shortcuts, and a back loop."""
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
     from raven.config.update_everos import clear_everos_section, set_everos_section
 
-    current = _everos_section("rerank").get("model")
-    if current:
-        action = questionary.select(
-            "Memory rerank:",
-            choices=[
-                questionary.Choice(f"Keep current: {current}", value="keep"),
-                questionary.Choice("Reconfigure", value="redo"),
-                questionary.Choice("Disable", value="off"),
-            ],
-            style=RAVEN_STYLE,
-        ).ask()
-        if action is None:
-            raise typer.Exit(1)
-        if action == "keep":
-            return
-        if action == "off":
-            clear_everos_section("rerank")
-            console.print("  [dim]Rerank disabled.[/dim]")
-            return
-    else:
-        action = questionary.select(
-            "Rerank model (optional — improves ranking, slightly slower):",
-            choices=[
-                questionary.Choice("1) Configure rerank", value="redo"),
-                questionary.Choice("0) Skip (no reranking)", value="skip"),
-            ],
-            style=RAVEN_STYLE,
-        ).ask()
-        if action in (None, "skip"):
-            console.print("  [dim]Skipped reranking; memory retrieval still works.[/dim]")
-            return
+    role = _EVEROS_ROLES[section]
+    label_en, label_zh = role["label"]
+    purpose_en, purpose_zh = role["purpose"]
+    optional = role["optional"]
+    verify_label = _t(label_en, label_zh)
 
-    provider = questionary.select(
-        "Rerank service type:",
-        choices=[
-            questionary.Choice("1) deepinfra", value="deepinfra"),
-            questionary.Choice("2) vllm", value="vllm"),
-        ],
-        style=RAVEN_STYLE,
-    ).ask()
-    if provider is None:
-        raise typer.Exit(1)
-    model = _prompt_text("Rerank model id:")
-    api_key, base_url = _maybe_reuse_memory_llm_creds()
-    if api_key is None:
-        api_key = _prompt_text("API key (hidden):", secret=True)
-        base_url = _prompt_text("base_url:")
-    set_everos_section(
-        "rerank",
-        {"provider": provider, "model": model, "api_key": api_key, "base_url": base_url},
+    # Tell the user what this model is for before asking them to configure it.
+    # Header sits on the 2-space info column (bold accent); the purpose nests
+    # one line under it (dim), matching the layout system used everywhere else.
+    tag = _t("optional", "可选")
+    console.print()
+    console.print(
+        _t(
+            f"  [bold #fbe23f]{label_en}[/bold #fbe23f]"
+            + (f" [dim]({tag})[/dim]" if optional else "")
+            + f"\n  [dim]{purpose_en}[/dim]",
+            f"  [bold #fbe23f]{label_zh}[/bold #fbe23f]"
+            + (f" [dim]({tag})[/dim]" if optional else "")
+            + f"\n  [dim]{purpose_zh}[/dim]",
+        )
     )
-    console.print("  [green]✓ rerank configured.[/green]")
+
+    while True:  # role-menu loop — a back-out of the source picker returns here
+        current = _everos_section(section).get("model")
+        if current:
+            choices = [
+                questionary.Choice(
+                    _t(f"Keep current: {current}", f"沿用当前:{current}"), value="keep"
+                ),
+                questionary.Choice(_t("Reconfigure", "重新配置"), value="redo"),
+            ]
+            if optional:
+                choices.append(questionary.Choice(_t("Disable", "停用"), value="off"))
+            action = questionary.select(
+                _t("Already configured — what now?", "已配置,怎么处理?"),
+                choices=choices,
+                style=RAVEN_STYLE,
+                qmark=_QMARK,
+            ).ask()
+            if action is None:
+                raise typer.Exit(1)
+            if action == "keep":
+                return
+            if action == "off":
+                clear_everos_section(section)
+                console.print(
+                    _t(f"  [dim]{label_en} disabled.[/dim]", f"  [dim]已停用 {label_zh}。[/dim]")
+                )
+                return
+        elif optional:
+            action = questionary.select(
+                _t("Configure it?", "要配置吗?"),
+                choices=[
+                    questionary.Choice(_t("Configure", "配置"), value="redo"),
+                    questionary.Choice(_t("Skip", "跳过"), value="skip"),
+                ],
+                style=RAVEN_STYLE,
+                qmark=_QMARK,
+            ).ask()
+            if action in (None, "skip"):
+                note_en, note_zh = role.get(
+                    "skip_note", (f"Skipped {label_en}.", f"已跳过 {label_zh}。")
+                )
+                console.print(_t(f"  [dim]{note_en}[/dim]", f"  [dim]{note_zh}[/dim]"))
+                return
+        # A required role with nothing configured falls straight into the picker.
+
+        result = _everos_pick_creds_and_model(
+            section=section,
+            example=role["example"],
+            main_model=main_model,
+            non_interactive=non_interactive,
+        )
+        if result is _BACK:
+            continue  # back to the role menu
+
+        if role["verify"]:
+            ok = _verify_everos_model(
+                verify_label,
+                model=result["model"],
+                api_key=result["api_key"],
+                base_url=result["base_url"],
+                non_interactive=non_interactive,
+                warnings=warnings,
+                continue_hint=role.get("continue_hint"),
+            )
+        else:
+            ok = True
+        if not ok:
+            continue  # "Re-enter" on a failed probe → back to the role menu
+
+        set_everos_section(section, result)
+        console.print(
+            _t(
+                f"  [green]✓ {label_en} configured.[/green]",
+                f"  [green]✓ 已配置 {label_zh}。[/green]",
+            )
+        )
+        return
 
 
-def _config_memory_multimodal(*, non_interactive: bool) -> None:
-    """4.4 — multimodal (optional)."""
-    questionary = _require_questionary()
-    from raven.cli._styles import RAVEN_STYLE
-    from raven.config.update_everos import clear_everos_section, set_everos_section
-
-    current = _everos_section("multimodal").get("model")
-    if current:
-        action = questionary.select(
-            "Memory multimodal:",
-            choices=[
-                questionary.Choice(f"Keep current: {current}", value="keep"),
-                questionary.Choice("Reconfigure", value="redo"),
-                questionary.Choice("Disable", value="off"),
-            ],
-            style=RAVEN_STYLE,
-        ).ask()
-        if action is None:
-            raise typer.Exit(1)
-        if action == "keep":
-            return
-        if action == "off":
-            clear_everos_section("multimodal")
-            console.print("  [dim]Multimodal disabled.[/dim]")
-            return
-    else:
-        action = questionary.select(
-            "Multimodal model (optional — only for image / PDF / audio memory):",
-            choices=[
-                questionary.Choice("1) Configure multimodal", value="redo"),
-                questionary.Choice("0) Skip", value="skip"),
-            ],
-            style=RAVEN_STYLE,
-        ).ask()
-        if action in (None, "skip"):
-            console.print("  [dim]Skipped; text-only memory is unaffected.[/dim]")
-            return
-
-    model = _prompt_text("Multimodal model id:")
-    api_key, base_url = _maybe_reuse_memory_llm_creds()
-    if api_key is None:
-        api_key = _prompt_text("API key (hidden):", secret=True)
-        base_url = _prompt_text("base_url:")
-    set_everos_section("multimodal", {"model": model, "api_key": api_key, "base_url": base_url})
-    console.print("  [green]✓ multimodal configured.[/green]")
-
-
-def _step4_memory(*, skip: bool, non_interactive: bool, main_model: Optional[str], warnings: list[str]) -> object:
+def _step4_memory(
+    *, skip: bool, non_interactive: bool, main_model: Optional[str], warnings: list[str]
+) -> object:
     """Step 4 — EverOS long-term memory (enable + model sub-screens).
 
     The bootstrap seeds ``memory.backend="everos"`` (schema default), so this
@@ -1771,7 +2666,7 @@ def _step4_memory(*, skip: bool, non_interactive: bool, main_model: Optional[str
     the enable prompt) and the "keep current" path only triggers once models
     are actually on disk.
     """
-    _step_header(4, "EverOS long-term memory")
+    _step_header(4, _t("EverOS long-term memory", "EverOS 长期记忆"))
 
     if skip or non_interactive:
         # Never configured the required models here → disable backend-driven
@@ -1780,7 +2675,12 @@ def _step4_memory(*, skip: bool, non_interactive: bool, main_model: Optional[str
         # already-enabled+configured setup is preserved.)
         if not _memory_enabled():
             _set_memory_backend(None)
-        console.print("  [dim]Keeping native Markdown memory.[/dim]")
+        console.print(
+            _t(
+                "  [dim]Keeping native Markdown memory.[/dim]",
+                "  [dim]保持原生 Markdown 记忆。[/dim]",
+            )
+        )
         return None
 
     questionary = _require_questionary()
@@ -1788,38 +2688,69 @@ def _step4_memory(*, skip: bool, non_interactive: bool, main_model: Optional[str
 
     if _memory_enabled():
         action = questionary.select(
-            "EverOS long-term memory:",
+            _t(
+                "EverOS long-term memory is already enabled. What would you like to do?",
+                "EverOS 长期记忆已启用。想做什么?",
+            ),
             choices=[
-                questionary.Choice("Keep current: EverOS enabled", value="keep"),
-                questionary.Choice("Reconfigure", value="redo"),
+                questionary.Choice(_t("Keep it enabled", "保持启用"), value="keep"),
+                questionary.Choice(_t("Reconfigure", "重新配置"), value="redo"),
             ],
             style=RAVEN_STYLE,
+            qmark=_QMARK,
         ).ask()
         if action is None:
             raise typer.Exit(1)
         if action == "keep":
             return None  # backend already "everos" + models on disk; leave as-is
     else:
+        console.print(
+            _t(
+                "  [dim]Enable to give Raven EverOS's stronger long-term memory — it needs a memory LLM and an "
+                "embedding model. Or skip and keep Raven's built-in Markdown memory (no extra setup).[/dim]",
+                "  [dim]启用后,Raven 获得 EverOS 提供的更强长期记忆能力,需额外配置记忆用的 LLM 和 embedding 模型;"
+                "不启用则使用 Raven 原生 Markdown 记忆,无需额外配置。[/dim]",
+            )
+        )
         action = questionary.select(
-            "Enable EverOS long-term memory? (stronger memory; needs an llm + embedding)",
+            _t("Enable EverOS long-term memory?", "启用 EverOS 长期记忆?"),
             choices=[
-                questionary.Choice("1) Enable EverOS long-term memory", value="on"),
-                questionary.Choice("0) Don't enable (use native Markdown memory)", value="off"),
+                questionary.Choice(
+                    _t("Enable (configure the memory models)", "启用(继续配置记忆模型)"), value="on"
+                ),
+                questionary.Choice(
+                    _t(
+                        "Don't enable (use Raven's native Markdown memory)",
+                        "不启用(使用 Raven 原生 Markdown 记忆)",
+                    ),
+                    value="off",
+                ),
             ],
             style=RAVEN_STYLE,
+            qmark=_QMARK,
         ).ask()
         if action in (None, "off"):
             _set_memory_backend(None)
-            console.print("  [dim]Using native Markdown memory.[/dim]")
+            console.print(
+                _t(
+                    "  [dim]Using native Markdown memory.[/dim]",
+                    "  [dim]使用原生 Markdown 记忆。[/dim]",
+                )
+            )
             return None
 
     # Configure required models FIRST, then flip the backend on — so a Ctrl+C
     # mid-configuration leaves backend at its prior (disabled) value rather
     # than an enabled-but-modelless state.
-    _config_memory_llm(main_model=main_model, non_interactive=non_interactive, warnings=warnings)
-    _config_memory_embedding(non_interactive=non_interactive, warnings=warnings)
-    _config_memory_rerank(non_interactive=non_interactive)
-    _config_memory_multimodal(non_interactive=non_interactive)
+    for _role in ("llm", "embedding", "rerank", "multimodal"):
+        # Each role prints one leading blank before its own header, so no extra
+        # separator here — avoids the double blank line between roles.
+        _config_everos_role(
+            section=_role,
+            main_model=main_model,
+            non_interactive=non_interactive,
+            warnings=warnings,
+        )
     _set_memory_backend("everos")
     return None
 
@@ -1830,23 +2761,88 @@ def _step4_memory(*, skip: bool, non_interactive: bool, main_model: Optional[str
 
 
 def _print_next_steps(*, warnings: list[str]) -> None:
+    from rich.table import Table
+
+    console.print()
     if warnings:
         console.print(
-            "\n[bold yellow]⚠ Setup finished, but these items didn't pass a "
-            f"connectivity test: {', '.join(warnings)}.[/bold yellow]"
-        )
-        console.print(
-            "[dim]Fix them before relying on the related features "
-            "(run 'raven doctor' to re-check).[/dim]"
+            Panel(
+                _t(
+                    "[bold yellow]⚠ Setup finished with warnings[/bold yellow]",
+                    "[bold yellow]⚠ 配置完成,但有警告[/bold yellow]",
+                )
+                + "\n\n"
+                + _t(
+                    "[dim]These items didn't pass a connectivity test:[/dim] ",
+                    "[dim]以下项目未通过连通测试:[/dim] ",
+                )
+                + f"{', '.join(warnings)}\n"
+                + _t(
+                    "[dim]Fix them before relying on the related features "
+                    "(run [/dim][#fbe23f]raven doctor[/#fbe23f][dim] to re-check).[/dim]",
+                    "[dim]在依赖相关功能前请先修复("
+                    "运行 [/dim][#fbe23f]raven doctor[/#fbe23f][dim] 复查)。[/dim]",
+                ),
+                border_style="yellow",
+                padding=(1, 2),
+            )
         )
     else:
-        console.print("\n[bold green]🎉 Setup complete![/bold green]")
+        console.print(
+            Panel(
+                _t(
+                    "[bold green]🎉 Setup complete![/bold green]",
+                    "[bold green]🎉 配置完成![/bold green]",
+                ),
+                border_style="green",
+                padding=(0, 2),
+            )
+        )
 
-    console.print("\nGet started:")
-    console.print('  [cyan]raven[/cyan]                                # launch the native TUI (default)')
-    console.print('  [cyan]raven tui[/cyan]                            # same, explicit')
-    console.print('  [cyan]raven gateway[/cyan]                        # run the gateway (serve channels)')
-    console.print('  [cyan]raven agent -m "hello, world"[/cyan]        # one-shot question')
+    # Recap what was configured (read from disk) so the user has closure.
+    provs = ", ".join(_provider_label(n).split(" (")[0] for n in _configured_providers()) or "—"
+    run_loc = (
+        _t("Host (direct)", "本机直接运行")
+        if _current_sandbox_backend() == "none"
+        else _t("Sandbox (boxlite)", "沙箱(boxlite)")
+    )
+    chans = ", ".join(_enabled_channels()) or _t("none", "无")
+    mem = _t("EverOS", "EverOS") if _memory_enabled() else _t("native Markdown", "原生 Markdown")
+    recap = Table(show_header=False, box=None, padding=(0, 2, 0, 0))
+    recap.add_column(style="dim", no_wrap=True)
+    recap.add_column()
+    recap.add_row(_t("Provider", "服务商"), provs)
+    recap.add_row(_t("Default model", "默认模型"), _load_current_default_model() or "—")
+    recap.add_row(_t("Run location", "运行位置"), run_loc)
+    recap.add_row(_t("Channels", "聊天渠道"), chans)
+    recap.add_row(_t("Memory", "长期记忆"), mem)
+    console.print(
+        Panel(
+            recap,
+            title=f"[bold]{_t('Your setup', '你的配置')}[/bold]",
+            title_align="left",
+            border_style="#8a6d00",
+            padding=(1, 2),
+        )
+    )
+
+    table = Table(show_header=False, box=None, padding=(0, 3, 0, 0))
+    table.add_column(style="#fbe23f", no_wrap=True)
+    table.add_column(style="dim")
+    table.add_row("raven", _t("launch the native TUI (default)", "启动原生 TUI(默认)"))
+    table.add_row("raven gateway", _t("run the gateway (serve channels)", "运行网关(对接渠道)"))
+    table.add_row('raven agent -m "hello, world"', _t("ask a one-shot question", "一次性提问"))
+    table.add_row("raven channels list", _t("see connected chat channels", "查看已接入的渠道"))
+    table.add_row("raven provider list", _t("check your provider config", "检查当前服务商配置"))
+    console.print(
+        Panel(
+            table,
+            title=f"[bold]{_t('Get started', '开始使用')}[/bold]",
+            title_align="left",
+            border_style="#c8a900",
+            padding=(1, 2),
+        )
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1873,15 +2869,76 @@ def run_wizard(
     The reusable entry point: the ``onboard`` CLI command and the startup gate
     both call this. Screens form a state machine so a ``0) Back`` choice can
     rewind one step; Ctrl+C exits keeping whatever was already written.
+
+    Internal INFO logs (config writes, etc.) are hushed for the wizard's
+    duration so they don't clutter the UI, then restored in ``finally`` —
+    display-only; logging elsewhere is unaffected.
     """
+    from loguru import logger as _logger
+
+    _logger.disable("raven")
+    try:
+        _run_wizard_body(
+            provider=provider,
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
+            channel=channel,
+            skip_sandbox=skip_sandbox,
+            skip_channel=skip_channel,
+            skip_memory=skip_memory,
+            non_interactive=non_interactive,
+            yes=yes,
+            reset=reset,
+        )
+    finally:
+        _logger.enable("raven")
+
+
+def _run_wizard_body(
+    *,
+    provider: Optional[str] = None,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    model: Optional[str] = None,
+    channel: Optional[str] = None,
+    skip_sandbox: bool = False,
+    skip_channel: bool = False,
+    skip_memory: bool = False,
+    non_interactive: bool = False,
+    yes: bool = False,
+    reset: bool = False,
+) -> None:
+    global _LANG
     _check_tty_or_die(non_interactive)
+    _LANG = _config_language()  # start from the saved language (default "en")
+    if not non_interactive:
+        _pick_language()  # may change _LANG (persisted after bootstrap below)
     _handle_existing_config(reset=reset, yes=yes, non_interactive=non_interactive)
     _bootstrap_empty_config()
+    if not non_interactive:
+        from raven.config.update import set_language
 
-    console.print("\n[bold cyan]✨ Welcome to the Raven setup wizard[/bold cyan]")
+        set_language(_LANG)  # persist now that config.json exists
+
+    console.print()
     console.print(
-        "We'll configure, in order: ① LLM  ② run location  ③ chat channel  ④ long-term memory\n"
-        "[dim]Press Ctrl+C anytime to quit (anything already written is kept).[/dim]"
+        Panel(
+            _t(
+                "[bold #fbe23f]✨ Welcome to the Raven setup wizard[/bold #fbe23f]\n\n"
+                "[dim]We'll configure, in order:[/dim]\n"
+                "  [#fbe23f]①[/#fbe23f] LLM      [#fbe23f]②[/#fbe23f] Run location      "
+                "[#fbe23f]③[/#fbe23f] Chat channel      [#fbe23f]④[/#fbe23f] Long-term memory\n\n"
+                "[dim]↑↓ select · Enter confirm · Ctrl+C quit anytime — anything already written is kept.[/dim]",
+                "[bold #fbe23f]✨ 欢迎使用 Raven 配置向导[/bold #fbe23f]\n\n"
+                "[dim]我们将依次配置:[/dim]\n"
+                "  [#fbe23f]①[/#fbe23f] LLM      [#fbe23f]②[/#fbe23f] 运行位置      "
+                "[#fbe23f]③[/#fbe23f] 聊天渠道      [#fbe23f]④[/#fbe23f] 长期记忆\n\n"
+                "[dim]↑↓ 选择 · Enter 确认 · 随时 Ctrl+C 退出 — 已写入的配置会保留。[/dim]",
+            ),
+            border_style="#c8a900",
+            padding=(1, 2),
+        )
     )
 
     warnings: list[str] = []
@@ -1899,9 +2956,7 @@ def run_wizard(
             warnings=warnings,
         ),
         lambda: _step2_sandbox(skip=skip_sandbox, non_interactive=non_interactive),
-        lambda: _step3_channel(
-            channel=channel, skip=skip_channel, non_interactive=non_interactive
-        ),
+        lambda: _step3_channel(channel=channel, skip=skip_channel, non_interactive=non_interactive),
         lambda: _step4_memory(
             skip=skip_memory,
             non_interactive=non_interactive,
@@ -1983,9 +3038,7 @@ def register(app: typer.Typer) -> None:
             "--non-interactive",
             help="Run without prompts (requires flags for any missing field)",
         ),
-        yes: bool = typer.Option(
-            False, "--yes", "-y", help="Skip all confirm prompts"
-        ),
+        yes: bool = typer.Option(False, "--yes", "-y", help="Skip all confirm prompts"),
         reset: bool = typer.Option(
             False, "--reset", help="Force re-run even if a config already exists"
         ),

--- a/raven/config/schema.py
+++ b/raven/config/schema.py
@@ -22,8 +22,12 @@ class WhatsAppConfig(Base):
     enabled: bool = False
     bridge_url: str = "ws://localhost:3001"
     bridge_token: str = ""  # Shared token for bridge auth (auto-generated when empty)
-    allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Allowed phone numbers; ['*'] = anyone
-    group_policy: Literal["open", "mention"] = "open"  # "open" responds to all, "mention" only when @mentioned
+    allow_from: list[str] = Field(
+        default_factory=lambda: ["*"]
+    )  # Allowed phone numbers; ['*'] = anyone
+    group_policy: Literal["open", "mention"] = (
+        "open"  # "open" responds to all, "mention" only when @mentioned
+    )
 
 
 class TelegramConfig(Base):
@@ -31,12 +35,16 @@ class TelegramConfig(Base):
 
     enabled: bool = False
     token: str = ""  # Bot token from @BotFather
-    allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Allowed user IDs or usernames; ['*'] = anyone
+    allow_from: list[str] = Field(
+        default_factory=lambda: ["*"]
+    )  # Allowed user IDs or usernames; ['*'] = anyone
     proxy: str | None = (
         None  # HTTP/SOCKS5 proxy URL, e.g. "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
     )
     reply_to_message: bool = False  # If true, bot replies quote the original message
-    group_policy: Literal["open", "mention"] = "mention"  # "mention" responds when @mentioned or replied to, "open" responds to all
+    group_policy: Literal["open", "mention"] = (
+        "mention"  # "mention" responds when @mentioned or replied to, "open" responds to all
+    )
 
 
 class FeishuConfig(Base):
@@ -47,11 +55,15 @@ class FeishuConfig(Base):
     app_secret: str = ""  # App Secret from Feishu Open Platform
     encrypt_key: str = ""  # Encrypt Key for event subscription (optional)
     verification_token: str = ""  # Verification Token for event subscription (optional)
-    allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Allowed user open_ids; ['*'] = anyone
+    allow_from: list[str] = Field(
+        default_factory=lambda: ["*"]
+    )  # Allowed user open_ids; ['*'] = anyone
     react_emoji: str = (
         "THUMBSUP"  # Emoji type for message reactions (e.g. THUMBSUP, OK, DONE, SMILE)
     )
-    group_policy: Literal["open", "mention"] = "mention"  # "mention" responds when @mentioned, "open" responds to all
+    group_policy: Literal["open", "mention"] = (
+        "mention"  # "mention" responds when @mentioned, "open" responds to all
+    )
 
 
 class DingTalkConfig(Base):
@@ -60,7 +72,9 @@ class DingTalkConfig(Base):
     enabled: bool = False
     client_id: str = ""  # AppKey
     client_secret: str = ""  # AppSecret
-    allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Allowed staff_ids; ['*'] = anyone
+    allow_from: list[str] = Field(
+        default_factory=lambda: ["*"]
+    )  # Allowed staff_ids; ['*'] = anyone
 
 
 class DiscordConfig(Base):
@@ -126,7 +140,9 @@ class EmailConfig(Base):
     mark_seen: bool = True
     max_body_chars: int = 12000
     subject_prefix: str = "Re: "
-    allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Allowed sender email addresses; ['*'] = anyone
+    allow_from: list[str] = Field(
+        default_factory=lambda: ["*"]
+    )  # Allowed sender email addresses; ['*'] = anyone
 
 
 class MochatMentionConfig(Base):
@@ -187,7 +203,9 @@ class SlackConfig(Base):
     user_token_read_only: bool = True
     reply_in_thread: bool = True
     react_emoji: str = "eyes"
-    allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Allowed Slack user IDs (sender-level); ['*'] = anyone
+    allow_from: list[str] = Field(
+        default_factory=lambda: ["*"]
+    )  # Allowed Slack user IDs (sender-level); ['*'] = anyone
     group_policy: str = "mention"  # "mention", "open", "allowlist"
     group_allow_from: list[str] = Field(default_factory=list)  # Allowed channel IDs if allowlist
     dm: SlackDMConfig = Field(default_factory=SlackDMConfig)
@@ -281,10 +299,13 @@ class AgentDefaults(Base):
     enable_personalization: bool = (
         False  # 4-step PAHF-inspired personalization flow (classify → ask → execute → learn)
     )
+
     @property
     def should_warn_deprecated_memory_window(self) -> bool:
         """Return True when old memoryWindow is present without contextWindowTokens."""
-        return self.memory_window is not None and "context_window_tokens" not in self.model_fields_set
+        return (
+            self.memory_window is not None and "context_window_tokens" not in self.model_fields_set
+        )
 
 
 class AgentsConfig(Base):
@@ -343,7 +364,9 @@ class GeminiProviderConfig(ProviderConfig):
         import itertools
 
         if not hasattr(self, "_key_cycle"):
-            keys = self.api_key_list if self.api_key_list else ([self.api_key] if self.api_key else [])
+            keys = (
+                self.api_key_list if self.api_key_list else ([self.api_key] if self.api_key else [])
+            )
             object.__setattr__(self, "_key_cycle", itertools.cycle(keys) if keys else None)
         cycle = getattr(self, "_key_cycle", None)
         if cycle is None:
@@ -369,16 +392,22 @@ class ProvidersConfig(Base):
     """Configuration for LLM providers."""
 
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
-    azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
+    azure_openai: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # Azure OpenAI (model = deployment name)
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
     deepseek: ProviderConfig = Field(default_factory=ProviderConfig)
     groq: ProviderConfig = Field(default_factory=ProviderConfig)
     zhipu: ProviderConfig = Field(default_factory=ProviderConfig)
-    dashscope: ProviderConfig = Field(default_factory=ProviderConfig)  # Alibaba Cloud Tongyi Qianwen
+    dashscope: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # Alibaba Cloud Tongyi Qianwen
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
-    gemini: GeminiProviderConfig = Field(default_factory=GeminiProviderConfig)  # Google Gemini / Vertex AI
+    gemini: GeminiProviderConfig = Field(
+        default_factory=GeminiProviderConfig
+    )  # Google Gemini / Vertex AI
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
@@ -534,6 +563,9 @@ class Config(BaseSettings):
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
     routing: RoutingConfig = Field(default_factory=RoutingConfig)
     cron: CronConfig = Field(default_factory=CronConfig)
+    # UI language chosen during onboarding. Drives the wizard/CLI copy and the
+    # agent's reply language (injected into the system prompt). "en" | "zh".
+    language: Literal["en", "zh"] = "en"
 
     @property
     def workspace_path(self) -> Path:
@@ -653,6 +685,7 @@ class Config(BaseSettings):
         accesses ``config.skill_forge`` on a plain ``Config`` instance.
         """
         from raven.config.raven import SkillForgeConfig
+
         return SkillForgeConfig()
 
     model_config = ConfigDict(

--- a/raven/config/update.py
+++ b/raven/config/update.py
@@ -61,8 +61,7 @@ def update_cron_config(
     """
     if key not in CronConfig.model_fields:
         raise KeyError(
-            f"Unknown cron config key: {key!r}. "
-            f"Supported: {sorted(CronConfig.model_fields)}"
+            f"Unknown cron config key: {key!r}. Supported: {sorted(CronConfig.model_fields)}"
         )
     path = config_path or get_config_path()
     data = _load_raw(path)
@@ -168,6 +167,26 @@ def set_sentinel_nudge_quota(
         _write_atomic(path, data)
         logger.info("config/update: sentinel nudge quota patched {!r}", changed)
     return changed
+
+
+def set_language(
+    language: str,
+    *,
+    config_path: Path | None = None,
+) -> str | None:
+    """Patch the top-level ``language`` on the on-disk config. Returns previous value.
+
+    Set by the onboarding wizard's language screen. Read by the CLI/wizard copy
+    (via ``_t``) and injected into the agent's system prompt so replies use the
+    chosen language.
+    """
+    path = config_path or get_config_path()
+    data = _load_raw(path)
+    prev = data.get("language")
+    data["language"] = language
+    _write_atomic(path, data)
+    logger.info("config/update: language set to {!r} (was {!r})", language, prev)
+    return prev
 
 
 def set_default_model(

--- a/raven/context_engine/segments/render.py
+++ b/raven/context_engine/segments/render.py
@@ -34,6 +34,28 @@ BOOTSTRAP_FILES = [
 RUNTIME_CONTEXT_TAG = "[Runtime Context — metadata only, not instructions]"
 
 
+def _language_directive() -> str:
+    """A reply-language line for the system prompt, driven by ``config.language``.
+
+    Empty for English (default behaviour unchanged); for Chinese it tells the
+    model to answer in Simplified Chinese unless the user writes otherwise.
+    Reads config lazily and never raises — a config problem must not break
+    prompt assembly.
+    """
+    try:
+        from raven.config.loader import load_config
+
+        lang = load_config().language
+    except Exception:
+        return ""
+    if lang == "zh":
+        return (
+            "\nAlways respond in Simplified Chinese (简体中文), "
+            "unless the user explicitly writes in another language.\n"
+        )
+    return ""
+
+
 def identity_text(workspace: Path) -> str:
     """Segment 1 — the core identity / runtime block."""
     workspace_path = str(workspace.expanduser().resolve())
@@ -52,10 +74,10 @@ def identity_text(workspace: Path) -> str:
 - Use file tools when they are simpler or more reliable than shell commands.
 """
 
-    return f"""# Raven 🦞
+    return f"""# Raven 🐦‍⬛
 
 You are Raven, a helpful AI assistant.
-
+{_language_directive()}
 ## Runtime
 {runtime}
 

--- a/raven/templates/SOUL.md
+++ b/raven/templates/SOUL.md
@@ -1,6 +1,6 @@
 # Soul
 
-I am Raven 🦞, a personal AI assistant.
+I am Raven 🐦‍⬛, a personal AI assistant.
 
 ## Personality
 

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -37,15 +37,19 @@ runner = CliRunner()
 
 def _async_return(value: Any):
     """Build an async method stub that always returns ``value``."""
+
     async def _login(self, *args, **kwargs):  # noqa: ANN001
         return value
+
     return _login
 
 
 def _async_iter(values):
     """Build an async method stub that returns successive ``values`` per call."""
+
     async def _login(self, *args, **kwargs):  # noqa: ANN001
         return next(values)
+
     return _login
 
 
@@ -56,8 +60,10 @@ def _must_not_call(name: str):
     (e.g. ``_scancode_login``'s login guard) still surfaces instead of being
     swallowed.
     """
+
     def _boom(*args, **kwargs):
         raise BaseException(f"{name} should not have been called")  # noqa: TRY002
+
     return _boom
 
 
@@ -117,9 +123,7 @@ def stub_verify(monkeypatch: pytest.MonkeyPatch):
             "elapsed_ms": 12,
         }
 
-    monkeypatch.setattr(
-        "raven.config.update_providers.test_provider", _ok
-    )
+    monkeypatch.setattr("raven.config.update_providers.test_provider", _ok)
     return _ok
 
 
@@ -161,17 +165,17 @@ def test_onboard_help_lists_all_flags() -> None:
 # --------------------------------------------------------------------------- non-interactive happy path
 
 
-def test_onboard_non_interactive_minimum_flags(
-    tmp_env: Path, stub_verify, stub_step3
-) -> None:
+def test_onboard_non_interactive_minimum_flags(tmp_env: Path, stub_verify, stub_step3) -> None:
     """Minimum non-interactive invocation runs all three steps and writes config."""
     r = runner.invoke(
         app,
         [
             "onboard",
             "--non-interactive",
-            "--provider", "openai",
-            "--api-key", "sk-fake-test-key",
+            "--provider",
+            "openai",
+            "--api-key",
+            "sk-fake-test-key",
             "--skip-channel",
             "--yes",
         ],
@@ -201,8 +205,10 @@ def test_onboard_non_interactive_skips_optional_steps(
         [
             "onboard",
             "--non-interactive",
-            "--provider", "openai",
-            "--api-key", "sk-fake",
+            "--provider",
+            "openai",
+            "--api-key",
+            "sk-fake",
             "--yes",
         ],
     )
@@ -222,8 +228,10 @@ def test_onboard_skip_channel_default(tmp_env: Path, stub_verify, stub_step3) ->
         [
             "onboard",
             "--non-interactive",
-            "--provider", "openai",
-            "--api-key", "sk-fake",
+            "--provider",
+            "openai",
+            "--api-key",
+            "sk-fake",
             "--skip-channel",
             "--yes",
         ],
@@ -254,8 +262,10 @@ def test_onboard_non_interactive_custom_requires_base_url(
         [
             "onboard",
             "--non-interactive",
-            "--provider", "custom",
-            "--api-key", "sk-fake",
+            "--provider",
+            "custom",
+            "--api-key",
+            "sk-fake",
             "--skip-channel",
             "--yes",
         ],
@@ -271,7 +281,8 @@ def test_onboard_oauth_non_interactive_errors(tmp_env: Path) -> None:
         [
             "onboard",
             "--non-interactive",
-            "--provider", "github_copilot",
+            "--provider",
+            "github_copilot",
             "--skip-channel",
             "--yes",
         ],
@@ -294,9 +305,7 @@ def test_onboard_non_tty_no_flag_fails(tmp_env: Path) -> None:
 # --------------------------------------------------------------------------- existing-config handling
 
 
-def test_onboard_existing_config_blocks_without_yes(
-    tmp_env: Path, stub_verify, stub_step3
-) -> None:
+def test_onboard_existing_config_blocks_without_yes(tmp_env: Path, stub_verify, stub_step3) -> None:
     """Re-running over an existing populated config fails closed."""
     # Seed a populated config.
     runner.invoke(
@@ -304,8 +313,10 @@ def test_onboard_existing_config_blocks_without_yes(
         [
             "onboard",
             "--non-interactive",
-            "--provider", "openai",
-            "--api-key", "sk-existing",
+            "--provider",
+            "openai",
+            "--api-key",
+            "sk-existing",
             "--skip-channel",
             "--yes",
         ],
@@ -316,8 +327,10 @@ def test_onboard_existing_config_blocks_without_yes(
         [
             "onboard",
             "--non-interactive",
-            "--provider", "anthropic",
-            "--api-key", "sk-newer",
+            "--provider",
+            "anthropic",
+            "--api-key",
+            "sk-newer",
             "--skip-channel",
         ],
     )
@@ -328,17 +341,17 @@ def test_onboard_existing_config_blocks_without_yes(
     assert data["providers"]["openai"]["apiKey"] == "sk-existing"
 
 
-def test_onboard_reset_flag_forces_redo(
-    tmp_env: Path, stub_verify, stub_step3
-) -> None:
+def test_onboard_reset_flag_forces_redo(tmp_env: Path, stub_verify, stub_step3) -> None:
     """``--reset`` bypasses the existing-config guard."""
     runner.invoke(
         app,
         [
             "onboard",
             "--non-interactive",
-            "--provider", "openai",
-            "--api-key", "sk-old",
+            "--provider",
+            "openai",
+            "--api-key",
+            "sk-old",
             "--skip-channel",
             "--yes",
         ],
@@ -348,8 +361,10 @@ def test_onboard_reset_flag_forces_redo(
         [
             "onboard",
             "--non-interactive",
-            "--provider", "openai",
-            "--api-key", "sk-new",
+            "--provider",
+            "openai",
+            "--api-key",
+            "sk-new",
             "--skip-channel",
             "--reset",
         ],
@@ -366,11 +381,16 @@ def test_onboard_provider_test_failure_warns_but_continues(
     tmp_env: Path, monkeypatch: pytest.MonkeyPatch, stub_step3
 ) -> None:
     """``test_provider`` failure should warn + continue in non-interactive mode."""
+
     def _fail(name: str, *args, **kwargs) -> dict[str, Any]:
         return {
-            "ok": False, "status": "invalid_key", "models_count": None,
-            "elapsed_ms": 5, "error": "401 Unauthorized",
+            "ok": False,
+            "status": "invalid_key",
+            "models_count": None,
+            "elapsed_ms": 5,
+            "error": "401 Unauthorized",
         }
+
     monkeypatch.setattr("raven.config.update_providers.test_provider", _fail)
 
     r = runner.invoke(
@@ -378,8 +398,10 @@ def test_onboard_provider_test_failure_warns_but_continues(
         [
             "onboard",
             "--non-interactive",
-            "--provider", "openai",
-            "--api-key", "sk-bad",
+            "--provider",
+            "openai",
+            "--api-key",
+            "sk-bad",
             "--skip-channel",
             "--yes",
         ],
@@ -405,8 +427,10 @@ def test_onboard_test_probe_failure_shows_warning_footer(
         [
             "onboard",
             "--non-interactive",
-            "--provider", "openai",
-            "--api-key", "sk-fake",
+            "--provider",
+            "openai",
+            "--api-key",
+            "sk-fake",
             "--skip-channel",
             "--yes",
         ],
@@ -428,10 +452,9 @@ def test_onboard_interactive_uses_stubbed_pickers(
     # CliRunner makes sys.stdout non-tty, so _check_tty_or_die would bail
     # before our stubs ever run. Skip it for this test.
     monkeypatch.setattr(onboard_commands, "_check_tty_or_die", lambda non_interactive: None)
+    monkeypatch.setattr(onboard_commands, "_pick_language", lambda: None)
     monkeypatch.setattr(onboard_commands, "_select_provider", lambda: "anthropic")
-    monkeypatch.setattr(
-        onboard_commands, "_prompt_api_key", lambda provider: "sk-int-test"
-    )
+    monkeypatch.setattr(onboard_commands, "_prompt_api_key", lambda provider, **kw: "sk-int-test")
     # Bypass the autocomplete picker — Step 1 catalog UI is exercised
     # separately by ``test_step1_picker_uses_catalog_when_available``.
     monkeypatch.setattr(
@@ -466,9 +489,7 @@ def test_step1_writes_via_ops_lib(
         calls.append((name, dict(fields)))
         return {}
 
-    monkeypatch.setattr(
-        "raven.config.update_providers.set_provider_fields", _spy
-    )
+    monkeypatch.setattr("raven.config.update_providers.set_provider_fields", _spy)
     monkeypatch.setattr(onboard_commands, "send_probe", lambda: ("hi", 1, 0.1))
 
     r = runner.invoke(
@@ -476,8 +497,10 @@ def test_step1_writes_via_ops_lib(
         [
             "onboard",
             "--non-interactive",
-            "--provider", "openai",
-            "--api-key", "sk-spy",
+            "--provider",
+            "openai",
+            "--api-key",
+            "sk-spy",
             "--skip-channel",
             "--yes",
         ],
@@ -499,18 +522,19 @@ def test_styles_module_loads() -> None:
 # --------------------------------------------------------------------------- model picker
 
 
-def test_step1_model_flag_overrides_picker(
-    tmp_env: Path, stub_verify, stub_step3
-) -> None:
+def test_step1_model_flag_overrides_picker(tmp_env: Path, stub_verify, stub_step3) -> None:
     """``--model X`` short-circuits the picker, even when a catalog exists."""
     r = runner.invoke(
         app,
         [
             "onboard",
             "--non-interactive",
-            "--provider", "openrouter",
-            "--api-key", "sk-or-fake",
-            "--model", "openrouter/openai/gpt-4o",
+            "--provider",
+            "openrouter",
+            "--api-key",
+            "sk-or-fake",
+            "--model",
+            "openrouter/openai/gpt-4o",
             "--skip-channel",
             "--yes",
         ],
@@ -529,8 +553,10 @@ def test_step1_falls_back_to_spec_default_in_non_interactive(
         [
             "onboard",
             "--non-interactive",
-            "--provider", "anthropic",
-            "--api-key", "sk-ant-fake",
+            "--provider",
+            "anthropic",
+            "--api-key",
+            "sk-ant-fake",
             "--skip-channel",
             "--yes",
         ],
@@ -557,14 +583,11 @@ def test_step1_picker_uses_catalog_when_available(
             "elapsed_ms": 9,
         }
 
-    monkeypatch.setattr(
-        "raven.config.update_providers.test_provider", _ok_with_catalog
-    )
+    monkeypatch.setattr("raven.config.update_providers.test_provider", _ok_with_catalog)
     monkeypatch.setattr(onboard_commands, "_check_tty_or_die", lambda non_interactive: None)
+    monkeypatch.setattr(onboard_commands, "_pick_language", lambda: None)
     monkeypatch.setattr(onboard_commands, "_select_provider", lambda: "anthropic")
-    monkeypatch.setattr(
-        onboard_commands, "_prompt_api_key", lambda provider: "sk-ant-test"
-    )
+    monkeypatch.setattr(onboard_commands, "_prompt_api_key", lambda provider, **kw: "sk-ant-test")
 
     import questionary
 
@@ -613,9 +636,7 @@ def test_format_model_for_provider_prefix_rules() -> None:
 
     # Gateway with prefix: bare id gets prefixed
     assert (
-        onboard_commands._format_model_for_provider(
-            openrouter, "anthropic/claude-sonnet-4-5"
-        )
+        onboard_commands._format_model_for_provider(openrouter, "anthropic/claude-sonnet-4-5")
         == "openrouter/anthropic/claude-sonnet-4-5"
     )
     # Already prefixed by us → idempotent
@@ -626,10 +647,7 @@ def test_format_model_for_provider_prefix_rules() -> None:
         == "openrouter/anthropic/claude-sonnet-4-5"
     )
     # Direct provider with empty prefix → pass-through
-    assert (
-        onboard_commands._format_model_for_provider(openai, "gpt-4o-mini")
-        == "gpt-4o-mini"
-    )
+    assert onboard_commands._format_model_for_provider(openai, "gpt-4o-mini") == "gpt-4o-mini"
     # skip_prefixes match → no double-prefix
     assert (
         onboard_commands._format_model_for_provider(deepseek, "deepseek/deepseek-chat")
@@ -672,8 +690,13 @@ def test_registry_default_models_present() -> None:
     from raven.providers.registry import find_by_name
 
     for name in (
-        "openrouter", "openai", "anthropic", "gemini",
-        "deepseek", "github_copilot", "openai_codex",
+        "openrouter",
+        "openai",
+        "anthropic",
+        "gemini",
+        "deepseek",
+        "github_copilot",
+        "openai_codex",
     ):
         spec = find_by_name(name)
         assert spec is not None, f"missing provider in registry: {name}"
@@ -693,7 +716,9 @@ def everos_isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return cfg
 
 
-def _seed_provider(provider: str = "openai", key: str = "sk-seed", model: str = "openai/gpt-4o-mini") -> None:
+def _seed_provider(
+    provider: str = "openai", key: str = "sk-seed", model: str = "openai/gpt-4o-mini"
+) -> None:
     """Write a minimal populated config via the ops layer."""
     from raven.config.update import set_default_model
     from raven.config.update_providers import set_provider_fields
@@ -744,9 +769,7 @@ def test_ensure_configured_runs_wizard_when_missing(
 # --------------------------------------------------------------------------- entry-point gate wiring
 
 
-def test_agent_gate_triggers_when_missing(
-    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_agent_gate_triggers_when_missing(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """`raven agent` (interactive, TTY, missing config) enters the wizard."""
     from raven.cli import agent_commands
 
@@ -764,9 +787,7 @@ def test_agent_gate_triggers_when_missing(
     assert r.exit_code == 0
 
 
-def test_agent_gate_skips_when_populated(
-    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_agent_gate_skips_when_populated(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """`raven agent` with complete config does NOT enter the wizard."""
     from raven.cli import agent_commands
 
@@ -774,7 +795,8 @@ def test_agent_gate_skips_when_populated(
     monkeypatch.setattr(agent_commands, "_stdout_isatty", lambda: True)
     gate_called: list[bool] = []
     monkeypatch.setattr(
-        onboard_commands, "ensure_configured_or_onboard",
+        onboard_commands,
+        "ensure_configured_or_onboard",
         lambda **_: gate_called.append(True),
     )
 
@@ -788,9 +810,7 @@ def test_agent_gate_skips_when_populated(
     assert gate_called == []
 
 
-def test_agent_gate_skips_oneshot_message(
-    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_agent_gate_skips_oneshot_message(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """`raven agent -m '...'` (one-shot) must NOT enter the wizard even on a
     TTY with missing config — scripted use fails loudly later instead."""
     from raven.cli import agent_commands
@@ -798,36 +818,38 @@ def test_agent_gate_skips_oneshot_message(
     monkeypatch.setattr(agent_commands, "_stdout_isatty", lambda: True)
     gate_called: list[bool] = []
     monkeypatch.setattr(
-        onboard_commands, "ensure_configured_or_onboard",
+        onboard_commands,
+        "ensure_configured_or_onboard",
         lambda **_: gate_called.append(True),
     )
-    monkeypatch.setattr("raven.cli._helpers.load_runtime_config",
-                        lambda *a, **kw: (_ for _ in ()).throw(typer.Exit(0)))
+    monkeypatch.setattr(
+        "raven.cli._helpers.load_runtime_config",
+        lambda *a, **kw: (_ for _ in ()).throw(typer.Exit(0)),
+    )
     runner.invoke(app, ["agent", "-m", "hi"])
     assert gate_called == []
 
 
-def test_agent_gate_skips_non_tty(
-    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_agent_gate_skips_non_tty(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Non-TTY (piped) `raven agent` must not enter the wizard (would block)."""
     from raven.cli import agent_commands
 
     monkeypatch.setattr(agent_commands, "_stdout_isatty", lambda: False)
     gate_called: list[bool] = []
     monkeypatch.setattr(
-        onboard_commands, "ensure_configured_or_onboard",
+        onboard_commands,
+        "ensure_configured_or_onboard",
         lambda **_: gate_called.append(True),
     )
-    monkeypatch.setattr("raven.cli._helpers.load_runtime_config",
-                        lambda *a, **kw: (_ for _ in ()).throw(typer.Exit(0)))
+    monkeypatch.setattr(
+        "raven.cli._helpers.load_runtime_config",
+        lambda *a, **kw: (_ for _ in ()).throw(typer.Exit(0)),
+    )
     runner.invoke(app, ["agent"])
     assert gate_called == []
 
 
-def test_tui_gate_triggers_when_missing(
-    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_tui_gate_triggers_when_missing(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """`raven tui` (TTY, missing config) enters the wizard before launching Node."""
     from raven.cli import tui_commands
 
@@ -844,16 +866,15 @@ def test_tui_gate_triggers_when_missing(
     assert r.exit_code == 0
 
 
-def test_tui_gate_skips_check_flag(
-    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_tui_gate_skips_check_flag(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """`raven tui --check` (no-TTY diagnostic) bypasses the wizard gate."""
     from raven.cli import tui_commands
 
     monkeypatch.setattr(tui_commands, "_stdout_isatty", lambda: True)
     gate_called: list[bool] = []
     monkeypatch.setattr(
-        onboard_commands, "ensure_configured_or_onboard",
+        onboard_commands,
+        "ensure_configured_or_onboard",
         lambda **_: gate_called.append(True),
     )
     # Stub find_node so --check exits fast without a real Node child.
@@ -870,8 +891,11 @@ def test_sandbox_backend_persisted_via_ops(tmp_env: Path, monkeypatch: pytest.Mo
     import questionary
 
     class _FQ:
-        def __init__(self, a): self._a = a
-        def ask(self): return self._a
+        def __init__(self, a):
+            self._a = a
+
+        def ask(self):
+            return self._a
 
     monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ("none"))
     onboard_commands._step2_sandbox(skip=False, non_interactive=False)
@@ -888,8 +912,11 @@ def test_sandbox_boxlite_probe_failure_falls_back(
     answers = iter(["boxlite"])
 
     class _FQ:
-        def __init__(self, a): self._a = a
-        def ask(self): return self._a
+        def __init__(self, a):
+            self._a = a
+
+        def ask(self):
+            return self._a
 
     monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ(next(answers)))
     monkeypatch.setattr(onboard_commands, "_probe_boxlite", lambda: (False, "missing"))
@@ -911,7 +938,8 @@ def test_sandbox_keep_current_first_option(tmp_env: Path, monkeypatch: pytest.Mo
     import questionary
 
     class _FQ:
-        def ask(self): return "keep"
+        def ask(self):
+            return "keep"
 
     def _select(message, choices, **kw):
         captured["choices"] = [getattr(c, "value", c) for c in choices]
@@ -934,7 +962,8 @@ def test_memory_disable_sets_backend_null(
     import questionary
 
     class _FQ:
-        def ask(self): return "off"
+        def ask(self):
+            return "off"
 
     monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ())
     onboard_commands._step4_memory(
@@ -952,44 +981,40 @@ def test_memory_disable_sets_backend_null(
 def test_memory_enable_writes_everos_sections(
     tmp_env: Path, everos_isolated: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Enabling memory + reuse-main-model LLM + embedding writes EverOS toml."""
+    """Enabling memory + LLM (custom source) + embedding (reuse LLM endpoint)
+    writes the EverOS toml; rerank/multimodal skipped."""
     import tomllib
 
     import questionary
 
     _seed_provider("openrouter", "sk-or", "openrouter/anthropic/claude-sonnet-4-5")
-    # The reuse path needs the provider's apiKey/apiBase on disk; openrouter
-    # isn't OpenAI-compatible per our heuristic, so LLM goes the 'separate' path.
 
-    select_answers = iter([
-        "on",        # enable memory
-        "separate",  # LLM: configure separately (openrouter not in compat set)
-        "skip",      # rerank skip
-        "skip",      # multimodal skip
-    ])
-    text_answers = iter([
-        "mem-llm", "k-llm", "https://llm/v1",      # LLM model/key/base
-        "mem-embed", "k-embed", "https://embed/v1",  # embedding model/key/base
-    ])
+    # _step4_memory select() calls, in order:
+    #   1. enable memory                -> "on"
+    #   2. LLM source picker            -> ("custom",)
+    #   3. embedding source picker      -> ("reuse_llm",)
+    #   4. rerank "Configure it?"       -> "skip"
+    #   5. multimodal "Configure it?"   -> "skip"
+    select_answers = iter(["on", ("custom",), ("reuse_llm",), "skip", "skip"])
+    # text(): LLM base_url, LLM model, embedding model (model lists can't be
+    # fetched offline, so the picker falls back to free-text entry).
+    text_answers = iter(["https://llm/v1", "mem-llm", "mem-embed"])
+    # password(): LLM api key.
+    password_answers = iter(["k-llm"])
 
     class _FQ:
-        def __init__(self, a): self._a = a
-        def ask(self): return self._a
+        def __init__(self, a):
+            self._a = a
+
+        def ask(self):
+            return self._a
 
     monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ(next(select_answers)))
-
-    def _text(label, **kw):
-        return _FQ(next(text_answers))
-
-    def _password(label, **kw):
-        return _FQ(next(text_answers))
-
-    monkeypatch.setattr(questionary, "text", _text)
-    monkeypatch.setattr(questionary, "password", _password)
-    # EverOS connectivity probe succeeds (no real network).
-    monkeypatch.setattr(
-        onboard_commands, "_probe_everos_endpoint", lambda *a, **kw: (True, "ok")
-    )
+    monkeypatch.setattr(questionary, "text", lambda *a, **kw: _FQ(next(text_answers)))
+    monkeypatch.setattr(questionary, "password", lambda *a, **kw: _FQ(next(password_answers)))
+    # No network: model list can't be fetched → free-text entry; probe succeeds.
+    monkeypatch.setattr(onboard_commands, "_fetch_everos_models", lambda *a, **kw: None)
+    monkeypatch.setattr(onboard_commands, "_probe_everos_endpoint", lambda *a, **kw: (True, "ok"))
 
     onboard_commands._step4_memory(
         skip=False,
@@ -1007,7 +1032,12 @@ def test_memory_enable_writes_everos_sections(
     with everos_isolated.open("rb") as f:
         everos = tomllib.load(f)
     assert everos["llm"]["model"] == "mem-llm"
+    assert everos["llm"]["api_key"] == "k-llm"
+    assert everos["llm"]["base_url"] == "https://llm/v1"
     assert everos["embedding"]["model"] == "mem-embed"
+    # embedding reused the LLM endpoint's key/base.
+    assert everos["embedding"]["api_key"] == "k-llm"
+    assert everos["embedding"]["base_url"] == "https://llm/v1"
     assert "rerank" not in everos
     assert "multimodal" not in everos
 
@@ -1025,19 +1055,19 @@ def test_memory_llm_reuse_pulls_provider_creds(
     import questionary
 
     class _FQ:
-        def __init__(self, a): self._a = a
-        def ask(self): return self._a
+        def __init__(self, a):
+            self._a = a
 
-    # openai IS OpenAI-compatible → reuse offered. Then embedding via text;
-    # rerank/multimodal skip.
-    select_answers = iter(["reuse"])
-    monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ(next(select_answers)))
-    monkeypatch.setattr(
-        onboard_commands, "_probe_everos_endpoint", lambda *a, **kw: (True, "ok")
-    )
+        def ask(self):
+            return self._a
 
-    onboard_commands._config_memory_llm(
-        main_model="openai/gpt-4o-mini", non_interactive=False, warnings=[]
+    # openai IS OpenAI-compatible → the source picker offers "reuse main chat
+    # model", which brings the model id + creds along (no further prompts).
+    monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ(("reuse_main",)))
+    monkeypatch.setattr(onboard_commands, "_probe_everos_endpoint", lambda *a, **kw: (True, "ok"))
+
+    onboard_commands._config_everos_role(
+        section="llm", main_model="openai/gpt-4o-mini", non_interactive=False, warnings=[]
     )
     with everos_isolated.open("rb") as f:
         everos = tomllib.load(f)
@@ -1047,10 +1077,10 @@ def test_memory_llm_reuse_pulls_provider_creds(
     assert everos["llm"]["base_url"] == "https://api.openai.com/v1"
 
 
-def test_memory_rerank_reuses_llm_creds_by_default(
+def test_memory_rerank_reuse_llm_endpoint(
     tmp_env: Path, everos_isolated: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """rerank 'separate' offers to reuse the memory LLM's key/base (spec §617①)."""
+    """rerank can reuse the memory LLM's endpoint via the source picker."""
     import tomllib
 
     from raven.config.update_everos import set_everos_section
@@ -1060,18 +1090,30 @@ def test_memory_rerank_reuses_llm_creds_by_default(
     import questionary
 
     class _FQ:
-        def __init__(self, a): self._a = a
-        def ask(self): return self._a
+        def __init__(self, a):
+            self._a = a
 
-    select_answers = iter(["redo", "deepinfra"])  # configure rerank, then provider
+        def ask(self):
+            return self._a
+
+    # rerank "Configure it?" -> redo; source -> reuse the LLM endpoint;
+    # rerank service type -> deepinfra.
+    select_answers = iter(["redo", ("reuse_llm",), "deepinfra"])
     monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ(next(select_answers)))
-    monkeypatch.setattr(questionary, "text", lambda label, **kw: _FQ("rerank-model"))
-    monkeypatch.setattr(questionary, "confirm", lambda *a, **kw: _FQ(True))  # reuse creds
+    monkeypatch.setattr(questionary, "text", lambda *a, **kw: _FQ("rerank-model"))
+    # Offline → model list can't be fetched, falls back to the free-text id.
+    monkeypatch.setattr(onboard_commands, "_fetch_everos_models", lambda *a, **kw: None)
 
-    onboard_commands._config_memory_rerank(non_interactive=False)
+    onboard_commands._config_everos_role(
+        section="rerank",
+        main_model="openrouter/anthropic/claude-sonnet-4-5",
+        non_interactive=False,
+        warnings=[],
+    )
     with everos_isolated.open("rb") as f:
         everos = tomllib.load(f)
     assert everos["rerank"]["provider"] == "deepinfra"
+    assert everos["rerank"]["model"] == "rerank-model"
     assert everos["rerank"]["api_key"] == "k-llm"  # reused, not re-prompted
     assert everos["rerank"]["base_url"] == "https://llm/v1"
 
@@ -1106,19 +1148,21 @@ def test_custom_model_reuse_is_compatible(
     assert creds["base_url"] == "https://my-llm/v1"
 
     # And the LLM reuse path writes those into the EverOS toml.
-    import questionary
     import tomllib
 
-    class _FQ:
-        def __init__(self, a): self._a = a
-        def ask(self): return self._a
+    import questionary
 
-    monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ("reuse"))
-    monkeypatch.setattr(
-        onboard_commands, "_probe_everos_endpoint", lambda *a, **kw: (True, "ok")
-    )
-    onboard_commands._config_memory_llm(
-        main_model="qwen-max", non_interactive=False, warnings=[]
+    class _FQ:
+        def __init__(self, a):
+            self._a = a
+
+        def ask(self):
+            return self._a
+
+    monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ(("reuse_main",)))
+    monkeypatch.setattr(onboard_commands, "_probe_everos_endpoint", lambda *a, **kw: (True, "ok"))
+    onboard_commands._config_everos_role(
+        section="llm", main_model="qwen-max", non_interactive=False, warnings=[]
     )
     with everos_isolated.open("rb") as fh:
         everos = tomllib.load(fh)
@@ -1140,12 +1184,20 @@ def test_channel_uses_interactive_login_real_specs() -> None:
     assert f("telegram") is False
 
 
-def test_channel_order_domestic_before_overseas() -> None:
-    """Curated picker order: China-domestic channels lead, overseas follow."""
+def test_channel_order_overseas_common_before_domestic() -> None:
+    """Curated picker order: US/global-common → China-common → uncommon tail.
+
+    (Reordered from the old domestic-first layout.)
+    """
     names = onboard_commands._ordered_channel_names()
-    for domestic in ("weixin", "feishu", "dingtalk"):
-        for overseas in ("telegram", "discord", "email"):
-            assert names.index(domestic) < names.index(overseas)
+    # US/global-common lead the list, ahead of the China-common group.
+    for overseas in ("telegram", "discord", "slack", "whatsapp"):
+        for domestic in ("weixin", "wecom", "feishu", "dingtalk", "qq"):
+            assert names.index(overseas) < names.index(domestic)
+    # China-common still come before the less-common tail (matrix / email).
+    for domestic in ("weixin", "feishu"):
+        for tail in ("matrix", "email"):
+            assert names.index(domestic) < names.index(tail)
 
 
 def test_scancode_login_success_enables_channel(
@@ -1167,9 +1219,7 @@ def test_scancode_login_success_enables_channel(
     assert data["channels"]["weixin"]["enabled"] is True
 
 
-def test_scancode_login_retry_then_success(
-    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_scancode_login_retry_then_success(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Login fails once → 'retry' submenu choice → second attempt succeeds."""
     results = iter([False, True])
     monkeypatch.setattr(
@@ -1179,7 +1229,8 @@ def test_scancode_login_retry_then_success(
     # Failure submenu: choose retry first; second login succeeds so menu isn't
     # reached again.
     monkeypatch.setattr(
-        onboard_commands, "_failure_choice",
+        onboard_commands,
+        "_failure_choice",
         lambda options, *, non_interactive: "retry",
     )
     onboard_commands._scancode_login("weixin")
@@ -1187,44 +1238,25 @@ def test_scancode_login_retry_then_success(
     assert data["channels"]["weixin"]["enabled"] is True
 
 
-def test_scancode_login_skip_leaves_enabled(
-    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """'skip' leaves the channel enabled-but-unauthenticated (login later)."""
+def test_scancode_login_skip_reverts_enable(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """'skip' on a failed scan reverts the enable so the channel isn't shown as
+    connected (config section is kept for a later `raven channels login`)."""
     monkeypatch.setattr(
         "raven.channels.adapters.weixin.channel.WeixinChannel.login",
         _async_return(False),
     )
     monkeypatch.setattr(
-        onboard_commands, "_failure_choice",
+        onboard_commands,
+        "_failure_choice",
         lambda options, *, non_interactive: "skip",
     )
     onboard_commands._scancode_login("weixin")
     data = json.loads(tmp_env.read_text())
-    # Enabled (so the channel is wired) even though scan didn't complete.
-    assert data["channels"]["weixin"]["enabled"] is True
+    # Not logged in → disabled, so it never falsely shows as connected.
+    assert data["channels"]["weixin"]["enabled"] is False
 
 
-def test_scancode_login_continue_leaves_enabled(
-    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """'continue' also leaves the channel enabled-but-unauthenticated."""
-    monkeypatch.setattr(
-        "raven.channels.adapters.weixin.channel.WeixinChannel.login",
-        _async_return(False),
-    )
-    monkeypatch.setattr(
-        onboard_commands, "_failure_choice",
-        lambda options, *, non_interactive: "continue",
-    )
-    onboard_commands._scancode_login("weixin")
-    data = json.loads(tmp_env.read_text())
-    assert data["channels"]["weixin"]["enabled"] is True
-
-
-def test_add_one_channel_routes_scancode(
-    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_add_one_channel_routes_scancode(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """`_add_one_channel` sends a scancode channel to login, NOT schema prompts."""
     monkeypatch.setattr(onboard_commands, "_select_provider", lambda: "weixin")
     monkeypatch.setattr(onboard_commands, "_select_channel", lambda: "weixin")
@@ -1237,11 +1269,9 @@ def test_add_one_channel_routes_scancode(
     assert routed == ["weixin"]
 
 
-def test_scancode_login_node_missing_skip(
-    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """WhatsApp with no Node/npm shows the install menu (NOT the QR menu) and
-    skip leaves it enabled; the adapter's login is never called."""
+def test_scancode_login_node_missing_skip(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """WhatsApp with no Node/npm shows the install menu (NOT the QR menu); skip
+    reverts the enable; the adapter's login is never called."""
     monkeypatch.setattr(onboard_commands, "_node_runtime_missing", lambda c: True)
     # The Node-missing menu is distinct from the QR menu — assert its options
     # (no 're-show QR') and that login is never reached.
@@ -1258,7 +1288,8 @@ def test_scancode_login_node_missing_skip(
     )
     onboard_commands._scancode_login("whatsapp")
     data = json.loads(tmp_env.read_text())
-    assert data["channels"]["whatsapp"]["enabled"] is True
+    # Not logged in → reverted to disabled.
+    assert data["channels"]["whatsapp"]["enabled"] is False
     # Install-then-retry menu, not "Re-show QR code".
     assert any("install" in lbl.lower() for lbl in captured["labels"])
     assert not any("qr" in lbl.lower() for lbl in captured["labels"])
@@ -1271,7 +1302,8 @@ def test_scancode_login_node_missing_retry_then_present(
     missing = iter([True, False])  # first check missing, then present
     monkeypatch.setattr(onboard_commands, "_node_runtime_missing", lambda c: next(missing))
     monkeypatch.setattr(
-        onboard_commands, "_failure_choice",
+        onboard_commands,
+        "_failure_choice",
         lambda options, *, non_interactive: "retry",
     )
     monkeypatch.setattr(
@@ -1296,8 +1328,11 @@ def test_provider_remove_clears_key(tmp_env: Path, monkeypatch: pytest.MonkeyPat
     import questionary
 
     class _FQ:
-        def __init__(self, a): self._a = a
-        def ask(self): return self._a
+        def __init__(self, a):
+            self._a = a
+
+        def ask(self):
+            return self._a
 
     # pick anthropic → remove → back
     select_answers = iter(["anthropic", "remove", onboard_commands._BACK])
@@ -1318,7 +1353,8 @@ def test_provider_picker_back_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, list] = {}
 
     class _FQ:
-        def ask(self): return onboard_commands._BACK
+        def ask(self):
+            return onboard_commands._BACK
 
     def _select(message, choices, **kw):
         captured["values"] = [getattr(c, "value", None) for c in choices]
@@ -1333,9 +1369,7 @@ def test_provider_picker_back_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
 # --------------------------------------------------------------------------- back navigation (state machine)
 
 
-def test_back_navigation_rewinds_one_screen(
-    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_back_navigation_rewinds_one_screen(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A screen returning _BACK rewinds the state machine by one index."""
     calls: list[str] = []
 
@@ -1353,6 +1387,7 @@ def test_back_navigation_rewinds_one_screen(
         return None
 
     monkeypatch.setattr(onboard_commands, "_check_tty_or_die", lambda non_interactive: None)
+    monkeypatch.setattr(onboard_commands, "_pick_language", lambda: None)
     monkeypatch.setattr(onboard_commands, "_handle_existing_config", lambda **_: None)
     monkeypatch.setattr(onboard_commands, "_bootstrap_empty_config", lambda: None)
     monkeypatch.setattr(onboard_commands, "_step1_provider", _s1)
@@ -1378,8 +1413,9 @@ def test_first_screen_back_does_not_skip_step1(
     """
     picks = iter([onboard_commands._BACK, "openai"])
     monkeypatch.setattr(onboard_commands, "_check_tty_or_die", lambda non_interactive: None)
+    monkeypatch.setattr(onboard_commands, "_pick_language", lambda: None)
     monkeypatch.setattr(onboard_commands, "_select_provider", lambda: next(picks))
-    monkeypatch.setattr(onboard_commands, "_prompt_api_key", lambda provider: "sk-back-test")
+    monkeypatch.setattr(onboard_commands, "_prompt_api_key", lambda provider, **kw: "sk-back-test")
     monkeypatch.setattr(onboard_commands, "_pick_model", lambda spec, **_: spec.default_model)
     # Optional steps are no-ops here; we only assert Step 1 wasn't skipped.
     monkeypatch.setattr(onboard_commands, "_step2_sandbox", lambda **_: None)
@@ -1407,17 +1443,25 @@ def test_switch_provider_returns_to_picker_keeps_steps(
     def _verify(name, *a, **kw):
         calls["n"] += 1
         if calls["n"] == 1:
-            return {"ok": False, "status": "invalid_key", "models_count": None,
-                    "model_ids": None, "elapsed_ms": 1, "error": "401"}
-        return {"ok": True, "status": "valid", "models_count": 0,
-                "model_ids": [], "elapsed_ms": 1}
+            return {
+                "ok": False,
+                "status": "invalid_key",
+                "models_count": None,
+                "model_ids": None,
+                "elapsed_ms": 1,
+                "error": "401",
+            }
+        return {"ok": True, "status": "valid", "models_count": 0, "model_ids": [], "elapsed_ms": 1}
 
     monkeypatch.setattr("raven.config.update_providers.test_provider", _verify)
     monkeypatch.setattr(onboard_commands, "_check_tty_or_die", lambda non_interactive: None)
+    monkeypatch.setattr(onboard_commands, "_pick_language", lambda: None)
     # Picker returns anthropic first (fails), then openai (succeeds on switch).
     picks = iter(["anthropic", "openai"])
     monkeypatch.setattr(onboard_commands, "_select_provider", lambda: next(picks))
-    monkeypatch.setattr(onboard_commands, "_prompt_api_key", lambda provider: f"sk-{provider}")
+    monkeypatch.setattr(
+        onboard_commands, "_prompt_api_key", lambda provider, **kw: f"sk-{provider}"
+    )
     monkeypatch.setattr(onboard_commands, "_pick_model", lambda spec, **_: spec.default_model)
     # On the failure submenu, choose "switch".
     monkeypatch.setattr(
@@ -1444,19 +1488,26 @@ def test_add_provider_keeps_existing(
     import questionary
 
     class _FQ:
-        def __init__(self, a): self._a = a
-        def ask(self): return self._a
+        def __init__(self, a):
+            self._a = a
+
+        def ask(self):
+            return self._a
 
     # Entry menu: "add" once, then "done".
     entry_answers = iter(["add", "done"])
     monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ(next(entry_answers)))
     monkeypatch.setattr(onboard_commands, "_select_provider", lambda: "anthropic")
-    monkeypatch.setattr(onboard_commands, "_prompt_api_key", lambda provider: "sk-second")
+    monkeypatch.setattr(onboard_commands, "_prompt_api_key", lambda provider, **kw: "sk-second")
     monkeypatch.setattr(onboard_commands, "_pick_model", lambda spec, **_: spec.default_model)
 
     onboard_commands._step1_provider(
-        provider=None, api_key=None, base_url=None, model=None,
-        non_interactive=False, warnings=[],
+        provider=None,
+        api_key=None,
+        base_url=None,
+        model=None,
+        non_interactive=False,
+        warnings=[],
     )
 
     data = json.loads(tmp_env.read_text())
@@ -1474,8 +1525,10 @@ def test_skip_memory_disables_backend_effective(
         [
             "onboard",
             "--non-interactive",
-            "--provider", "openai",
-            "--api-key", "sk-fake",
+            "--provider",
+            "openai",
+            "--api-key",
+            "sk-fake",
             "--skip-channel",
             "--skip-memory",
             "--yes",
@@ -1526,11 +1579,15 @@ def test_bootstrap_backfills_preexisting_config(
     next onboard — without clobbering values the user already set."""
     # Simulate an older config: populated, memory.backend set, but no plugins
     # / skillForge blocks and a hand-tuned memoryTopK.
-    tmp_env.write_text(json.dumps({
-        "providers": {"openai": {"apiKey": "sk-keep"}},
-        "agents": {"defaults": {"model": "openai/gpt-4o"}},
-        "memory": {"backend": "everos", "memoryTopK": 20},
-    }))
+    tmp_env.write_text(
+        json.dumps(
+            {
+                "providers": {"openai": {"apiKey": "sk-keep"}},
+                "agents": {"defaults": {"model": "openai/gpt-4o"}},
+                "memory": {"backend": "everos", "memoryTopK": 20},
+            }
+        )
+    )
 
     onboard_commands._bootstrap_empty_config()
     data = json.loads(tmp_env.read_text())


### PR DESCRIPTION
## Change description

Overhaul the interactive onboarding wizard: bilingual UI with a persisted
language setting, a unified EverOS memory-model flow (provider -> key ->
model list -> verify) with reuse shortcuts, empty-submit back navigation,
OAuth retry/back, a base-less-provider verify skip, reordered channels with
credential hints, a cleaner 2-space layout, raven branding, and a WhatsApp
bridge source-path fix. Onboard tests updated to match.

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Document
- [x] Others (refactor / branding / tests)

## Checklists
### Development
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass
### Security
- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
### Code review
- [x] Pull request has a descriptive title and context useful to a reviewer
- [ ] Pull request linked to JIRA ticket when applicable
