### PR TITLE
feat(tui): make everos memory work out-of-box in the tui

### DIFF
--- a/raven/cli/_log_file.py
+++ b/raven/cli/_log_file.py
@@ -87,7 +87,7 @@ def _intercept_stdlib_logging(logger) -> None:
 
 def _strip_tty_stream_handlers() -> None:
     """Remove TTY ``StreamHandler``s that third-party libs attach directly to
-    named loggers.
+    named loggers or the root logger.
 
     ``basicConfig(force=True)`` only resets the ROOT logger's handlers. Some
     libraries (notably ``litellm``) install their own ``StreamHandler(stderr)``
@@ -96,14 +96,23 @@ def _strip_tty_stream_handlers() -> None:
     direct-to-TTY write overlays the Ink alt-screen. Stripping
     them keeps records reaching the file sink via ``propagate=True`` → root →
     InterceptHandler.
+
+    Also strips TTY StreamHandlers from the root logger itself, which some
+    libraries (e.g. everos configure_logging) install after basicConfig runs.
     """
     tty_streams = (sys.stderr, sys.stdout)
+
+    def _strip_from(logger_obj: _stdlib_logging.Logger) -> None:
+        for handler in list(logger_obj.handlers):
+            if isinstance(handler, _stdlib_logging.StreamHandler) and getattr(handler, "stream", None) in tty_streams:
+                logger_obj.removeHandler(handler)
+
+    _strip_from(_stdlib_logging.getLogger())
+
     for obj in list(_stdlib_logging.Logger.manager.loggerDict.values()):
         if not isinstance(obj, _stdlib_logging.Logger):
             continue  # skip PlaceHolder entries
-        for handler in list(obj.handlers):
-            if isinstance(handler, _stdlib_logging.StreamHandler) and getattr(handler, "stream", None) in tty_streams:
-                obj.removeHandler(handler)
+        _strip_from(obj)
 
 
 __all__ = ["redirect_loguru_to_file"]

--- a/raven/cli/_log_file.py
+++ b/raven/cli/_log_file.py
@@ -13,10 +13,11 @@ Env vars:
 
 from __future__ import annotations
 
+import contextlib
 import logging as _stdlib_logging
 import os
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from pathlib import Path
 
 from raven.config.paths import get_logs_dir
@@ -115,4 +116,35 @@ def _strip_tty_stream_handlers() -> None:
         _strip_from(obj)
 
 
-__all__ = ["redirect_loguru_to_file"]
+@contextlib.contextmanager
+def redirect_terminal_fds_to_file(path: Path) -> Generator[None, None, None]:
+    """Redirect fd 1 (stdout) and fd 2 (stderr) to ``path`` for the duration of
+    the block, then restore the originals.
+
+    everos embedded structlog prints directly to stdout via PrintLogger, bypassing
+    the stdlib logging module entirely; redirecting fds at the OS level is the only
+    layer that catches those writes before they corrupt the full-screen TUI.
+    The file is opened in append mode so it coexists with loguru's rotating sink
+    targeting the same path.  Restore is guaranteed via a finally block.
+    """
+    saved_out = os.dup(1)
+    saved_err = os.dup(2)
+    file_fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    try:
+        os.dup2(file_fd, 1)
+        os.dup2(file_fd, 2)
+        os.close(file_fd)
+        file_fd = -1
+        try:
+            yield
+        finally:
+            os.dup2(saved_out, 1)
+            os.dup2(saved_err, 2)
+    finally:
+        if file_fd >= 0:
+            os.close(file_fd)
+        os.close(saved_out)
+        os.close(saved_err)
+
+
+__all__ = ["redirect_loguru_to_file", "redirect_terminal_fds_to_file"]

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -27,7 +27,7 @@ from typing import Optional, Tuple
 
 import typer
 
-from raven.cli._log_file import _strip_tty_stream_handlers, redirect_loguru_to_file
+from raven.cli._log_file import _strip_tty_stream_handlers, redirect_loguru_to_file, redirect_terminal_fds_to_file
 
 tui_app = typer.Typer(name="tui", help="Launch Raven native TUI (Ink+React).")
 
@@ -590,76 +590,85 @@ async def _run_rpc_server_until_done(
         build_error=build_error,
     )
 
-    # Start the embedded backend before serving so the EverOS runtime is up
-    # and its index lock is held for the session. No-op for http/no-op backends.
-    if agent_loop is not None and agent_loop.backend is not None:
-        try:
-            await agent_loop.backend.start()
-        except Exception:
-            from loguru import logger as _logger
+    from raven.config.paths import get_logs_dir
 
-            _logger.exception(
-                "tui: memory backend start failed; continuing with degraded memory path",
-            )
-    # everos configure_logging installs a root stdout StreamHandler during start();
-    # strip it so everos records flow to the file sink and never reach the terminal.
-    _strip_tty_stream_handlers()
-
-    serve_task = asyncio.create_task(server.serve_forever())
-
-    try:
-        # Wait until EITHER handshake completes OR deadline expires OR child exits.
-        done, pending = await asyncio.wait(
-            {
-                asyncio.create_task(handshake_done.wait()),
-                asyncio.create_task(proc_done.wait()),
-            },
-            timeout=handshake_deadline_s,
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        for t in pending:
-            t.cancel()
-        # Drain cancelled tasks to suppress warnings.
-        for t in pending:
-            try:
-                await t
-            except (asyncio.CancelledError, Exception):
-                pass
-
-        if not handshake_done.is_set():
-            return False
-        # Handshake OK — continue serving until child exits.
-        await proc_done.wait()
-        return True
-    finally:
-        # Fail-safe any pending confirm so a paused dispatch's worker thread
-        # is released when the connection drops.
-        confirm_broker.cancel_all()
-        if agent_loop is not None and agent_loop.cron_service is not None:
-            try:
-                agent_loop.cron_service.stop()
-            except Exception:
-                pass
-        if turn_teardown is not None:
-            try:
-                await turn_teardown()
-            except Exception:
-                pass
-        # Release the embedded index lock so the next process can start.
+    # everos embedded structlog uses PrintLogger which calls print() → writes
+    # directly to fd 1, bypassing stdlib logging entirely. Redirect both fds so
+    # no everos output can corrupt the full-screen TUI, starting before
+    # backend.start() (which may trigger lazy warns) through the end of stop().
+    # The Node child already inherited the real terminal fds at Popen time (before
+    # this function ran), so this dup2 does not affect the child's terminal.
+    with redirect_terminal_fds_to_file(get_logs_dir() / "tui.log"):
+        # Start the embedded backend before serving so the EverOS runtime is up
+        # and its index lock is held for the session. No-op for http/no-op backends.
         if agent_loop is not None and agent_loop.backend is not None:
             try:
-                await agent_loop.backend.stop()
+                await agent_loop.backend.start()
             except Exception:
                 from loguru import logger as _logger
 
                 _logger.exception(
-                    "tui: memory backend stop failed; continuing shutdown",
+                    "tui: memory backend start failed; continuing with degraded memory path",
                 )
-        serve_task.cancel()
+        # everos configure_logging installs a root stdout StreamHandler during start();
+        # strip it so everos records flow to the file sink and never reach the terminal.
+        _strip_tty_stream_handlers()
+
+        serve_task = asyncio.create_task(server.serve_forever())
+
         try:
-            await serve_task
-        except (asyncio.CancelledError, Exception):
-            pass
+            # Wait until EITHER handshake completes OR deadline expires OR child exits.
+            done, pending = await asyncio.wait(
+                {
+                    asyncio.create_task(handshake_done.wait()),
+                    asyncio.create_task(proc_done.wait()),
+                },
+                timeout=handshake_deadline_s,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for t in pending:
+                t.cancel()
+            # Drain cancelled tasks to suppress warnings.
+            for t in pending:
+                try:
+                    await t
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+            if not handshake_done.is_set():
+                return False
+            # Handshake OK — continue serving until child exits.
+            await proc_done.wait()
+            return True
+        finally:
+            # Fail-safe any pending confirm so a paused dispatch's worker thread
+            # is released when the connection drops.
+            confirm_broker.cancel_all()
+            if agent_loop is not None and agent_loop.cron_service is not None:
+                try:
+                    agent_loop.cron_service.stop()
+                except Exception:
+                    pass
+            if turn_teardown is not None:
+                try:
+                    await turn_teardown()
+                except Exception:
+                    pass
+            # Release the embedded index lock so the next process can start.
+            if agent_loop is not None and agent_loop.backend is not None:
+                try:
+                    await agent_loop.backend.stop()
+                except Exception:
+                    from loguru import logger as _logger
+
+                    _logger.exception(
+                        "tui: memory backend stop failed; continuing shutdown",
+                    )
+            serve_task.cancel()
+            try:
+                await serve_task
+            except (asyncio.CancelledError, Exception):
+                pass
 
 
 def _spawn_with_rpc_socket(

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -27,7 +27,7 @@ from typing import Optional, Tuple
 
 import typer
 
-from raven.cli._log_file import redirect_loguru_to_file
+from raven.cli._log_file import _strip_tty_stream_handlers, redirect_loguru_to_file
 
 tui_app = typer.Typer(name="tui", help="Launch Raven native TUI (Ink+React).")
 
@@ -601,6 +601,9 @@ async def _run_rpc_server_until_done(
             _logger.exception(
                 "tui: memory backend start failed; continuing with degraded memory path",
             )
+    # everos configure_logging installs a root stdout StreamHandler during start();
+    # strip it so everos records flow to the file sink and never reach the terminal.
+    _strip_tty_stream_handlers()
 
     serve_task = asyncio.create_task(server.serve_forever())
 

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -590,6 +590,18 @@ async def _run_rpc_server_until_done(
         build_error=build_error,
     )
 
+    # Start the embedded backend before serving so the EverOS runtime is up
+    # and its index lock is held for the session. No-op for http/no-op backends.
+    if agent_loop is not None and agent_loop.backend is not None:
+        try:
+            await agent_loop.backend.start()
+        except Exception:
+            from loguru import logger as _logger
+
+            _logger.exception(
+                "tui: memory backend start failed; continuing with degraded memory path",
+            )
+
     serve_task = asyncio.create_task(server.serve_forever())
 
     try:
@@ -630,6 +642,16 @@ async def _run_rpc_server_until_done(
                 await turn_teardown()
             except Exception:
                 pass
+        # Release the embedded index lock so the next process can start.
+        if agent_loop is not None and agent_loop.backend is not None:
+            try:
+                await agent_loop.backend.stop()
+            except Exception:
+                from loguru import logger as _logger
+
+                _logger.exception(
+                    "tui: memory backend stop failed; continuing shutdown",
+                )
         serve_task.cancel()
         try:
             await serve_task

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -339,6 +339,11 @@ def _build_tui_agent_loop():
         from raven.agent.loop import AgentLoop
         from raven.agent.loop.recovery import limits_from_defaults
         from raven.cli._helpers import load_runtime_config, make_provider
+        from raven.cli._plugin_stack import (
+            build_plugin_registry,
+            build_plugin_tools,
+            maybe_build_memory_backend,
+        )
         from raven.config.paths import get_cron_dir
         from raven.config.raven import load_raven_config
         from raven.proactive_engine.schedulers.cron.service import CronService
@@ -355,6 +360,18 @@ def _build_tui_agent_loop():
         cron = CronService(
             get_cron_dir() / "jobs.json",
             allowed_channels={"tui"},
+        )
+
+        plugin_registry = build_plugin_registry(ec_config)
+        backend = maybe_build_memory_backend(
+            config.workspace_path,
+            ec_config,
+            registry=plugin_registry,
+        )
+        plugin_tools = build_plugin_tools(
+            config.workspace_path,
+            ec_config,
+            registry=plugin_registry,
         )
 
         agent_loop = AgentLoop(
@@ -378,6 +395,8 @@ def _build_tui_agent_loop():
             channels_config=config.channels,
             skill_forge_config=skill_forge_cfg,
             runtime_config=ec_config.runtime,
+            backend=backend,
+            plugin_tools=plugin_tools,
             # TUI is always a multi-turn interactive session.
             interactive=True,
         )

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -724,9 +724,7 @@ class EverosBackend:
             if not content and not tool_calls:
                 continue
             entry: dict[str, Any] = {
-                "sender_id": agent_id
-                if role in ("assistant", "tool")
-                else (m.get("sender_id") or user_id),
+                "sender_id": agent_id if role in ("assistant", "tool") else (m.get("sender_id") or user_id),
                 "role": role,
                 "timestamp": m.get("timestamp") or now_ms,
                 "content": content,

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -54,12 +54,8 @@ _OwnerType = Literal["user", "agent"]
 # request for a new adapter — see ``EverosBackend._validate_config``.
 _VALID_MODES: tuple[str, ...] = ("embedded", "http")
 
-# Default agent identity stamped on stored agent-track messages when
-# ``plugins.config["everos-memory"].agent_id`` is unset. The agent is a
-# stable, pre-configured entity (its skills / cases accrue under this id
-# across sessions). Must match the ``agent_id`` the host passes to
-# recall for stored agent memory to be retrievable.
-_DEFAULT_AGENT_ID: str = "agent:default"
+_DEFAULT_AGENT_ID: str = "default"
+_DEFAULT_USER_ID: str = "default"
 
 
 # ---------------------------------------------------------------------------
@@ -401,14 +397,8 @@ class EverosBackend:
         self._services = ctx.services
         self._logger = ctx.logger
         self._mode = self._config.get("mode", "embedded")
-        # Agent identity stamped on stored agent-track messages. Must
-        # match the ``agent_id`` the host passes to recall for stored
-        # agent memory to be retrievable.
         self._agent_id: str = self._config.get("agent_id") or _DEFAULT_AGENT_ID
-        # User identity stamped on stored user-track messages. Must match
-        # the ``user_id`` the host passes to recall for stored user
-        # memory to be retrievable.
-        self._user_id: str | None = self._config.get("user_id")
+        self._user_id: str = self._config.get("user_id") or _DEFAULT_USER_ID
         # everos accumulates raw turns and only extracts episodes / cases /
         # skills on a boundary flush. Flush every N store() calls so short
         # sessions still build memory (mirrors the EverMe plugin's
@@ -688,7 +678,7 @@ class EverosBackend:
         messages: list[dict[str, Any]],
         *,
         agent_id: str,
-        user_id: str | None = None,
+        user_id: str = "default",
     ) -> list[dict[str, Any]]:
         """Adapt raven AgentLoop messages into EverOS's MessageItemDTO shape.
 
@@ -708,7 +698,7 @@ class EverosBackend:
           ``recall(user_id=<X>)`` must use that same ``<X>``.
 
         Other conversions: drop ``system``; missing ``sender_id`` on a
-        user message → ``"raven-user"``; missing ``timestamp`` → now (ms);
+        user message → ``user_id``; missing ``timestamp`` → now (ms);
         multimodal ``content`` → space-joined text; empty text → drop.
         """
         now_ms = int(time.time() * 1000)
@@ -736,7 +726,7 @@ class EverosBackend:
             entry: dict[str, Any] = {
                 "sender_id": agent_id
                 if role in ("assistant", "tool")
-                else (m.get("sender_id") or user_id or "raven-user"),
+                else (m.get("sender_id") or user_id),
                 "role": role,
                 "timestamp": m.get("timestamp") or now_ms,
                 "content": content,

--- a/tests/test_cli_log_file.py
+++ b/tests/test_cli_log_file.py
@@ -229,14 +229,13 @@ def test_redirect_terminal_fds_captures_print_and_raw_fd_write(tmp_path, capfd) 
 
     with capfd.disabled():
         with redirect_terminal_fds_to_file(target):
-            # Flush sys.stdout to drain any buffered Python-level bytes, then
-            # write via the underlying fd — this is exactly the PrintLogger path.
-            sys.stdout.flush()
-            os.write(1, b"print-leak-line\n")
+            # Real print() through sys.stdout — this is the structlog PrintLogger path.
+            print("print-leak-line", flush=True)
+            # Raw fd write — exercises the os.write path directly.
             os.write(1, b"raw-fd-write\n")
 
     content = target.read_bytes()
-    assert b"print-leak-line" in content, "os.write(1, ...) of print payload must land in the file"
+    assert b"print-leak-line" in content, "print() output must land in the redirect file (structlog PrintLogger path)"
     assert b"raw-fd-write" in content, "os.write(1, ...) during redirect must land in the file"
 
 

--- a/tests/test_cli_log_file.py
+++ b/tests/test_cli_log_file.py
@@ -9,6 +9,7 @@ has its own real-litellm regression guard in
 from __future__ import annotations
 
 import logging
+import logging.handlers
 from pathlib import Path
 
 import pytest
@@ -160,3 +161,46 @@ def test_file_sink_does_not_dump_local_variable_values(tmp_logs: Path) -> None:
     content = _flush_and_read(log_path)
     assert "processing failed" in content
     assert "SECRET-TOKEN-9z9z9z" not in content
+
+
+# ---------------------------------------------------------------------------
+# Root-logger TTY StreamHandler stripping
+# ---------------------------------------------------------------------------
+
+
+def test_strip_tty_stream_handlers_removes_root_stdout_handler(tmp_logs: Path) -> None:
+    """_strip_tty_stream_handlers() must remove a StreamHandler(sys.stdout)
+    installed on the ROOT logger (not just on named loggers)."""
+    import sys
+
+    from raven.cli._log_file import _strip_tty_stream_handlers
+
+    root = logging.getLogger()
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    root.addHandler(stdout_handler)
+
+    try:
+        _strip_tty_stream_handlers()
+        assert stdout_handler not in root.handlers, (
+            "_strip_tty_stream_handlers must remove root stdout StreamHandler"
+        )
+    finally:
+        root.removeHandler(stdout_handler)
+
+
+def test_strip_tty_stream_handlers_keeps_root_non_tty_handler(tmp_logs: Path) -> None:
+    """_strip_tty_stream_handlers() must NOT remove a non-TTY handler (e.g. a
+    MemoryHandler) from the ROOT logger."""
+    from raven.cli._log_file import _strip_tty_stream_handlers
+
+    root = logging.getLogger()
+    mem_handler = logging.handlers.MemoryHandler(capacity=10)
+    root.addHandler(mem_handler)
+
+    try:
+        _strip_tty_stream_handlers()
+        assert mem_handler in root.handlers, (
+            "_strip_tty_stream_handlers must not remove non-TTY root handlers"
+        )
+    finally:
+        root.removeHandler(mem_handler)

--- a/tests/test_cli_log_file.py
+++ b/tests/test_cli_log_file.py
@@ -181,9 +181,7 @@ def test_strip_tty_stream_handlers_removes_root_stdout_handler(tmp_logs: Path) -
 
     try:
         _strip_tty_stream_handlers()
-        assert stdout_handler not in root.handlers, (
-            "_strip_tty_stream_handlers must remove root stdout StreamHandler"
-        )
+        assert stdout_handler not in root.handlers, "_strip_tty_stream_handlers must remove root stdout StreamHandler"
     finally:
         root.removeHandler(stdout_handler)
 
@@ -199,9 +197,7 @@ def test_strip_tty_stream_handlers_keeps_root_non_tty_handler(tmp_logs: Path) ->
 
     try:
         _strip_tty_stream_handlers()
-        assert mem_handler in root.handlers, (
-            "_strip_tty_stream_handlers must not remove non-TTY root handlers"
-        )
+        assert mem_handler in root.handlers, "_strip_tty_stream_handlers must not remove non-TTY root handlers"
     finally:
         root.removeHandler(mem_handler)
 
@@ -221,7 +217,6 @@ def test_redirect_terminal_fds_captures_print_and_raw_fd_write(tmp_path, capfd) 
     the redirect — the fd-level dup2 takes exclusive effect.
     """
     import os
-    import sys
 
     from raven.cli._log_file import redirect_terminal_fds_to_file
 

--- a/tests/test_cli_log_file.py
+++ b/tests/test_cli_log_file.py
@@ -204,3 +204,79 @@ def test_strip_tty_stream_handlers_keeps_root_non_tty_handler(tmp_logs: Path) ->
         )
     finally:
         root.removeHandler(mem_handler)
+
+
+# ---------------------------------------------------------------------------
+# redirect_terminal_fds_to_file — fd-level stdout/stderr capture
+# ---------------------------------------------------------------------------
+
+
+def test_redirect_terminal_fds_captures_print_and_raw_fd_write(tmp_path, capfd) -> None:
+    """Inside redirect_terminal_fds_to_file, both print() (flushed to the real fd)
+    and os.write(1, ...) must land in the target file, not the terminal.
+
+    This proves the context manager captures the structlog PrintLogger path
+    (which does print(message, file=None) writing to the live fd 1) AND raw fd writes.
+    We run under capfd.disabled() so pytest is not fighting for the fds during
+    the redirect — the fd-level dup2 takes exclusive effect.
+    """
+    import os
+    import sys
+
+    from raven.cli._log_file import redirect_terminal_fds_to_file
+
+    target = tmp_path / "capture.log"
+
+    with capfd.disabled():
+        with redirect_terminal_fds_to_file(target):
+            # Flush sys.stdout to drain any buffered Python-level bytes, then
+            # write via the underlying fd — this is exactly the PrintLogger path.
+            sys.stdout.flush()
+            os.write(1, b"print-leak-line\n")
+            os.write(1, b"raw-fd-write\n")
+
+    content = target.read_bytes()
+    assert b"print-leak-line" in content, "os.write(1, ...) of print payload must land in the file"
+    assert b"raw-fd-write" in content, "os.write(1, ...) during redirect must land in the file"
+
+
+def test_redirect_terminal_fds_restores_fd1_after_exit(tmp_path, capfd) -> None:
+    """After the context manager exits, fd1 must be restored to the original
+    target (e.g. the original stdout) — writes after exit must NOT go to the
+    redirect file."""
+    import os
+
+    from raven.cli._log_file import redirect_terminal_fds_to_file
+
+    target = tmp_path / "capture.log"
+    marker_after = b"marker-after-restore\n"
+
+    with capfd.disabled():
+        with redirect_terminal_fds_to_file(target):
+            pass
+        # After exit: write a marker — it should NOT appear in the file.
+        os.write(1, marker_after)
+
+    content = target.read_bytes() if target.exists() else b""
+    assert marker_after not in content, "writes after CM exit must not go to the redirect file"
+
+
+def test_redirect_terminal_fds_restores_on_exception(tmp_path, capfd) -> None:
+    """fd1/fd2 must be restored even when an exception is raised inside the CM."""
+    import os
+
+    from raven.cli._log_file import redirect_terminal_fds_to_file
+
+    target = tmp_path / "capture.log"
+    marker_after = b"marker-after-exception\n"
+
+    with capfd.disabled():
+        try:
+            with redirect_terminal_fds_to_file(target):
+                raise RuntimeError("boom inside CM")
+        except RuntimeError:
+            pass
+        os.write(1, marker_after)
+
+    content = target.read_bytes() if target.exists() else b""
+    assert marker_after not in content, "fd1 must be restored on exception so writes land back on real stdout"

--- a/tests/test_cli_tui_commands.py
+++ b/tests/test_cli_tui_commands.py
@@ -383,3 +383,37 @@ async def test_rpc_runner_skips_lifecycle_when_no_backend(rpc_server_deps, monke
 
     assert rpc_server_deps["start_calls"] == []
     assert rpc_server_deps["stop_calls"] == []
+
+
+# ---------------------------------------------------------------------------
+# Root-logger TTY handler stripped after backend.start()
+# ---------------------------------------------------------------------------
+
+
+async def test_rpc_runner_strips_root_stdout_handler_after_backend_start(
+    rpc_server_deps, monkeypatch
+) -> None:
+    """``_run_rpc_server_until_done`` must strip a root stdout StreamHandler
+    installed during ``backend.start()`` (mimicking everos configure_logging)
+    before the RPC server begins serving."""
+    import logging
+    import sys
+
+    installed_handler: list[logging.Handler] = []
+
+    original_start = rpc_server_deps["backend"].start
+
+    async def _start_with_root_handler():
+        h = logging.StreamHandler(sys.stdout)
+        logging.getLogger().addHandler(h)
+        installed_handler.append(h)
+        await original_start()
+
+    rpc_server_deps["backend"].start = _start_with_root_handler
+
+    await _run_until_done_with_immediate_proc_done(monkeypatch, rpc_server_deps)
+
+    assert len(installed_handler) == 1, "spy backend.start() did not run"
+    assert installed_handler[0] not in logging.getLogger().handlers, (
+        "_run_rpc_server_until_done must strip root stdout StreamHandler installed by backend.start()"
+    )

--- a/tests/test_cli_tui_commands.py
+++ b/tests/test_cli_tui_commands.py
@@ -1,0 +1,198 @@
+"""CLI tests for ``raven tui`` commands — ``_build_tui_agent_loop`` wiring.
+
+Verifies the memory backend and plugin tools are wired into the AgentLoop
+constructed by ``_build_tui_agent_loop``, mirroring the agent-path coverage
+in ``test_cli_agent_commands.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, sentinel
+
+import pytest
+
+
+@pytest.fixture
+def patched_tui_loop_deps(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """Patch all heavy deps of ``_build_tui_agent_loop`` for isolation.
+
+    Mirrors ``patched_tui_build_deps`` in ``test_tui_cron_tool_wired.py``
+    but additionally stubs the plugin-stack helpers so we can assert their
+    return values flow into the AgentLoop constructor kwargs.
+
+    Returns ``captured`` dict the tests inspect.
+    """
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, Any] = {}
+
+    config = MagicMock()
+    config.workspace_path = tmp_path
+    config.agents.defaults.model = "stub-model"
+    config.agents.defaults.max_tool_iterations = 5
+    config.agents.defaults.context_window_tokens = 65_536
+    config.agents.defaults.enable_personalization = False
+    config.agents.defaults.max_concurrent_subagents = 2
+    config.agents.defaults.max_subagent_spawns_per_hour = 10
+    config.tools.web.search.api_key = None
+    config.tools.web.proxy = None
+    config.tools.exec = MagicMock()
+    config.tools.restrict_to_workspace = True
+    config.tools.mcp_servers = []
+    config.tools.sandbox = MagicMock()
+    config.channels = MagicMock()
+    monkeypatch.setattr("raven.cli._helpers.load_runtime_config", lambda _a, _b: config)
+    monkeypatch.setattr("raven.cli._helpers.make_provider", lambda _c: MagicMock())
+
+    ec_config = MagicMock()
+    ec_config.skill_forge = MagicMock()
+    ec_config.runtime = MagicMock()
+    monkeypatch.setattr("raven.config.raven.load_raven_config", lambda: ec_config)
+
+    monkeypatch.setattr("raven.session.manager.SessionManager", lambda _wp: MagicMock())
+    cron_dir = tmp_path / "cron"
+    cron_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr("raven.config.paths.get_cron_dir", lambda: cron_dir)
+
+    # AgentLoop spy captures all ctor kwargs.
+    class _AgentLoopSpy:
+        def __init__(self, **kwargs):
+            captured["agent_loop_kwargs"] = kwargs
+            self.tools = MagicMock()
+            self.configure_personalization = MagicMock()
+
+    monkeypatch.setattr("raven.agent.loop.AgentLoop", _AgentLoopSpy)
+
+    # Stub plugin-stack helpers at the source module so patching works
+    # before and after the import is added to tui_commands.
+    fake_registry = sentinel.fake_registry
+    fake_backend = sentinel.fake_backend
+    fake_tools = [sentinel.fake_tool_1]
+
+    monkeypatch.setattr(
+        "raven.cli._plugin_stack.build_plugin_registry",
+        lambda cfg: fake_registry,
+    )
+    monkeypatch.setattr(
+        "raven.cli._plugin_stack.maybe_build_memory_backend",
+        lambda ws, cfg, *, registry=None: fake_backend,
+    )
+    monkeypatch.setattr(
+        "raven.cli._plugin_stack.build_plugin_tools",
+        lambda ws, cfg, *, registry=None: fake_tools,
+    )
+
+    captured["fake_registry"] = fake_registry
+    captured["fake_backend"] = fake_backend
+    captured["fake_tools"] = fake_tools
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# memory backend wired into AgentLoop
+# ---------------------------------------------------------------------------
+
+
+def test_tui_agent_loop_receives_non_none_backend(patched_tui_loop_deps) -> None:
+    """``_build_tui_agent_loop`` must pass ``backend=<non-None>`` to AgentLoop
+    when the plugin stack returns a backend (today it passes nothing, so
+    ``AgentLoop.backend`` defaults to ``None`` and store/recall are no-ops)."""
+    from raven.cli.tui_commands import _build_tui_agent_loop
+
+    _build_tui_agent_loop()
+
+    kwargs = patched_tui_loop_deps["agent_loop_kwargs"]
+    assert kwargs.get("backend") is not None, (
+        "AgentLoop must receive backend= from _build_tui_agent_loop; got None"
+    )
+    assert kwargs["backend"] is patched_tui_loop_deps["fake_backend"]
+
+
+# ---------------------------------------------------------------------------
+# plugin tools wired into AgentLoop
+# ---------------------------------------------------------------------------
+
+
+def test_tui_agent_loop_receives_plugin_tools(patched_tui_loop_deps) -> None:
+    """``_build_tui_agent_loop`` must pass ``plugin_tools=`` to AgentLoop
+    so plugin-contributed tools are registered in the TUI agent's tool registry."""
+    from raven.cli.tui_commands import _build_tui_agent_loop
+
+    _build_tui_agent_loop()
+
+    kwargs = patched_tui_loop_deps["agent_loop_kwargs"]
+    assert "plugin_tools" in kwargs, "AgentLoop must receive plugin_tools kwarg"
+    assert kwargs["plugin_tools"] is patched_tui_loop_deps["fake_tools"]
+
+
+# ---------------------------------------------------------------------------
+# single shared plugin registry (build_plugin_registry called once)
+# ---------------------------------------------------------------------------
+
+
+def test_tui_build_plugin_registry_called_once(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """The plugin registry must be built once and shared between the backend
+    and tools calls — avoids double discovery overhead and ensures coherence."""
+    monkeypatch.chdir(tmp_path)
+
+    config = MagicMock()
+    config.workspace_path = tmp_path
+    config.agents.defaults.model = "stub-model"
+    config.agents.defaults.max_tool_iterations = 5
+    config.agents.defaults.context_window_tokens = 65_536
+    config.agents.defaults.enable_personalization = False
+    config.agents.defaults.max_concurrent_subagents = 2
+    config.agents.defaults.max_subagent_spawns_per_hour = 10
+    config.tools.web.search.api_key = None
+    config.tools.web.proxy = None
+    config.tools.exec = MagicMock()
+    config.tools.restrict_to_workspace = True
+    config.tools.mcp_servers = []
+    config.tools.sandbox = MagicMock()
+    config.channels = MagicMock()
+    monkeypatch.setattr("raven.cli._helpers.load_runtime_config", lambda _a, _b: config)
+    monkeypatch.setattr("raven.cli._helpers.make_provider", lambda _c: MagicMock())
+
+    ec_config = MagicMock()
+    ec_config.skill_forge = MagicMock()
+    ec_config.runtime = MagicMock()
+    monkeypatch.setattr("raven.config.raven.load_raven_config", lambda: ec_config)
+
+    monkeypatch.setattr("raven.session.manager.SessionManager", lambda _wp: MagicMock())
+    cron_dir = tmp_path / "cron"
+    cron_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr("raven.config.paths.get_cron_dir", lambda: cron_dir)
+
+    monkeypatch.setattr(
+        "raven.agent.loop.AgentLoop",
+        lambda **kw: MagicMock(tools=MagicMock(), configure_personalization=MagicMock()),
+    )
+
+    call_count = {"build": 0}
+    passed_registries: list[Any] = []
+
+    def _spy_registry(cfg):
+        call_count["build"] += 1
+        return sentinel.shared_registry
+
+    def _spy_backend(ws, cfg, *, registry=None):
+        passed_registries.append(("backend", registry))
+        return None
+
+    def _spy_tools(ws, cfg, *, registry=None):
+        passed_registries.append(("tools", registry))
+        return []
+
+    monkeypatch.setattr("raven.cli._plugin_stack.build_plugin_registry", _spy_registry)
+    monkeypatch.setattr("raven.cli._plugin_stack.maybe_build_memory_backend", _spy_backend)
+    monkeypatch.setattr("raven.cli._plugin_stack.build_plugin_tools", _spy_tools)
+
+    from raven.cli.tui_commands import _build_tui_agent_loop
+
+    _build_tui_agent_loop()
+
+    assert call_count["build"] == 1, "build_plugin_registry should be called exactly once"
+    backend_reg = next(r for name, r in passed_registries if name == "backend")
+    tools_reg = next(r for name, r in passed_registries if name == "tools")
+    assert backend_reg is sentinel.shared_registry
+    assert tools_reg is sentinel.shared_registry

--- a/tests/test_cli_tui_commands.py
+++ b/tests/test_cli_tui_commands.py
@@ -417,3 +417,66 @@ async def test_rpc_runner_strips_root_stdout_handler_after_backend_start(
     assert installed_handler[0] not in logging.getLogger().handlers, (
         "_run_rpc_server_until_done must strip root stdout StreamHandler installed by backend.start()"
     )
+
+
+# ---------------------------------------------------------------------------
+# fd-level stdout/stderr redirect spans the serve region
+# ---------------------------------------------------------------------------
+
+
+async def test_rpc_runner_activates_fd_redirect_before_backend_start(
+    rpc_server_deps, monkeypatch, tmp_path
+) -> None:
+    """``_run_rpc_server_until_done`` must activate redirect_terminal_fds_to_file
+    before calling backend.start() so that everos structlog PrintLogger output
+    during start and serve lands in the log file, not on the terminal.
+
+    Spies on the CM entry/exit and on start/stop to assert ordering:
+    redirect_enter < start ... stop < redirect_exit (held through the finally).
+    """
+    import contextlib
+
+    call_log: list[str] = []
+
+    original_start = rpc_server_deps["backend"].start
+    original_stop = rpc_server_deps["backend"].stop
+
+    async def _spy_start():
+        call_log.append("start")
+        await original_start()
+
+    async def _spy_stop():
+        call_log.append("stop")
+        await original_stop()
+
+    rpc_server_deps["backend"].start = _spy_start
+    rpc_server_deps["backend"].stop = _spy_stop
+
+    @contextlib.contextmanager
+    def _spy_redirect(path):
+        call_log.append("redirect_enter")
+        try:
+            yield
+        finally:
+            call_log.append("redirect_exit")
+
+    monkeypatch.setattr(
+        "raven.cli.tui_commands.redirect_terminal_fds_to_file",
+        _spy_redirect,
+    )
+    monkeypatch.setattr(
+        "raven.config.paths.get_logs_dir",
+        lambda: tmp_path,
+    )
+
+    await _run_until_done_with_immediate_proc_done(monkeypatch, rpc_server_deps)
+
+    assert "redirect_enter" in call_log, "redirect_terminal_fds_to_file must be entered"
+    enter_idx = call_log.index("redirect_enter")
+    start_idx = call_log.index("start")
+    assert enter_idx < start_idx, "redirect must be activated BEFORE backend.start()"
+
+    assert "redirect_exit" in call_log, "redirect_terminal_fds_to_file must be exited (restored)"
+    exit_idx = call_log.index("redirect_exit")
+    stop_idx = call_log.index("stop")
+    assert stop_idx < exit_idx, "redirect must be held THROUGH backend.stop()"

--- a/tests/test_cli_tui_commands.py
+++ b/tests/test_cli_tui_commands.py
@@ -103,9 +103,7 @@ def test_tui_agent_loop_receives_non_none_backend(patched_tui_loop_deps) -> None
     _build_tui_agent_loop()
 
     kwargs = patched_tui_loop_deps["agent_loop_kwargs"]
-    assert kwargs.get("backend") is not None, (
-        "AgentLoop must receive backend= from _build_tui_agent_loop; got None"
-    )
+    assert kwargs.get("backend") is not None, "AgentLoop must receive backend= from _build_tui_agent_loop; got None"
     assert kwargs["backend"] is patched_tui_loop_deps["fake_backend"]
 
 
@@ -323,9 +321,7 @@ async def test_rpc_runner_calls_backend_start_before_serving(rpc_server_deps, mo
     entering the serve loop when ``agent_loop.backend`` is not None."""
     await _run_until_done_with_immediate_proc_done(monkeypatch, rpc_server_deps)
 
-    assert rpc_server_deps["start_calls"] == ["start"], (
-        "backend.start() must be called exactly once before serving"
-    )
+    assert rpc_server_deps["start_calls"] == ["start"], "backend.start() must be called exactly once before serving"
 
 
 async def test_rpc_runner_calls_backend_stop_on_exit(rpc_server_deps, monkeypatch) -> None:
@@ -333,9 +329,7 @@ async def test_rpc_runner_calls_backend_stop_on_exit(rpc_server_deps, monkeypatc
     block so the embedded index lock is released on normal exit."""
     await _run_until_done_with_immediate_proc_done(monkeypatch, rpc_server_deps)
 
-    assert rpc_server_deps["stop_calls"] == ["stop"], (
-        "backend.stop() must be called exactly once in the finally block"
-    )
+    assert rpc_server_deps["stop_calls"] == ["stop"], "backend.stop() must be called exactly once in the finally block"
 
 
 async def test_rpc_runner_stop_called_even_when_serve_raises(rpc_server_deps, monkeypatch) -> None:
@@ -390,9 +384,7 @@ async def test_rpc_runner_skips_lifecycle_when_no_backend(rpc_server_deps, monke
 # ---------------------------------------------------------------------------
 
 
-async def test_rpc_runner_strips_root_stdout_handler_after_backend_start(
-    rpc_server_deps, monkeypatch
-) -> None:
+async def test_rpc_runner_strips_root_stdout_handler_after_backend_start(rpc_server_deps, monkeypatch) -> None:
     """``_run_rpc_server_until_done`` must strip a root stdout StreamHandler
     installed during ``backend.start()`` (mimicking everos configure_logging)
     before the RPC server begins serving."""
@@ -424,9 +416,7 @@ async def test_rpc_runner_strips_root_stdout_handler_after_backend_start(
 # ---------------------------------------------------------------------------
 
 
-async def test_rpc_runner_activates_fd_redirect_before_backend_start(
-    rpc_server_deps, monkeypatch, tmp_path
-) -> None:
+async def test_rpc_runner_activates_fd_redirect_before_backend_start(rpc_server_deps, monkeypatch, tmp_path) -> None:
     """``_run_rpc_server_until_done`` must activate redirect_terminal_fds_to_file
     before calling backend.start() so that everos structlog PrintLogger output
     during start and serve lands in the log file, not on the terminal.

--- a/tests/test_cli_tui_commands.py
+++ b/tests/test_cli_tui_commands.py
@@ -7,8 +7,9 @@ in ``test_cli_agent_commands.py``.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
-from unittest.mock import MagicMock, sentinel
+from unittest.mock import AsyncMock, MagicMock, sentinel
 
 import pytest
 
@@ -196,3 +197,187 @@ def test_tui_build_plugin_registry_called_once(monkeypatch: pytest.MonkeyPatch, 
     tools_reg = next(r for name, r in passed_registries if name == "tools")
     assert backend_reg is sentinel.shared_registry
     assert tools_reg is sentinel.shared_registry
+
+
+# ---------------------------------------------------------------------------
+# _run_rpc_server_until_done — embedded backend lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rpc_server_deps(monkeypatch: pytest.MonkeyPatch):
+    """Stub all heavy deps of ``_run_rpc_server_until_done`` so the function
+    can be exercised in-process without a real socket or Node child.
+
+    Returns a ``ctx`` dict with the spy backend and call-tracking lists.
+    """
+    ctx: dict[str, Any] = {
+        "start_calls": [],
+        "stop_calls": [],
+    }
+
+    class _SpyBackend:
+        async def start(self):
+            ctx["start_calls"].append("start")
+
+        async def stop(self):
+            ctx["stop_calls"].append("stop")
+
+    spy_backend = _SpyBackend()
+    ctx["backend"] = spy_backend
+
+    fake_agent_loop = MagicMock()
+    fake_agent_loop.backend = spy_backend
+    fake_agent_loop.cron_service = None
+    fake_agent_loop.tools.get.return_value = None
+    fake_agent_loop.subagents.set_submit = MagicMock()
+    ctx["agent_loop"] = fake_agent_loop
+
+    monkeypatch.setattr(
+        "raven.cli.tui_commands._build_tui_agent_loop",
+        lambda: fake_agent_loop,
+    )
+
+    # Stub RPC machinery so _run_rpc_server_until_done can import + construct
+    # without a real socket transport.
+    fake_dispatcher = MagicMock()
+    fake_dispatcher.register = MagicMock()
+    monkeypatch.setattr("raven.tui_rpc.dispatcher.Dispatcher", lambda: fake_dispatcher)
+
+    async def _fake_serve_forever():
+        await asyncio.sleep(0)
+
+    fake_server = MagicMock()
+    fake_server.send_frame = AsyncMock()
+    fake_server.serve_forever = _fake_serve_forever
+    monkeypatch.setattr(
+        "raven.tui_rpc.server.RpcServer",
+        lambda **kw: fake_server,
+    )
+
+    fake_emitter = MagicMock()
+    monkeypatch.setattr(
+        "raven.tui_rpc.subscriptions.SubscriptionEmitter",
+        lambda **kw: fake_emitter,
+    )
+
+    fake_confirm_broker = MagicMock()
+    fake_confirm_broker.cancel_all = MagicMock()
+    monkeypatch.setattr(
+        "raven.tui_rpc.confirm_broker.ConfirmBroker",
+        lambda **kw: fake_confirm_broker,
+    )
+
+    fake_question_broker = MagicMock()
+    monkeypatch.setattr(
+        "raven.tui_rpc.question_broker.QuestionBroker",
+        lambda **kw: fake_question_broker,
+    )
+
+    async def _fake_system_hello(params):
+        return {"version": "0.0.0"}
+
+    monkeypatch.setattr("raven.tui_rpc.methods.system.system_hello", _fake_system_hello)
+    monkeypatch.setattr("raven.tui_rpc.methods.system.system_ping", AsyncMock())
+    monkeypatch.setattr("raven.tui_rpc.methods.system.system_version", AsyncMock())
+    monkeypatch.setattr(
+        "raven.tui_rpc.methods.register_aligned_methods_except_system",
+        MagicMock(),
+    )
+
+    fake_turn_scheduler = MagicMock()
+    fake_turn_hub = MagicMock()
+    fake_turn_ids: dict = {}
+
+    async def _fake_turn_teardown():
+        pass
+
+    monkeypatch.setattr(
+        "raven.tui_rpc.spine.build_tui",
+        lambda *a, **kw: (fake_turn_scheduler, fake_turn_hub, fake_turn_ids, _fake_turn_teardown),
+    )
+
+    monkeypatch.setattr("raven.cli._cron_handler.make_on_cron_job", MagicMock())
+    monkeypatch.setattr("raven.tui_rpc.methods.turn.clear_active", MagicMock())
+
+    ctx["fake_server"] = fake_server
+    ctx["fake_confirm_broker"] = fake_confirm_broker
+    return ctx
+
+
+async def _run_until_done_with_immediate_proc_done(monkeypatch, ctx):
+    """Helper: drive ``_run_rpc_server_until_done`` with proc_done set immediately
+    so the function exits as fast as possible (handshake timeout path — still
+    exercises the full try/finally, including start/stop)."""
+    from raven.cli.tui_commands import _run_rpc_server_until_done
+
+    proc_done = asyncio.Event()
+    proc_done.set()
+
+    fake_sock = MagicMock()
+    await _run_rpc_server_until_done(fake_sock, "test-token", 0.01, proc_done)
+
+
+async def test_rpc_runner_calls_backend_start_before_serving(rpc_server_deps, monkeypatch) -> None:
+    """``_run_rpc_server_until_done`` must await ``backend.start()`` once before
+    entering the serve loop when ``agent_loop.backend`` is not None."""
+    await _run_until_done_with_immediate_proc_done(monkeypatch, rpc_server_deps)
+
+    assert rpc_server_deps["start_calls"] == ["start"], (
+        "backend.start() must be called exactly once before serving"
+    )
+
+
+async def test_rpc_runner_calls_backend_stop_on_exit(rpc_server_deps, monkeypatch) -> None:
+    """``_run_rpc_server_until_done`` must await ``backend.stop()`` in the finally
+    block so the embedded index lock is released on normal exit."""
+    await _run_until_done_with_immediate_proc_done(monkeypatch, rpc_server_deps)
+
+    assert rpc_server_deps["stop_calls"] == ["stop"], (
+        "backend.stop() must be called exactly once in the finally block"
+    )
+
+
+async def test_rpc_runner_stop_called_even_when_serve_raises(rpc_server_deps, monkeypatch) -> None:
+    """``backend.stop()`` must be awaited even when the serve task raises, verifying
+    the try/finally pairing (the embedded index lock is released regardless).
+
+    The serve exception is swallowed by the finally cleanup (by design — the task
+    is cancelled there), so we only assert stop() was called, not that the error
+    propagates.
+    """
+    async def _boom():
+        raise RuntimeError("simulated serve error")
+
+    fake_server = rpc_server_deps["fake_server"]
+    fake_server.serve_forever = _boom
+
+    from raven.cli.tui_commands import _run_rpc_server_until_done
+
+    proc_done = asyncio.Event()
+    proc_done.set()
+    fake_sock = MagicMock()
+
+    await _run_rpc_server_until_done(fake_sock, "test-token", 0.01, proc_done)
+
+    assert rpc_server_deps["stop_calls"] == ["stop"], (
+        "backend.stop() must still run via finally even after serve raises"
+    )
+
+
+async def test_rpc_runner_start_and_stop_each_called_once(rpc_server_deps, monkeypatch) -> None:
+    """Exactly one start and one stop — no double-start or double-stop."""
+    await _run_until_done_with_immediate_proc_done(monkeypatch, rpc_server_deps)
+
+    assert len(rpc_server_deps["start_calls"]) == 1
+    assert len(rpc_server_deps["stop_calls"]) == 1
+
+
+async def test_rpc_runner_skips_lifecycle_when_no_backend(rpc_server_deps, monkeypatch) -> None:
+    """When ``agent_loop.backend is None`` (no plugin wired), start/stop are skipped."""
+    rpc_server_deps["agent_loop"].backend = None
+
+    await _run_until_done_with_immediate_proc_done(monkeypatch, rpc_server_deps)
+
+    assert rpc_server_deps["start_calls"] == []
+    assert rpc_server_deps["stop_calls"] == []

--- a/tests/test_cli_tui_commands.py
+++ b/tests/test_cli_tui_commands.py
@@ -339,29 +339,31 @@ async def test_rpc_runner_calls_backend_stop_on_exit(rpc_server_deps, monkeypatc
 
 
 async def test_rpc_runner_stop_called_even_when_serve_raises(rpc_server_deps, monkeypatch) -> None:
-    """``backend.stop()`` must be awaited even when the serve task raises, verifying
-    the try/finally pairing (the embedded index lock is released regardless).
+    """``backend.stop()`` must be awaited even when an exception propagates through
+    the try block of ``_run_rpc_server_until_done``, proving the embedded index lock
+    is released regardless of errors.
 
-    The serve exception is swallowed by the finally cleanup (by design — the task
-    is cancelled there), so we only assert stop() was called, not that the error
-    propagates.
+    ``asyncio.wait`` is patched to raise inside the try body so the exception
+    genuinely propagates through the try block (not just through the finally during
+    task cancellation). The exception is expected to surface out of the function.
     """
-    async def _boom():
-        raise RuntimeError("simulated serve error")
+    exc = RuntimeError("simulated asyncio.wait failure")
 
-    fake_server = rpc_server_deps["fake_server"]
-    fake_server.serve_forever = _boom
+    async def _raising_wait(*args, **kwargs):
+        raise exc
+
+    monkeypatch.setattr("raven.cli.tui_commands.asyncio.wait", _raising_wait)
 
     from raven.cli.tui_commands import _run_rpc_server_until_done
 
     proc_done = asyncio.Event()
-    proc_done.set()
     fake_sock = MagicMock()
 
-    await _run_rpc_server_until_done(fake_sock, "test-token", 0.01, proc_done)
+    with pytest.raises(RuntimeError, match="simulated asyncio.wait failure"):
+        await _run_rpc_server_until_done(fake_sock, "test-token", 0.01, proc_done)
 
     assert rpc_server_deps["stop_calls"] == ["stop"], (
-        "backend.stop() must still run via finally even after serve raises"
+        "backend.stop() must still run via finally even when an exception propagates through the try block"
     )
 
 

--- a/tests/test_em2_backend.py
+++ b/tests/test_em2_backend.py
@@ -497,6 +497,48 @@ class TestStoreConversion:
 
 
 # ---------------------------------------------------------------------------
+# Default identity alignment (store side must match recall-side defaults)
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultIdentityAlignment:
+    async def test_user_track_default_owner_is_default(self, tmp_path: Path) -> None:
+        """Backend with no user_id in config stamps user messages with
+        'default', not 'raven-user', so store and recall use the same owner."""
+        adapter = _FakeAdapter()
+        b = EverosBackend(_ctx(tmp_path), adapter=adapter)
+        await b.store("s", [{"role": "user", "content": "hi"}])
+        payload = adapter.memorize_calls[0]["payload_messages"]
+        assert payload[0]["sender_id"] == "default"
+
+    async def test_agent_track_default_id_is_default(self, tmp_path: Path) -> None:
+        """Backend with no agent_id in config resolves _agent_id to 'default',
+        not 'agent:default', and stamps assistant messages accordingly."""
+        adapter = _FakeAdapter()
+        b = EverosBackend(_ctx(tmp_path), adapter=adapter)
+        assert b._agent_id == "default"
+        await b.store("s", [{"role": "assistant", "content": "hello"}])
+        payload = adapter.memorize_calls[0]["payload_messages"]
+        assert payload[0]["sender_id"] == "default"
+
+    async def test_explicit_user_and_agent_id_preserved(self, tmp_path: Path) -> None:
+        """Explicitly configured user_id and agent_id are used verbatim."""
+        adapter = _FakeAdapter()
+        b = EverosBackend(_ctx(tmp_path, user_id="alice", agent_id="bob"), adapter=adapter)
+        await b.store(
+            "s",
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ],
+        )
+        payload = adapter.memorize_calls[0]["payload_messages"]
+        by_role = {m["role"]: m["sender_id"] for m in payload}
+        assert by_role["user"] == "alice"
+        assert by_role["assistant"] == "bob"
+
+
+# ---------------------------------------------------------------------------
 # Feedback — no-op contract
 # ---------------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -3152,7 +3152,7 @@ wheels = [
 
 [[package]]
 name = "raven"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Makes EverOS memory work out-of-box in the TUI. Previously `_build_tui_agent_loop` constructed the `AgentLoop` with `backend=None`, so every TUI memory store/recall was a silent no-op — the TUI had no long-term memory even with models configured. The `raven agent` path already wired memory; the TUI slice had omitted it.

This branch:

- **Wires memory into the TUI** — `_build_tui_agent_loop` now builds the plugin registry, memory backend, and plugin tools and passes `backend=`/`plugin_tools=` into `AgentLoop`, at parity with `raven agent` (the pre-existing sub-agent and cron wiring is untouched).
- **Manages the embedded backend lifecycle** — `_run_rpc_server_until_done` starts the backend before serving and stops it in a `finally` (embedded is the default memory mode), so the in-process EverOS runtime comes up and releases its `~/.everos/.index` lock on exit.
- **Aligns the default store identity (defensive)** — when the `everos-memory` config block is absent/incomplete, the backend's store-side identity now resolves to `default` on both the user and agent tracks, matching the recall-side defaults. Onboard-seeded configs are unaffected (they set the ids explicitly, short-circuiting the fallback). This is not a default-path bug — the onboard seeder already aligns all four ids — it closes the non-onboard / minimal / programmatic-config gap.
- **Stops embedded log leakage into the TUI** — starting the embedded backend surfaced that EverOS's unconfigured structlog `PrintLogger` writes directly to stdout, which corrupts the full-screen TUI. The TUI now redirects its stdout/stderr file descriptors to the log file for the serve duration and restores them on exit, so embedded-backend output cannot reach the terminal.

Out of scope (tracked separately): sub-agent activity visibility in the TUI; the single-identity-source refactor that would remove the store/recall dual knob (deferred to the plugin owner).

## Type

- [x] Fix
- [x] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_cli_tui_commands.py tests/test_cli_log_file.py tests/test_em2_backend.py` -> 57 passed
- Human smoke on a live TUI with real EverOS: store then recall round-trips correctly; no log leakage into the TUI; the embedded index lock releases on exit and a subsequent start succeeds.

- [x] Relevant tests pass locally
- [ ] Relevant lint / type checks pass locally (not run locally; enforced by CI)
- [ ] User-facing docs or screenshots are updated when needed (N/A — no doc surface change)

## Risk

- Security: no new attack surface; the fd redirect only affects the TUI process's own stdout/stderr and is restored on exit.
- Backward compatibility: TUI gains working memory; the block-missing config path now stores under `default` instead of `raven-user`/`agent:default`; the onboard, explicit-config, and `raven agent` paths are unchanged.
- Rollback: the change is localized to the TUI launch/runner path and the backend identity defaults; reverting the branch restores prior behavior.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

EVE-59 (internal tracker).
