### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raven"
-version = "0.1.1"
+version = "0.1.2"
 description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "Apache-2.0"

--- a/raven/__init__.py
+++ b/raven/__init__.py
@@ -42,5 +42,5 @@ class _LiteLLMBotocorePreloadFilter(_logging.Filter):
 
 _logging.getLogger("LiteLLM").addFilter(_LiteLLMBotocorePreloadFilter())
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __logo__ = "🐦‍⬛"


### PR DESCRIPTION
## Summary

- Bump the Python package version to 0.1.2.
- Keep raven.__version__ aligned with the release version.

## Why

v0.1.2 publishes the Windows compatibility fixes that landed after v0.1.1, including the TUI transport, portable locking, runtime dependency, and installer updates.

## Validation

- git diff --check
- npx commitlint --from HEAD~1 --to HEAD --config commitlint.config.cjs
- PYTHONPATH=. python3 scripts/check_commit_messages.py HEAD~1..HEAD