### PR TITLE
docs: use https for install urls in install.ps1 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ internals may still evolve before v1.0.
 ### Installation
 
 ```bash
-curl -fsSL http://raven.evermind.ai/install.sh | bash
+curl -fsSL https://raven.evermind.ai/install.sh | bash
 ```
 
 ### Release Status

--- a/install.ps1
+++ b/install.ps1
@@ -1,7 +1,7 @@
 # Raven one-line installer for native Windows PowerShell.
 #
 # Remote:
-#   irm http://raven.evermind.ai/install.ps1 | iex
+#   irm https://raven.evermind.ai/install.ps1 | iex
 #
 # Goal: a clean Windows machine ends up able to run `raven` / `raven tui`
 # without admin rights. The script is idempotent: it reuses existing tools when


### PR DESCRIPTION
## Change description

The one-line install snippets should always show `https://`, never `http://`. #75 already fixed both READMEs. This aligns the two remaining public-facing occurrences so nothing exposes a plaintext `http://` install URL:

- `install.ps1` line 4 -- the header usage comment (`irm http://... | iex` -> `https`)
- `CHANGELOG.md` -- the macOS install snippet (`curl ... http://... | bash` -> `https`)

Both are non-executable text (a comment and a doc snippet); the scripts' actual download logic is unaffected. Users who copy-paste the shown command now get an all-encrypted first hop instead of a plaintext request that only reaches https via the 308 redirect.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Document
- [ ] Others

## Checklists

### Development
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security
- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review
- [x] Pull request has a descriptive title and context useful to a reviewer