### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raven"
-version = "0.1.0"
+version = "0.1.1"
 description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "Apache-2.0"

--- a/raven/__init__.py
+++ b/raven/__init__.py
@@ -42,5 +42,5 @@ class _LiteLLMBotocorePreloadFilter(_logging.Filter):
 
 _logging.getLogger("LiteLLM").addFilter(_LiteLLMBotocorePreloadFilter())
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __logo__ = "🐦‍⬛"


### PR DESCRIPTION
## Change description

Bump the package version `0.1.0` -> `0.1.1` (and keep `raven.__version__` in
sync).

Context: the published `v0.1.0` release wheel was tagged before `oauth-cli-kit`
became a core runtime dependency (PR #54). As a result, the one-line install
pulls a wheel where `oauth-cli-kit` is only an optional `tools` extra, so a
fresh `uv tool install` fails during onboarding the moment an OAuth provider
(Codex / GitHub Copilot) is selected.

This bump lets a fresh release ship the fix as the latest wheel without
colliding with the existing `v0.1.0` release asset (the wheel filename is
derived from this static version string, not from the git tag). After merge,
tagging `v0.1.1` triggers the release workflow to build `raven-0.1.1-*.whl`.

No source/behavior change beyond the version strings.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Document
- [x] Others

## Related issues (if there is)

> N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
