### PR TITLE
docs: drop the pr-preview prohibition from the collab spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,6 @@ Filling rules:
 
 **Not allowed:**
 - pushing and walking away, leaving PR creation to the user;
-- running `gh pr create` without letting the user preview the description (they must get a chance to edit);
 - delivering a description without grepping for non-English residue.
 
 ---


### PR DESCRIPTION
## Summary

Remove the `AGENTS.md` §3.7 "Not allowed" bullet that forbade running
`gh pr create` without a user preview of the description. Opening a PR with a
drafted description no longer requires a separate preview round-trip.

The other §3.7 guardrails stay in force: no pushing-and-walking-away, and the
non-English residue grep before creating a PR.

`CLAUDE.md` is a symlink to `AGENTS.md`, so both reflect the change.

## Type

- [ ] Fix
- [ ] Feature
- [x] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `CLAUDE.md -> AGENTS.md` symlink confirmed; the removed line is gone from both.

## Risk

- [x] Backward compatibility considered

Documentation-only change to the collaboration spec; no code impact.

## Related Issues

N/A
