### PR TITLE
fix(agent): route subagent results to the originating session (+ per-spawn watcher leak)

### DIFF
--- a/raven/agent/context/builder.py
+++ b/raven/agent/context/builder.py
@@ -37,6 +37,8 @@ class ContextBuilder:
         skill_forge_config: Any = None,
         llm_provider: "LLMProvider | None" = None,
         now_fn: Callable[[], datetime] | None = None,
+        *,
+        start_watcher: bool = True,
     ):
         self.workspace = workspace
         self.memory = MemoryStore(workspace)
@@ -44,6 +46,7 @@ class ContextBuilder:
             workspace,
             config=skill_forge_config,
             llm_provider=llm_provider,
+            start_watcher=start_watcher,
         )
         # Optional fake-clock injection for benchmark harnesses (longrun).
         # When provided, runtime "Current Time:" injected to LLM prompt

--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -1069,12 +1069,20 @@ class AgentLoop:
                 self._mcp_stack = None
             raise
 
-    def _set_tool_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
+    def _set_tool_context(
+        self, channel: str, chat_id: str, message_id: str | None = None, session_key: str | None = None
+    ) -> None:
         """Update context for all tools that need routing info."""
         for name in ("message", "spawn", "cron"):
             if tool := self.tools.get(name):
-                if hasattr(tool, "set_context"):
-                    tool.set_context(channel, chat_id, *([message_id] if name == "message" else []))
+                if not hasattr(tool, "set_context"):
+                    continue
+                if name == "message":
+                    tool.set_context(channel, chat_id, message_id)
+                elif name == "spawn":
+                    tool.set_context(channel, chat_id, session_key or f"{channel}:{chat_id}")
+                else:
+                    tool.set_context(channel, chat_id)
 
     @staticmethod
     def _strip_think(text: str | None) -> str | None:
@@ -1917,7 +1925,7 @@ class AgentLoop:
                     # generate_question failed: skip silently and proceed
         # ── End personalization flow ─────────────────────────────────────────
 
-        self._set_tool_context(channel, chat_id, metadata.get("message_id"))
+        self._set_tool_context(channel, chat_id, metadata.get("message_id"), session_key=key)
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
                 message_tool.start_turn()

--- a/raven/agent/subagent/manager.py
+++ b/raven/agent/subagent/manager.py
@@ -296,7 +296,7 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
 
         # Use a transient ContextBuilder to access the runtime-context
         # builder; SubagentManager doesn't have its own ContextBuilder.
-        time_ctx = ContextBuilder(self.workspace)._build_runtime_context(None, None)
+        time_ctx = ContextBuilder(self.workspace, start_watcher=False)._build_runtime_context(None, None)
         parts = [
             f"""# Subagent
 

--- a/raven/agent/subagent/manager.py
+++ b/raven/agent/subagent/manager.py
@@ -100,7 +100,7 @@ class SubagentManager:
         window.append(now)
         task_id = str(uuid.uuid4())[:8]
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
-        origin = {"channel": origin_channel, "chat_id": origin_chat_id}
+        origin = {"channel": origin_channel, "chat_id": origin_chat_id, "session_key": quota_key}
 
         bg_task = asyncio.create_task(self._run_subagent(task_id, task, display_label, origin))
         self._running_tasks[task_id] = bg_task
@@ -284,10 +284,10 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
                     chat_type=ChatType.DM,
                 ),
                 text=announce_content,
-                conversation=f"{origin['channel']}:{origin['chat_id']}",
+                conversation=origin["session_key"],
             )
         )
-        logger.debug("Subagent [{}] announced result to {}:{}", task_id, origin["channel"], origin["chat_id"])
+        logger.debug("Subagent [{}] announced result to {}", task_id, origin["session_key"])
 
     def _build_subagent_prompt(self) -> str:
         """Build a focused system prompt for the subagent."""

--- a/raven/agent/tools/spawn.py
+++ b/raven/agent/tools/spawn.py
@@ -19,10 +19,7 @@ class _SpawnOrigin:
 
     channel: str
     chat_id: str
-
-    @property
-    def session_key(self) -> str:
-        return f"{self.channel}:{self.chat_id}"
+    session_key: str
 
 
 class SpawnTool(Tool):
@@ -34,15 +31,15 @@ class SpawnTool(Tool):
 
     def __init__(self, manager: "SubagentManager"):
         self._manager = manager
-        self._default = _SpawnOrigin(channel="cli", chat_id="direct")
+        self._default = _SpawnOrigin(channel="cli", chat_id="direct", session_key="cli:direct")
         self._origin: ContextVar[_SpawnOrigin] = ContextVar("spawn_origin")
 
     def _cur(self) -> _SpawnOrigin:
         return self._origin.get(None) or self._default
 
-    def set_context(self, channel: str, chat_id: str) -> None:
+    def set_context(self, channel: str, chat_id: str, session_key: str) -> None:
         """Set the origin context for subagent announcements (turn-local)."""
-        self._origin.set(replace(self._cur(), channel=channel, chat_id=chat_id))
+        self._origin.set(replace(self._cur(), channel=channel, chat_id=chat_id, session_key=session_key))
 
     @property
     def name(self) -> str:

--- a/tests/test_agent_loop_run_emit.py
+++ b/tests/test_agent_loop_run_emit.py
@@ -580,9 +580,9 @@ async def test_run_turn_reconstructs_metadata_from_source_extras(tmp_path):
     seen: dict = {}
     real = loop._set_tool_context
 
-    def _spy(channel, chat_id, message_id=None):
+    def _spy(channel, chat_id, message_id=None, session_key=None):
         seen["message_id"] = message_id
-        return real(channel, chat_id, message_id)
+        return real(channel, chat_id, message_id, session_key=session_key)
 
     loop._set_tool_context = _spy
 
@@ -611,7 +611,7 @@ async def test_run_turn_empty_extras_reconstructs_empty_metadata(tmp_path):
     _stub_edges(loop)
     seen: dict = {"message_id": "sentinel"}
 
-    def _spy(channel, chat_id, message_id=None):
+    def _spy(channel, chat_id, message_id=None, session_key=None):
         seen["message_id"] = message_id
 
     loop._set_tool_context = _spy

--- a/tests/test_sandbox_unit.py
+++ b/tests/test_sandbox_unit.py
@@ -1125,7 +1125,9 @@ class TestSubagentSandboxLifecycle:
                 await manager._announce_result(task_id, label, task, "done", origin, "ok")
 
             manager._run_subagent_inner = _fast_inner
-            await manager._run_subagent("t1", "test task", "test", {"channel": "cli", "chat_id": "direct"})
+            await manager._run_subagent(
+                "t1", "test task", "test", {"channel": "cli", "chat_id": "direct", "session_key": "cli:direct"}
+            )
         finally:
             subagent_mod.build_executor = original
 
@@ -1158,7 +1160,7 @@ class TestSubagentSandboxLifecycle:
             "label",
             "task",
             "done",
-            {"channel": "weixin", "chat_id": "u1"},
+            {"channel": "weixin", "chat_id": "u1", "session_key": "weixin:u1"},
             "ok",
         )
 

--- a/tests/test_security_untrusted_context.py
+++ b/tests/test_security_untrusted_context.py
@@ -84,7 +84,7 @@ async def test_subagent_result_is_fenced(tmp_path: Path) -> None:
         "label",
         "do a thing",
         poison,
-        {"channel": "cli", "chat_id": "direct"},
+        {"channel": "cli", "chat_id": "direct", "session_key": "cli:direct"},
         "ok",
     )
 

--- a/tests/test_subagent_manager.py
+++ b/tests/test_subagent_manager.py
@@ -168,3 +168,45 @@ async def test_cancel_by_session_clears_spawn_history(monkeypatch):
 
     await mgr.cancel_by_session("sessA")
     assert "sessA" not in mgr._session_spawn_times
+
+
+async def test_announce_result_routes_to_tui_session_key(monkeypatch):
+    """TUI origins pass an authoritative session_key distinct from channel:chat_id
+    (chat_id falls back to "default" while the live subscription is keyed by
+    session_key); the re-injected TurnRequest must land on that session, not on
+    the derived channel:chat_id."""
+    mgr = _make_manager(max_concurrent=1)
+    submitted = []
+    mgr.set_submit(lambda req: submitted.append(req))
+
+    await mgr._announce_result(
+        task_id="t1",
+        label="label",
+        task="task",
+        result="result",
+        origin={"channel": "tui", "chat_id": "default", "session_key": "tui:sess123"},
+        status="ok",
+    )
+
+    assert len(submitted) == 1
+    assert submitted[0].conversation == "tui:sess123"
+
+
+async def test_announce_result_routes_non_tui_origin_unchanged(monkeypatch):
+    """Non-TUI origins (e.g. a channel with a real chat_id) still announce on
+    their existing channel:chat_id conversation — no regression."""
+    mgr = _make_manager(max_concurrent=1)
+    submitted = []
+    mgr.set_submit(lambda req: submitted.append(req))
+
+    await mgr._announce_result(
+        task_id="t2",
+        label="label",
+        task="task",
+        result="result",
+        origin={"channel": "whatsapp", "chat_id": "12345", "session_key": "whatsapp:12345"},
+        status="ok",
+    )
+
+    assert len(submitted) == 1
+    assert submitted[0].conversation == "whatsapp:12345"

--- a/tests/test_subagent_manager.py
+++ b/tests/test_subagent_manager.py
@@ -210,3 +210,24 @@ async def test_announce_result_routes_non_tui_origin_unchanged(monkeypatch):
 
     assert len(submitted) == 1
     assert submitted[0].conversation == "whatsapp:12345"
+
+
+def test_build_subagent_prompt_does_not_start_skill_watcher(monkeypatch):
+    """_build_subagent_prompt uses a transient ContextBuilder just for
+    _build_runtime_context; it must not leave a skill-catalog file watcher
+    running behind it (one leaked watchfiles/inotify thread per spawn)."""
+    import raven.agent.context as context_mod
+
+    calls = []
+    real_init = context_mod.ContextBuilder.__init__
+
+    def _spy_init(self, workspace, *args, **kwargs):
+        calls.append(kwargs.get("start_watcher", True))
+        return real_init(self, workspace, *args, **kwargs)
+
+    monkeypatch.setattr(context_mod.ContextBuilder, "__init__", _spy_init)
+
+    mgr = _make_manager(max_concurrent=1)
+    mgr._build_subagent_prompt()
+
+    assert calls == [False]


### PR DESCRIPTION
## Summary

A spawned subagent's result never reached the TUI. `_announce_result` re-injected the summary turn on conversation `channel:chat_id`, which for the TUI collapses to `tui:default` (the TUI sends no `chat_id`), while the live front-end subscribes on the session key `tui:<session_id>`. The turn was delivered to a subscriber-less session (persisted to a phantom `default` session file) and never rendered.

Two related fixes in the subagent path:

1. **Route subagent results to the originating session.** Thread the parent turn's authoritative conversation key into the subagent origin as a required `_SpawnOrigin.session_key` field (removing the derived `channel:chat_id` fallback, so the mis-route cannot recur through a future call path), and route the announce on it. Non-TUI origins (channels, CLI, proactive) route identically to before. The now-misleading announce debug log is corrected to report the real conversation.
2. **Stop leaking a skill-catalog file watcher per spawn.** `_build_subagent_prompt` built a transient `ContextBuilder` only to read a runtime-context string, but that unconditionally started a `watchfiles`/inotify watcher which was never stopped, leaking one watcher thread and fd per spawn (eventually `Too many open files`). Add a `start_watcher` passthrough to `ContextBuilder` and disable it for the transient builder; the main agent loop's builder is unchanged.

Complements #71 (which redirects the TUI's stdout/stderr fds to the log file, masking the terminal symptom of such errors); this PR fixes the underlying routing bug and the fd leak itself. Supersedes #67 (same routing bug, closed as duplicate) — this branch takes the stronger required-field form and also fixes the debug log.

## Type

- [x] Fix

## Verification

Commands run:

- `uv run pytest tests/test_subagent_manager.py tests/test_agent_loop_run_emit.py tests/test_sandbox_unit.py tests/test_security_untrusted_context.py -q` -> 107 passed (rebased on latest main)
- `uv run ruff check` on the five changed files -> All checks passed

New tests (RED proven against pre-fix code before implementing):

- `test_announce_result_routes_to_tui_session_key`
- `test_announce_result_routes_non_tui_origin_unchanged`
- `test_build_subagent_prompt_does_not_start_skill_watcher`

Live TUI smoke: spawned a subagent; its result now renders in the originating session (`tui:<session_id>`), and the phantom `default` session is no longer written.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed (N/A: no doc or UI-surface change)

## Risk

- [x] Security impact considered (the subagent result is still wrapped as untrusted before re-injection; unchanged)
- [x] Backward compatibility considered (non-TUI origins route identically; only the TUI mis-route changes)
- [x] Rollback path is clear for risky changes (revert the two commits; no schema, dependency, or wire-contract change)

## Related Issues

Supersedes #67 (closed as duplicate). No tracked issue for the root-cause bug.
