### PR TITLE
test(tui): assert chat e2e pipeline liveness, drop model-content probe

### DIFF
--- a/tests/tui/autotest/tests/test_e2e_raven_chat_cli.py
+++ b/tests/tui/autotest/tests/test_e2e_raven_chat_cli.py
@@ -1,41 +1,99 @@
-"""E2E: `raven chat` line-mode round-trip with real Qwen provider.
+"""E2E: `raven chat` line-mode round-trip — pipeline liveness.
 
 Controls-on chat path for the alt-screen ACCEPTANCE gate
-(test_e2e_raven_tui_chat). If THIS test fails, chat layer is broken
+(test_e2e_raven_tui_chat). If THIS test fails, the chat layer is broken
 regardless of TUI; if THIS passes but tui_chat fails, the bug is in the
 TUI/RPC/Ink path.
 
-Requires user has OpenRouter / Qwen provider configured locally
-(per spike verification 2026-05-20 — `~/.raven/config.json`).
+Like the TUI acceptance test, this asserts the chat PIPELINE is alive (a turn
+runs through and the app exits cleanly), NOT any specific model output —
+asserting a particular answer is non-deterministic.
+
+Currently xfail(strict): `raven chat` is not a registered top-level subcommand
+(the CLI exposes channels / cron / provider / sandbox / sentinel / skill / tui /
+sessions, no `chat`). The body is written as a liveness round-trip so that the
+day a `chat` REPL lands, strict-xfail flips this to a real failure and the test
+becomes a live liveness check with no further edits.
+
+Requires an accessible default model configured locally (`~/.raven/config.json`);
+without one the run skips rather than fails.
 """
 
 from __future__ import annotations
 
+import re
+import time
+
 import pytest
+
+from tests.tui.autotest.runner import BackendError
+
+_PROMPT = "Reply with a short friendly sentence."
+
+# Working-state verbs mirrored from ui-tui/src/content/verbs.ts (VERBS); the
+# CLI REPL shares the turn-state vocabulary. Keep in sync with that pool.
+_WORKING_RE = re.compile(
+    r"\b(pondering|contemplating|musing|cogitating|ruminating|deliberating|"
+    r"mulling|reflecting|processing|reasoning|analyzing|computing|"
+    r"synthesizing|formulating|brainstorming)…",
+    re.IGNORECASE,
+)
+_READY_RE = re.compile(r"\bready\b", re.IGNORECASE)
 
 
 @pytest.mark.e2e
 @pytest.mark.xfail(
     reason=(
-        "`raven chat` top-level subcommand still does not exist on "
-        "20260519-TUI-refactor post tui-chat L2-A merge — tui-chat "
-        "scope was TUI streaming side only (turn.send/turn.subscribe + "
-        "SubscriptionEmitter). CLI `chat` REPL is a separate piece. Live "
-        "chat ACCEPTANCE for now = `test_e2e_raven_tui_chat.py` (TUI "
-        "alt-screen, wired post tui-chat). strict=True ensures this test "
-        "starts FAILing if a `chat` subcommand lands."
+        "`raven chat` top-level subcommand does not exist — the CLI exposes "
+        "channels / cron / provider / sandbox / sentinel / skill / tui / "
+        "sessions, with no `chat` REPL. Live chat ACCEPTANCE for now is "
+        "`test_e2e_raven_tui_chat.py` (TUI alt-screen). strict=True ensures "
+        "this test starts FAILing the day a `chat` subcommand lands."
     ),
     strict=True,
 )
-def test_chat_cli_qwen_round_trip(harness):
+def test_chat_cli_round_trip(harness):
     harness.spawn("uv run raven chat")
     # Wait for chat REPL prompt; the exact glyph may vary but ❯ is the
     # prompt-toolkit-style indicator we saw during spike.
     assert harness.wait(r"❯|>", timeout=15.0), f"chat REPL prompt not ready in 15s; screen=\n{harness.screen()}"
-    harness.type("What's your model's name?")
+
+    harness.type(_PROMPT)
     harness.press("enter")
-    assert harness.wait(r"Qwen", timeout=60.0), f"Qwen model did not respond within 60s; screen=\n{harness.screen()}"
+
+    # Race the working state against model_not_available from t=0 — a blocking
+    # skip-probe would blind us to a transient working phase.
+    started = False
+    deadline = time.monotonic() + 20.0
+    while time.monotonic() < deadline:
+        screen = harness.screen()
+        if re.search(r"error:\s*model_not_available", screen):
+            pytest.skip(
+                "default model returned model_not_available — the pipeline "
+                "could not run a turn; configure an accessible default model "
+                "and re-run."
+            )
+        if _WORKING_RE.search(screen):
+            started = True
+            break
+        time.sleep(0.2)
+    assert started, (
+        "pipeline liveness failed: no turn started (status never entered a "
+        f"working state) within 20s of submitting.\nscreen=\n{harness.screen()}"
+    )
+    assert harness.wait(_READY_RE, timeout=60.0), (
+        "pipeline liveness failed: the turn never completed (status did not "
+        f"return to ready) within 60s.\nscreen=\n{harness.screen()}"
+    )
+
+    # Turn settled; exit via the standard double Ctrl+C (first clears input,
+    # second exits).
     harness.press("ctrl+c")
+    time.sleep(0.5)
+    try:
+        harness.press("ctrl+c")
+    except BackendError:
+        pass  # already exiting after the first Ctrl+C
     assert harness.expect_exit(0, timeout=10.0), (
         f"chat CLI did not exit 0 after Ctrl+C; final screen=\n{harness.screen()}"
     )

--- a/tests/tui/autotest/tests/test_e2e_raven_tui_chat.py
+++ b/tests/tui/autotest/tests/test_e2e_raven_tui_chat.py
@@ -1,24 +1,57 @@
-"""E2E ⭐ ACCEPTANCE: `raven tui` alt-screen chat with real Qwen.
+"""E2E ⭐ ACCEPTANCE: `raven tui` alt-screen chat pipeline liveness.
 
 If this passes, the harness can drive a full Ink alt-screen TUI through
 RPC + streaming + slash routing + Ctrl+C autonomy — i.e., Claude Code can
 independently reproduce any TUI bug from `Bash()`.
 
+This asserts the chat PIPELINE is alive (a prompt is accepted, a turn runs
+through RPC + agent-loop + streaming, and the app exits cleanly), NOT any
+specific model output. Asserting the model produced a particular answer (its
+own name, a fact, a colour) is non-deterministic and therefore an illegitimate
+e2e assertion — the model may or may not self-name, and any factual answer can
+vary run to run.
+
+Liveness is read from the status bar's turn state (working -> ready), which is
+content-agnostic and robust: the Ink alt-screen redraws the entire frame each
+tick (welcome art, borders, side panel), so a naive screen-text delta reports
+chrome as if it were a reply. The turn-state cycle proves the pipeline ran the
+turn regardless of what — or whether — the model rendered any text.
+
 Requires:
 - `tui-use` >=0.1.20 on PATH (npm install -g tui-use)
 - Built `ui-tui/dist/entry.js` (npm install + npm run build in ui-tui/)
-- User has OpenRouter / Qwen provider configured
+- An accessible default model configured (else the run skips, not fails)
 
 Ink Ctrl+C autonomy yields exit 0, NOT 130. expect_exit(0) is correct.
 """
 
 from __future__ import annotations
 
+import re
+import time
+
 import pytest
+
+from tests.tui.autotest.runner import BackendError
+
+# Content-neutral prompt: we never assert WHAT the model says, only that the
+# pipeline ran the turn.
+_PROMPT = "Reply with a short friendly sentence."
+
+# Working-state verbs the status bar shows while a turn is in flight, mirrored
+# from ui-tui/src/content/verbs.ts (VERBS). Keep in sync with that pool.
+_WORKING_RE = re.compile(
+    r"\b(pondering|contemplating|musing|cogitating|ruminating|deliberating|"
+    r"mulling|reflecting|processing|reasoning|analyzing|computing|"
+    r"synthesizing|formulating|brainstorming)…",
+    re.IGNORECASE,
+)
+# Idle turn state in the status bar (word-bounded so "readiness" won't match).
+_READY_RE = re.compile(r"\bready\b", re.IGNORECASE)
 
 
 @pytest.mark.e2e
-def test_tui_chat_qwen_round_trip(harness):
+def test_tui_chat_round_trip(harness):
     # turn.send/turn.subscribe + SubscriptionEmitter are wired; this test
     # runs as a regular live E2E ACCEPTANCE for the chat streaming path
     # through the TUI.
@@ -30,21 +63,45 @@ def test_tui_chat_qwen_round_trip(harness):
     assert harness.wait(r"Raven", timeout=25.0), (
         f"TUI Raven readiness banner not seen in 25s; screen=\n{harness.screen()}"
     )
-    harness.type("What's your model's name?")
+
+    harness.type(_PROMPT)
     harness.press("enter")
-    assert harness.wait(r"Qwen", timeout=60.0), f"Qwen model did not respond within 60s; screen=\n{harness.screen()}"
-    # Cancel UX volatile post-streaming (same class as dogfood overlay tests).
-    # Use Esc + Ctrl+C robust pattern.
-    import time as _t
 
-    from tests.tui.autotest.runner import BackendError
-
-    for key in ("escape", "ctrl+c"):
-        try:
-            harness.press(key)
-        except BackendError:
+    # Liveness, content-agnostic: the pipeline accepts the prompt (status bar
+    # enters a working state) and completes the turn (status returns to ready).
+    # Race the working state against model_not_available from t=0 — a blocking
+    # skip-probe would blind us to a working phase that starts and ends inside
+    # its window (the status verb is transient).
+    started = False
+    deadline = time.monotonic() + 20.0
+    while time.monotonic() < deadline:
+        screen = harness.screen()
+        if re.search(r"error:\s*model_not_available", screen):
+            pytest.skip(
+                "default model returned model_not_available — the pipeline "
+                "could not run a turn; configure an accessible default model "
+                "and re-run."
+            )
+        if _WORKING_RE.search(screen):
+            started = True
             break
-        _t.sleep(0.5)
-    assert harness.expect_exit(0, timeout=10.0), (
-        f"TUI did not exit 0 after Esc+Ctrl+C; final screen=\n{harness.screen()}"
+        time.sleep(0.2)
+    assert started, (
+        "pipeline liveness failed: no turn started (status bar never entered a "
+        f"working state) within 20s of submitting.\nscreen=\n{harness.screen()}"
     )
+    assert harness.wait(_READY_RE, timeout=60.0), (
+        "pipeline liveness failed: the turn never completed (status bar did not "
+        f"return to ready) within 60s.\nscreen=\n{harness.screen()}"
+    )
+
+    # Turn has settled (status returned to ready); exit via the standard Raven
+    # double Ctrl+C (first clears any composer/overlay state, second exits), the
+    # pattern the idle/typing Ctrl+C e2e tests use.
+    harness.press("ctrl+c")
+    time.sleep(0.5)
+    try:
+        harness.press("ctrl+c")
+    except BackendError:
+        pass  # already exiting after the first Ctrl+C
+    assert harness.expect_exit(0, timeout=10.0), f"TUI did not exit 0 after Ctrl+C; final screen=\n{harness.screen()}"


### PR DESCRIPTION
## Summary

The two `raven` chat e2e tests asserted specific model output — `harness.wait("Qwen")`
after asking "What's your model's name?" — which is non-deterministic: the model may
not self-name, and any factual answer varies run to run, so the tests false-fail even
when chat works. This reworks both to assert the chat PIPELINE ran a turn instead,
content-agnostic.

- `test_tui_chat_qwen_round_trip` -> `test_tui_chat_round_trip`: submit a
  content-neutral prompt, assert the status bar enters a working state (verbs mirrored
  from `ui-tui/src/content/verbs.ts`) then returns to `ready`, plus `expect_exit(0)`.
  A `model_not_available` skip is raced from t=0 so a blocking skip-probe cannot blind
  the transient working verb.
- `test_chat_cli_qwen_round_trip` -> `test_chat_cli_round_trip`: the `raven chat`
  subcommand still does not exist (the CLI exposes channels / cron / provider / sandbox
  / sentinel / skill / tui / sessions, no `chat`), so this stays `xfail(strict=True)`;
  the body is rewritten as a liveness round-trip and the reason refreshed, so the day a
  `chat` REPL lands, strict-xfail flips it to a real liveness check with no further edits.

Turn-state liveness is used over a screen-text delta because the Ink alt-screen redraws
the whole frame each tick (welcome art, borders, side panel), which makes a naive text
delta report chrome as if it were a reply. Test-only; no product code changed.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other (test-only)

## Verification

- `uv run pytest tests/tui/autotest -m "not e2e"` -> 38 passed, 24 deselected
- `uv run ruff check` + `uv run ruff format` on both files -> clean
- `uv run pytest tests/tui/autotest/tests/test_e2e_raven_tui_chat.py -m e2e` (live) ->
  the liveness assertion (`working -> ready`) passes reliably; the run then fails only
  at `expect_exit(0)` because `raven tui` currently segfaults on exit (exit code 139)
  on this host. That crash is pre-existing and independent of this change — the other
  tui e2e exit tests (`test_e2e_ctrl_c`, `test_e2e_tui_status_slash`) fail identically;
  it should be triaged as its own bug. A full e2e green needs that crash resolved.
- `test_chat_cli_round_trip` -> xfailed (strict), as expected while `raven chat` is absent.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

EVE-27 (internal tracker). No GitHub issue.