### PR TITLE
feat(model): seed /model picker with a curated common-model shortlist

### DIFF
--- a/raven/providers/common_models.py
+++ b/raven/providers/common_models.py
@@ -1,0 +1,41 @@
+"""Curated "common models" shortlist per provider slug.
+
+Hand-maintained on purpose. Provider ``/v1/models`` endpoints return the full
+catalog (OpenRouter alone ships 300+ models) with no "popular"/"common" flag,
+so a small, recognizable default set has to be curated rather than derived.
+
+The TUI ``/model`` picker shows this shortlist *after* whatever the user has
+configured in ``config.providers.<slug>.models``; users can always type any
+model id by hand (``model.add_model``), so this list only needs to cover the
+common case, not every model.
+
+Model ids drift as providers ship releases — update this list as needed. Only
+``openrouter`` (the default provider) is seeded today; other providers fall
+back to their configured list until curated here.
+"""
+
+from __future__ import annotations
+
+COMMON_MODELS: dict[str, list[str]] = {
+    "openrouter": [
+        "anthropic/claude-opus-4.8",
+        "anthropic/claude-sonnet-5",
+        "anthropic/claude-fable-5",
+        "openai/gpt-5.5",
+        "openai/gpt-5.5-pro",
+        "openai/gpt-5.4-mini",
+        "google/gemini-3.5-flash",
+        "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-v4-flash",
+        "x-ai/grok-4.3",
+        "qwen/qwen3.7-max",
+        "moonshotai/kimi-k2-thinking",
+        "meta-llama/llama-4-maverick",
+        "mistralai/mistral-medium-3-5",
+    ],
+}
+
+
+def common_models_for(slug: str) -> list[str]:
+    """Return a copy of the curated common-model shortlist for ``slug``."""
+    return list(COMMON_MODELS.get(slug, []))

--- a/raven/tui_rpc/methods/model.py
+++ b/raven/tui_rpc/methods/model.py
@@ -30,6 +30,7 @@ from raven.config.update_providers import (
     reset_provider,
     set_provider_fields,
 )
+from raven.providers.common_models import common_models_for
 from raven.providers.registry import find_by_model, find_by_name
 from raven.tui_rpc.errors import (
     ConfigValidationError,
@@ -64,9 +65,14 @@ def _provider_models(slug: str) -> list[str]:
     try:
         cfg = get_provider_config(slug, redact_secrets=False)
     except KeyError:
-        return []
-    models = cfg.get("models", [])
-    return list(models) if isinstance(models, list) else []
+        cfg = {}
+    configured = cfg.get("models", [])
+    configured = list(configured) if isinstance(configured, list) else []
+    # Priority: the user's configured models first (manual entry via
+    # ``model.add_model`` writes here), then our curated "common" shortlist,
+    # deduped. Keeps the picker useful out of the box without a network call.
+    seen = set(configured)
+    return configured + [m for m in common_models_for(slug) if m not in seen]
 
 
 def _build_provider_entry(slug: str, *, current_provider: str | None) -> dict[str, Any]:

--- a/tests/test_tui_rpc_model.py
+++ b/tests/test_tui_rpc_model.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from raven.providers.common_models import common_models_for
 from raven.tui_rpc.errors import ConfigValidationError, NotSupportedInV01Error
 from raven.tui_rpc.methods.model import (
     model_add_model,
@@ -249,3 +250,40 @@ async def test_options_accepts_session_id(fake_home: Path) -> None:
 async def test_save_key_custom_without_api_base_rejected(fake_home: Path) -> None:
     with pytest.raises(ConfigValidationError):
         await model_save_key({"slug": "custom", "api_key": "x"})
+
+
+# ----------------------------------------------------------------------------
+# common-model shortlist (curated defaults shown in the picker)
+# ----------------------------------------------------------------------------
+
+
+async def test_options_openrouter_seeds_common_models(fake_home: Path) -> None:
+    # A provider with a key but no explicitly configured models still lists the
+    # curated "common" shortlist, so the picker is never empty.
+    _write_config(
+        fake_home,
+        {
+            "agents": {"defaults": {"model": "openrouter/anthropic/claude-opus-4.8"}},
+            "providers": {"openrouter": {"apiKey": "sk-or-xxx", "models": []}},
+        },
+    )
+    entry = _entry(await model_options({}), "openrouter")
+    assert entry["models"] == common_models_for("openrouter")
+    assert entry["total_models"] == len(common_models_for("openrouter"))
+
+
+async def test_options_config_models_rank_before_common_and_dedup(fake_home: Path) -> None:
+    # Configured models come first; the common shortlist follows with duplicates
+    # removed (a configured id already in the shortlist is not listed twice).
+    dup = common_models_for("openrouter")[0]
+    _write_config(
+        fake_home,
+        {
+            "agents": {"defaults": {"model": dup}},
+            "providers": {"openrouter": {"apiKey": "sk-or-xxx", "models": ["my/custom-model", dup]}},
+        },
+    )
+    models = _entry(await model_options({}), "openrouter")["models"]
+    assert models[:2] == ["my/custom-model", dup]
+    assert models.count(dup) == 1
+    assert set(common_models_for("openrouter")).issubset(set(models))


### PR DESCRIPTION
## Problem
The TUI `/model` picker showed **"no models listed"** whenever a provider's `config.providers.<slug>.models` was empty (e.g. a fresh OpenRouter setup). `_provider_models` only ever read that config array.

## Why not just live-fetch the catalog?
`GET /v1/models` returns the **full** catalog (OpenRouter ships ~340 models) with **no "common"/"popular"/rank field** (verified against the live endpoint). A fixed picker of 340 is unusable, and a live fetch on every `/model` open adds latency and couples the picker to key/quota — `model.options` is intentionally network-free.

## Change
- Add `raven/providers/common_models.py`: a small hand-curated "common models" shortlist per provider (same idea as hermes' recommended list). Seeds `openrouter` today; other providers fall back to their configured list until curated.
- `_provider_models(slug)` now returns **the user's configured models first, then the curated shortlist (deduped)**.

Picker display priority: **manual entry (existing `model.add_model`) → configured models → common shortlist**. A hand-typed id is written into the configured list, so it ranks first.

`onboard` is unchanged — it already live-fetches `/v1/models` into a type-to-filter autocomplete with a manual-entry fallback, which is the better UX there.

## Tests
- `tests/test_tui_rpc_model.py`: +2 cases (empty config → common shortlist; configured-first + dedup). 19 passing.
- `ruff check` + `ruff format` clean; 145 passing across model / provider / update_providers / onboard suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)