### PR TITLE
chore(deps): reduce dependabot noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,64 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
+    labels:
+      - dependencies
+      - security
+    groups:
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: uv
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
+    labels:
+      - dependencies
+      - security
+    groups:
+      python-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
+    labels:
+      - dependencies
+      - security
+    groups:
+      npm-root-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: npm
     directory: /ui-tui
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
+    labels:
+      - dependencies
+      - security
+    groups:
+      tui-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: npm
     directory: /bridge
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
+    labels:
+      - dependencies
+      - security
+    groups:
+      bridge-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- stop routine Dependabot version-update PRs by setting `open-pull-requests-limit: 0` for each configured ecosystem
- keep security-update grouping in place so future security PRs are batched by ecosystem instead of flooding the PR queue
- preserve Dependabot alerts/security posture while reducing launch-week PR noise

## Verification
- uv run pre-commit run --files .github/dependabot.yml
- npx --no-install commitlint --from origin/main --to HEAD --config commitlint.config.cjs
- PYTHONPATH=. python3 scripts/check_commit_messages.py origin/main..HEAD
- uv run pre-commit run --from-ref origin/main --to-ref HEAD

## Notes
This does not disable Dependabot alerts. It only stops routine weekly version-update PR churn. Security work should be handled intentionally in grouped security PRs or manual security PRs.