### PR TITLE
docs(readme): update Raven positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,9 @@
 
 # Raven
 
-Raven is **The Self-Improving Agent Harness**, built on top of
-[EverOS](https://github.com/EverMind-AI/EverOS).
+Raven is **The Self-Improving Agent Harness**, built on [EverOS](https://github.com/EverMind-AI/EverOS).
 
-Raven continuously improves the harness that surrounds an agent: tools, skills,
-memory, code execution runtime, policies, and working environment. EverOS gives
-the harness durable user memory, agent memory, and world knowledge across
-sessions, so each run can refine how the agent acts, what it knows, and how
-repeatable workflows become reusable Agent Templates and digital workers.
+Raven helps agents improve across runs by continuously refining the systems around them: tools, skills, memory, code execution, policies, and working environment. EverOS provides durable user memory, agent memory, and world knowledge across sessions, so successful workflows can evolve into reusable Agent Templates and digital workers.
 
 <details>
   <summary><kbd>Table of Contents</kbd></summary>

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Raven is **The Self-Improving Agent Harness**, built on [EverOS](https://github.
 
 Raven helps agents improve across runs by continuously refining the systems around them: tools, skills, memory, code execution, policies, and working environment. EverOS provides durable user memory, agent memory, and world knowledge across sessions, so successful workflows can evolve into reusable Agent Templates and digital workers.
 
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/a4dc5b21-c8e7-4397-95e1-50afeeb826e4" alt="Starting Raven from the command line" width="100%">
+</p>
+
 <details>
   <summary><kbd>Table of Contents</kbd></summary>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,6 +32,10 @@ runtime、policies 和工作环境。EverOS 为这个 harness 提供跨会话持
 记忆、Agent 记忆和世界知识，让每一次运行都能改进 Agent 的行动方式、知识状态，
 并把可重复工作流沉淀成可复用 Agent Templates 和 digital workers。
 
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/a4dc5b21-c8e7-4397-95e1-50afeeb826e4" alt="从命令行启动 Raven" width="100%">
+</p>
+
 <details>
   <summary><kbd>目录</kbd></summary>
 


### PR DESCRIPTION
## What changed

- Updated the Raven README intro copy under the main heading.
- Rephrased the positioning around improving agents across runs and reusable Agent Templates/digital workers.

## Why

This makes the first README screen clearer and more product-focused while keeping the existing Raven banner, badges, links, and documentation sections intact.

## Impact

Documentation-only change. No runtime behavior is affected.

## Validation

- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- Verified the Raven heading and updated intro copy are present at the top of `README.md` with `rg`.