### PR TITLE
docs: drop dangling adr reference from CONTEXT.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,7 +17,7 @@ session key (`channel:chat_id`). Identity lives in the `chat_id` slot: a TUI/CLI
 session mints an opaque, sortable `chat_id` (`%Y%m%d_%H%M%S_xxxxxx`), so one surface
 can hold many sessions while the `session_key={channel}:{chat_id}` invariant is
 unchanged. Channel is a dimension (key prefix + store subdirectory + metadata
-field), not part of the user-facing identity. See `docs/adr/0001`.
+field), not part of the user-facing identity.
 
 **Session id** (user-facing term only):
 The bare `chat_id` value shown to and accepted from users (the channel prefix is


### PR DESCRIPTION
## Change description

The tracked root `CONTEXT.md` ended the Session definition with `See `docs/adr/0001``, but the `docs/adr/` tree is git-excluded and never landed in the tracked repo (the project converged at 0 ADRs). The pointer therefore dangled.

This removes the trailing clause. The Session definition is self-contained without it; no other content changes.

## Type of change
- [x] Document

## Checklists

### Development
- [x] Application changes have been tested thoroughly

### Security
- [x] Security impact of change has been considered

### Code review
- [x] Merge request has a descriptive title and context useful to a reviewer