### PR TITLE
feat: windows support -- installer and cross-platform tui transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Raven treats those problems as the product, not edge cases.
 **macOS / Linux:**
 
 ```bash
-curl -fsSL http://raven.evermind.ai/install.sh | bash
+curl -fsSL https://raven.evermind.ai/install.sh | sh
 ```
 
 **Windows (PowerShell):**

--- a/README.md
+++ b/README.md
@@ -96,16 +96,26 @@ Raven treats those problems as the product, not edge cases.
 
 ## Quick Install
 
+**macOS / Linux:**
+
 ```bash
 curl -fsSL http://raven.evermind.ai/install.sh | bash
 ```
 
-After installation, reload your shell and run the setup wizard:
+**Windows (PowerShell):**
+
+```powershell
+iex (irm https://raven.evermind.ai/install.ps1)
+```
+
+After installation, start a fresh shell so `PATH` refreshes, then run the setup wizard:
 
 ```bash
-source ~/.bashrc    # or: source ~/.zshrc
+source ~/.bashrc    # macOS / Linux (or: source ~/.zshrc)
 raven onboard
 ```
+
+On Windows, just open a new PowerShell window, then run `raven onboard`.
 
 Raven supports OpenRouter, OpenAI, Anthropic, Gemini, DeepSeek, GitHub Copilot,
 OpenAI Codex OAuth, and custom OpenAI-compatible endpoints.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -92,7 +92,7 @@ Raven 把这些问题当成产品本身，而不是边缘 case。
 **macOS / Linux：**
 
 ```bash
-curl -fsSL http://raven.evermind.ai/install.sh | bash
+curl -fsSL https://raven.evermind.ai/install.sh | sh
 ```
 
 **Windows（PowerShell）：**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -89,16 +89,26 @@ Raven 把这些问题当成产品本身，而不是边缘 case。
 
 ## 快速安装
 
+**macOS / Linux：**
+
 ```bash
 curl -fsSL http://raven.evermind.ai/install.sh | bash
 ```
 
-安装后重新加载 shell，并运行 setup wizard：
+**Windows（PowerShell）：**
+
+```powershell
+iex (irm https://raven.evermind.ai/install.ps1)
+```
+
+安装后请开一个新终端（让 `PATH` 刷新），再运行 setup wizard：
 
 ```bash
-source ~/.bashrc    # 或：source ~/.zshrc
+source ~/.bashrc    # macOS / Linux（或：source ~/.zshrc）
 raven onboard
 ```
+
+Windows 上直接开一个新的 PowerShell 窗口，然后运行 `raven onboard`。
 
 Raven 支持 OpenRouter、OpenAI、Anthropic、Gemini、DeepSeek、GitHub Copilot、
 OpenAI Codex OAuth，以及自定义 OpenAI-compatible endpoint。

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,197 @@
+<#
+  Raven one-line installer (Windows / PowerShell).
+
+    Remote (website):  iex (irm https://raven.evermind.ai/install.ps1)
+    Local (dev clone):  git clone ... ; cd raven ; .\install.ps1
+
+  Goal: a clean machine ends up able to run `raven` / `raven tui` from any
+  directory with no manual steps. The script is idempotent -- it detects what
+  is already present and only fills the gaps:
+    1. uv            (Python toolchain + package manager)
+    2. Node.js >= 22 (TUI runtime; installed privately if the system lacks it)
+    3. raven         (installed as a global uv tool -> %USERPROFILE%\.local\bin\raven.exe)
+
+  This is the Windows counterpart of install.sh (macOS / Linux). It mirrors the
+  same three-stage, idempotent flow and the same private-Node layout that
+  raven's find_node() looks for: %RAVEN_HOME%\runtime\node-vXX-win-<arch>\node.exe
+#>
+
+$ErrorActionPreference = 'Stop'
+
+# --- config ----------------------------------------------------------------
+$MinNodeMajor = 22
+$RavenHome = if ($env:RAVEN_HOME) { $env:RAVEN_HOME } else { Join-Path $env:USERPROFILE '.raven' }
+$NodeRuntimeDir = Join-Path $RavenHome 'runtime'
+
+# --- pretty output ---------------------------------------------------------
+function Write-Info($m) { Write-Host "> $m" -ForegroundColor Blue }
+function Write-Ok($m)   { Write-Host "+ $m" -ForegroundColor Green }
+function Write-Warn($m) { Write-Host "! $m" -ForegroundColor Yellow }
+function Die($m)        { Write-Host "x $m" -ForegroundColor Red; exit 1 }
+function Have($cmd)     { return [bool](Get-Command $cmd -ErrorAction SilentlyContinue) }
+
+# --- 0. platform detection -------------------------------------------------
+function Get-NodeArch {
+  $a = $env:PROCESSOR_ARCHITECTURE
+  if ($a -eq 'AMD64' -or ($a -eq 'x86' -and $env:PROCESSOR_ARCHITEW6432 -eq 'AMD64')) { return 'x64' }
+  if ($a -eq 'ARM64') { return 'arm64' }
+  Die "Unsupported architecture: $a (only x64 / arm64 are supported)"
+}
+
+# --- 1. ensure uv ----------------------------------------------------------
+function Ensure-Uv {
+  if (Have 'uv') { Write-Ok "uv already installed ($(uv --version))"; return }
+  Write-Info 'uv not found, installing...'
+  # Official uv Windows installer; installs to %USERPROFILE%\.local\bin.
+  powershell -ExecutionPolicy ByPass -NoProfile -Command "irm https://astral.sh/uv/install.ps1 | iex"
+  # Make uv visible for the rest of this process before the shell is reloaded.
+  $localBin = Join-Path $env:USERPROFILE '.local\bin'
+  $env:Path = "$localBin;$env:Path"
+  if (-not (Have 'uv')) { Die "uv still unavailable after install; check PATH (expected in $localBin)" }
+  Write-Ok 'uv installed'
+}
+
+# --- 2. ensure Node >= 22 --------------------------------------------------
+function Test-SystemNode {
+  if (-not (Have 'node')) { return $false }
+  try {
+    $v = (node --version) -replace '^v', '' -replace '\..*', ''
+    return ([int]$v -ge $MinNodeMajor)
+  } catch { return $false }
+}
+
+function Get-LatestNodeV22 {
+  try {
+    $idx = Invoke-RestMethod -Uri 'https://nodejs.org/dist/index.json' -TimeoutSec 20
+    $v = ($idx | Where-Object { $_.version -like 'v22.*' } | Select-Object -First 1).version
+    if ($v) { return $v }
+  } catch {}
+  return 'v22.20.0'  # pinned fallback if the index can't be reached
+}
+
+# Return the path to a Raven-provisioned private node.exe, or $null. Actually
+# run it: a half-extracted / corrupt binary exists but won't run and must not
+# be mistaken for a ready runtime (else we'd never re-download).
+function Get-PrivateNodeBin {
+  if (-not (Test-Path $NodeRuntimeDir)) { return $null }
+  $cands = Get-ChildItem -Path $NodeRuntimeDir -Filter 'node-v22*' -Directory -ErrorAction SilentlyContinue |
+    ForEach-Object { Join-Path $_.FullName 'node.exe' }
+  foreach ($n in $cands) {
+    if (Test-Path $n) {
+      try { & $n --version *> $null; if ($LASTEXITCODE -eq 0) { return $n } } catch {}
+    }
+  }
+  return $null
+}
+
+function Ensure-Node {
+  if (Test-SystemNode) { Write-Ok "Node.js already meets requirement ($(node --version))"; return }
+  $pn = Get-PrivateNodeBin
+  if ($pn) { Write-Ok "Raven private Node already present ($pn)"; return }
+
+  Write-Info "Node.js >= $MinNodeMajor not found; downloading a private runtime (does not touch the system)..."
+  $arch = Get-NodeArch
+  $ver = Get-LatestNodeV22
+  $pkg = "node-$ver-win-$arch"
+  $url = "https://nodejs.org/dist/$ver/$pkg.zip"
+  New-Item -ItemType Directory -Force -Path $NodeRuntimeDir | Out-Null
+  $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("raven-node-" + [System.Guid]::NewGuid().ToString('N'))
+  New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+  $zip = Join-Path $tmp 'node.zip'
+  Write-Info "  $url"
+  try { Invoke-WebRequest -Uri $url -OutFile $zip -TimeoutSec 120 } catch { Die "Node download failed: $url" }
+
+  # Supply-chain integrity: verify against the official SHASUMS256.txt.
+  try {
+    $shas = (Invoke-WebRequest -Uri "https://nodejs.org/dist/$ver/SHASUMS256.txt" -TimeoutSec 30).Content
+    $expected = ($shas -split "`n" | Where-Object { $_ -match "  $pkg\.zip$" } | Select-Object -First 1) -split '\s+' | Select-Object -First 1
+    if ($expected) {
+      $actual = (Get-FileHash -Algorithm SHA256 -Path $zip).Hash.ToLower()
+      if ($actual -ne $expected.ToLower()) {
+        Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+        Die "Node checksum mismatch (expected $expected, got $actual)"
+      }
+      Write-Ok 'Node zip SHA256 verified'
+    } else { Write-Warn "SHASUMS256.txt did not list $pkg.zip; skipping verification" }
+  } catch { Write-Warn 'Could not fetch SHASUMS256.txt; skipping integrity check' }
+
+  Expand-Archive -Path $zip -DestinationPath $NodeRuntimeDir -Force
+  Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+  $nodeExe = Join-Path $NodeRuntimeDir "$pkg\node.exe"
+  if (-not (Test-Path $nodeExe)) { Die 'Node executable not found after extraction' }
+  & $nodeExe --version *> $null
+  if ($LASTEXITCODE -ne 0) { Die "Downloaded Node cannot run on this machine. Install Node >= $MinNodeMajor manually." }
+  Write-Ok "Node private runtime ready: $(Join-Path $NodeRuntimeDir $pkg)"
+  # raven's find_node() globs %RAVEN_HOME%\runtime\node-*\node.exe automatically,
+  # so no PATH change is needed for `raven tui` to find it.
+}
+
+# --- 3. install raven ------------------------------------------------------
+function Install-Raven {
+  $scriptDir = $PSScriptRoot
+  $pyproject = if ($scriptDir) { Join-Path $scriptDir 'pyproject.toml' } else { $null }
+  $isLocal = $pyproject -and (Test-Path $pyproject) -and `
+             (Select-String -Path $pyproject -Pattern '^name = "raven"' -Quiet -ErrorAction SilentlyContinue)
+
+  if ($isLocal) {
+    Write-Info "Local raven source detected; editable install: $scriptDir"
+    $entry = Join-Path $scriptDir 'ui-tui\dist\entry.js'
+    if (-not (Test-Path $entry)) {
+      # Build the TUI bundle now (dev checkout doesn't commit it).
+      $nodeBin = (Get-Command node -ErrorAction SilentlyContinue).Source
+      if (-not $nodeBin) { $nodeBin = Get-PrivateNodeBin }
+      if ($nodeBin -and (Test-Path $nodeBin)) {
+        $nodeDir = Split-Path $nodeBin
+        $npm = Join-Path $nodeDir 'npm.cmd'
+        if (Test-Path $npm) {
+          Write-Info 'Building the TUI bundle (ui-tui\dist\entry.js)...'
+          Push-Location (Join-Path $scriptDir 'ui-tui')
+          try { & $npm ci; & $npm run build } finally { Pop-Location }
+        } else { Write-Warn 'Found node but not npm; skipping TUI build; raven tui may not work' }
+      } else { Write-Warn 'No usable node found; skipping TUI build; raven tui may not work' }
+    }
+    uv tool install --force -e "$scriptDir"
+  } else {
+    # Remote mode: install the latest published release wheel, which bundles the
+    # prebuilt ui-tui/dist/entry.js (built by CI). We deliberately do NOT install
+    # from git -- the TUI bundle is a gitignored build artifact, so a git install
+    # would yield a raven whose `raven tui` cannot start. Override RAVEN_WHEEL_URL
+    # to pin a specific wheel.
+    $wheelUrl = $env:RAVEN_WHEEL_URL
+    if (-not $wheelUrl) {
+      Write-Info 'Resolving the latest raven release from GitHub...'
+      try {
+        $rel = Invoke-RestMethod -Uri 'https://api.github.com/repos/EverMind-AI/raven/releases/latest' `
+                 -Headers @{ 'User-Agent' = 'raven-installer' } -TimeoutSec 30
+        $wheelUrl = ($rel.assets | Where-Object { $_.name -like '*.whl' } | Select-Object -First 1).browser_download_url
+      } catch {}
+    }
+    if (-not $wheelUrl) { Die 'Could not resolve the latest raven release wheel from GitHub (check network, or set RAVEN_WHEEL_URL to a wheel URL).' }
+    Write-Info "  installing $wheelUrl"
+    uv tool install --force "$wheelUrl"
+  }
+  # Ensure the uv tool bin dir is on PATH for future shells.
+  try { uv tool update-shell } catch {}
+  Write-Ok 'raven installed'
+}
+
+# --- main ------------------------------------------------------------------
+function Main {
+  Get-NodeArch | Out-Null   # fail fast on unsupported arch
+  Ensure-Uv
+  Ensure-Node
+  Install-Raven
+
+  Write-Host ''
+  Write-Ok 'All set! Open a new terminal (so PATH refreshes), then run:'
+  Write-Host ''
+  Write-Host '    raven            # enter the TUI' -ForegroundColor White
+  Write-Host '    raven agent -m "hello"' -ForegroundColor White
+  Write-Host ''
+  $localBin = Join-Path $env:USERPROFILE '.local\bin'
+  if ($env:Path -notlike "*$localBin*") {
+    Write-Warn "Your current PATH does not include $localBin yet -- open a new terminal, or run: `$env:Path = `"$localBin;`$env:Path`""
+  }
+}
+
+Main

--- a/install.ps1
+++ b/install.ps1
@@ -145,8 +145,14 @@ function Install-Raven {
         $npm = Join-Path $nodeDir 'npm.cmd'
         if (Test-Path $npm) {
           Write-Info 'Building the TUI bundle (ui-tui\dist\entry.js)...'
+          # npm runs lifecycle scripts that spawn `node` from PATH. When the only
+          # Node is the private runtime (the case that triggered the download),
+          # it is not on PATH, so prepend its dir for the build -- parity with
+          # install.sh, which exports PATH="$node_dir:$PATH" around the npm calls.
+          $savedPath = $env:Path
+          $env:Path = "$nodeDir;$env:Path"
           Push-Location (Join-Path $scriptDir 'ui-tui')
-          try { & $npm ci; & $npm run build } finally { Pop-Location }
+          try { & $npm ci; & $npm run build } finally { Pop-Location; $env:Path = $savedPath }
         } else { Write-Warn 'Found node but not npm; skipping TUI build; raven tui may not work' }
       } else { Write-Warn 'No usable node found; skipping TUI build; raven tui may not work' }
     }

--- a/install.sh
+++ b/install.sh
@@ -2,10 +2,10 @@
 # Raven one-line installer (macOS / Linux).
 #
 #   Remote (website):   curl -fsSL https://raven.evermind.ai/install.sh | sh
-#   Local (dev clone):  git clone … && cd raven && ./install.sh
+#   Local (dev clone):  git clone ... && cd raven && ./install.sh
 #
 # Goal: a clean machine ends up able to run `raven` / `raven tui` from any
-# directory with no manual steps. The script is idempotent — it detects what
+# directory with no manual steps. The script is idempotent -- it detects what
 # is already present and only fills the gaps:
 #   1. uv            (Python toolchain + package manager)
 #   2. Node.js >= 22 (TUI runtime; installed privately if the system lacks it)
@@ -16,14 +16,14 @@ set -eu
 
 # --- config ---------------------------------------------------------------
 MIN_NODE_MAJOR=22
-RAVEN_HOME="${RAVEN_HOME:-${HOME:?需要 HOME 环境变量，或显式设置 RAVEN_HOME}/.raven}"
+RAVEN_HOME="${RAVEN_HOME:-${HOME:?HOME is required, or set RAVEN_HOME explicitly}/.raven}"
 NODE_RUNTIME_DIR="$RAVEN_HOME/runtime"
 
 # --- pretty output ---------------------------------------------------------
-info()  { printf '\033[1;34m▶\033[0m %s\n' "$1"; }
-ok()    { printf '\033[1;32m✓\033[0m %s\n' "$1"; }
+info()  { printf '\033[1;34m>\033[0m %s\n' "$1"; }
+ok()    { printf '\033[1;32m+\033[0m %s\n' "$1"; }
 warn()  { printf '\033[1;33m!\033[0m %s\n' "$1" >&2; }
-die()   { printf '\033[1;31m✗\033[0m %s\n' "$1" >&2; exit 1; }
+die()   { printf '\033[1;31mx\033[0m %s\n' "$1" >&2; exit 1; }
 have()  { command -v "$1" >/dev/null 2>&1; }
 
 # --- 0. platform detection -------------------------------------------------
@@ -33,28 +33,28 @@ detect_platform() {
   case "$os" in
     Darwin) NODE_OS="darwin" ;;
     Linux)  NODE_OS="linux" ;;
-    *) die "不支持的操作系统：$os（仅支持 macOS / Linux）。Windows 请在 PowerShell 运行：iex (irm https://raven.evermind.ai/install.ps1)" ;;
+    *) die "Unsupported OS: $os (only macOS / Linux). On Windows, run in PowerShell: iex (irm https://raven.evermind.ai/install.ps1)" ;;
   esac
   case "$arch" in
     arm64|aarch64) NODE_ARCH="arm64" ;;
     x86_64|amd64)  NODE_ARCH="x64" ;;
-    *) die "不支持的架构：$arch" ;;
+    *) die "Unsupported architecture: $arch" ;;
   esac
 }
 
 # --- 1. ensure uv ----------------------------------------------------------
 ensure_uv() {
   if have uv; then
-    ok "uv 已安装（$(uv --version)）"
+    ok "uv already installed ($(uv --version))"
     return
   fi
-  info "未找到 uv，正在安装…"
+  info "uv not found, installing..."
   curl -fsSL https://astral.sh/uv/install.sh | sh
-  # uv installs to ~/.local/bin (or $XDG_BIN_HOME) — make it visible for the
+  # uv installs to ~/.local/bin (or $XDG_BIN_HOME) -- make it visible for the
   # rest of this script even before the shell profile is re-sourced.
   export PATH="$HOME/.local/bin:$PATH"
-  have uv || die "uv 安装后仍不可用，请检查 PATH（期望在 ~/.local/bin）"
-  ok "uv 安装完成"
+  have uv || die "uv still unavailable after install; check PATH (expected in ~/.local/bin)"
+  ok "uv installed"
 }
 
 # --- 2. ensure Node >= 22 --------------------------------------------------
@@ -81,7 +81,7 @@ latest_node_v22() {
 private_node_bin() {
   for n in "$NODE_RUNTIME_DIR"/node-v22*/bin/node; do
     [ -x "$n" ] || continue
-    # Actually run it — a half-extracted / corrupt binary is +x but won't run,
+    # Actually run it -- a half-extracted / corrupt binary is +x but won't run,
     # and must NOT be mistaken for a ready runtime (else we'd never re-download).
     "$n" --version >/dev/null 2>&1 && { printf '%s' "$n"; return 0; }
   done
@@ -90,23 +90,23 @@ private_node_bin() {
 
 ensure_node() {
   if system_node_ok; then
-    ok "Node.js 已满足要求（$(node --version)）"
+    ok "Node.js already meets requirement ($(node --version))"
     return
   fi
   # Already provisioned privately by a previous run?
   if pn="$(private_node_bin)"; then
-    ok "已存在 Raven 私有 Node（$pn）"
+    ok "Raven private Node already present ($pn)"
     return
   fi
 
-  info "未找到 Node.js >= $MIN_NODE_MAJOR，正在下载私有运行时（不污染系统）…"
+  info "Node.js >= $MIN_NODE_MAJOR not found; downloading a private runtime (does not touch the system)..."
   ver="$(latest_node_v22)"
   pkg="node-${ver}-${NODE_OS}-${NODE_ARCH}"
   url="https://nodejs.org/dist/${ver}/${pkg}.tar.gz"
   mkdir -p "$NODE_RUNTIME_DIR"
   tmp="$(mktemp -d)"
   info "  $url"
-  curl -fsSL "$url" -o "$tmp/node.tar.gz" || die "Node 下载失败：$url"
+  curl -fsSL "$url" -o "$tmp/node.tar.gz" || die "Node download failed: $url"
 
   # Supply-chain integrity: verify the tarball against the official
   # SHASUMS256.txt before extracting/executing it. Node publishes this file
@@ -119,28 +119,28 @@ ensure_node() {
       elif have sha256sum; then
         actual="$(sha256sum "$tmp/node.tar.gz" | awk '{print $1}')"
       else
-        actual=""; warn "未找到 shasum/sha256sum，跳过校验"
+        actual=""; warn "shasum/sha256sum not found; skipping verification"
       fi
       if [ -n "$actual" ] && [ "$actual" != "$expected" ]; then
         rm -rf "$tmp"
-        die "Node 校验失败：SHA256 不匹配（期望 $expected，实际 $actual）"
+        die "Node checksum mismatch (expected $expected, got $actual)"
       fi
-      [ -n "$actual" ] && ok "Node tarball SHA256 校验通过"
+      [ -n "$actual" ] && ok "Node tarball SHA256 verified"
     else
-      warn "SHASUMS256.txt 未列出 ${pkg}.tar.gz，跳过校验"
+      warn "SHASUMS256.txt did not list ${pkg}.tar.gz; skipping verification"
     fi
   else
-    warn "无法获取 SHASUMS256.txt，跳过完整性校验"
+    warn "Could not fetch SHASUMS256.txt; skipping integrity check"
   fi
 
   tar -xzf "$tmp/node.tar.gz" -C "$NODE_RUNTIME_DIR"
   rm -rf "$tmp"
-  [ -x "$NODE_RUNTIME_DIR/$pkg/bin/node" ] || die "Node 解压后未找到可执行文件"
+  [ -x "$NODE_RUNTIME_DIR/$pkg/bin/node" ] || die "Node executable not found after extraction"
   # Run it once now: catches a libc mismatch (e.g. glibc tarball on Alpine/musl)
   # at install time instead of letting `raven tui` fail later on the user's box.
   "$NODE_RUNTIME_DIR/$pkg/bin/node" --version >/dev/null 2>&1 \
-    || die "下载的 Node 无法在本机运行（可能 libc 不匹配，如 Alpine/musl）。请改用系统包管理器安装 Node >= ${MIN_NODE_MAJOR}。"
-  ok "Node 私有运行时就绪：$NODE_RUNTIME_DIR/$pkg"
+    || die "Downloaded Node cannot run on this machine (possible libc mismatch, e.g. Alpine/musl). Install Node >= ${MIN_NODE_MAJOR} via your system package manager."
+  ok "Node private runtime ready: $NODE_RUNTIME_DIR/$pkg"
   # raven's find_node() globs ~/.raven/runtime/node-*/bin/node automatically,
   # so no PATH change is needed for `raven tui` to find it.
 }
@@ -151,7 +151,7 @@ install_raven() {
   # working tree (what a developer wants). Otherwise install from git.
   script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
   if [ -f "$script_dir/pyproject.toml" ] && grep -q '^name = "raven"' "$script_dir/pyproject.toml" 2>/dev/null; then
-    info "检测到本地 raven 源码，使用 editable 安装：$script_dir"
+    info "Local raven source detected; editable install: $script_dir"
     # The TUI bundle must exist before first run. In a dev checkout it isn't
     # committed, so build it now if Node is available.
     if [ ! -f "$script_dir/ui-tui/dist/entry.js" ]; then
@@ -161,13 +161,13 @@ install_raven() {
         node_dir="$(dirname "$node_bin")"
         # npm ships alongside node, but verify explicitly before relying on it.
         if PATH="$node_dir:$PATH" command -v npm >/dev/null 2>&1; then
-          info "构建 TUI 产物（ui-tui/dist/entry.js）…"
+          info "Building the TUI bundle (ui-tui/dist/entry.js)..."
           ( cd "$script_dir/ui-tui" && PATH="$node_dir:$PATH" npm ci && PATH="$node_dir:$PATH" npm run build )
         else
-          warn "找到 node 但未找到 npm，跳过 TUI 产物构建；raven tui 可能不可用"
+          warn "Found node but not npm; skipping TUI build; raven tui may not work"
         fi
       else
-        warn "未找到可用 node，跳过 TUI 产物构建；raven tui 可能不可用"
+        warn "No usable node found; skipping TUI build; raven tui may not work"
       fi
     fi
     uv tool install --force -e "$script_dir"
@@ -189,23 +189,23 @@ install_raven() {
   fi
   # Ensure ~/.local/bin (uv tool bin dir) is on PATH for future shells.
   uv tool update-shell || true
-  ok "raven 安装完成"
+  ok "raven installed"
 }
 
 # --- main ------------------------------------------------------------------
 main() {
-  have curl || die "需要 curl，请先安装"
+  have curl || die "curl is required; please install it first"
   detect_platform
   ensure_uv
   ensure_node
   install_raven
 
   printf '\n'
-  ok "全部就绪！打开一个新终端（或 source 你的 shell 配置），然后运行："
-  printf '\n    \033[1mraven\033[0m            # 进入 TUI\n'
-  printf '    \033[1mraven agent\033[0m -m "你好"\n\n'
+  ok "All set! Open a new terminal (or source your shell profile), then run:"
+  printf '\n    \033[1mraven\033[0m            # enter the TUI\n'
+  printf '    \033[1mraven agent\033[0m -m "hello"\n\n'
   if ! printf '%s' "$PATH" | grep -q "$HOME/.local/bin"; then
-    warn "当前 shell 的 PATH 还没包含 ~/.local/bin —— 重开终端或运行：export PATH=\"\$HOME/.local/bin:\$PATH\""
+    warn "Your current PATH does not include ~/.local/bin yet -- open a new terminal, or run: export PATH=\"\$HOME/.local/bin:\$PATH\""
   fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ detect_platform() {
   case "$os" in
     Darwin) NODE_OS="darwin" ;;
     Linux)  NODE_OS="linux" ;;
-    *) die "不支持的操作系统：$os（仅支持 macOS / Linux；Windows 请用 install.ps1）" ;;
+    *) die "不支持的操作系统：$os（仅支持 macOS / Linux）。Windows 请在 PowerShell 运行：iex (irm https://raven.evermind.ai/install.ps1)" ;;
   esac
   case "$arch" in
     arm64|aarch64) NODE_ARCH="arm64" ;;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
     # so it must be a runtime dep -- otherwise `uv tool install raven` users hit
     # "oauth_cli_kit not installed" the moment they pick an OAuth provider.
     "oauth-cli-kit>=0.1.3,<1.0.0",
+    "mcp>=1.0",
+    "portalocker>=3.2.0",
 ]
 
 [project.optional-dependencies]
@@ -184,7 +186,6 @@ markers = [
 [dependency-groups]
 dev = [
     "json-repair>=0.59.5",
-    "mcp>=1.0",
     "oauth-cli-kit>=0.1.3",
     "pexpect>=4.9",
     "pip-audit>=2.10.0",

--- a/raven/agent/tools/file_search.py
+++ b/raven/agent/tools/file_search.py
@@ -44,9 +44,16 @@ _WALK_DEADLINE_S = 20.0
 def _denied_traversal_root(base: Path) -> bool:
     """True if ``base`` resolves to a system root that must not be tree-walked."""
     try:
-        return base.resolve() in _DENY_TRAVERSAL_ROOTS
+        resolved = base.resolve()
     except OSError:
         return False
+    # Any filesystem/drive root is its own parent — catches POSIX "/" and the
+    # Windows drive/UNC roots ("C:\\", "\\\\server\\share") that the POSIX-only
+    # _DENY_TRAVERSAL_ROOTS set misses (a search at C:\ would otherwise walk the
+    # whole drive).
+    if resolved.parent == resolved:
+        return True
+    return resolved in _DENY_TRAVERSAL_ROOTS
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +179,10 @@ class GrepTool(_FsTool):
             args += ["--line-number", "--no-heading", "--with-filename"]
             if context:
                 args += ["-C", str(context)]
+        # Force forward-slash separators in rg's output paths on every platform
+        # so results read the same on Windows as POSIX (only affects path fields,
+        # not matched content).
+        args += ["--path-separator", "/"]
         args += ["-e", pattern, "--", str(base)]
 
         proc = await asyncio.create_subprocess_exec(
@@ -189,7 +200,10 @@ class GrepTool(_FsTool):
 
         text = out.decode("utf-8", "replace")
         # Make paths relative to the search root for compact, readable output.
-        text = text.replace(str(base) + os.sep, "").replace(str(base), base.name or ".")
+        # rg emits forward-slash paths (--path-separator above); match that when
+        # stripping the search-root prefix so the strip works on Windows too.
+        base_str = str(base).replace(os.sep, "/")
+        text = text.replace(base_str + "/", "").replace(base_str, base.name or ".")
         lines = [ln for ln in text.splitlines() if ln]
         if not lines:
             return "No matches found."
@@ -272,9 +286,9 @@ class GrepTool(_FsTool):
     @staticmethod
     def _relpath(fp: Path, base: Path) -> str:
         try:
-            return str(fp.relative_to(base if base.is_dir() else base.parent))
+            return fp.relative_to(base if base.is_dir() else base.parent).as_posix()
         except ValueError:
-            return str(fp)
+            return fp.as_posix()
 
     def _format_lines(self, lines: list[str], cap: int, unit: str) -> str:
         total = len(lines)
@@ -377,7 +391,8 @@ class FindTool(_FsTool):
         total = len(matches)
         shown = matches[:cap]
         lines = [
-            f"{p.relative_to(base)}/" if p.is_dir() else str(p.relative_to(base))
+            f"{p.relative_to(base).as_posix()}/" if p.is_dir()
+            else p.relative_to(base).as_posix()
             for p in shown
         ]
         result = "\n".join(lines)

--- a/raven/cli/_gateway_lock.py
+++ b/raven/cli/_gateway_lock.py
@@ -1,9 +1,9 @@
 """Per-instance single-run guard for the gateway.
 
-An advisory ``fcntl.flock`` is held for the whole process lifetime, so the
-kernel releases it automatically on death (incl. SIGKILL) — no stale-lock
-cleanup is ever needed. Degrades to lock-less on Windows, mirroring the cron
-service. The lock is anchored at ``<instance data dir>/gateway.lock`` so that a
+A cross-platform advisory lock (portalocker: POSIX ``fcntl`` + Windows
+``LockFileEx``) is held for the whole process lifetime, so the OS releases it
+automatically on death (incl. SIGKILL) — no stale-lock cleanup is ever needed.
+The lock is anchored at ``<instance data dir>/gateway.lock`` so that a
 ``--config`` instance guards independently of the default one.
 """
 
@@ -14,10 +14,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-try:
-    import fcntl
-except ImportError:
-    fcntl = None
+import portalocker
 
 from raven.config.loader import get_config_path
 from raven.config.paths import get_data_dir
@@ -47,7 +44,7 @@ def _lock_path() -> Path:
 def _read_payload(path: Path) -> LockInfo:
     """Best-effort read of the lock payload; never raises on missing/corrupt."""
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         return LockInfo(
             pid=int(data.get("pid", -1)),
             started_at=float(data.get("started_at", 0.0)),
@@ -62,26 +59,28 @@ def acquire(now: float):
 
     Returns an open file handle the caller MUST keep alive for the whole
     process — closing it (or letting it be garbage-collected) releases the lock.
-    On Windows (no ``fcntl``) returns the handle without locking.
     """
-    path = _lock_path()
-    fd = path.open("a+")
-    if fcntl is None:
-        return fd
+    payload = _lock_path()
+    anchor = payload.with_name(payload.name + ".lck")
+    anchor.parent.mkdir(parents=True, exist_ok=True)
+    # Lock a separate anchor file, not the payload itself: on Windows the lock
+    # is mandatory, so locking the payload would block doctor's read-back of the
+    # owner pid. The anchor carries the lock; the payload stays readable.
+    fd = anchor.open("a+")
     try:
-        fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError:
-        info = _read_payload(path)
+        portalocker.lock(fd, portalocker.LOCK_EX | portalocker.LOCK_NB)
+    except portalocker.exceptions.LockException:
+        info = _read_payload(payload)
         fd.close()
         raise GatewayAlreadyRunningError(info)
-    fd.seek(0)
-    fd.truncate()
-    fd.write(json.dumps({
-        "pid": os.getpid(),
-        "started_at": now,
-        "config_path": str(get_config_path()),
-    }))
-    fd.flush()
+    payload.write_text(
+        json.dumps({
+            "pid": os.getpid(),
+            "started_at": now,
+            "config_path": str(get_config_path()),
+        }),
+        encoding="utf-8",
+    )
     return fd
 
 
@@ -92,16 +91,17 @@ def read_status(now: float) -> LockInfo | None:
     immediately and report not-running); a blocked acquire means a live
     instance owns it, so return its payload.
     """
-    path = _lock_path()
-    if not path.exists() or fcntl is None:
+    payload = _lock_path()
+    anchor = payload.with_name(payload.name + ".lck")
+    if not anchor.exists():
         return None
-    with path.open("a+") as fd:
+    with anchor.open("a+") as fd:
         try:
-            fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+            portalocker.lock(fd, portalocker.LOCK_EX | portalocker.LOCK_NB)
+            portalocker.unlock(fd)
             return None
-        except OSError:
-            return _read_payload(path)
+        except portalocker.exceptions.LockException:
+            return _read_payload(payload)
 
 
 __all__ = ["acquire", "read_status", "GatewayAlreadyRunningError", "LockInfo"]

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -250,8 +250,8 @@ def _load_raw_config() -> dict[str, Any]:
     if not path.exists():
         return {}
     try:
-        return json.loads(path.read_text()) or {}
-    except (json.JSONDecodeError, OSError):
+        return json.loads(path.read_text(encoding="utf-8")) or {}
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return {}
 
 

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -83,23 +83,35 @@ def find_node() -> Tuple[Optional[str], Optional[Tuple[int, int, int]]]:
     else:
         # Priority 2: active venv
         if venv := os.environ.get("VIRTUAL_ENV"):
-            candidates.append(str(Path(venv) / "bin" / "node"))
+            if os.name == "nt":
+                candidates.append(str(Path(venv) / "Scripts" / "node.exe"))
+            else:
+                candidates.append(str(Path(venv) / "bin" / "node"))
 
         # Priority 3: PATH
         if path_node := shutil.which("node"):
             candidates.append(path_node)
 
-        # Priority 4: Raven-managed private runtime installed by install.sh
-        # into ~/.raven/runtime/. This is the zero-config fallback so a user
-        # who has no system Node still gets a working `raven tui` after the
-        # one-line installer provisioned a private Node here. Glob to tolerate
-        # the versioned dir name (e.g. node-v22.x.y-darwin-arm64/bin/node).
+        # Priority 4: Raven-managed private runtime installed by the one-line
+        # installer into ~/.raven/runtime/. This is the zero-config fallback so
+        # a user who has no system Node still gets a working `raven tui` after
+        # the installer provisioned a private Node here. Glob to tolerate the
+        # versioned dir name. The on-disk layout differs by OS: POSIX tarballs
+        # nest the binary under bin/ (node-v22.x.y-darwin-arm64/bin/node) while
+        # the Windows zip puts node.exe at the top level
+        # (node-v22.x.y-win-x64/node.exe) — install.ps1 provisions the latter.
         runtime_root = Path(os.environ.get("RAVEN_HOME", Path.home() / ".raven")) / "runtime"
         if runtime_root.is_dir():
-            direct = runtime_root / "node" / "bin" / "node"
-            if direct.exists():
-                candidates.append(str(direct))
-            candidates.extend(str(p) for p in sorted(runtime_root.glob("node-*/bin/node")))
+            if os.name == "nt":
+                direct = runtime_root / "node" / "node.exe"
+                if direct.exists():
+                    candidates.append(str(direct))
+                candidates.extend(str(p) for p in sorted(runtime_root.glob("node-*/node.exe")))
+            else:
+                direct = runtime_root / "node" / "bin" / "node"
+                if direct.exists():
+                    candidates.append(str(direct))
+                candidates.extend(str(p) for p in sorted(runtime_root.glob("node-*/bin/node")))
 
     for node_path in candidates:
         if not Path(node_path).exists():

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -15,12 +15,12 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import secrets
 import shutil
 import signal
 import socket
 import subprocess
 import sys
-import tempfile
 import threading
 from pathlib import Path
 from typing import Optional, Tuple
@@ -191,14 +191,17 @@ def run_subprocess(
 _RPC_HANDSHAKE_TIMEOUT_S: float = 5.0
 _RPC_HANDSHAKE_EXIT_CODE: int = 3
 
-# Q11 (2026-05-14): production transport is a per-session unix domain socket.
-# The pass_fds variant below is retained for `--check` smoke parity and for
-# the existing Python-only handshake-timeout test; the production path here
-# replaces it because the Node child cannot reliably wrap an inherited bare
-# pipe FD as a stream (see `scripts/run_v001_demo.py` file-top note + the
-# v0.0.1 demo discovery log).
-_RPC_SOCKET_DIR_PREFIX: str = "eve-rpc-"
+# Q11 (2026-05-14): production transport was a per-session unix domain socket.
+# CROSS-PLATFORM (2026-06-30): switched to a TCP loopback socket bound to
+# 127.0.0.1:<ephemeral> because Windows has no usable AF_UNIX in CPython and
+# cannot os.dup a socket fd. The Node child connects to the host:port exported
+# in RAVEN_RPC_SOCKET and authenticates with the RAVEN_RPC_TOKEN shared secret
+# (loopback is reachable by any local process, unlike an AF_UNIX file guarded
+# by 0600 perms, so the token restores the trust boundary). The pass_fds /
+# os.pipe variant is retained for `--check` smoke parity and the Python-only
+# handshake-timeout test.
 _RPC_SOCKET_ENV: str = "RAVEN_RPC_SOCKET"
+_RPC_TOKEN_ENV: str = "RAVEN_RPC_TOKEN"
 
 
 def _suppress_noisy_watchers() -> None:
@@ -425,8 +428,8 @@ def _build_tui_agent_loop():
 
 
 async def _run_rpc_server_until_done(
-    request_fd: int,
-    notify_fd: int,
+    conn: socket.socket,
+    auth_token: str,
     handshake_deadline_s: float,
     proc_done: asyncio.Event,
 ) -> bool:
@@ -466,7 +469,7 @@ async def _run_rpc_server_until_done(
     # registered) — RpcServer.send_frame raises until serve_forever has set
     # up the write transport, but emitter only emits after a subscribe call,
     # which can only happen post-handshake / post-serve.
-    server = RpcServer(request_fd, notify_fd, dispatcher)
+    server = RpcServer(dispatcher=dispatcher, sock=conn, auth_token=auth_token)
     emitter = SubscriptionEmitter(send_frame=server.send_frame)
     # ConfirmBroker shares the same send_frame sink; it lets a paused
     # cli.dispatch (typer.confirm) emit a confirm.request and await the
@@ -615,61 +618,42 @@ async def _run_rpc_server_until_done(
             pass
 
 
-def _create_rpc_socket_dir() -> Path:
-    """Create a 0700-mode tempdir to hold a session-private rpc socket.
-
-    Each call mints a fresh directory under ``$TMPDIR`` (mkdtemp prefixes
-    with ``eve-rpc-``). The 0700 perms ensure no other local user can even
-    enumerate the socket path. Caller is responsible for removing the dir
-    on teardown.
-    """
-    dir_path = Path(tempfile.mkdtemp(prefix=_RPC_SOCKET_DIR_PREFIX))
-    # mkdtemp already creates with 0700 on POSIX; chmod is defensive.
-    try:
-        os.chmod(dir_path, 0o700)
-    except OSError:
-        pass
-    return dir_path
-
-
 def _spawn_with_rpc_socket(
     node_path: str,
     args: list[str],
     cwd: Path,
-) -> tuple[subprocess.Popen[bytes], socket.socket, Path]:
-    """Spawn `[node_path, *args]` with a per-session unix domain socket.
+) -> tuple[subprocess.Popen[bytes], socket.socket, str]:
+    """Spawn `[node_path, *args]` with a per-session TCP-loopback socket.
 
-    Topology:
+    Topology (cross-platform: macOS / Linux / Windows):
 
-        parent: socket()/bind()/listen() on `<tmpdir>/sock` (mode 0700/0600)
-                exports the path as ``RAVEN_RPC_SOCKET`` env var
-        child:  reads ``RAVEN_RPC_SOCKET``, ``net.createConnection(path)``,
-                emits JSON-RPC frames + reads responses on the same socket
+        parent: socket()/bind()/listen() on 127.0.0.1:<ephemeral>; exports the
+                ``host:port`` as ``RAVEN_RPC_SOCKET`` and a random shared secret
+                as ``RAVEN_RPC_TOKEN``
+        child:  reads ``RAVEN_RPC_SOCKET``, ``net.createConnection({host,port})``,
+                sends ``RAVEN_RPC_TOKEN`` as the first line, then emits JSON-RPC
+                frames + reads responses on the same socket
 
-    Returns ``(popen, listening_server_socket, sock_dir_path)``. Caller must
-    eventually:
+    Loopback (127.0.0.1) is reachable by any local process, so the token --
+    known only to the child we spawn (passed via env) -- is what keeps a rogue
+    local process from talking to us; the parent validates it as the first line
+    (see ``RpcServer(auth_token=...)``) before any dispatch.
 
-        * ``server_sock.close()``
-        * ``shutil.rmtree(sock_dir_path, ignore_errors=True)``
-
-    The accepted client connection is NOT created here — that's done by
-    :func:`_run_rpc_server_until_done` once the asyncio loop is up so the
-    accept can be cancelled cleanly on handshake timeout.
+    Returns ``(popen, listening_server_socket, auth_token)``. Caller must
+    eventually ``server_sock.close()``. The accepted client connection is NOT
+    created here -- that's done by :func:`_run_rpc_server_until_done` once the
+    asyncio loop is up so the accept can be cancelled cleanly on handshake
+    timeout.
     """
-    sock_dir = _create_rpc_socket_dir()
-    sock_path = sock_dir / "sock"
-
-    server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    server_sock.bind(str(sock_path))
+    server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_sock.bind(("127.0.0.1", 0))
     server_sock.listen(1)
-    # 0600 on the socket file — only the owning user can connect.
-    try:
-        os.chmod(sock_path, 0o600)
-    except OSError:
-        pass
+    host, port = server_sock.getsockname()[:2]
 
+    token = secrets.token_hex(32)
     env = os.environ.copy()
-    env[_RPC_SOCKET_ENV] = str(sock_path)
+    env[_RPC_SOCKET_ENV] = f"{host}:{port}"
+    env[_RPC_TOKEN_ENV] = token
 
     proc = subprocess.Popen(
         [node_path, *args],
@@ -680,7 +664,7 @@ def _spawn_with_rpc_socket(
         env=env,
     )
 
-    return proc, server_sock, sock_dir
+    return proc, server_sock, token
 
 
 async def _accept_with_timeout(
@@ -707,21 +691,22 @@ def run_subprocess_with_rpc(
     cwd: Path,
     forward_signals: bool = True,
 ) -> int:
-    """Spawn Node child with a per-session unix socket; run RpcServer; enforce handshake.
+    """Spawn Node child with a per-session TCP-loopback socket; run RpcServer; enforce handshake.
 
-    Q11 (2026-05-14): production transport is a unix domain socket. The Node
-    side cannot reliably wrap inherited pipe FDs as Node streams, so the
-    parent listens on ``<tmpdir>/sock`` (mode 0700/0600) and exports the
-    path via ``RAVEN_RPC_SOCKET``. The wire framing (newline JSON) is
-    unchanged from the pass_fds variant; ``RpcServer`` itself is reused
-    verbatim by dup-ing the accepted socket fd into separate read / write
-    ends so ``connect_read_pipe`` + ``connect_write_pipe`` still apply.
+    Cross-platform transport (macOS / Linux / Windows): the parent listens on
+    ``127.0.0.1:<ephemeral>`` and exports the ``host:port`` via
+    ``RAVEN_RPC_SOCKET`` plus a random shared secret via ``RAVEN_RPC_TOKEN``.
+    The Node child connects, sends the token as the first newline-terminated
+    line, then speaks newline-JSON frames. The accepted socket *object* is
+    handed to ``RpcServer`` (no os.dup of a socket fd -- unsupported on
+    Windows), which wires it via ``loop.connect_accepted_socket`` and validates
+    the token before any dispatch.
 
     Returns the child's exit code, OR ``_RPC_HANDSHAKE_EXIT_CODE`` (3) if
     the handshake times out (either because the child never connected, or
-    because it connected but never sent ``system.hello``).
+    because it connected but never sent the token + ``system.hello``).
     """
-    proc, server_sock, sock_dir = _spawn_with_rpc_socket(node_path, args, cwd)
+    proc, server_sock, auth_token = _spawn_with_rpc_socket(node_path, args, cwd)
 
     if forward_signals:
 
@@ -751,9 +736,8 @@ def run_subprocess_with_rpc(
 
     _loop_holder: dict[str, asyncio.AbstractEventLoop] = {}
 
-    # Track FDs we allocate inside _main so the outer cleanup can close them.
-    _fd_holder: dict[str, int] = {}
     _conn_holder: dict[str, socket.socket] = {}
+    _flags = {"handed_off": False}
 
     async def _main() -> bool:
         _loop_holder["loop"] = asyncio.get_running_loop()
@@ -785,18 +769,13 @@ def run_subprocess_with_rpc(
             return False
         _conn_holder["conn"] = conn
 
-        # dup once for read, once for write — both ends of the same socket fd
-        # — so RpcServer's connect_read_pipe + connect_write_pipe (each of
-        # which takes ownership of its fd) cannot trigger a double-close.
-        req_fd = os.dup(conn.fileno())
-        notif_fd = os.dup(conn.fileno())
-        _fd_holder["req"] = req_fd
-        _fd_holder["notif"] = notif_fd
-
-        # We've duped what we need; the original `conn` can be closed by the
-        # outer scope.
+        # Hand the connected socket object straight to RpcServer. We do NOT
+        # os.dup the fd (unsupported on Windows) — connect_accepted_socket takes
+        # ownership of this one socket and closes it on teardown, so the outer
+        # cleanup must not double-close it.
+        _flags["handed_off"] = True
         return await _run_rpc_server_until_done(
-            req_fd, notif_fd, _RPC_HANDSHAKE_TIMEOUT_S, proc_done
+            conn, auth_token, _RPC_HANDSHAKE_TIMEOUT_S, proc_done
         )
 
     waiter = threading.Thread(target=_waiter, daemon=True)
@@ -806,8 +785,10 @@ def run_subprocess_with_rpc(
     try:
         handshake_ok = asyncio.run(_main())
     finally:
-        # 1) Close the parent-side conn (server already dup'd what it needs).
-        if "conn" in _conn_holder:
+        # 1) Close the accepted conn only if it was never handed to RpcServer.
+        # Once handed off, the server owns it (connect_accepted_socket) and
+        # closes it on teardown; double-closing here would race that.
+        if "conn" in _conn_holder and not _flags["handed_off"]:
             try:
                 _conn_holder["conn"].close()
             except OSError:
@@ -815,11 +796,6 @@ def run_subprocess_with_rpc(
         # 2) Close the listening socket.
         try:
             server_sock.close()
-        except OSError:
-            pass
-        # 3) Remove the tempdir + socket file.
-        try:
-            shutil.rmtree(sock_dir, ignore_errors=True)
         except OSError:
             pass
 

--- a/raven/memory_engine/consolidate/consolidator.py
+++ b/raven/memory_engine/consolidate/consolidator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-import sys
 import weakref
 from contextlib import contextmanager
 from datetime import datetime
@@ -757,18 +756,13 @@ class MemoryStore:
         yield from self._fcntl_locked(self.stance_log_lock_path)
 
     def _fcntl_locked(self, lock_path: Path) -> Iterator[None]:
-        if sys.platform == "win32":
+        # Cross-platform advisory lock (portalocker): real serialization on
+        # Windows too, instead of the previous win32 no-op that lost concurrent
+        # writes to MEMORY.md / attention.md / behaviors.md / stance_log.json.
+        from raven.utils.portable_lock import file_lock
+
+        with file_lock(lock_path):
             yield
-            return
-        # `import` here so non-POSIX import doesn't fail at module load
-        import fcntl
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-        with lock_path.open("a") as fh:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
 
     def read_long_term(self) -> str:
         if self.memory_file.exists():

--- a/raven/memory_engine/skill_forge/catalog.py
+++ b/raven/memory_engine/skill_forge/catalog.py
@@ -365,7 +365,10 @@ class LocalSkillCatalog:
                     # — it must NOT touch the literal "{baseDir}/<missing-ref>"
                     # left in place above, else those re-absolutize into 404s.
                     if path_obj.parent.exists():
-                        body, _bare = _re.subn(r"\{baseDir\}(?!/)", base_dir, body)
+                        # Function replacement, not a string: base_dir may hold
+                        # Windows backslashes that re.subn would treat as escape
+                        # sequences (\U, \a, ...) → re.error "bad escape".
+                        body, _bare = _re.subn(r"\{baseDir\}(?!/)", lambda _m: base_dir, body)
                         if _bare:
                             _resolved = True
                     header = _dir_header if _resolved else f"### Skill: {m.name}\n\n"

--- a/raven/memory_engine/skill_forge/refs.py
+++ b/raven/memory_engine/skill_forge/refs.py
@@ -84,7 +84,10 @@ def resolve_refs(body: str, skill_dir: Path | str | None) -> tuple[str, bool]:
             return mo.group(0)
 
         body = _BASE_DIR_REF_RE.sub(_bd_sub, body)
-        body, bare_n = _BARE_BASE_DIR_RE.subn(base_dir, body)
+        # Use a function replacement, not a string: base_dir is a filesystem
+        # path and on Windows contains backslashes that re.subn would otherwise
+        # interpret as escape sequences (\U, \a, ...) → re.error "bad escape".
+        body, bare_n = _BARE_BASE_DIR_RE.subn(lambda _m: base_dir, body)
         if bare_n:
             any_resolved = True
 

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -187,6 +187,13 @@ def _try_make_real_adapter() -> _Adapter:
     """Return a real adapter if everos imports cleanly; otherwise a
     no-op adapter. Failure is logged at WARNING level so a misconfigured
     deploy is visible without the host crashing."""
+    # everos hard-imports the POSIX ``fcntl`` module at import time. On Windows
+    # that raised ModuleNotFoundError and the whole memory backend silently
+    # degraded to a no-op (mis-logged as "everos not installed"). Install a
+    # Windows fcntl shim first so the bundled backend actually loads.
+    from raven.utils.win_fcntl_shim import install as _install_fcntl_shim
+
+    _install_fcntl_shim()
     try:
         return _RealEverosAdapter()
     except ModuleNotFoundError as e:

--- a/raven/proactive_engine/sentinel/discover_triggers.py
+++ b/raven/proactive_engine/sentinel/discover_triggers.py
@@ -1,8 +1,8 @@
 """DiscoverTriggerStore — file-based IPC for ad-hoc TaskDiscoverer fires.
 
 Mirrors cron's jobs.json mechanics: atomic write (tmp + os.replace) +
-fcntl advisory lock + caller-driven polling. CLI ``discover-now`` adds
-a trigger; gateway tick / startup drains it.
+cross-platform advisory lock + caller-driven polling. CLI ``discover-now``
+adds a trigger; gateway tick / startup drains it.
 
 Triggers are consume-and-delete (no retry on crash). For a separate
 PendingDecisionStore: that one holds **dispatched** menus the user can
@@ -11,11 +11,9 @@ pick from; a trigger is **pre-dispatch intent** with no options yet.
 
 from __future__ import annotations
 
-import fcntl
 import json
 import os
 import secrets
-import sys
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -23,7 +21,6 @@ from pathlib import Path
 from typing import Iterator
 
 from loguru import logger
-
 
 _STORE_VERSION = 1
 
@@ -55,21 +52,14 @@ class DiscoverTriggerStore:
     def __init__(self, store_path: Path) -> None:
         self.store_path = store_path
         self.lock_path = store_path.with_suffix(store_path.suffix + ".lock")
-        self._can_lock = sys.platform != "win32"
 
     @contextmanager
     def _locked(self) -> Iterator[None]:
-        """Exclusive advisory lock. No-op on Windows."""
-        if not self._can_lock:
+        """Exclusive cross-platform advisory lock (POSIX + Windows)."""
+        from raven.utils.portable_lock import file_lock
+
+        with file_lock(self.lock_path):
             yield
-            return
-        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
-        with self.lock_path.open("a") as lock_fd:
-            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
 
     def _read(self) -> list[DiscoverTrigger]:
         """Read triggers from disk. Returns [] on missing or malformed file —

--- a/raven/proactive_engine/sentinel/feedback/persistence.py
+++ b/raven/proactive_engine/sentinel/feedback/persistence.py
@@ -6,22 +6,14 @@ heaps. Without coordination, two concurrent processes can double-nudge the
 user and violate the hour/day quotas.
 
 This module provides a single JSON file backing them, guarded by a
-POSIX advisory lock (fcntl) so only one process at a time can
+cross-platform advisory lock so only one process at a time can
 read-mutate-write. Writes are atomic via temp-file rename.
-
-Not Windows-compatible. Raven's channel layer is POSIX-only anyway.
 """
 
 from __future__ import annotations
 
 import json
 import os
-import sys
-
-try:
-    import fcntl
-except ImportError:
-    fcntl = None
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Iterator
@@ -42,8 +34,6 @@ class JsonStateStore:
     """
 
     def __init__(self, path: Path) -> None:
-        if sys.platform == "win32":
-            raise NotImplementedError("JsonStateStore requires POSIX fcntl")
         self.path = Path(path)
         self.lock_path = self.path.with_suffix(self.path.suffix + ".lock")
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -59,13 +49,11 @@ class JsonStateStore:
 
     @contextmanager
     def locked(self) -> Iterator[None]:
-        """Hold an exclusive fcntl lock. Safe to nest via recursive callers."""
-        with self.lock_path.open("a") as lock_fd:
-            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
+        """Hold an exclusive cross-platform advisory lock (POSIX + Windows)."""
+        from raven.utils.portable_lock import file_lock
+
+        with file_lock(self.lock_path):
+            yield
 
     def update(
         self, fn: Callable[[dict[str, Any]], dict[str, Any]]

--- a/raven/sandbox/direct_executor.py
+++ b/raven/sandbox/direct_executor.py
@@ -25,6 +25,15 @@ _ENV_ALLOWLIST = (
     "SSL_CERT_FILE", "SSL_CERT_DIR", "REQUESTS_CA_BUNDLE",
     "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
     "http_proxy", "https_proxy", "no_proxy",
+    # Windows OS basics: absent on POSIX (filtered out by _baseline_env), but
+    # required on Windows for cmd.exe/PowerShell and any spawned tool to
+    # resolve temp dirs, the user profile, and system DLLs. Omitting these
+    # leaves the child with no SystemRoot/TEMP/etc. (temp files land in cwd,
+    # SSL/winsock/.NET tools fail). None are crown-jewel secrets.
+    "SystemRoot", "SystemDrive", "windir", "COMSPEC", "ComSpec", "PATHEXT",
+    "TEMP", "TMP", "USERPROFILE", "HOMEDRIVE", "HOMEPATH",
+    "APPDATA", "LOCALAPPDATA", "PROGRAMDATA", "PROGRAMFILES",
+    "NUMBER_OF_PROCESSORS", "PROCESSOR_ARCHITECTURE", "USERNAME", "USERDOMAIN",
 )
 
 

--- a/raven/skill_hub/client.py
+++ b/raven/skill_hub/client.py
@@ -194,7 +194,10 @@ class SkillHubClient:
                     continue
                 target = (dest / name).resolve()
                 # Path traversal is a security boundary, never tolerated.
-                if not str(target).startswith(str(dest.resolve()) + "/"):
+                # Use Path containment (not string prefix + "/"): on Windows the
+                # separator is "\\", so a hardcoded "/" never matches and every
+                # entry would be wrongly rejected as unsafe.
+                if not target.is_relative_to(dest.resolve()):
                     raise SkillHubError(f"unsafe zip path: {name!r}")
                 if Path(name).suffix.lower() not in _ALLOWED_SUFFIXES:
                     logger.warning("skipping disallowed file in skill zip: %r", name)

--- a/raven/tui_rpc/server.py
+++ b/raven/tui_rpc/server.py
@@ -1,9 +1,12 @@
-"""asyncio JSON-RPC 2.0 server loop bound to two POSIX pipe FDs.
+"""asyncio JSON-RPC 2.0 server loop over a full-duplex socket (or, for tests, a
+POSIX pipe pair).
 
-Topology (design.md §1):
-
-    Node child writes requests  → FD 3 → Python parent reads here
-    Python parent writes resp/notif → FD 4 → Node child reads here
+Topology: the parent listens on a TCP-loopback socket; the Node child connects,
+sends an auth token line, then exchanges newline-JSON frames over the same
+connection. ``RpcServer`` is given the accepted socket *object* and wires it via
+``loop.connect_accepted_socket`` (cross-platform: selector + proactor loops).
+A legacy pipe path (``request_fd``/``notify_fd`` + ``connect_read/write_pipe``)
+is retained for the ``--check`` smoke and unit tests.
 
 `RpcServer` owns the read pump (one line-delimited JSON frame per iteration),
 dispatches concurrently via `asyncio.create_task` so a long-running streaming
@@ -46,13 +49,25 @@ class RpcServer:
 
     def __init__(
         self,
-        request_fd: int,
-        notify_fd: int,
-        dispatcher: "Dispatcher",
+        request_fd: int = -1,
+        notify_fd: int = -1,
+        dispatcher: "Dispatcher | None" = None,
+        *,
+        sock: "socket.socket | None" = None,
+        auth_token: str | None = None,
     ) -> None:
         self._request_fd = request_fd
         self._notify_fd = notify_fd
         self._dispatcher = dispatcher
+        # Cross-platform production transport: a single connected TCP-loopback
+        # socket passed as an object (no os.dup of a socket fd, which is not
+        # supported on Windows). When set it takes precedence over the fd pair.
+        self._sock = sock
+        # Optional shared-secret line the peer MUST send first. TCP loopback is
+        # reachable by any local process (unlike an AF_UNIX file guarded by
+        # 0600 perms), so the token restores the "only our spawned child can
+        # talk to us" trust boundary. None disables the check (pipe/test paths).
+        self._auth_token = auth_token
 
         self._reader: asyncio.StreamReader | None = None
         self._write_transport: asyncio.WriteTransport | None = None
@@ -107,13 +122,25 @@ class RpcServer:
         # the same fd instead. The transport's ``.write()`` works without
         # the spurious peer-close detection. We keep the pipe-based path as a
         # fallback for tests/CI that wire bare ``os.pipe()`` pairs.
-        try:
-            req_is_sock = stat.S_ISSOCK(os.fstat(self._request_fd).st_mode)
-            notif_is_sock = stat.S_ISSOCK(os.fstat(self._notify_fd).st_mode)
-        except OSError:
-            req_is_sock = notif_is_sock = False
+        req_is_sock = notif_is_sock = False
+        if self._sock is None:
+            try:
+                req_is_sock = stat.S_ISSOCK(os.fstat(self._request_fd).st_mode)
+                notif_is_sock = stat.S_ISSOCK(os.fstat(self._notify_fd).st_mode)
+            except OSError:
+                req_is_sock = notif_is_sock = False
 
-        if req_is_sock and notif_is_sock:
+        if self._sock is not None:
+            # Cross-platform production path: full-duplex transport over a single
+            # connected socket object (TCP loopback). connect_accepted_socket is
+            # implemented on both the selector (POSIX) and proactor (Windows)
+            # event loops, and passing the socket object avoids os.dup of a
+            # socket fd -- which is unsupported on Windows.
+            self._sock.setblocking(False)
+            transport, _ = await loop.connect_accepted_socket(lambda: reader_protocol, self._sock)
+            self._write_transport = transport
+            self._write_protocol = reader_protocol
+        elif req_is_sock and notif_is_sock:
             # Both fds are dups of the same accepted socket. Close the read
             # dup and reclaim the write dup as a ``socket.socket`` — only one
             # handle is needed for a full-duplex transport.
@@ -148,8 +175,25 @@ class RpcServer:
             os.getpid(),
             self._request_fd,
             self._notify_fd,
-            "socket" if req_is_sock and notif_is_sock else "pipe",
+            "socket-obj" if self._sock is not None else ("socket" if req_is_sock else "pipe"),
         )
+
+        # Trust-boundary gate for the TCP-loopback transport: the peer must send
+        # the shared secret as the very first newline-terminated line before any
+        # JSON-RPC frame. Only our spawned Node child knows it (passed via env),
+        # so a rogue local process that connects to the port is rejected here
+        # before any dispatch. Disabled (None) for the pipe/test paths.
+        if self._auth_token is not None:
+            try:
+                first = await asyncio.wait_for(reader.readuntil(b"\n"), timeout=10.0)
+            except (asyncio.TimeoutError, asyncio.IncompleteReadError, asyncio.LimitOverrunError):
+                logger.error("tui_rpc: auth token not received; closing connection")
+                self._stopped.set()
+                return
+            if first.rstrip(b"\n") != self._auth_token.encode("utf-8"):
+                logger.error("tui_rpc: auth token mismatch; closing connection")
+                self._stopped.set()
+                return
 
         try:
             while not self._stopped.is_set():

--- a/raven/utils/atomic_io.py
+++ b/raven/utils/atomic_io.py
@@ -1,10 +1,10 @@
 """Crash-safe JSONL file primitives: locked append and atomic replace.
 
-Both helpers serialize cross-process writers with an advisory
-``fcntl.flock`` on a sidecar lock kept in a hidden ``.lock/`` subdir of the
-target's own parent (auto-released on process death, so no stale-lock
-cleanup is needed). On platforms without ``fcntl`` they degrade to unlocked
-operation.
+Both helpers serialize cross-process writers with an advisory lock on a
+sidecar lock kept in a hidden ``.lock/`` subdir of the target's own parent
+(auto-released on process death, so no stale-lock cleanup is needed). The
+lock is cross-platform (``portalocker``: POSIX ``fcntl`` + Windows
+``LockFileEx``), so concurrent writers are serialized on Windows too.
 """
 
 import os
@@ -12,27 +12,15 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
 
-try:
-    import fcntl
-except ImportError:
-    fcntl = None
+from raven.utils.portable_lock import file_lock
 
 
 @contextmanager
 def _locked(path: Path) -> Iterator[None]:
     path.parent.mkdir(parents=True, exist_ok=True)
-    if fcntl is None:
+    lock_path = path.parent / ".lock" / (path.name + ".lock")
+    with file_lock(lock_path):
         yield
-        return
-    lock_dir = path.parent / ".lock"
-    lock_dir.mkdir(parents=True, exist_ok=True)
-    lock_path = lock_dir / (path.name + ".lock")
-    with open(lock_path, "w") as lock_file:
-        fcntl.flock(lock_file, fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(lock_file, fcntl.LOCK_UN)
 
 
 def locked_append(path: Path, lines: list[str]) -> None:

--- a/raven/utils/portable_lock.py
+++ b/raven/utils/portable_lock.py
@@ -1,0 +1,55 @@
+"""Cross-platform advisory file lock.
+
+Serializes cross-process (and cross-thread) writers to a shared file by
+taking an exclusive lock on a sibling ``.lock`` anchor via ``portalocker``
+(POSIX ``fcntl.flock`` + Windows ``LockFileEx`` under the hood).
+
+Replaces the previous ``fcntl``-only lock paths that silently degraded to
+*unlocked* on Windows (``import fcntl`` → ``ImportError`` / ``sys.platform ==
+"win32"`` no-op branches), which lost concurrent writes on Windows.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import portalocker
+
+
+class LockTimeoutError(RuntimeError):
+    """Raised for a non-blocking acquire when another holder has the lock."""
+
+
+@contextmanager
+def file_lock(lock_path: Path, *, blocking: bool = True) -> Iterator[None]:
+    """Hold an exclusive advisory lock on ``lock_path`` for the block's body.
+
+    The anchor file is created on first use. With ``blocking=False`` a
+    :class:`LockTimeoutError` is raised immediately if another process holds it.
+    """
+    lock_path = Path(lock_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    flags = portalocker.LOCK_EX
+    if not blocking:
+        flags |= portalocker.LOCK_NB
+
+    fh = open(lock_path, "a+")
+    try:
+        try:
+            portalocker.lock(fh, flags)
+        except portalocker.exceptions.LockException as exc:
+            raise LockTimeoutError(f"lock already held: {lock_path}") from exc
+        try:
+            yield
+        finally:
+            try:
+                portalocker.unlock(fh)
+            except Exception:
+                pass
+    finally:
+        fh.close()
+
+
+__all__ = ["file_lock", "LockTimeoutError"]

--- a/raven/utils/win_fcntl_shim.py
+++ b/raven/utils/win_fcntl_shim.py
@@ -1,0 +1,103 @@
+"""Windows shim for the POSIX ``fcntl`` module.
+
+Scoped to satisfy third-party dependencies (notably the bundled ``everos``
+memory backend) that ``import fcntl`` at module top and call ``fcntl.flock``.
+Without this, ``import everos.*`` raises ``ModuleNotFoundError: fcntl`` on
+Windows and the whole memory backend silently degrades to a no-op.
+
+``flock`` is backed by ``msvcrt`` byte-range locking; any msvcrt quirk
+degrades to a no-op so a locking edge case can never break the dependency's
+import or runtime. raven's own code uses :mod:`raven.utils.portable_lock`
+(portalocker) instead and does not depend on this shim.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+# fcntl.flock operation flags (values are internal to this shim; callers use
+# these attributes, so only self-consistency matters).
+LOCK_SH = 0x1
+LOCK_EX = 0x2
+LOCK_NB = 0x4
+LOCK_UN = 0x8
+
+
+def _fileno(fd: object) -> int | None:
+    if isinstance(fd, int):
+        return fd
+    getter = getattr(fd, "fileno", None)
+    if not callable(getter):
+        return None
+    try:
+        return int(getter())
+    except Exception:
+        return None
+
+
+def flock(fd: object, operation: int) -> None:
+    """Best-effort ``fcntl.flock`` on Windows via ``msvcrt.locking``.
+
+    Locks a single byte at offset 0 of the anchor file. Any error degrades to
+    a no-op — the goal is to let POSIX-only deps import and run, not to
+    guarantee cross-process exclusion under every edge case.
+    """
+    try:
+        import msvcrt
+    except ImportError:
+        return
+    fileno = _fileno(fd)
+    if fileno is None:
+        return
+    try:
+        saved = os.lseek(fileno, 0, os.SEEK_CUR)
+    except OSError:
+        saved = None
+    try:
+        os.lseek(fileno, 0, os.SEEK_SET)
+        if operation & LOCK_UN:
+            msvcrt.locking(fileno, msvcrt.LK_UNLCK, 1)
+        else:
+            mode = msvcrt.LK_NBLCK if (operation & LOCK_NB) else msvcrt.LK_LOCK
+            msvcrt.locking(fileno, mode, 1)
+    except Exception:
+        # Never let a locking quirk break the caller's import/runtime.
+        pass
+    finally:
+        if saved is not None:
+            try:
+                os.lseek(fileno, saved, os.SEEK_SET)
+            except OSError:
+                pass
+
+
+def lockf(fd: object, operation: int, length: int = 0, start: int = 0, whence: int = 0) -> None:
+    """``fcntl.lockf`` API parity — delegates to :func:`flock`."""
+    flock(fd, operation)
+
+
+def install() -> None:
+    """Register this module as ``fcntl`` in ``sys.modules``.
+
+    Windows-only, idempotent, and never clobbers a real ``fcntl`` (if one
+    somehow exists it is preferred). Call before importing a POSIX-only
+    dependency that hard-imports ``fcntl``.
+    """
+    if sys.platform != "win32":
+        return
+    if "fcntl" in sys.modules:
+        return
+    try:
+        import fcntl  # noqa: F401 — a real fcntl exists; prefer it
+        return
+    except ImportError:
+        pass
+    module = types.ModuleType("fcntl")
+    for name in ("LOCK_SH", "LOCK_EX", "LOCK_NB", "LOCK_UN", "flock", "lockf"):
+        setattr(module, name, globals()[name])
+    sys.modules["fcntl"] = module
+
+
+__all__ = ["install", "flock", "lockf", "LOCK_SH", "LOCK_EX", "LOCK_NB", "LOCK_UN"]

--- a/tests/integration/test_tui_rpc_production_smoke.py
+++ b/tests/integration/test_tui_rpc_production_smoke.py
@@ -35,8 +35,12 @@ import os
 import socket
 import sys
 
-sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-sock.connect(os.environ["RAVEN_RPC_SOCKET"])
+host, port = os.environ["RAVEN_RPC_SOCKET"].rsplit(":", 1)
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.connect((host, int(port)))
+_tok = os.environ.get("RAVEN_RPC_TOKEN")
+if _tok:
+    sock.sendall((_tok + "\n").encode("utf-8"))
 buf = b""
 
 

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -3,7 +3,6 @@
 import multiprocessing
 from pathlib import Path
 
-from raven.utils import atomic_io
 from raven.utils.atomic_io import atomic_replace, locked_append
 
 WRITERS = 2
@@ -89,9 +88,10 @@ def test_atomic_replace_creates_missing_file(tmp_path: Path):
     assert path.read_text(encoding="utf-8") == "data\n"
 
 
-def test_degrades_without_fcntl(tmp_path: Path, monkeypatch):
-    """With fcntl unavailable (non-POSIX), both helpers still work unlocked."""
-    monkeypatch.setattr(atomic_io, "fcntl", None)
+def test_helpers_work_cross_platform(tmp_path: Path):
+    """Both helpers work on every platform. Locking is cross-platform via
+    portalocker (POSIX fcntl + Windows LockFileEx) — there is no longer an
+    fcntl-absent 'degrade to unlocked' path."""
     path = tmp_path / "s.jsonl"
     locked_append(path, ["x"])
     atomic_replace(path, "y\n")

--- a/tests/test_cli_gateway_lock.py
+++ b/tests/test_cli_gateway_lock.py
@@ -92,10 +92,15 @@ def test_read_payload_corrupt_returns_placeholder(tmp_instance: Path) -> None:
     assert info.config_path == ""
 
 
-def test_acquire_degrades_without_fcntl(tmp_instance: Path, monkeypatch) -> None:
-    """Windows path: fcntl is None → acquire never locks, never raises."""
-    monkeypatch.setattr(_gateway_lock, "fcntl", None)
-    first = acquire(now=1.0)
-    second = acquire(now=2.0)  # no contention without a real lock
-    first.close()
-    second.close()
+def test_payload_readable_while_lock_held(tmp_instance: Path) -> None:
+    """The lock anchor is a separate file from the payload, so a concurrent
+    reader (doctor) can read the owner payload even while the lock is held —
+    including on Windows, where the lock is mandatory and would otherwise
+    block a read of the locked file."""
+    held = acquire(now=222.0)
+    try:
+        info = _gateway_lock._read_payload(tmp_instance / "gateway.lock")
+        assert info.pid == os.getpid()
+        assert info.started_at == 222.0
+    finally:
+        held.close()

--- a/tests/test_cli_tui_bootstrap.py
+++ b/tests/test_cli_tui_bootstrap.py
@@ -293,12 +293,13 @@ def test_rpc_handshake_timeout_helper_real(tmp_path, monkeypatch):
 # Python-only tests above; do NOT remove those.
 
 
-def test_rpc_socket_dir_constants_exposed():
-    """Sanity: the production socket helper exposes its tempdir prefix so
-    integration smoke can clean stale dirs."""
+def test_rpc_socket_env_constants_exposed():
+    """Sanity: the production transport exposes the env var names the Node
+    child reads -- the TCP-loopback address and the auth token."""
     from raven.cli import tui_commands
 
-    assert tui_commands._RPC_SOCKET_DIR_PREFIX.startswith("eve-rpc-")
+    assert tui_commands._RPC_SOCKET_ENV == "RAVEN_RPC_SOCKET"
+    assert tui_commands._RPC_TOKEN_ENV == "RAVEN_RPC_TOKEN"
 
 
 def test_production_dispatcher_includes_all_umbrella_methods():
@@ -348,8 +349,7 @@ def test_production_dispatcher_includes_all_umbrella_methods():
     # production. These are the ones the dogfood bug surfaced.
     for required in ("slash.exec", "session.status", "complete.slash", "complete.path"):
         assert required in production_methods, (
-            f"{required} missing from production dispatcher — "
-            f"`raven tui` will return -32601 for it"
+            f"{required} missing from production dispatcher — `raven tui` will return -32601 for it"
         )
 
 
@@ -377,13 +377,14 @@ def test_confirm_registered_when_broker_present():
 
 
 def test_rpc_socket_transport_handshake_ok(tmp_path, monkeypatch):
-    """End-to-end: spawn a tiny Python child that connects to the unix socket
-    via the `RAVEN_RPC_SOCKET` env var and sends ``system.hello`` — the
-    parent helper must complete the handshake and the child must exit 0.
+    """End-to-end: spawn a tiny Python child that connects to the TCP-loopback
+    address in `RAVEN_RPC_SOCKET`, sends the `RAVEN_RPC_TOKEN` auth line, then
+    ``system.hello`` — the parent helper must complete the handshake and the
+    child must exit 0.
 
     We use a Python child rather than the real Node demo here so the test
-    doesn't depend on the ui-tui build artifact; the wire protocol (newline
-    JSON over the socket) is identical regardless of language.
+    doesn't depend on the ui-tui build artifact; the wire protocol (an auth
+    line then newline JSON over the socket) is identical regardless of language.
     """
     from raven.cli import tui_commands
 
@@ -393,9 +394,12 @@ def test_rpc_socket_transport_handshake_ok(tmp_path, monkeypatch):
     child_src = """
 import json, os, socket, sys
 
-sock_path = os.environ["RAVEN_RPC_SOCKET"]
-s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-s.connect(sock_path)
+host, port = os.environ["RAVEN_RPC_SOCKET"].rsplit(":", 1)
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.connect((host, int(port)))
+tok = os.environ.get("RAVEN_RPC_TOKEN")
+if tok:
+    s.sendall((tok + "\\n").encode("utf-8"))
 req = {"jsonrpc": "2.0", "id": 1, "method": "system.hello",
        "params": {"client_version": "0.1.0"}}
 s.sendall((json.dumps(req) + "\\n").encode("utf-8"))

--- a/ui-tui/src/__tests__/paths.test.ts
+++ b/ui-tui/src/__tests__/paths.test.ts
@@ -38,6 +38,31 @@ describe('shortCwd', () => {
   })
 })
 
+describe('shortCwd on Windows (USERPROFILE, no HOME)', () => {
+  const origHome = process.env.HOME
+  const origUserProfile = process.env.USERPROFILE
+
+  beforeEach(() => {
+    delete process.env.HOME
+    process.env.USERPROFILE = 'C:\\Users\\bb'
+  })
+
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.HOME
+    else process.env.HOME = origHome
+    if (origUserProfile === undefined) delete process.env.USERPROFILE
+    else process.env.USERPROFILE = origUserProfile
+  })
+
+  it('collapses USERPROFILE to ~ when HOME is unset', () => {
+    expect(shortCwd('C:\\Users\\bb\\proj\\repo')).toBe('~\\proj\\repo')
+  })
+
+  it('leaves non-home Windows paths alone', () => {
+    expect(shortCwd('D:\\work')).toBe('D:\\work')
+  })
+})
+
 describe('fmtCwdBranch', () => {
   const origHome = process.env.HOME
 

--- a/ui-tui/src/domain/paths.ts
+++ b/ui-tui/src/domain/paths.ts
@@ -1,5 +1,7 @@
 export const shortCwd = (cwd: string, max = 28) => {
-  const h = process.env.HOME
+  // Windows has no HOME; fall back to USERPROFILE so the cwd collapses to ~
+  // instead of showing the full C:\Users\... path in the status bar.
+  const h = process.env.HOME || process.env.USERPROFILE
   const p = h && cwd.startsWith(h) ? `~${cwd.slice(h.length)}` : cwd
 
   return p.length <= max ? p : `…${p.slice(-(max - 1))}`

--- a/ui-tui/src/rpc/client.ts
+++ b/ui-tui/src/rpc/client.ts
@@ -1,10 +1,11 @@
 // Raven TUI RPC — production JSON-RPC 2.0 client.
 //
-// Transport: unix domain socket (per Q11 decision — see
-// `docs/RepoMem/temp/tui-ipc-bridge/11-tui-commands-transport-decision.md`).
-// The Python parent listens; the Node child connects via `net.createConnection`.
-// Bare FD inheritance (pass_fds=(3,4)) was rejected — Node has no stable way
-// to wrap inherited pipe FDs as streams when running as the child process.
+// Transport: TCP loopback (cross-platform — Windows has no usable AF_UNIX).
+// The Python parent listens on 127.0.0.1:<ephemeral>; the Node child connects
+// via `net.createConnection({host, port})`, sends RAVEN_RPC_TOKEN as the first
+// line (the parent validates it before any dispatch), then speaks JSON frames.
+// A unix-socket path is still accepted for legacy setups. Bare FD inheritance
+// (pass_fds=(3,4)) was rejected — Node can't reliably wrap inherited pipe FDs.
 //
 // Framing: newline-delimited UTF-8 JSON (specs §2.5). Each frame is
 // `JSON.stringify(obj) + '\n'`. Single frame limit: 1 MiB.
@@ -35,7 +36,7 @@ type Pending = {
 };
 
 export interface RpcClientOptions {
-  /** Unix socket path. Defaults to env `RAVEN_RPC_SOCKET`. */
+  /** RPC target: "host:port" (TCP loopback) or a unix socket path. Defaults to env `RAVEN_RPC_SOCKET`. */
   socketPath?: string;
   /** Optional logger for non-fatal protocol oddities. Defaults to stderr. */
   warn?: (msg: string) => void;
@@ -64,23 +65,37 @@ export class RpcClient {
   private readonly connectPromise: Promise<void>;
 
   constructor(opts: RpcClientOptions = {}) {
-    const socketPath = opts.socketPath ?? process.env.RAVEN_RPC_SOCKET;
-    if (!socketPath) {
+    const target = opts.socketPath ?? process.env.RAVEN_RPC_SOCKET;
+    if (!target) {
       throw new Error(
-        'RpcClient: no socket path supplied; pass `socketPath` or set ' +
+        'RpcClient: no RPC target supplied; pass `socketPath` or set ' +
           'RAVEN_RPC_SOCKET env var.',
       );
     }
     this.warn = opts.warn ?? ((m) => process.stderr.write(`[rpc-client] ${m}\n`));
     this.onNotification = opts.onNotification;
 
-    this.socket = createConnection(socketPath);
+    // Cross-platform transport: the parent exports either a TCP-loopback
+    // "host:port" (current Python parent; works on Windows too) or, for legacy
+    // setups, a unix socket path. A trailing ":<digits>" disambiguates TCP.
+    const tcp = /^(.+):(\d+)$/.exec(target);
+    if (tcp) {
+      this.socket = createConnection({ host: tcp[1], port: Number(tcp[2]) });
+    } else {
+      this.socket = createConnection(target);
+    }
     this.socket.setEncoding('utf-8');
+
+    // Shared secret the parent validates as the first line before any frame
+    // (the loopback port is reachable by any local process, so this gates it).
+    const authToken = process.env.RAVEN_RPC_TOKEN;
 
     this.connectPromise = new Promise<void>((resolve, reject) => {
       const onConnect = () => {
         this.connected = true;
         this.socket.off('error', onError);
+        // Must be the very first bytes on the wire, ahead of any RPC frame.
+        if (authToken) this.socket.write(authToken + '\n');
         resolve();
       };
       const onError = (err: Error) => {

--- a/uv.lock
+++ b/uv.lock
@@ -3152,7 +3152,7 @@ wheels = [
 
 [[package]]
 name = "raven"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },
@@ -3161,7 +3161,9 @@ dependencies = [
     { name = "json-repair" },
     { name = "litellm" },
     { name = "loguru" },
+    { name = "mcp" },
     { name = "oauth-cli-kit" },
+    { name = "portalocker" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -3257,7 +3259,6 @@ tools = [
 [package.dev-dependencies]
 dev = [
     { name = "json-repair" },
-    { name = "mcp" },
     { name = "oauth-cli-kit" },
     { name = "pexpect" },
     { name = "pip-audit" },
@@ -3283,11 +3284,13 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.82.1,<2.0.0" },
     { name = "loguru", specifier = ">=0.7.3,<1.0.0" },
     { name = "matrix-nio", marker = "sys_platform != 'win32' and extra == 'channel-matrix'", specifier = ">=0.25.2" },
+    { name = "mcp", specifier = ">=1.0" },
     { name = "mistune", marker = "extra == 'channel-matrix'", specifier = ">=3.0.0,<4.0.0" },
     { name = "msgpack", marker = "extra == 'channel-mochat'", specifier = ">=1.2.1,<2.0.0" },
     { name = "nh3", marker = "extra == 'channel-matrix'", specifier = ">=0.2.17,<1.0.0" },
     { name = "oauth-cli-kit", specifier = ">=0.1.3,<1.0.0" },
     { name = "oauth-cli-kit", marker = "extra == 'tools'", specifier = ">=0.1.3,<1.0.0" },
+    { name = "portalocker", specifier = ">=3.2.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.0" },
     { name = "pycryptodome", marker = "extra == 'channel-weixin'", specifier = ">=3.20.0" },
     { name = "pydantic", specifier = ">=2.12.0,<3.0.0" },
@@ -3334,7 +3337,6 @@ provides-extras = ["channel-telegram", "channel-slack", "channel-discord", "chan
 [package.metadata.requires-dev]
 dev = [
     { name = "json-repair", specifier = ">=0.59.5" },
-    { name = "mcp", specifier = ">=1.0" },
     { name = "oauth-cli-kit", specifier = ">=0.1.3" },
     { name = "pexpect", specifier = ">=4.9" },
     { name = "pip-audit", specifier = ">=2.10.0" },


### PR DESCRIPTION
## Change description

Full Windows support for the one-line install + TUI, so Windows gets a command
equivalent to the macOS/Linux `curl -fsSL .../install.sh | sh`:

```powershell
iex (irm https://raven.evermind.ai/install.ps1)
```

Two layers:

### 1. Install layer
- **`install.ps1`** (new): PowerShell counterpart of `install.sh` — ensures uv,
  a private Node >= 22 (downloads `node-vXX-win-<arch>.zip` to
  `%RAVEN_HOME%\runtime`, SHA256-verified, self-tested), then `uv tool install`
  raven (latest release wheel for remote mode; editable for a local checkout).
- **`find_node()`**: Windows-aware — globs `%RAVEN_HOME%\runtime\node-*\node.exe`
  (Windows zip has node.exe at the package root, no `bin/`). POSIX behavior
  unchanged (`os.name == "nt"` guard).
- **`install.sh`**: unsupported-OS message now prints the real PowerShell command.

### 2. Cross-platform TUI transport (the part that lets `raven tui` actually run on Windows)
The Python<->Node RPC transport used an AF_UNIX unix-domain socket with
`os.dup`'d fds + `connect_read/write_pipe` — all unsupported on Windows. Replaced with:
- **TCP loopback** `127.0.0.1:<ephemeral>` + a **256-bit random auth token**.
  The accepted socket *object* is handed to `RpcServer` (no socket-fd dup) and
  wired via `loop.connect_accepted_socket` (works on both selector and proactor
  loops). The parent validates the token as the first line **before any
  dispatch** — loopback is reachable by any local process, so the token
  restores the trust boundary the old `0600` socket file provided.
- Node client (`ui-tui/src/rpc/client.ts`) parses `RAVEN_RPC_SOCKET` as
  `host:port`, connects over TCP, sends `RAVEN_RPC_TOKEN` first.
- The legacy pipe/fd path in `RpcServer` is retained for `--check`/unit tests.

## Verification
- 306 tui/rpc tests pass; real Node bundle exercised under a PTY (TCP + token +
  `system.hello`); wrong/missing token rejected (exit 3), correct token accepted;
  listener bound to `127.0.0.1` only.
- **Zero regressions**: full-suite failure set is identical to a pristine `main`
  baseline (all pre-existing environmental/ordering failures).

## ⚠️ Not verified — needs real Windows QA
Developed/verified on macOS. The cross-platform logic is exercised here and the
Windows-specific paths were statically reviewed, but **`install.ps1` execution
and the TUI on a real Windows console have NOT been run on Windows**. Please
smoke on a Windows box before relying on it: run `install.ps1`, then `raven`
(confirm Ink TUI renders + interacts).

## Type of change
- [x] New feature

## Checklists
### Development
- [x] Lint rules pass locally (ruff)
- [ ] Application changes tested thoroughly (Windows paths NOT run on Windows — see above)
- [x] Automated tests covering modified code pass (CI)
### Security
- [x] Security impact considered (256-bit token, loopback-only, validated pre-dispatch; Node SHA256-verified)
### Code review
- [x] Descriptive title and context provided
