### PR TITLE
fix(tui): preserve streamed content when a turn is cancelled

### DIFF
--- a/ui-tui/src/__tests__/chatStream.test.ts
+++ b/ui-tui/src/__tests__/chatStream.test.ts
@@ -14,6 +14,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { TurnEvent, TurnSendResult } from '../rpc/index.js'
+import type { Msg } from '../types.js'
 
 import { createChatStream, type ChatStreamRpcClient } from '../app/chatStream.js'
 import { turnController } from '../app/turnController.js'
@@ -276,5 +277,114 @@ describe('createChatStream — wedge defenses', () => {
 
     expect(sysCalls.some(m => /no response/i.test(m))).toBe(false)
     expect(stream.isTurnActive()).toBe(true)
+  })
+})
+
+describe('createChatStream — cancel preserves streamed content', () => {
+  beforeEach(() => {
+    resetTurnState()
+    resetUiState()
+    turnController.fullReset()
+  })
+
+  it('keeps the streamed partial in the transcript on a server cancelled_by_client', async () => {
+    const appended: Msg[] = []
+    const fake = makeFakeRpc()
+    const stream = createChatStream({
+      appendMessage: m => appended.push(m),
+      rpcClient: fake,
+      sessionKey: 'tui:default'
+    })
+    await stream.attach()
+    patchUiState({ busy: true })
+    await stream.send('question')
+
+    fake.__pushEvent({ type: 'message.start', payload: { turn_id: 'turn-1' } })
+    fake.__pushEvent({ type: 'token.delta', payload: { text: 'Partial answer so far' } })
+    fake.__pushEvent({
+      type: 'error',
+      payload: { code: -32000, message: 'cancelled', reason: 'cancelled_by_client' }
+    })
+
+    const assistant = appended.find(m => m.role === 'assistant')
+    expect(assistant).toBeDefined()
+    expect(assistant!.text).toContain('Partial answer so far')
+    expect(assistant!.text).toContain('[interrupted]')
+  })
+
+  it('keeps the streamed partial in the transcript on a local forceReset', async () => {
+    const appended: Msg[] = []
+    const fake = makeFakeRpc()
+    const stream = createChatStream({
+      appendMessage: m => appended.push(m),
+      rpcClient: fake,
+      sessionKey: 'tui:default'
+    })
+    await stream.attach()
+    patchUiState({ busy: true })
+    await stream.send('question')
+
+    fake.__pushEvent({ type: 'message.start', payload: { turn_id: 'turn-1' } })
+    fake.__pushEvent({ type: 'token.delta', payload: { text: 'Half a reply' } })
+
+    stream.forceReset()
+
+    const assistant = appended.find(m => m.role === 'assistant')
+    expect(assistant).toBeDefined()
+    expect(assistant!.text).toContain('Half a reply')
+    expect(assistant!.text).toContain('[interrupted]')
+  })
+
+  it('does not emit a redundant interrupted note when a second cancel re-enters after content was already preserved', async () => {
+    const appended: Msg[] = []
+    const sysCalls: string[] = []
+    const fake = makeFakeRpc()
+    const stream = createChatStream({
+      appendMessage: m => appended.push(m),
+      rpcClient: fake,
+      sessionKey: 'tui:default',
+      sys: m => sysCalls.push(m)
+    })
+    await stream.attach()
+    patchUiState({ busy: true })
+    await stream.send('question')
+
+    fake.__pushEvent({ type: 'message.start', payload: { turn_id: 'turn-1' } })
+    fake.__pushEvent({ type: 'token.delta', payload: { text: 'A streamed reply' } })
+
+    // First Ctrl+C escape hatch preserves the partial.
+    stream.forceReset()
+    // The server's cancel error then arrives (turnId was not cleared on cancel),
+    // re-entering finalize on now-empty state.
+    fake.__pushEvent({
+      type: 'error',
+      payload: { code: -32000, message: 'cancelled', reason: 'cancelled_by_client' }
+    })
+
+    // Content preserved exactly once; no spurious second interrupted sys note.
+    expect(appended.filter(m => m.role === 'assistant')).toHaveLength(1)
+    expect(sysCalls.filter(m => m === 'interrupted')).toHaveLength(0)
+  })
+
+  it('does not append an empty assistant message when nothing was streamed', async () => {
+    const appended: Msg[] = []
+    const sysCalls: string[] = []
+    const fake = makeFakeRpc()
+    const stream = createChatStream({
+      appendMessage: m => appended.push(m),
+      rpcClient: fake,
+      sessionKey: 'tui:default',
+      sys: m => sysCalls.push(m)
+    })
+    await stream.attach()
+    patchUiState({ busy: true })
+    await stream.send('question')
+
+    fake.__pushEvent({ type: 'message.start', payload: { turn_id: 'turn-1' } })
+    // No token.delta: the turn is cancelled before any content streamed.
+    stream.forceReset()
+
+    expect(appended.some(m => m.role === 'assistant')).toBe(false)
+    expect(sysCalls).toContain('interrupted')
   })
 })

--- a/ui-tui/src/app/chatStream.ts
+++ b/ui-tui/src/app/chatStream.ts
@@ -132,7 +132,7 @@ const dispatch = (
       onMessageComplete(state, event, appendMessage)
       return
     case 'error':
-      onError(state, event, sys)
+      onError(state, event, sys, appendMessage)
       return
     case 'cron.delivered': {
       if (sys) {
@@ -202,11 +202,16 @@ const onMessageComplete = (
   patchUiState({ status: 'ready' })
 }
 
-const onError = (state: InternalState, ev: ErrorEvent, sys?: (msg: string) => void): void => {
+const onError = (
+  state: InternalState,
+  ev: ErrorEvent,
+  sys?: (msg: string) => void,
+  appendMessage?: (msg: Msg) => void
+): void => {
   const { reason, message, code } = ev.payload
   state.turnId = null
   if (reason === 'cancelled_by_client') {
-    restoreInputPrompt()
+    restoreInputPrompt(appendMessage, sys)
     return
   }
   // Non-cancellation error: surface a sys note, idle the turn, and reset
@@ -219,17 +224,16 @@ const onError = (state: InternalState, ev: ErrorEvent, sys?: (msg: string) => vo
   patchTurnState({ activity: [], outcome: '' })
 }
 
-const restoreInputPrompt = (): void => {
+const restoreInputPrompt = (appendMessage?: (msg: Msg) => void, sys?: (msg: string) => void): void => {
   // Mirror the visible end-state of turnController.interruptTurn without
-  // routing through the legacy `session.interrupt` RPC: drop streaming state,
-  // clear pending tools, release `busy`, and settle status. The
-  // 'interrupted' status hint is consistent with the legacy interrupt path
-  // so users see the same affordance regardless of which chat path is live.
-  turnController.idle()
-  turnController.clearReasoning()
+  // routing through the legacy `session.interrupt` RPC: preserve the streamed
+  // content into the transcript (shared finalize), drop streaming state,
+  // release `busy`, and settle status. The 'interrupted' status hint is
+  // consistent with the legacy interrupt path so users see the same
+  // affordance regardless of which chat path is live.
+  turnController.finalizeInterruptedTurn({ appendMessage, sys })
   turnController.clearStatusTimer()
   patchUiState({ busy: false, status: 'interrupted' })
-  patchTurnState({ activity: [], outcome: '' })
   // Reset to 'ready' after the brief cooldown window so the prompt looks
   // settled if the user is just watching.
   setTimeout(() => {
@@ -266,7 +270,7 @@ export const createChatStream = (opts: ChatStreamOptions): ChatStreamHandle => {
     clearWatchdog()
     sendInFlight = false
     state.turnId = null
-    restoreInputPrompt()
+    restoreInputPrompt(opts.appendMessage, opts.sys)
   }
 
   const armAckWatchdog = (): void => {

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -102,6 +102,11 @@ export interface InterruptDeps {
   sys: (text: string) => void
 }
 
+export interface FinalizeInterruptDeps {
+  appendMessage?: (msg: Msg) => void
+  sys?: (text: string) => void
+}
+
 type Timer = null | ReturnType<typeof setTimeout>
 
 const clear = (t: Timer): null => {
@@ -186,10 +191,18 @@ class TurnController {
     resetFlowOverlays()
   }
 
-  interruptTurn({ appendMessage, gw, sid, sys }: InterruptDeps) {
+  // Preserve the interrupted turn's already-streamed content in the transcript
+  // and drop live turn state. Shared by the legacy `interruptTurn` and the
+  // typed spine cancel path (chatStream.restoreInputPrompt) so the two cannot
+  // diverge on what survives a cancel. `appendMessage`/`sys` are optional:
+  // callers without a transcript sink (older/no-op cases) get the idle-only
+  // teardown with nothing appended.
+  finalizeInterruptedTurn({ appendMessage, sys }: FinalizeInterruptDeps) {
+    // A re-entrant call (e.g. a second Ctrl+C force-reset racing the server's
+    // cancel error) finds turn state already drained: it must not re-emit the
+    // bare interrupted indicator that the first call already surfaced.
+    const reentrant = this.interrupted
     this.interrupted = true
-    gw.request<SessionInterruptResponse>('session.interrupt', { session_id: sid }).catch(() => {})
-
     this.closeReasoningSegment()
 
     const segments = this.segmentMessages
@@ -203,6 +216,10 @@ class TurnController {
     this.clearReasoning()
     this.turnTools = []
     patchTurnState({ activity: [], outcome: '' })
+
+    if (!appendMessage) {
+      return
+    }
 
     for (const msg of segments) {
       appendMessage(msg)
@@ -218,9 +235,15 @@ class TurnController {
         text: partial ? `${partial}\n\n*[interrupted]*` : '*[interrupted]*',
         ...(tools.length && { tools })
       })
-    } else {
-      sys('interrupted')
+    } else if (!reentrant) {
+      sys?.('interrupted')
     }
+  }
+
+  interruptTurn({ appendMessage, gw, sid, sys }: InterruptDeps) {
+    gw.request<SessionInterruptResponse>('session.interrupt', { session_id: sid }).catch(() => {})
+
+    this.finalizeInterruptedTurn({ appendMessage, sys })
 
     patchUiState({ status: 'interrupted' })
     this.clearStatusTimer()


### PR DESCRIPTION
## Change description

In the TUI, pressing Ctrl+C to stop a streaming turn wiped the assistant content that had already streamed into the transcript.

Root cause: the TUI has two turn-cancel paths. The legacy `turnController.interruptTurn()` preserved the streamed content (committing prior segments and folding the in-flight partial into a single `*[interrupted]*` assistant message). The newer typed spine cancel path — `turn.cancel` -> server `error(reason=cancelled_by_client)`, plus the local `forceReset` escape hatch (second Ctrl+C / server-ack watchdog) — routed through `chatStream.restoreInputPrompt`, which only called `turnController.idle()` and dropped the streamed content, never committing it to the transcript. Since the turn path was submitted onto the spine, this typed path is the one users hit. It is a gap in the newer path, not a regression of the earlier cancel rework.

Fix:
- Extract the preserve-into-transcript logic from `interruptTurn` into a shared `TurnController.finalizeInterruptedTurn({ appendMessage, sys })`.
- `interruptTurn` keeps its legacy-only prelude (`session.interrupt` RPC) and postlude (interrupted-status cooldown timer) and delegates the transcript work to the shared method — its visible end-state is unchanged.
- `chatStream.restoreInputPrompt` now calls the shared method with `appendMessage`/`sys` threaded from `onError(cancelled_by_client)` and `forceReset`, so both typed cancel entry points preserve the streamed partial marked interrupted.
- A reentrant guard suppresses a redundant interrupted note when a second cancel (double Ctrl+C) races the server cancel error after content was already preserved.

Scope: TUI (Node) only. No Python / RPC-contract / dependency change.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Document
- [ ] Others

## Related issues (if there is)

> Tracked internally as EVE-63 (no public GitHub issue).

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary