### PR TITLE
docs: correct skillforge + tui glossary terms vs code

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -299,13 +299,14 @@ installed as a built-in tool in Raven.
 
 **SkillForge** (`memory_engine/skill_forge/`):
 A skill retrieval and injection subsystem — it fuses candidates from three sources
-(local BM25-indexed files, self-evolved skills recalled from the EverOS memory backend,
-and remote skills from the Skill Hub) via weighted RRF, with optional LLM gating and
-query rewriting before injecting them into the agent prompt. Skill distillation/evolution
-is handled by the embedded EverOS extraction pipeline (`skillForge.everos`), not by
-SkillForge itself — there is no feedback-driven evolution or versioning, and retirement is
-a confidence-floor soft-delete. The name is retained; it is now a live module under the
-Memory Engine, not the old top-level husk.
+(local BM25-indexed files, self-evolved skills recalled from the pluggable `MemoryBackend`
+— typically the EverOS plugin — and remote skills from the Skill Hub) via weighted RRF,
+with optional LLM gating and query rewriting before injecting them into the agent prompt.
+Skill distillation/evolution is handled by the embedded EverOS extraction pipeline
+(`skillForge.everos`), not by SkillForge itself — there is no feedback-driven evolution or
+versioning, and the retirement knobs (`retire_confidence`, `retirement_idle_days`) are
+unwired config placeholders, not active behavior. The name is retained; it is now a live
+module under the Memory Engine, not the old top-level husk.
 
 **Skill Hub** (`skill_hub/`):
 A remote OpenAPI skill marketplace, configured via `skillForge.router.hub` (`endpoint` /

--- a/ui-tui/CONTEXT.md
+++ b/ui-tui/CONTEXT.md
@@ -1,8 +1,8 @@
 # TUI
 
 > **Status: review baseline (2026-06-28).** Under team review via this PR (owner @sheng.zhao).
-> Pending: StatusRulePane → Status Bar correction + candidate additions (Turn Cycle,
-> Streaming Segment, RPC Client, Composer, Slash Command System, …).
+> Pending: candidate additions (Turn Cycle, Streaming Segment, Subagent Tree, RPC Client,
+> ChatStream, Composer, Slash Command System, …) — owner @sheng.zhao to select.
 
 The terminal front-end (`ui-tui/`, React/Ink). Renders the chat transcript and overlays;
 talks to the Runtime only via TUI-RPC. Single-session per client in v0.1.
@@ -10,15 +10,19 @@ talks to the Runtime only via TUI-RPC. Single-session per client in v0.1.
 ## Language
 
 **Overlay**:
-A modal layer over the chat view, tracked in overlay state and driven by keyboard
-(Agents Overlay, Confirm Overlay, FPS Overlay).
+A modal layer over the chat view, tracked in `overlayStore` and driven by keyboard. Kinds
+split into RPC-driven (Confirm, Approval, Clarify, Sudo, Secret) and user-toggled (Agents,
+Model Picker, Picker, Pager) overlays; the FPS counter is a separate component, not an
+overlay-store kind.
 
 **MessageLine**:
 The UI element rendering one transcript row in the chat view.
 _Avoid_: "chat stream" for the UI — chat stream is the data feed it renders
 
-**StatusRulePane**:
-The bottom status rule of the layout.
+**Status Bar**:
+The status rule at the top or bottom of the layout, rendered by the `StatusRule` component;
+placement is set by `StatusBarMode` (`top` | `bottom` | `off`).
+_Avoid_: "StatusRulePane" — the exported component is `StatusRule`, there is no "Pane".
 
 **Agents Overlay**:
 The overlay showing the subagent tree (`SubagentNode` hierarchy with subtree


### PR DESCRIPTION
Contributor review (gap-scan §2/§6) of the terms I touch — SkillForge (memory_engine/skill_forge/) and the TUI (ui-tui/) — against current code.

SkillForge:
- backend is the pluggable MemoryBackend (EverOS is the typical plugin), not a hardcoded "EverOS memory backend"
- retirement is not implemented: retire_confidence / retirement_idle_days are unwired config placeholders, not a confidence-floor soft-delete

TUI:
- StatusRulePane -> Status Bar: exported component is StatusRule, placement via StatusBarMode (top|bottom|off); there is no "Pane"
- Overlay: list the real overlayStore kinds (RPC-driven + user-toggled); FPS is a separate component, not an overlay-store kind

## Summary

<!-- What changed, and why? -->

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

<!-- List the exact commands you ran and the result. -->

- [ ] Relevant tests pass locally
- [ ] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [ ] Security impact considered
- [ ] Backward compatibility considered
- [ ] Rollback path is clear for risky changes

## Related Issues

<!-- Fixes #123, closes #123, or N/A -->
