### PR TITLE
docs: update readme hero links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <div align="center" id="readme-top">
 
-<img src="https://github.com/user-attachments/assets/224c1623-2705-4a48-8a60-fd5681ca0cb2" alt="Raven banner" width="100%">
-
-<br>
+![Raven banner](https://github.com/user-attachments/assets/224c1623-2705-4a48-8a60-fd5681ca0cb2)
 
 <p align="center">
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 <img src="https://github.com/user-attachments/assets/224c1623-2705-4a48-8a60-fd5681ca0cb2" alt="Raven banner" width="100%">
 
+<br>
+
 <p align="center">
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>
   <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/🤗_HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge" alt="HuggingFace"></a>
@@ -9,7 +11,7 @@
   <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_社区-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
 </p>
 
-[Website](https://raven.evermind.ai) · [EverOS](https://github.com/EverMind-AI/EverOS) · [中文](README.zh-CN.md)
+[Website](https://raven.evermind.ai) · [中文](README.zh-CN.md)
 
 </div>
 
@@ -38,10 +40,14 @@
 ## Why Raven
 
 Raven is a native command line agent, not a chat box wrapped around a shell.
-It is built for users who already think in terminals, repos, logs, scripts,
-sessions, and long-running workflows. The goal is simple: give your terminal an
-agent that can remember, act, use tools, manage context, and improve its own
-procedural skills over time.
+Built by EverMind, Raven is the first memory-first, self-improving agent OS:
+its model, code, modules, and policy are decoupled so it can improve across the
+whole stack, not just the skills layer. Layered memory and 100,000 built-in
+skills let Raven serve personal agents, cloud fleets, and reusable digital
+workers that get better with every session. It is built for users who already
+think in terminals, repos, logs, scripts, sessions, and long-running workflows.
+The goal is simple: give your terminal an agent that can remember, act, use
+tools, manage context, and improve its own procedural skills over time.
 
 Most agent CLIs stop at "LLM + tools + loop." That works for demos, but it
 breaks down when the agent becomes part of your daily environment:


### PR DESCRIPTION
## Summary

- Add rendered spacing between the README banner and badge row.
- Remove the EverOS link from the hero navigation, leaving Website and Chinese links.
- Add a condensed memory-first Raven positioning statement to the first Why Raven paragraph.

## Validation

- `git diff --check origin/main..HEAD`
- `npm run commitlint -- --from origin/main --to HEAD`
- `PR_TITLE="docs: update readme hero links" PYTHONPATH=. python3 scripts/check_pr_title.py`
