### PR TITLE
fix(cli): hard-exit past finalization to avoid lancedb segfault (139)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ eval = [
 ]
 
 [project.scripts]
-raven = "raven.cli.commands:app"
+raven = "raven.cli.commands:run"
 
 [build-system]
 requires = ["hatchling"]

--- a/raven/__main__.py
+++ b/raven/__main__.py
@@ -2,7 +2,7 @@
 Entry point for running Raven as a module: python -m raven
 """
 
-from raven.cli.commands import app
+from raven.cli.commands import run
 
 if __name__ == "__main__":
-    app()
+    run()

--- a/raven/cli/_exit.py
+++ b/raven/cli/_exit.py
@@ -1,0 +1,46 @@
+"""Hard-exit past CPython interpreter finalization for native-unsafe runtimes.
+
+Building the agent loop opens a lancedb-backed store, and lancedb starts a
+process-global ``LanceDBBackgroundEventLoop`` (Rust/tokio) daemon thread with
+no public shutdown hook. Finalizing the interpreter while that native runtime
+is still live segfaults (``Py_FinalizeEx``; SIGSEGV, exit 139), masking the
+command's real exit code. Every raven command that builds the loop starts that
+thread, so the guard lives once at the CLI exit chokepoint
+(:func:`raven.cli.commands.run`): when the hazard is live, flush and
+``os._exit`` past finalization.
+
+CliRunner invokes the Typer ``app`` object directly (in-process), never the
+console-script ``run`` wrapper, so test hosts keep normal exit semantics.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from typing import NoReturn
+
+
+def lancedb_finalization_hazard() -> bool:
+    """Whether lancedb's Rust/tokio background thread is live in this process.
+
+    Merely importing lancedb is safe — the thread only exists once a connection
+    is opened — so key on the live thread, not the imported module.
+    """
+    return any(t.name == "LanceDBBackgroundEventLoop" for t in threading.enumerate())
+
+
+def flush_and_hard_exit(code: int) -> NoReturn:
+    """Flush stdio + loguru sinks, then ``os._exit`` past interpreter finalization."""
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except (ValueError, OSError):
+        pass
+    try:
+        from loguru import logger
+
+        logger.remove()
+    except Exception:
+        pass
+    os._exit(code & 0xFF)

--- a/raven/cli/agent_commands.py
+++ b/raven/cli/agent_commands.py
@@ -14,7 +14,6 @@ This module owns:
 from __future__ import annotations
 
 import asyncio
-import os
 import signal
 import sys
 
@@ -461,15 +460,10 @@ def register(app: typer.Typer) -> None:
                             )
 
             asyncio.run(run_once())
-            # One-shot headless exit: torch's global teardown segfaults during
-            # interpreter finalization (faulthandler shows a C-level fault with
-            # no Python frame, torch._C in the loaded extensions). The response
-            # is already printed and MCP/extractions drained inside run_once(),
-            # so hard-exit to skip the buggy native destructors. Scripted /
-            # subprocess callers otherwise see a spurious returncode 139.
-            sys.stdout.flush()
-            sys.stderr.flush()
-            os._exit(0)
+            # Native runtimes loaded by the agent loop (lancedb's Rust/tokio
+            # thread, torch) segfault during interpreter finalization. The exit
+            # chokepoint in raven.cli.commands.run hard-exits past finalization
+            # when that hazard is live, so this path just returns normally.
         else:
             # Interactive mode — user turns run through spine (submit -> lane ->
             # hub -> CliOutlet); cron/sentinel nudges go via the spine hub

--- a/raven/cli/commands.py
+++ b/raven/cli/commands.py
@@ -146,5 +146,28 @@ from raven.cli.session_commands import session_app
 app.add_typer(session_app, name="sessions")
 
 
+def run() -> None:
+    """Console-script entry point.
+
+    Runs the Typer app, then hard-exits past CPython interpreter finalization
+    when a native runtime that segfaults at finalization is live (lancedb's
+    Rust/tokio background thread — see :mod:`raven.cli._exit`). Any command that
+    builds the agent loop starts that thread, so guarding here covers them all
+    at once. CliRunner invokes ``app`` directly and never reaches this wrapper,
+    so in-process test hosts keep normal exit semantics.
+    """
+    from raven.cli._exit import flush_and_hard_exit, lancedb_finalization_hazard
+
+    try:
+        app()
+    except SystemExit as exc:
+        code = exc.code
+        if not isinstance(code, int):
+            code = 0 if code is None else 1
+        if lancedb_finalization_hazard():
+            flush_and_hard_exit(code)
+        raise
+
+
 if __name__ == "__main__":
-    app()
+    run()

--- a/tests/integration/test_tui_exit_e2e.py
+++ b/tests/integration/test_tui_exit_e2e.py
@@ -1,0 +1,93 @@
+"""`raven` commands that build the agent loop must not segfault on exit.
+
+The agent loop opens a lancedb-backed store; lancedb starts a process-global
+Rust/tokio background thread (``LanceDBBackgroundEventLoop``) with no public
+shutdown hook. A normal CPython interpreter finalization races that live native
+runtime and segfaults (exit 139), masking the command's real exit code and
+failing ``expect_exit(0)`` for the whole TUI e2e suite.
+
+Fix: the CLI exit chokepoint ``raven.cli.commands.run`` hard-exits past
+finalization (flush stdio + loguru, then ``os._exit``) when
+``raven.cli._exit.lancedb_finalization_hazard`` reports the thread live. These
+tests build the real agent loop in a subprocess so the native thread is
+genuinely live.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# Exit code the child uses to signal "agent loop could not be built in this
+# environment" (e.g. no provider configured) so the test skips instead of
+# reporting a false regression.
+_BUILD_FAILED = 42
+
+_BUILD_LOOP = """
+import sys
+try:
+    from raven.cli.tui_commands import _build_tui_agent_loop
+    loop = _build_tui_agent_loop()
+except BaseException as e:
+    print(f"BUILD_FAILED: {type(e).__name__}: {e}", file=sys.stderr)
+    sys.exit(42)
+"""
+
+
+def _run(child_src: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(child_src)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+# Exit code the child uses to signal "the hazard gate failed to detect the
+# live lancedb thread" — distinct from a clean 0 or the build-failed sentinel.
+_HAZARD_ABSENT = 43
+
+
+def test_hazard_gate_fires_and_hard_exit_is_clean():
+    """After building the loop the hazard gate reports the native thread live
+    (so the CLI chokepoint knows to guard), and exiting via the hard-exit
+    helper returns cleanly (exit 0) instead of a SIGSEGV."""
+    src = (
+        _BUILD_LOOP
+        + "from raven.cli._exit import flush_and_hard_exit, lancedb_finalization_hazard\n"
+        + "if not lancedb_finalization_hazard():\n"
+        + "    sys.exit(43)\n"
+        + "flush_and_hard_exit(0)\n"
+    )
+    result = _run(src)
+    if result.returncode == _BUILD_FAILED:
+        pytest.skip(f"agent loop unbuildable here: {result.stderr.strip()[-200:]}")
+    assert result.returncode != _HAZARD_ABSENT, (
+        "hazard gate did not detect the live lancedb thread after building the loop"
+    )
+    assert result.returncode == 0, (
+        f"hard-exit path did not exit 0 (rc={result.returncode}); "
+        f"stderr tail:\n{result.stderr[-1500:]}"
+    )
+
+
+def test_normal_finalization_still_reproduces_the_crash():
+    """Guard that the hard-exit is load-bearing: with the native memory stack
+    live, a normal interpreter finalization crashes. Skips when the current
+    environment cannot reproduce the crash (so the suite stays green on hosts
+    without the offending native runtime)."""
+    src = _BUILD_LOOP + "sys.exit(0)\n"
+    result = _run(src)
+    if result.returncode == _BUILD_FAILED:
+        pytest.skip(f"agent loop unbuildable here: {result.stderr.strip()[-200:]}")
+    if result.returncode == 0:
+        pytest.skip("native finalization crash not reproducible in this environment")
+    # subprocess.run reports a signal-killed child as a negative return code
+    # (-11 for SIGSEGV, -6 for a Rust abort, etc.); the native runtime tearing
+    # down mid-finalization is a fatal signal, never a clean nonzero exit.
+    assert result.returncode < 0, (
+        f"expected a fatal-signal crash on finalization, got rc={result.returncode}"
+    )

--- a/tests/integration/test_tui_exit_e2e.py
+++ b/tests/integration/test_tui_exit_e2e.py
@@ -69,8 +69,7 @@ def test_hazard_gate_fires_and_hard_exit_is_clean():
         "hazard gate did not detect the live lancedb thread after building the loop"
     )
     assert result.returncode == 0, (
-        f"hard-exit path did not exit 0 (rc={result.returncode}); "
-        f"stderr tail:\n{result.stderr[-1500:]}"
+        f"hard-exit path did not exit 0 (rc={result.returncode}); stderr tail:\n{result.stderr[-1500:]}"
     )
 
 
@@ -88,6 +87,4 @@ def test_normal_finalization_still_reproduces_the_crash():
     # subprocess.run reports a signal-killed child as a negative return code
     # (-11 for SIGSEGV, -6 for a Rust abort, etc.); the native runtime tearing
     # down mid-finalization is a fatal signal, never a clean nonzero exit.
-    assert result.returncode < 0, (
-        f"expected a fatal-signal crash on finalization, got rc={result.returncode}"
-    )
+    assert result.returncode < 0, f"expected a fatal-signal crash on finalization, got rc={result.returncode}"


### PR DESCRIPTION
## Change description

`raven tui` segfaulted on exit (exit code 139 / SIGSEGV) after Ctrl+C, failing
`expect_exit(0)` for the ENTIRE TUI e2e suite (`test_e2e_ctrl_c` both variants,
`test_e2e_tui_status_slash`) and gating live-green for all TUI e2e.

Root cause (verified — not a build artifact; reproduces on a clean build and
with no node child / no TTY): any command that builds the agent loop opens a
lancedb-backed store, and lancedb starts a process-global Rust/tokio background
thread (`LanceDBBackgroundEventLoop`) that is a daemon thread with no public
shutdown hook. A normal CPython interpreter finalization tears down while that
native runtime is still live and segfaults. The crash is 100% in `Py_FinalizeEx`
(both "loop built" and "reached end of main" print before the fault; faulthandler
shows `<no Python frame>` with the pyarrow/numpy lance stack loaded). It is
independent of the long-term memory backend (reproduces with `memory.backend`
disabled too).

Because lancedb has no clean shutdown, the fix guards the single CLI exit
chokepoint rather than one exit path: `raven.cli.commands.run` (the
console-script entry) runs the Typer app, and on the way out — when the lancedb
thread is live — flushes stdio + loguru and `os._exit`s past finalization;
otherwise it exits normally. Every command that builds the loop is covered at
once, so this also subsumes and removes an ad-hoc per-command `os._exit` that
already existed for the `agent` headless one-shot. CliRunner invokes the Typer
app object directly and never reaches the wrapper, so in-process test hosts keep
normal exit semantics.

Verification: real PTY-driven `raven tui` + idle Ctrl+C and cancel-then-exit
Ctrl+C both exit 0 (were 139); `--help` / `--version` and other no-loop commands
still exit normally; new subprocess regression test builds the real loop, asserts
the hazard gate fires, and confirms a clean guarded exit (with a companion test
that the crash reproduces under normal finalization, so the guard stays
load-bearing); the full in-process CliRunner TUI + CLI-smoke suites pass.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Document
- [ ] Others

## Related issues (if there is)

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary