### PR TITLE
fix: remove internal defaults and bump vulnerable deps

### DIFF
--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -7,11 +7,12 @@
     "": {
       "name": "raven-whatsapp-bridge",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@whiskeysockets/baileys": "7.0.0-rc13",
         "pino": "^9.0.0",
         "qrcode-terminal": "^0.12.0",
-        "ws": "^8.17.1"
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "@types/node": "^20.14.0",
@@ -20,8 +21,7 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      },
-      "license": "Apache-2.0"
+      }
     },
     "node_modules/@borewit/text-codec": {
       "version": "0.2.2",

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@whiskeysockets/baileys": "7.0.0-rc13",
-    "ws": "^8.17.1",
+    "ws": "^8.21.0",
     "qrcode-terminal": "^0.12.0",
     "pino": "^9.0.0"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tiktoken>=0.7.0,<1.0.0",
     "questionary>=2.0.0,<3.0.0",
     "watchfiles>=0.21,<2.0",
-    "everos[multimodal]==1.0.0",
+    "everos[multimodal]==1.0.1",
     "tomli-w>=1.2.0",
     # OAuth provider login (Codex / GitHub Copilot) imports this during onboard,
     # so it must be a runtime dep -- otherwise `uv tool install raven` users hit
@@ -62,8 +62,8 @@ channel-matrix = [
 channel-feishu = ["lark-oapi>=1.5.0,<2.0.0"]
 channel-wecom = ["wecom-aibot-sdk-python>=0.1.5"]
 channel-mochat = [
-    "python-socketio>=5.16.2,<6.0.0",
-    "msgpack>=1.1.0,<2.0.0",
+    "python-socketio>=5.16.3,<6.0.0",
+    "msgpack>=1.2.1,<2.0.0",
     "websocket-client>=1.9.0,<2.0.0",
 ]
 channel-qq = ["qq-botpy>=1.2.0,<2.0.0"]
@@ -96,7 +96,7 @@ retrieval = [
     "transformers>=4.45.0",
 ]
 sandbox = [
-    "boxlite==0.8.2",
+    "boxlite==0.9.5",
     "anyio>=4.0",
 ]
 dev = [
@@ -158,7 +158,11 @@ include = [
 [tool.uv]
 constraint-dependencies = [
     "aiohttp>=3.13.4",
+    "pip>=26.1.2",
+    "pyjwt>=2.13.0",
+    "python-engineio>=4.13.3",
     "python-dotenv>=1.2.2",
+    "starlette>=1.3.1",
 ]
 
 [tool.ruff]

--- a/raven/config/raven.py
+++ b/raven/config/raven.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Literal
-
 import warnings
+from pathlib import Path
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.alias_generators import to_camel
@@ -113,9 +113,9 @@ class DndWindow(_Base):
     """
 
     start_hour: int  # 0-23
-    end_hour: int    # 1-24 (24 = end-of-day; wraps to next day if < start_hour)
+    end_hour: int  # 1-24 (24 = end-of-day; wraps to next day if < start_hour)
     start_minute: int = 0  # 0-59
-    end_minute: int = 0    # 0-59
+    end_minute: int = 0  # 0-59
     weekdays: list[int] | None = None
     """List of 0=Mon .. 6=Sun. None means every day."""
     why: str = ""
@@ -171,7 +171,7 @@ class NudgePolicyConfig(_Base):
     min_interval_seconds: int = 300
 
     # Quiet hours — 24h tuple (start_hour, end_hour); nudges outside high priority suppressed
-    quiet_hours: tuple[int, int] = (23, 7)   # (start_hour_24, end_hour_24), local time
+    quiet_hours: tuple[int, int] = (23, 7)  # (start_hour_24, end_hour_24), local time
 
     # Per-persona Do-Not-Disturb windows — additional quiet bands beyond
     # the global quiet_hours. Each window is matched only on its weekdays
@@ -220,8 +220,8 @@ class NudgePolicyConfig(_Base):
     #   - day:   stops "anniversary daily countdown" spam
     #   - week:  caps slow-burn topics (book reading reminder, fitness goal)
     # Set any cap to 0 to disable that layer.
-    max_per_topic_per_window: int = 1     # legacy alias for max_per_topic_per_hour
-    topic_dedup_window_seconds: int = 3600   # 1h
+    max_per_topic_per_window: int = 1  # legacy alias for max_per_topic_per_hour
+    topic_dedup_window_seconds: int = 3600  # 1h
     max_per_topic_per_day: int = 2
     # Weekly cap raised 4 → 8: deadline reminders (clawtrack 5/12-5/14,
     # birthday 5/20-5/24) need ~1 fire every 1-2 days across the
@@ -232,12 +232,12 @@ class NudgePolicyConfig(_Base):
     max_per_topic_per_week: int = 8
 
     # NudgeInjector settings
-    inject_ttl_seconds: int = 1800           # 30min — inject queued longer than this is stale
+    inject_ttl_seconds: int = 1800  # 30min — inject queued longer than this is stale
     inject_max_pending_per_session: int = 3  # cap queue growth
 
     # DeferManager settings
-    defer_idle_threshold_seconds: int = 300   # session must be idle this long before defer fires
-    defer_max_wait_seconds: int = 86400       # 24h — give up if never settled
+    defer_idle_threshold_seconds: int = 300  # session must be idle this long before defer fires
+    defer_max_wait_seconds: int = 86400  # 24h — give up if never settled
 
 
 # Single source of truth for the Planner's attention.md section allowlist.
@@ -588,11 +588,26 @@ class DailyAnalysisConfig(_Base):
     """Model for the daily analysis call. None → inherits
     ``SentinelConfig.evaluator_model``."""
 
-    stance_prefix_fallback: list[str] = Field(default_factory=lambda: [
-        "i prefer", "i like", "i don't like", "stop ", "avoid ", "never ",
-        "always ", "i want ", "from now on", "going forward",
-        "请", "别", "不要", "应该", "总是", "永远",
-    ])
+    stance_prefix_fallback: list[str] = Field(
+        default_factory=lambda: [
+            "i prefer",
+            "i like",
+            "i don't like",
+            "stop ",
+            "avoid ",
+            "never ",
+            "always ",
+            "i want ",
+            "from now on",
+            "going forward",
+            "请",
+            "别",
+            "不要",
+            "应该",
+            "总是",
+            "永远",
+        ]
+    )
     """Prefix list scanned against the inbound window when the LLM call
     fails and ``enable_prefix_fallback`` is True. Lowercase-matched;
     extend to support more languages or domain-specific stance verbs."""
@@ -813,50 +828,41 @@ class SkillForgeConfig(_Base):
     Prevents unbounded filesystem walks on huge mirrors."""
 
     # --- Retrieval / reranker knobs ---
-    embedding_model: str = "embedding-our-new"
+    embedding_model: str = "default"
     """Dense embedding model identifier. MUST match the embedding model
     that produced ``mass_library_db``'s stored vectors, otherwise dense
-    retrieval returns garbage (query vector lives in a different space).
-    Default ``embedding-our-new`` is our in-house self-trained model
-    (``/new`` endpoint) and matches the current ``mass_library.db``."""
+    retrieval returns garbage because the query vector lives in a different
+    space. Configure this to match the embedding service and corpus used by
+    your deployment."""
 
-    embedding_url: str = "http://192.168.0.172:1357/new"
-    """Remote embedding service URL — defaults to the shared in-house
-    embedding endpoint. The ``/new/`` path prefix is mandatory (calling
-    ``/embed`` directly without a prefix returns 404) and selects the
-    in-house self-trained model that matches the re-embedded
-    ``mass_library.db`` (label ``embedding-our-new``).
-    Retrieval calls ``POST <embedding_url>/embed``. Falls back to env
-    ``REMOTE_EMBEDDING_URL`` (update that env too on the deployed instance).
+    embedding_url: str = "http://localhost:1357"
+    """Remote embedding service base URL.
 
-    Endpoint history: 192.168.7.215:9000 → 192.168.5.57:9000 →
-    192.168.0.240:1357 → 192.168.0.152:1357 (/v6) →
-    192.168.0.172:1357/new (current, 2026-05-30, new self-trained model;
-    /v6 vectors are incompatible — corpus was fully re-embedded)."""
+    Retrieval calls ``POST <embedding_url>/embed``. Override this with
+    ``REMOTE_EMBEDDING_URL`` or user config when using a hosted embedding
+    service."""
 
     reranker_enabled: bool = True
     """Run a reranker pass after dense retrieval. On by default — adds
     200-500ms per query (cross-encoder GPU inference) but lifts mass-pool
     precision noticeably. Disable when latency matters more than ranking."""
 
-    reranker_model: str = "reranker-our-new"
-    """Reranker model label. Informational only — the active reranker
-    is fixed to the in-house model behind ``reranker_url``."""
+    reranker_model: str = "default"
+    """Reranker model label used for configuration and observability."""
 
-    reranker_url: str = "http://192.168.0.172:1357/new"
-    """Remote reranker service URL — defaults to the same in-house
-    endpoint as ``embedding_url``. Reranking calls ``POST /score`` against
-    this URL with ``{"prompts": [...]}`` and reads ``{"scores": [...]}``.
-    Falls back to env ``REMOTE_RERANKER_URL`` (update that env too on the
-    deployed instance)."""
+    reranker_url: str = "http://localhost:1357"
+    """Remote reranker service base URL.
 
-    embedding_api_key: str | None = "83a423b2-1da6-435c-b65c-b59ae286673d"
-    """API key for the shared in-house embedding/reranker endpoint
-    (Bearer token)."""
+    Reranking calls ``POST <reranker_url>/score`` with
+    ``{"prompts": [...]}`` and reads ``{"scores": [...]}``. Override this
+    with ``REMOTE_RERANKER_URL`` or user config when using a hosted reranker
+    service."""
 
-    reranker_api_key: str | None = "83a423b2-1da6-435c-b65c-b59ae286673d"
-    """API key for the shared in-house embedding/reranker endpoint
-    (Bearer token)."""
+    embedding_api_key: str | None = None
+    """Optional bearer token for the configured embedding service."""
+
+    reranker_api_key: str | None = None
+    """Optional bearer token for the configured reranker service."""
 
     embedding_dimensions: int | None = None
     """Request specific embedding dimensions (for models that support it)."""
@@ -890,13 +896,11 @@ class SkillForgeConfig(_Base):
     finish_reason=length truncations with empty visible content, which
     surfaced as 'Failed to parse rewrite response as JSON' fallbacks."""
 
-    mass_library_db: str | None = "/Evermind/bj_share/wangyanze/mass_library.db"
+    mass_library_db: str | None = None
     """Path to a pre-built SQLite skill library (the "mass pool").
-    Defaults to the shared in-house build at
-    ``/Evermind/bj_share/wangyanze/mass_library.db`` (intranet-accessible;
-    embeddings = ``embedding-our-new``, see ``embedding_model``).
     Set to ``None`` to disable the mass pool entirely — only the file-based
-    local pool (workspace + builtin + everos) will be used.
+    local pool (workspace + builtin + everos) will be used. Set this to a
+    deployment-specific database path when shipping a pre-built skill library.
 
     When set, ``SkillService`` attaches the file in **read-only** mode at
     startup and uses its (metadata + embedding) rows for dense retrieval
@@ -1066,9 +1070,7 @@ class SkillForgeConfig(_Base):
         if lw is not None:
             lw = float(lw)
             if lw < 1.0 or lw > 2.0:
-                raise ValueError(
-                    f"local_weight={lw} out of valid range [1.0, 2.0]"
-                )
+                raise ValueError(f"local_weight={lw} out of valid range [1.0, 2.0]")
         return data
 
 
@@ -1171,7 +1173,9 @@ class SkillForgeRouterConfig(_Base):
 
     weights: dict[str, float] = Field(
         default_factory=lambda: {
-            "local": 1.0, "everos": 0.9, "hub": 0.85,
+            "local": 1.0,
+            "everos": 0.9,
+            "hub": 0.85,
         },
     )
     """Per-source RRF weight. Higher = more rank mass when the same skill

--- a/raven/config/update.py
+++ b/raven/config/update.py
@@ -259,12 +259,11 @@ def init_extension_block_defaults(*, config_path: Path | None = None) -> None:
       - ``plugins.config["everos-memory"]`` is seeded with the plugin's identity
         wiring so the block is never empty and the user can see/edit it.
 
-    The internal-infra fields on ``SkillForgeConfig`` (``embedding_url`` /
+    The optional service fields on ``SkillForgeConfig`` (``embedding_url`` /
     ``embedding_api_key`` / ``reranker_url`` / ``reranker_api_key`` /
-    ``mass_library_db``) are deliberately NOT written — they carry hardcoded
-    intranet endpoints + a real Bearer token, which must never land in a user's
-    plaintext config. They stay at their schema defaults and the few who need
-    them add them by hand.
+    ``mass_library_db``) are deliberately NOT written. They stay at public
+    schema defaults and deployments that need hosted services add explicit
+    values by hand.
 
     Key casing follows each block's convention: ``memory`` / ``skillForge`` use
     camelCase (the file-level alias); ``plugins.config`` is a verbatim

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1556,8 +1556,8 @@ def test_fresh_bootstrap_seeds_extension_blocks(
     tmp_env: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Bootstrap materializes the memory / plugins / skillForge safe subset so a
-    fresh config exposes the knobs — without leaking the hardcoded intranet
-    endpoints / Bearer token from SkillForgeConfig's schema defaults."""
+    fresh config exposes the knobs without writing optional service endpoints
+    or bearer tokens into the user's plaintext config."""
     onboard_commands._bootstrap_empty_config()
     data = json.loads(tmp_env.read_text())
 
@@ -1567,7 +1567,7 @@ def test_fresh_bootstrap_seeds_extension_blocks(
     assert data["skillForge"]["everos"] == {"enabled": True}
     assert data["skillForge"]["router"]["hub"]["endpoint"] == "https://skillhub.evermind.ai"
     assert data["skillForge"]["router"]["hub"]["apiKey"] is None
-    # No internal infra fields written to the user's plaintext config.
+    # No optional service fields written to the user's plaintext config.
     for leaked in ("embeddingApiKey", "rerankerApiKey", "massLibraryDb"):
         assert leaked not in data["skillForge"]
 

--- a/tests/test_config_cfg1.py
+++ b/tests/test_config_cfg1.py
@@ -3,21 +3,22 @@
 from __future__ import annotations
 
 import json
+import re
 import warnings
 from pathlib import Path
 
 import pytest
 
+from raven.config.loader import EXTENSION_KEYS
 from raven.config.raven import (
-    RavenConfig,
     HubSourceConfig,
     MemoryConfig,
     PluginsConfig,
+    RavenConfig,
+    SkillForgeConfig,
     SkillForgeRouterConfig,
     load_raven_config,
 )
-from raven.config.loader import EXTENSION_KEYS
-
 
 # ---------------------------------------------------------------------------
 # Default-construction sanity
@@ -56,6 +57,22 @@ class TestDefaults:
         assert c.hub.timeout_s == pytest.approx(2.0)
         assert c.hub.min_safety == pytest.approx(0.7)
 
+    def test_skill_forge_public_defaults(self) -> None:
+        c = SkillForgeConfig()
+        assert c.embedding_model == "default"
+        assert c.embedding_url == "http://localhost:1357"
+        assert c.embedding_api_key is None
+        assert c.reranker_model == "default"
+        assert c.reranker_url == "http://localhost:1357"
+        assert c.reranker_api_key is None
+        assert c.mass_library_db is None
+
+        exported = c.model_dump_json()
+        assert not re.search(
+            r"https?://(?:10\.|127\.|192\.168\.|172\.(?:1[6-9]|2\d|3[0-1])\.)",
+            exported,
+        )
+
     def test_root_default_factories_wired(self) -> None:
         c = RavenConfig()
         assert isinstance(c.plugins, PluginsConfig)
@@ -70,28 +87,33 @@ class TestDefaults:
 
 class TestKeyAliasing:
     def test_camel_keys_accepted(self) -> None:
-        c = MemoryConfig.model_validate({
-            "userId": "alice",
-            "agentId": "alpha",
-            "memoryTopK": 7,
-        })
+        c = MemoryConfig.model_validate(
+            {
+                "userId": "alice",
+                "agentId": "alpha",
+                "memoryTopK": 7,
+            }
+        )
         assert c.user_id == "alice"
         assert c.agent_id == "alpha"
         assert c.memory_top_k == 7
 
     def test_snake_keys_accepted(self) -> None:
-        c = MemoryConfig.model_validate({
-            "user_id": "bob",
-            "memory_top_k": 3,
-        })
+        c = MemoryConfig.model_validate(
+            {
+                "user_id": "bob",
+                "memory_top_k": 3,
+            }
+        )
         assert c.user_id == "bob"
         assert c.memory_top_k == 3
 
     def test_router_hub_subblock_camel(self) -> None:
-        c = SkillForgeRouterConfig.model_validate({
-            "hub": {"endpoint": "http://hub.test", "timeoutS": 5.0,
-                    "minSafety": 0.8},
-        })
+        c = SkillForgeRouterConfig.model_validate(
+            {
+                "hub": {"endpoint": "http://hub.test", "timeoutS": 5.0, "minSafety": 0.8},
+            }
+        )
         assert c.hub.endpoint == "http://hub.test"
         assert c.hub.timeout_s == pytest.approx(5.0)
         assert c.hub.min_safety == pytest.approx(0.8)
@@ -132,25 +154,28 @@ def _write_config(tmp_path: Path, body: dict) -> Path:
 
 class TestLoaderIntegration:
     def test_loads_new_sections_from_file(self, tmp_path: Path) -> None:
-        path = _write_config(tmp_path, {
-            "plugins": {
-                "disabled": ["mem0-memory"],
-                "config": {"everos-memory": {"mode": "embedded"}},
+        path = _write_config(
+            tmp_path,
+            {
+                "plugins": {
+                    "disabled": ["mem0-memory"],
+                    "config": {"everos-memory": {"mode": "embedded"}},
+                },
+                "memory": {
+                    "backend": "everos",
+                    "userId": "alice",
+                    "memoryTopK": 10,
+                },
+                # Legacy top-level skillRouter is migrated into skillForge.router;
+                # the retired ``mass`` sub-block is dropped during migration.
+                "skillRouter": {
+                    "weights": {"local": 1.5, "everos": 1.0, "hub": 0.7},
+                    "topK": 8,
+                    "mass": {"endpoint": "http://mass.internal:9001"},
+                    "hub": {"endpoint": "http://hub.internal:9001"},
+                },
             },
-            "memory": {
-                "backend": "everos",
-                "userId": "alice",
-                "memoryTopK": 10,
-            },
-            # Legacy top-level skillRouter is migrated into skillForge.router;
-            # the retired ``mass`` sub-block is dropped during migration.
-            "skillRouter": {
-                "weights": {"local": 1.5, "everos": 1.0, "hub": 0.7},
-                "topK": 8,
-                "mass": {"endpoint": "http://mass.internal:9001"},
-                "hub": {"endpoint": "http://hub.internal:9001"},
-            },
-        })
+        )
         cfg = load_raven_config(path)
         assert cfg.plugins.disabled == ["mem0-memory"]
         assert cfg.plugins.config["everos-memory"]["mode"] == "embedded"
@@ -170,13 +195,17 @@ class TestLoaderIntegration:
         assert cfg.skill_forge.router.enabled is True
 
     def test_explicit_null_section_uses_defaults(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
-        path = _write_config(tmp_path, {
-            "plugins": None,
-            "memory": None,
-            "skillForge": None,
-        })
+        path = _write_config(
+            tmp_path,
+            {
+                "plugins": None,
+                "memory": None,
+                "skillForge": None,
+            },
+        )
         cfg = load_raven_config(path)
         # ``None`` is treated as "use default" rather than rejected.
         assert isinstance(cfg.plugins, PluginsConfig)
@@ -191,11 +220,15 @@ class TestLoaderIntegration:
 
 class TestMassLibraryDbDeprecation:
     def test_legacy_only_emits_deprecation_warning(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
-        path = _write_config(tmp_path, {
-            "skill_forge": {"mass_library_db": "/tmp/old.db"},
-        })
+        path = _write_config(
+            tmp_path,
+            {
+                "skill_forge": {"mass_library_db": "/tmp/old.db"},
+            },
+        )
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             load_raven_config(path)
@@ -205,16 +238,20 @@ class TestMassLibraryDbDeprecation:
         assert "skillForge.router.hub.endpoint" in str(deps[0].message)
 
     def test_both_old_and_new_no_deprecation_warning(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         """When the user has set the new Hub endpoint, the legacy field
         becomes a no-op — info log only, no warning."""
-        path = _write_config(tmp_path, {
-            "skill_forge": {
-                "mass_library_db": "/tmp/old.db",
-                "router": {"hub": {"endpoint": "http://hub.test"}},
+        path = _write_config(
+            tmp_path,
+            {
+                "skill_forge": {
+                    "mass_library_db": "/tmp/old.db",
+                    "router": {"hub": {"endpoint": "http://hub.test"}},
+                },
             },
-        })
+        )
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             load_raven_config(path)
@@ -222,9 +259,12 @@ class TestMassLibraryDbDeprecation:
         assert deps == []
 
     def test_no_legacy_field_no_warning(self, tmp_path: Path) -> None:
-        path = _write_config(tmp_path, {
-            "skill_router": {"mass": {"endpoint": "http://m"}},
-        })
+        path = _write_config(
+            tmp_path,
+            {
+                "skill_router": {"mass": {"endpoint": "http://m"}},
+            },
+        )
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             load_raven_config(path)
@@ -241,9 +281,13 @@ class TestStrictness:
     def test_unknown_field_in_plugins_rejected(self) -> None:
         with pytest.raises(Exception):
             # ``extra='forbid'`` — typo catches at startup
-            PluginsConfig.model_validate({
-                "disabled": [], "config": {}, "unknown_field": True,
-            })
+            PluginsConfig.model_validate(
+                {
+                    "disabled": [],
+                    "config": {},
+                    "unknown_field": True,
+                }
+            )
 
     def test_unknown_field_in_memory_rejected(self) -> None:
         with pytest.raises(Exception):

--- a/tests/test_config_update.py
+++ b/tests/test_config_update.py
@@ -41,7 +41,8 @@ def test_nudge_quota_writes_camel_into_empty_config(cfg_path: Path) -> None:
     changed = set_sentinel_nudge_quota(per_hour=1, per_day=3, config_path=cfg_path)
     data = _read(cfg_path)
     assert data["sentinel"]["nudgePolicy"] == {
-        "maxNudgesPerHour": 1, "maxNudgesPerDay": 3,
+        "maxNudgesPerHour": 1,
+        "maxNudgesPerDay": 3,
     }
     assert changed == {
         "max_nudges_per_hour": (None, 1),
@@ -59,9 +60,14 @@ def test_nudge_quota_partial_update_returns_prev(cfg_path: Path) -> None:
 
 
 def test_nudge_quota_respects_existing_snake_casing(cfg_path: Path) -> None:
-    cfg_path.write_text(json.dumps({
-        "sentinel": {"nudge_policy": {"max_nudges_per_hour": 9}},
-    }), encoding="utf-8")
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "sentinel": {"nudge_policy": {"max_nudges_per_hour": 9}},
+            }
+        ),
+        encoding="utf-8",
+    )
     set_sentinel_nudge_quota(per_hour=1, per_day=3, config_path=cfg_path)
     np = _read(cfg_path)["sentinel"]["nudge_policy"]
     # no duplicate camel keys introduced alongside the snake ones
@@ -210,9 +216,7 @@ def test_set_sandbox_backend_writes_and_returns_prev(cfg_path: Path) -> None:
 
 
 def test_set_sandbox_backend_preserves_siblings(cfg_path: Path) -> None:
-    cfg_path.write_text(
-        json.dumps({"providers": {"openai": {"apiKey": "sk-keep"}}})
-    )
+    cfg_path.write_text(json.dumps({"providers": {"openai": {"apiKey": "sk-keep"}}}))
     set_sandbox_backend("boxlite", config_path=cfg_path)
     data = _read(cfg_path)
     assert data["providers"]["openai"]["apiKey"] == "sk-keep"
@@ -243,9 +247,7 @@ def test_set_memory_backend_everos_then_none(cfg_path: Path) -> None:
 
 
 def test_set_memory_backend_preserves_siblings(cfg_path: Path) -> None:
-    cfg_path.write_text(
-        json.dumps({"agents": {"defaults": {"model": "openai/gpt-4o"}}})
-    )
+    cfg_path.write_text(json.dumps({"agents": {"defaults": {"model": "openai/gpt-4o"}}}))
     set_memory_backend("everos", config_path=cfg_path)
     data = _read(cfg_path)
     assert data["agents"]["defaults"]["model"] == "openai/gpt-4o"
@@ -279,7 +281,9 @@ def test_init_extension_defaults_seeds_safe_subset(cfg_path: Path) -> None:
     assert data["skillForge"]["enabled"] is True
     assert data["skillForge"]["everos"] == {"enabled": True}
     assert data["skillForge"]["router"]["weights"] == {
-        "local": 1.0, "everos": 0.9, "hub": 0.85,
+        "local": 1.0,
+        "everos": 0.9,
+        "hub": 0.85,
     }
     assert data["skillForge"]["router"]["hub"] == {
         "endpoint": "https://skillhub.evermind.ai",
@@ -301,14 +305,18 @@ def test_init_extension_defaults_plugin_identity_matches_memory(cfg_path: Path) 
 
 
 def test_init_extension_defaults_omits_internal_infra_fields(cfg_path: Path) -> None:
-    # The hardcoded intranet endpoints + Bearer token on SkillForgeConfig must
-    # never be materialized into a user's plaintext config; they stay at their
-    # schema defaults and only the safe subset is written.
+    # Service endpoints and optional tokens must never be materialized into a
+    # user's plaintext config by onboarding; only the safe subset is written.
     init_extension_block_defaults(config_path=cfg_path)
     sf = _read(cfg_path)["skillForge"]
     for leaked in (
-        "embeddingUrl", "embeddingApiKey", "rerankerUrl", "rerankerApiKey",
-        "massLibraryDb", "embedding_url", "embedding_api_key",
+        "embeddingUrl",
+        "embeddingApiKey",
+        "rerankerUrl",
+        "rerankerApiKey",
+        "massLibraryDb",
+        "embedding_url",
+        "embedding_api_key",
     ):
         assert leaked not in sf
 
@@ -316,17 +324,15 @@ def test_init_extension_defaults_omits_internal_infra_fields(cfg_path: Path) -> 
 def test_init_extension_defaults_is_idempotent_and_non_clobbering(cfg_path: Path) -> None:
     # An existing memory.backend (the bootstrap safety pin) and any user-set
     # value must survive — setdefault only fills what's absent.
-    cfg_path.write_text(
-        json.dumps({"memory": {"backend": None, "memoryTopK": 20}})
-    )
+    cfg_path.write_text(json.dumps({"memory": {"backend": None, "memoryTopK": 20}}))
     init_extension_block_defaults(config_path=cfg_path)
     first = _read(cfg_path)
-    assert first["memory"]["backend"] is None       # not overwritten
-    assert first["memory"]["memoryTopK"] == 20       # user value kept
-    assert first["memory"]["userId"] == "default"    # filled in
+    assert first["memory"]["backend"] is None  # not overwritten
+    assert first["memory"]["memoryTopK"] == 20  # user value kept
+    assert first["memory"]["userId"] == "default"  # filled in
 
     init_extension_block_defaults(config_path=cfg_path)
-    assert _read(cfg_path) == first                  # second run is a no-op
+    assert _read(cfg_path) == first  # second run is a no-op
 
 
 def test_init_extension_defaults_round_trips_through_loader(cfg_path: Path) -> None:
@@ -336,5 +342,7 @@ def test_init_extension_defaults_round_trips_through_loader(cfg_path: Path) -> N
     rc = load_raven_config(cfg_path)
     assert rc.memory.memory_top_k == 5
     assert rc.skill_forge.router.hub.endpoint == "https://skillhub.evermind.ai"
-    # The non-written internal field still resolves to its schema default.
-    assert rc.skill_forge.embedding_url.startswith("http://")
+    # Non-written service fields still resolve to public schema defaults.
+    assert rc.skill_forge.embedding_url == "http://localhost:1357"
+    assert rc.skill_forge.embedding_api_key is None
+    assert rc.skill_forge.mass_library_db is None

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,11 @@ resolution-markers = [
 [manifest]
 constraints = [
     { name = "aiohttp", specifier = ">=3.13.4" },
+    { name = "pip", specifier = ">=26.1.2" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "python-engineio", specifier = ">=4.13.3" },
+    { name = "starlette", specifier = ">=1.3.1" },
 ]
 
 [[package]]
@@ -273,21 +277,21 @@ wheels = [
 
 [[package]]
 name = "boxlite"
-version = "0.8.2"
+version = "0.9.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/d0/c8036da6041e159b1b286fa1c5cc1548263be2f3bd2119beb248493d8be8/boxlite-0.8.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:95c50dacb01755650021a84b6d88089970524a26e35170202fc602af8010d627", size = 34294066, upload-time = "2026-04-02T11:01:54.531Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/3b/ea99ae3c6dcd6175888420604c2f316273f4706e9a8035a6b563bb3d97ed/boxlite-0.8.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b94914de6c714b5eebab193f82a3b20162c49992a938b55bb03c3575fe8d8e6b", size = 36274983, upload-time = "2026-04-02T11:01:57.434Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/9a/363b8f185bf887ece70abc69ae4e294e45cd385aabbe9ff3703beba0e6c9/boxlite-0.8.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:827b7d7d65dddd10c475afe5edb94db0eb34ec0067cd899a5d9107b8b804d546", size = 32376800, upload-time = "2026-04-02T11:02:00.322Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/3a/5ba99e68957bf1acb43b8f12ceb5111fed90a67639034252cd6ddfa9c003/boxlite-0.8.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:65a6d3f7f1eaa4bd8fb4703d6dbf3403167478b1dd5be9d1e589466e83c3e730", size = 34294278, upload-time = "2026-04-02T11:02:02.757Z" },
-    { url = "https://files.pythonhosted.org/packages/68/36/6f2919d8cf79a8260938b9d0fac9afab586e6d28ae5f0a52cf3ceb68a75b/boxlite-0.8.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:9b29c2b91a1b1e869df50702cc19d101578a97e7ac823ec73f8242b77937fa2d", size = 36274095, upload-time = "2026-04-02T11:02:05.502Z" },
-    { url = "https://files.pythonhosted.org/packages/02/36/0e56a5ecf89a82923b2d78faa2117503a5318a1050ce5bba1a6a60b6582d/boxlite-0.8.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:56e15e724e8491ce8529e57bd691d5afc5e855af2569bc2303c40849cc6bce44", size = 32375933, upload-time = "2026-04-02T11:02:08.48Z" },
-    { url = "https://files.pythonhosted.org/packages/74/7c/085b6a7dd032b1c9c33a195c91668fc59dd14f18287e0dabcfe455da3537/boxlite-0.8.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:13066929107776dd0bf41beda48be8f5a8de5c76fb91bad37a42fc4b4c3e0988", size = 34294166, upload-time = "2026-04-02T11:02:11.073Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/86/ef91d47845160933c7f79134d5aed0d4d17f0edba1240ecdfb9cde5e4580/boxlite-0.8.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:29a51c979632d9a7d09f696d77305774b60b975bfd91aca79af941b516e041ed", size = 36275704, upload-time = "2026-04-02T11:02:13.672Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/e4/99cd86a9eb90724adf356649284bacff80d8bb48ed1ed02654bf70ba4625/boxlite-0.8.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:af88caa5fb6f6166cb0f55ec45c8de5331e13455aa542046efa2809a969b6ae6", size = 32372787, upload-time = "2026-04-02T11:02:16.079Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/a1/761430becf22917f910062509d50755652e7634c2ac096bfd4f486f9739c/boxlite-0.8.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:5c0999a0e47d9ede99598aa6888e0314076a52fb4366bc923c5e39408ed73e92", size = 34293175, upload-time = "2026-04-02T11:02:19.181Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/2f/8295cbf15e5f6fa013760d7bc1128b7106ee40aa4da4076a42fe1690e8f4/boxlite-0.8.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d631a8a0ae60e16aa626d8f0562adb0fae4779847be1f9aebcc14076e19813b2", size = 36276827, upload-time = "2026-04-02T11:02:22.316Z" },
-    { url = "https://files.pythonhosted.org/packages/51/c5/bc327b2a3ea18e173cd81eafb5e9db84c40a558e4e5513b7f4b946a16f5f/boxlite-0.8.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:16249ec7471652326118a38862c550170cba0c5f9a896f5a06958f7cc9a6022a", size = 32371802, upload-time = "2026-04-02T11:02:25.141Z" },
+    { url = "https://files.pythonhosted.org/packages/39/15/ba26c392e0e4d9dbde10ac8ece830e08c0fd3ef341852605d03c4394ddee/boxlite-0.9.5-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:4a9a8bbdadf51980e7791430f00e63fb8104e454b4efe266dde3d8535fd512f5", size = 34861042, upload-time = "2026-05-16T13:47:34.689Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a4/fb96c5c94d88d784597f8c24e9984a7b7287075cb091afc7ddc556854efa/boxlite-0.9.5-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3262b942e2157255428a3f371a49c72f65afe115ae12bfc19257a61fa153c002", size = 37011336, upload-time = "2026-05-16T13:47:37.907Z" },
+    { url = "https://files.pythonhosted.org/packages/61/cb/bcfa2dd8caa40f75c1640b9e50d2ba61fcc788263cb68070df095a28fd7b/boxlite-0.9.5-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f195df633219be69fec6492bde7a66fe3bda2c02d76226f80ae1ddd46b388498", size = 33112198, upload-time = "2026-05-16T13:47:41.218Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/0c6399665aeeb057312b50600aaf7b56791aa5d174e914363aa58542e5de/boxlite-0.9.5-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:a092252f8df79cb8da95d2c6f8d5865f6917e9d41b24b27b3dd301ee66988813", size = 34861292, upload-time = "2026-05-16T13:47:44.081Z" },
+    { url = "https://files.pythonhosted.org/packages/90/24/7f51aca1d85e0c0bda82cc10af0c82f39b316fbca062738b030324501f78/boxlite-0.9.5-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:515cbab5376b4a81ad67e1f3aacae4692978d13710c2a412874c9d9ff5475556", size = 37010785, upload-time = "2026-05-16T13:47:47.414Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7d/ce13d093e4f2653f28efd4ae89989a286f4aa00d910b051e90e44c2ee30b/boxlite-0.9.5-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4e2df5236136c9f263114671c649a27c15fb57c809e15a8771cf0c9176c70c02", size = 33110395, upload-time = "2026-05-16T13:47:50.382Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/8f/03ddd8915aebde31534e7b28b4a40e5b386e84ac0774760f60c81ec20b44/boxlite-0.9.5-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:51ccae9d665189278a194451e2178ed60e5f0eab0f2993f863bc6f670a4da890", size = 34861146, upload-time = "2026-05-16T13:47:53.397Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/80/9eede0dd4e36c77ee8fcab3161ef98d39efc6eff3ed78643517458e62c80/boxlite-0.9.5-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1ea7405f6bc64467e9152ada50bd0beb1ef04de475789c762c0c13a6f2c7b7ee", size = 37011759, upload-time = "2026-05-16T13:47:56.802Z" },
+    { url = "https://files.pythonhosted.org/packages/28/11/debb90db06be5d00b8852669b59a559e8b1b498686b9bfd5ed7718ed10a4/boxlite-0.9.5-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:40b441fb5d602a737e085d9f2a5702f4aa609442c6ec972a7f7a3fa5562e2e36", size = 33109317, upload-time = "2026-05-16T13:47:59.616Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bf/375e3e8994786946ffe76ff02b814394aac4b05f7b3aa36e969dbd098341/boxlite-0.9.5-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:ae3dce0bf2ac1449f906aea62cb439a6778b8192581fc1d2bf9ff46321896b64", size = 34864330, upload-time = "2026-05-16T13:48:02.687Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ae/f9e7e6da083e4846d598d0c795f86505df0e44c4b76e13dbb74c2ff15fbc/boxlite-0.9.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ac2ff04991807d97451c51f5fb25769559eddfb10a0017eabe8ce996c4d83f9", size = 37012881, upload-time = "2026-05-16T13:48:06.412Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/db/25c828b044dea57058b148dafec2348243b782b1090aeb388eccd0407a53/boxlite-0.9.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d8f00bb59724d5bd88452347f8f104f8fc8c8d1f3bca3b39df455d184eceb1eb", size = 33113959, upload-time = "2026-05-16T13:52:06.276Z" },
 ]
 
 [[package]]
@@ -933,7 +937,7 @@ wheels = [
 
 [[package]]
 name = "everos"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -963,9 +967,9 @@ dependencies = [
     { name = "watchdog" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/f9/30bd2f9492cb9e17641e4687e5cd99f7ae7a5d691c7ff98ed14c4e073bf0/everos-1.0.0.tar.gz", hash = "sha256:f12e23d5125d3f6ae60e5fd792511e141c3c2c728f2b7b9d15fcb7e961d7dede", size = 1281859, upload-time = "2026-06-03T12:17:27.265Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/e6/7e6c79e566e50261cb49ad0933788b6ebd8b2f97ec890871e0e6d65a155e/everos-1.0.1.tar.gz", hash = "sha256:e9c46bac253aa9371e06ecbb02dd1473826ba48647901bbd92c65d2fbdc7b41e", size = 1289916, upload-time = "2026-06-16T04:59:06.074Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/e9/6b24c06610859909f6d4136ec5b5f00028289bc0be1b8123edfe0fbf4a41/everos-1.0.0-py3-none-any.whl", hash = "sha256:3656236362df8bc470a814b8b6663b70f86d313371ad6102d06919351633c3ac", size = 396219, upload-time = "2026-06-03T12:17:25.774Z" },
+    { url = "https://files.pythonhosted.org/packages/31/db/3c814106a419a3074b0548d2afc00bcc198f65acc8f6901893569a073fa3/everos-1.0.1-py3-none-any.whl", hash = "sha256:6c35016fdf994087ae1183c9f60cfb0084041a8f11b775a0c3a2626c649828e1", size = 397746, upload-time = "2026-06-16T04:59:04.378Z" },
 ]
 
 [package.optional-dependencies]
@@ -1908,46 +1912,54 @@ wheels = [
 
 [[package]]
 name = "msgpack"
-version = "1.1.2"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
-    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
-    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
-    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
-    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
-    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
-    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
-    { url = "https://files.pythonhosted.org/packages/67/32/f3cd1667028424fa7001d82e10ee35386eea1408b93d399b09fb0aa7875f/msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c", size = 65037, upload-time = "2025-10-08T09:15:21.416Z" },
-    { url = "https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9", size = 72631, upload-time = "2025-10-08T09:15:22.431Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/db/0314e4e2db56ebcf450f277904ffd84a7988b9e5da8d0d61ab2d057df2b6/msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84", size = 64118, upload-time = "2025-10-08T09:15:23.402Z" },
-    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
-    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
-    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
-    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
-    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
-    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
-    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
-    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
-    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
+    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
+    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
 ]
 
 [[package]]
@@ -2444,11 +2456,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]
@@ -2862,11 +2874,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -2995,15 +3007,15 @@ wheels = [
 
 [[package]]
 name = "python-socketio"
-version = "5.16.2"
+version = "5.16.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bidict" },
     { name = "python-engineio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/dd/6fd4112b941f7d39b8171b6ba17902609bd8fa2059c3812a3c29dade13e7/python_socketio-5.16.2.tar.gz", hash = "sha256:ad88c228d921646efa436c0a0df217e364ef30ec072df4041484e54d49c15989", size = 128011, upload-time = "2026-05-21T22:03:44.418Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/2d/ffce71017c106b75099fea569df6518c63fee5d6202ce0cfe7b01e6f22c3/python_socketio-5.16.3.tar.gz", hash = "sha256:89b136f677ae65607a84cecda9b4d6c5377b40a97582c504c25df89af16d520e", size = 128095, upload-time = "2026-06-15T22:07:04.003Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/dc/0decaf5da92a7a969374474025787102d811d42aed1d32191fa338620e15/python_socketio-5.16.2-py3-none-any.whl", hash = "sha256:bef2da3374fd533aed4297f57b4f6512b52aa51604cb0da2165f401291c5ca20", size = 82137, upload-time = "2026-05-21T22:03:42.616Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/38/8c5e72d53ff8eb27497c4f268a7f6d9121e727a50b65248288ad79a93053/python_socketio-5.16.3-py3-none-any.whl", hash = "sha256:e7ad14202a5e6448824c7c2f86161d04e13dec05992257df5c709e6a2798c041", size = 82087, upload-time = "2026-06-15T22:07:02.498Z" },
 ]
 
 [[package]]
@@ -3260,10 +3272,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", marker = "extra == 'sandbox'", specifier = ">=4.0" },
-    { name = "boxlite", marker = "extra == 'sandbox'", specifier = "==0.8.2" },
+    { name = "boxlite", marker = "extra == 'sandbox'", specifier = "==0.9.5" },
     { name = "croniter", specifier = ">=6.0.0,<7.0.0" },
     { name = "dingtalk-stream", marker = "extra == 'channel-dingtalk'", specifier = ">=0.24.0,<1.0.0" },
-    { name = "everos", extras = ["multimodal"], specifier = "==1.0.0" },
+    { name = "everos", extras = ["multimodal"], specifier = "==1.0.1" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "huggingface-hub", marker = "extra == 'eval'", specifier = ">=1.11.0" },
     { name = "json-repair", specifier = ">=0.30.0" },
@@ -3272,7 +3284,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.3,<1.0.0" },
     { name = "matrix-nio", marker = "sys_platform != 'win32' and extra == 'channel-matrix'", specifier = ">=0.25.2" },
     { name = "mistune", marker = "extra == 'channel-matrix'", specifier = ">=3.0.0,<4.0.0" },
-    { name = "msgpack", marker = "extra == 'channel-mochat'", specifier = ">=1.1.0,<2.0.0" },
+    { name = "msgpack", marker = "extra == 'channel-mochat'", specifier = ">=1.2.1,<2.0.0" },
     { name = "nh3", marker = "extra == 'channel-matrix'", specifier = ">=0.2.17,<1.0.0" },
     { name = "oauth-cli-kit", specifier = ">=0.1.3,<1.0.0" },
     { name = "oauth-cli-kit", marker = "extra == 'tools'", specifier = ">=0.1.3,<1.0.0" },
@@ -3282,7 +3294,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.14.2,<3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0,<10.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
-    { name = "python-socketio", marker = "extra == 'channel-mochat'", specifier = ">=5.16.2,<6.0.0" },
+    { name = "python-socketio", marker = "extra == 'channel-mochat'", specifier = ">=5.16.3,<6.0.0" },
     { name = "python-socks", extras = ["asyncio"], marker = "sys_platform != 'win32' and extra == 'channel-telegram'", specifier = ">=2.8.0,<3.0.0" },
     { name = "python-telegram-bot", extras = ["socks"], marker = "extra == 'channel-telegram'", specifier = ">=22.6,<23.0" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
## Summary
- replace SkillForge embedding/reranker defaults with localhost endpoints, neutral model labels, and empty optional secrets
- remove the built-in mass library path default and neutralize related config docs/tests
- bump vulnerable Python and bridge dependencies: boxlite, everos, msgpack, python-socketio, pyjwt, pip, ws; add uv constraints for transitive safety lines

## Verification
- uv run --extra dev pytest tests/test_config_cfg1.py tests/test_config_update.py tests/test_cli_onboard_commands.py -q
- uv run --group dev ruff check raven/config/raven.py raven/config/update.py tests/test_config_cfg1.py tests/test_config_update.py tests/test_cli_onboard_commands.py
- uv run --extra sandbox --extra channel-mochat --group dev pip-audit -f json -o /tmp/raven-pip-audit-after.json
- npm audit --prefix bridge --json
- uv lock --check
- git diff --check