### PR TITLE
docs: simplify readme header badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,6 @@
   <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_社区-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
 </p>
 
-<p align="center">
-  <a href="https://github.com/EverMind-AI/raven/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/EverMind-AI/raven/ci.yml?branch=main&label=CI" alt="CI"></a>
-  <a href="https://github.com/EverMind-AI/raven/releases"><img src="https://img.shields.io/github/v/release/EverMind-AI/raven?label=Release" alt="Release"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/EverMind-AI/raven" alt="License"></a>
-  <img src="https://img.shields.io/badge/Python-3.12%2B-3776AB?logo=python&logoColor=white" alt="Python 3.12+">
-</p>
-
 [Website](https://raven.evermind.ai) · [中文](README.zh-CN.md)
 
 </div>
@@ -32,7 +25,7 @@ Raven helps agents improve across runs by continuously refining the systems arou
   <img src="https://github.com/user-attachments/assets/a4dc5b21-c8e7-4397-95e1-50afeeb826e4" alt="Starting Raven from the command line" width="100%">
 </p>
 
-<details open>
+<details>
   <summary><kbd>Table of Contents</kbd></summary>
 
 <br>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,13 +9,6 @@
   <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_社区-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
 </p>
 
-<p align="center">
-  <a href="https://github.com/EverMind-AI/raven/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/EverMind-AI/raven/ci.yml?branch=main&label=CI" alt="CI"></a>
-  <a href="https://github.com/EverMind-AI/raven/releases"><img src="https://img.shields.io/github/v/release/EverMind-AI/raven?label=Release" alt="Release"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/EverMind-AI/raven" alt="License"></a>
-  <img src="https://img.shields.io/badge/Python-3.12%2B-3776AB?logo=python&logoColor=white" alt="Python 3.12+">
-</p>
-
 [官网](https://raven.evermind.ai) · [English](README.md)
 
 </div>
@@ -36,7 +29,7 @@ runtime、policies 和工作环境。EverOS 为这个 harness 提供跨会话持
   <img src="https://github.com/user-attachments/assets/a4dc5b21-c8e7-4397-95e1-50afeeb826e4" alt="从命令行启动 Raven" width="100%">
 </p>
 
-<details open>
+<details>
   <summary><kbd>目录</kbd></summary>
 
 <br>


### PR DESCRIPTION
## Summary
- Remove the CI, release, license, and Python version badge row from the English and Chinese README headers.
- Collapse the README table of contents by default in both languages.

## Impact
This keeps the project header cleaner while preserving the community links and language navigation.

## Validation
- `git diff --check -- README.md README.zh-CN.md`
- `rg -n "github/actions/workflow/status|github/v/release|github/license|Python-3\\.12|<details open>" README.md README.zh-CN.md` returned no matches.