### PR TITLE
fix(memory): lazy-import contract-test classes to avoid pulling pytest

### DIFF
--- a/raven/memory_engine/__init__.py
+++ b/raven/memory_engine/__init__.py
@@ -26,12 +26,16 @@ Post-Phase-B layout:
   ``SkillService``).
 """
 
+from typing import TYPE_CHECKING
+
 from raven.memory_engine.backend import Memory, MemoryBackend
 from raven.memory_engine.base import AssembledContext, TokenBudget
-from raven.memory_engine.contract_test import (
-    LifecycleContractTests,
-    MemoryBackendContractTests,
-)
+
+if TYPE_CHECKING:
+    from raven.memory_engine.contract_test import (
+        LifecycleContractTests,
+        MemoryBackendContractTests,
+    )
 
 __all__ = [
     "AssembledContext",
@@ -41,3 +45,18 @@ __all__ = [
     "MemoryBackendContractTests",
     "TokenBudget",
 ]
+
+
+# The contract-test base classes live in ``contract_test``, which imports
+# ``pytest`` (a dev-only dependency) at module top level. Importing them
+# eagerly here would pull pytest into every ``import raven.memory_engine`` —
+# breaking any production install without pytest (e.g. a packaged `raven tui`),
+# with ``ModuleNotFoundError: No module named 'pytest'``. Expose them lazily
+# (PEP 562) so they resolve only when actually accessed — which happens under
+# pytest in the test suite, where the import succeeds.
+def __getattr__(name: str):
+    if name in ("LifecycleContractTests", "MemoryBackendContractTests"):
+        from raven.memory_engine import contract_test
+
+        return getattr(contract_test, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Change description

Fix a pre-existing main bug: `raven/memory_engine/__init__.py` imported the test-helper module `contract_test` at package-init top level, and `contract_test` imports `pytest` (a dev-only dependency). That pulled `pytest` into **every** `import raven.memory_engine`, so any production/install environment without pytest (e.g. a packaged `raven tui`) crashed with `ModuleNotFoundError: No module named 'pytest'` (real launch path: spine → agent → memory_engine → contract_test → pytest).

Switched to **PEP 562 lazy `__getattr__`**: production imports no longer touch pytest; test code (run under pytest) still resolves the two contract-test base classes on access. No behavior change — only import timing.

## Verification
- clean venv without pytest: `import raven.memory_engine` and `import raven.tui_rpc.spine` (real launch chain) both succeed (crashed before)
- with pytest: top-level `from raven.memory_engine import LifecycleContractTests, MemoryBackendContractTests` works; `tests/test_memory_backend_contract.py` → 8 passed
- ruff check / format clean

## Type of change
- [x] Bug fix

## Checklists
### Development
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass
### Security
- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
### Code review
- [x] Pull request has a descriptive title and context useful to a reviewer
- [ ] Pull request linked to JIRA ticket when applicable
