### PR TITLE
fix(providers): silence litellm never-awaited coroutine warning

### DIFF
--- a/raven/providers/litellm_provider.py
+++ b/raven/providers/litellm_provider.py
@@ -4,6 +4,7 @@ import hashlib
 import os
 import secrets
 import string
+import warnings
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -14,6 +15,21 @@ from loguru import logger
 
 from raven.providers.base import LLMProvider, LLMResponse, StreamDelta, ToolCallRequest
 from raven.providers.registry import find_by_model, find_gateway
+
+# LiteLLM's async logging worker (LoggingWorker) binds its queue to a single
+# event loop. Raven runs each turn under a fresh loop (asyncio.run per call), so
+# on the next turn the queue is reset and any pending ``Logging.async_*_handler``
+# coroutine is dropped without being awaited. Python then prints a
+# ``coroutine ... was never awaited`` RuntimeWarning that bleeds into the Ink TUI
+# render. The dropped callback is LiteLLM's own success/failure logging, which
+# Raven does not rely on. Scope the filter to LiteLLM's ``Logging`` handlers only
+# -- a bare ``coroutine '.*'`` pattern would also hide genuine never-awaited bugs
+# in Raven's own coroutines.
+warnings.filterwarnings(
+    "ignore",
+    message=r"coroutine 'Logging\.async_.*' was never awaited",
+    category=RuntimeWarning,
+)
 
 # Standard chat-completion message keys.
 _ALLOWED_MSG_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name", "reasoning_content"})


### PR DESCRIPTION
## Problem

Running a turn in the native TUI prints a `RuntimeWarning` that bleeds into the Ink render:

```
.../litellm/litellm_core_utils/logging_worker.py:76: RuntimeWarning: coroutine 'Logging.async_success_handler' was never awaited
  self._queue = None
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

## Root cause

litellm's `LoggingWorker` binds its queue to a single event loop. Raven runs each turn under a fresh loop (`asyncio.run` per call), so on the next turn `_ensure_queue` detects the loop change and resets the queue (`self._queue = None`). Any pending `Logging.async_*_handler` coroutine bound to the old loop is then dropped without being awaited, and Python emits the `coroutine ... was never awaited` warning. Raven has no warnings filter, so it leaks to stderr and corrupts the TUI display.

The dropped callback is litellm's own success/failure logging. Raven registers no litellm callbacks and computes cost synchronously (`litellm.cost_per_token` / `response.usage`), so nothing Raven consumes is lost -- the turn completes normally. This is purely display noise.

## Fix

Filter that `RuntimeWarning` at `litellm_provider` import time (module scope). This module is imported by every process that makes LLM calls (TUI backend, `raven agent`, gateway, cron), so one place covers all entry points. Consistent with the existing `litellm.suppress_debug_info = True` noise suppression.

The pattern is scoped to litellm's `Logging` handlers (`coroutine 'Logging\.async_.*' was never awaited`), not a bare `coroutine '.*'`, so genuine never-awaited-coroutine bugs in Raven's own code stay visible. No litellm behavior changes.

## Verification

Independently checked by three isolated reviews:
- **Correctness/scope**: regex matches litellm's real warning; scoped pattern silences `Logging.async_success_handler` / `async_failure_handler` but NOT Raven-owned coroutines (e.g. `AgentLoop.run_turn`) -- verified empirically. `module=` scoping was tested and does not work for GC-finalized coroutine warnings.
- **Real-path efficacy**: the warning is emitted by the same parent Python process that runs the TUI turn; the filter is installed before the first `acompletion`; not clobbered by any later `resetwarnings`/`catch_warnings`; survives even `PYTHONWARNINGS=error::RuntimeWarning` (programmatic filters prepend and win).
- **Regressions**: no pytest `filterwarnings=error`/`-W` config; full suite parity with main (fix 121 fail vs main 122 fail, identical pre-existing env-dependent categories); provider tests 107/107 pass. `ruff check` / `ruff format` / full `pre-commit` pass. Diff is a single file, ASCII-only.