### PR TITLE
docs: correct everos glossary entry to reflect memory-backend role

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -293,9 +293,13 @@ and injects into the main agent's system prompt so evicted facts stay present.
 
 ### Memory
 
-**EverOS**:
-An external memory system ([EverMind-AI/EverOS](https://github.com/EverMind-AI/EverOS))
-installed as a built-in tool in Raven.
+**EverOS** (`raven/plugin/memory/everos/`):
+Raven's default bundled memory-backend plugin (`everos-memory`; ships enabled, works
+out of the box). Provides dual-track semantic recall — the user track (episodes/profiles,
+injected into the `# Memory` segment) and the agent track (skills/cases, one of
+SkillForge's three sources at RRF weight 0.9). The name refers to the external package
+[EverMind-AI/EverOS](https://github.com/EverMind-AI/EverOS); the in-tree code is only an
+adapter. The same plugin also contributes the `understand_media` multimodal-parsing tool.
 
 **SkillForge** (`memory_engine/skill_forge/`):
 A skill retrieval and injection subsystem — it fuses candidates from three sources


### PR DESCRIPTION
## Change description

> Owner review of the **EverOS** glossary term (assigned to @yan.xiao in the
> 2026-06-28 glossary gap-scan). Refines the entry in `CONTEXT.md` -> `### Memory`
> and merges back into the review baseline branch `docs/glossary_baseline_and_init_docstring`.

The baseline entry read:

> EverOS: An external memory system installed as a built-in tool in Raven.

Verified against the code, this misstates the role on two counts:

- **Primary role is a memory backend, not "a tool".** It ships as a bundled
  plugin (`raven/plugin/memory/everos/raven-plugin.toml`: `id=everos-memory`,
  `bundled=true`, `enabled_by_default=true`) contributing a `memory_backends`
  factory `everos`. The `understand_media` tool is a *secondary* contribution of
  the same plugin, not the headline.
- **"External system" is misleading.** The name refers to the external pip
  package `EverMind-AI/EverOS` (`pyproject.toml`: `everos[multimodal]`); the
  in-tree `raven/plugin/memory/everos/` code is only a thin adapter that
  delegates to it.

Revised entry: a default bundled memory-backend plugin providing dual-track
semantic recall — user track (episodes/profiles, injected into the `# Memory`
segment) and agent track (skills/cases, one of SkillForge's three sources at RRF
weight 0.9) — plus the `understand_media` multimodal-parsing tool.

Note: the adjacent terms touched by EverOS (SkillForge, Skill Hub, the `# Memory`
segment) were cross-checked and are accurate; `skillForge.everos` is a real config
key (`raven/config/loader.py`, `update.py`, `raven.py`), so the SkillForge entry's
reference to it is correct and needs no change.

cc @sheng.zhao for review.

## Type of change
- [x] Document

## Related issues (if there is)

> Glossary finalize (EVE-55)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows security best practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
