### PR TITLE
fix(agent): route subagent results to the originating conversation

### DIFF
--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -1069,12 +1069,25 @@ class AgentLoop:
                 self._mcp_stack = None
             raise
 
-    def _set_tool_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
+    def _set_tool_context(
+        self,
+        channel: str,
+        chat_id: str,
+        message_id: str | None = None,
+        conversation: str | None = None,
+    ) -> None:
         """Update context for all tools that need routing info."""
         for name in ("message", "spawn", "cron"):
             if tool := self.tools.get(name):
                 if hasattr(tool, "set_context"):
-                    tool.set_context(channel, chat_id, *([message_id] if name == "message" else []))
+                    if name == "message":
+                        tool.set_context(channel, chat_id, message_id)
+                    elif name == "spawn":
+                        # spawn carries the conversation so subagent results
+                        # re-inject on the originating turn's key (TUI mints one).
+                        tool.set_context(channel, chat_id, conversation)
+                    else:
+                        tool.set_context(channel, chat_id)
 
     @staticmethod
     def _strip_think(text: str | None) -> str | None:
@@ -1917,7 +1930,7 @@ class AgentLoop:
                     # generate_question failed: skip silently and proceed
         # ── End personalization flow ─────────────────────────────────────────
 
-        self._set_tool_context(channel, chat_id, metadata.get("message_id"))
+        self._set_tool_context(channel, chat_id, metadata.get("message_id"), conversation=msg_session_key)
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
                 message_tool.start_turn()

--- a/raven/agent/subagent/manager.py
+++ b/raven/agent/subagent/manager.py
@@ -76,6 +76,7 @@ class SubagentManager:
         label: str | None = None,
         origin_channel: str = "cli",
         origin_chat_id: str = "direct",
+        origin_conversation: str | None = None,
         session_key: str | None = None,
     ) -> str:
         """Spawn a subagent to execute a task in the background."""
@@ -100,7 +101,14 @@ class SubagentManager:
         window.append(now)
         task_id = str(uuid.uuid4())[:8]
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
-        origin = {"channel": origin_channel, "chat_id": origin_chat_id}
+        origin = {
+            "channel": origin_channel,
+            "chat_id": origin_chat_id,
+            # Re-injection/emit key of the originating turn. Falls back to
+            # channel:chat_id when not supplied (channels/CLI), but the TUI
+            # passes its minted session key so the reply reaches the subscriber.
+            "conversation": origin_conversation or f"{origin_channel}:{origin_chat_id}",
+        }
 
         bg_task = asyncio.create_task(self._run_subagent(task_id, task, display_label, origin))
         self._running_tasks[task_id] = bg_task
@@ -284,7 +292,9 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
                     chat_type=ChatType.DM,
                 ),
                 text=announce_content,
-                conversation=f"{origin['channel']}:{origin['chat_id']}",
+                # Emit key = originating turn's conversation (TUI mints its own,
+                # which the front-end subscribes on). Fall back to channel:chat_id.
+                conversation=origin.get("conversation") or f"{origin['channel']}:{origin['chat_id']}",
             )
         )
         logger.debug("Subagent [{}] announced result to {}:{}", task_id, origin["channel"], origin["chat_id"])

--- a/raven/agent/tools/spawn.py
+++ b/raven/agent/tools/spawn.py
@@ -19,10 +19,15 @@ class _SpawnOrigin:
 
     channel: str
     chat_id: str
+    # The originating turn's conversation key. For channels this equals
+    # ``channel:chat_id``, but the TUI mints a per-session key (``tui:<sid>``)
+    # that the front-end subscribes on, so it must be carried explicitly:
+    # subagent results re-inject on this key, and the reply is emitted to it.
+    conversation: str | None = None
 
     @property
     def session_key(self) -> str:
-        return f"{self.channel}:{self.chat_id}"
+        return self.conversation or f"{self.channel}:{self.chat_id}"
 
 
 class SpawnTool(Tool):
@@ -40,9 +45,9 @@ class SpawnTool(Tool):
     def _cur(self) -> _SpawnOrigin:
         return self._origin.get(None) or self._default
 
-    def set_context(self, channel: str, chat_id: str) -> None:
+    def set_context(self, channel: str, chat_id: str, conversation: str | None = None) -> None:
         """Set the origin context for subagent announcements (turn-local)."""
-        self._origin.set(replace(self._cur(), channel=channel, chat_id=chat_id))
+        self._origin.set(replace(self._cur(), channel=channel, chat_id=chat_id, conversation=conversation))
 
     @property
     def name(self) -> str:
@@ -81,5 +86,6 @@ class SpawnTool(Tool):
             label=label,
             origin_channel=org.channel,
             origin_chat_id=org.chat_id,
+            origin_conversation=org.session_key,
             session_key=org.session_key,
         )

--- a/tests/test_subagent_manager.py
+++ b/tests/test_subagent_manager.py
@@ -168,3 +168,40 @@ async def test_cancel_by_session_clears_spawn_history(monkeypatch):
 
     await mgr.cancel_by_session("sessA")
     assert "sessA" not in mgr._session_spawn_times
+
+
+@pytest.mark.asyncio
+async def test_announce_result_reinjects_on_conversation_key():
+    """Regression: subagent results must re-inject on the originating turn's
+    conversation key. The TUI mints ``tui:<sid>`` and the front-end subscribes
+    on it; if the reply is emitted to a ``channel:chat_id`` fallback instead,
+    it lands on a key nobody is subscribed to and the user never sees the
+    subagent result (the TUI bug this fix addresses)."""
+    mgr = _make_manager(max_concurrent=2)
+    captured: dict = {}
+    mgr.set_submit(lambda req: captured.__setitem__("req", req))
+
+    # TUI-shaped origin: minted conversation differs from channel:chat_id.
+    origin = {"channel": "tui", "chat_id": "default", "conversation": "tui:sid_abc123"}
+    await mgr._announce_result("t1", "label", "do x", "the result", origin, "ok")
+
+    req = captured["req"]
+    # Fix: reply rides the minted conversation the front-end subscribes on.
+    assert req.conversation == "tui:sid_abc123"
+    # Source is unchanged, so gateway (routes by source.chat_id) stays correct.
+    assert req.source.chat_id == "default"
+    assert req.source.channel == "tui"
+
+
+@pytest.mark.asyncio
+async def test_announce_result_falls_back_to_channel_chatid():
+    """No conversation carried (channels/CLI) -> fall back to channel:chat_id,
+    preserving prior behavior for non-TUI paths."""
+    mgr = _make_manager(max_concurrent=2)
+    captured: dict = {}
+    mgr.set_submit(lambda req: captured.__setitem__("req", req))
+
+    origin = {"channel": "telegram", "chat_id": "42"}  # no 'conversation' key
+    await mgr._announce_result("t2", "label", "do y", "res", origin, "ok")
+
+    assert captured["req"].conversation == "telegram:42"


### PR DESCRIPTION
## Change description

**Bug**: in the TUI, a spawned subagent's result never showed up. On completion
the subagent re-injects a `SUBAGENT`-origin turn, and its `conversation` was
hardcoded to `f"{channel}:{chat_id}"` -> `"tui:default"`. But the TUI front-end
subscribes on the **minted session key** (`tui:<sid>`, from `session.create`).
The reply was emitted to `"tui:default"`, which has no subscriber, so it was
silently dropped and the user never saw the subagent result.

**Fix**: carry the originating turn's `conversation` through the spawn path and
use it as the re-injected turn's conversation:
- `_SpawnOrigin` gains a `conversation` field; `session_key` prefers it.
- `AgentLoop._set_tool_context` passes the turn's `conversation` (`msg_session_key`) to the spawn tool.
- `SubagentManager.spawn` records it in `origin`; `_announce_result` uses `origin.get("conversation") or f"{channel}:{chat_id}"`.

Only `conversation` changes. `source` is untouched, so **CLI** (renders directly,
ignores conversation) and **gateway** (routes by `source.chat_id`) behavior is
unchanged. Side benefit: for CLI / Telegram-topic paths the re-injection now
lands on the originating turn's lane instead of a divergent `channel:chat_id`
lane, which is more correct.

## Verification
- New regression tests (`tests/test_subagent_manager.py`): minted-key path
  asserts the announce conversation == the minted key (would fail without the
  fix), plus a channel fallback test for non-TUI paths.
- Three independent reviewers (functional / three-path-no-regression / cross-platform+e2e) all PASS:
  - functional: relevant suites 211 passed, stable across 2 runs, ruff clean;
  - no-regression: `source` unchanged -> CLI/gateway delivery identical; new params optional/back-compat;
  - cross-platform: diff touches **zero** platform/transport/install code; real Node PTY transport probe still PASS; end-to-end proof that the reply now reaches the minted-key subscriber (and previously reached 0 subscribers on `tui:default`).
- Pre-existing unrelated failure `test_find_node_discovers_windows_private_runtime` is NOT touched by this PR.

## Type of change
- [x] Bug fix

## Checklists
### Development
- [x] Lint rules pass locally (ruff)
- [x] Application changes tested (unit + e2e proof; see above)
- [x] Automated tests covering modified code pass
### Security
- [x] Security impact considered (subagent result still fenced via wrap_untrusted; no change to trust boundary)
### Code review
- [x] Descriptive title and context provided
