### PR TITLE
test: cover raven 1.0 acceptance cases across session/providers/logging/tui

### DIFF
--- a/tests/test_bedrock_stub.py
+++ b/tests/test_bedrock_stub.py
@@ -1,0 +1,56 @@
+"""Bedrock is a warning-suppress stub, not a real backend.
+
+Two things are pinned so that actually wiring a Bedrock `converse` backend
+later will break a test and force this file to be revisited:
+
+  (a) the import-time log filter drops only the two known LiteLLM
+      botocore-preload warnings and nothing else;
+  (b) there is no Bedrock code path — no `bedrock` provider spec, and the sole
+      bedrock touchpoint in cli/_helpers.py is the ``model.startswith("bedrock/")``
+      key-gate bypass that falls through to LiteLLM (no `converse` call).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import raven.cli._helpers as helpers_mod
+from raven import _LiteLLMBotocorePreloadFilter
+from raven.providers.registry import PROVIDERS, find_by_model, find_by_name
+
+
+def _record(msg: str) -> logging.LogRecord:
+    return logging.LogRecord("LiteLLM", logging.WARNING, __file__, 1, msg, (), None)
+
+
+def test_filter_drops_the_two_botocore_preload_warnings():
+    filt = _LiteLLMBotocorePreloadFilter()
+    assert filt._patterns == (
+        "could not pre-load bedrock-runtime response stream shape",
+        "could not pre-load sagemaker-runtime response stream shape",
+    )
+    for pattern in filt._patterns:
+        assert filt.filter(_record(pattern)) is False
+
+
+def test_filter_keeps_unrelated_log_records():
+    filt = _LiteLLMBotocorePreloadFilter()
+    assert filt.filter(_record("a perfectly normal log line")) is True
+
+
+def test_no_bedrock_provider_in_registry():
+    assert "bedrock" not in {spec.name for spec in PROVIDERS}
+    assert find_by_name("bedrock") is None
+    # A bedrock-prefixed model without provider keywords resolves to no spec —
+    # nothing in the registry claims to route Bedrock traffic.
+    assert find_by_model("bedrock/amazon.titan-text-express-v1") is None
+
+
+def test_only_bedrock_touchpoint_is_the_helpers_key_gate_bypass():
+    source = Path(helpers_mod.__file__).read_text(encoding="utf-8")
+    # The sole bedrock reference: the key-gate bypass in make_provider.
+    assert source.count("bedrock") == 1
+    assert 'model.startswith("bedrock/")' in source
+    # No Bedrock Converse backend has been wired in.
+    assert "converse" not in source

--- a/tests/test_cli_gateway_commands.py
+++ b/tests/test_cli_gateway_commands.py
@@ -189,3 +189,22 @@ def test_gateway_channels_excludes_tui_alongside_enabled_im() -> None:
     assert "tui" not in result
     assert "telegram" in result
     assert "discord" not in result
+
+
+def test_stop_dispatch_cancels_both_scheduler_and_subagents() -> None:
+    """The gateway ``/stop`` path must fan out to BOTH the scheduler lane cancel
+    and the subagent-session cancel, summing their counts.
+
+    ``_inbound_dispatch`` is a closure nested inside the gateway serve command
+    with no import seam, so this pins the /stop branch of the command source:
+    dropping either cancel call (or the summed count) breaks this test.
+    """
+    import inspect
+
+    from raven.cli import gateway_commands
+
+    src = inspect.getsource(gateway_commands.register)
+    stop_branch = src.split('if cmd == "/stop":', 1)[1].split('elif cmd == "/restart":', 1)[0]
+    assert "cancel_conversation(cid)" in stop_branch
+    assert "cancel_by_session(cid)" in stop_branch
+    assert "stopped +=" in stop_branch

--- a/tests/test_cli_session_commands.py
+++ b/tests/test_cli_session_commands.py
@@ -339,6 +339,18 @@ def test_fork_unknown_id_errors(patched_workspace: Path) -> None:
     assert r.exit_code != 0
 
 
+def test_fork_empty_session_errors(patched_workspace: Path, manager: SessionManager) -> None:
+    cid = new_chat_id()
+    empty = manager.get_or_create(f"cli:{cid}")
+    manager.save(empty)  # persisted metadata line, zero messages
+    assert manager.exists(f"cli:{cid}")
+
+    r = runner.invoke(session_app, ["fork", cid])
+    assert r.exit_code != 0
+    normalized = " ".join(r.stdout.split())
+    assert "session is empty or missing" in normalized
+
+
 def test_fork_title_option(two_sessions: list[str], patched_workspace: Path, manager: SessionManager) -> None:
     cid = two_sessions[0]
     r = runner.invoke(session_app, ["fork", cid, "--title", "Spinoff"])

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -19,12 +19,18 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from raven.cli.commands import app
 from raven.config.loader import set_config_path
 
 runner = CliRunner()
+
+
+def _registered_command_names() -> set[str]:
+    """All top-level command / subcommand-group names on the root app."""
+    return set(typer.main.get_command(app).commands.keys())
 
 
 @pytest.fixture
@@ -143,3 +149,33 @@ def test_cron_list_body_does_not_crash(tmp_config: Path) -> None:
     r = runner.invoke(app, ["cron", "list"])
     assert r.exception is None
     assert r.exit_code == 0
+
+
+# Full set of top-level commands + subcommand groups registered on the root
+# app (superset of TOP_LEVEL_COMMANDS, which only lists the --help-probed ones).
+REGISTERED_COMMAND_NAMES = {
+    "agent",
+    "channels",
+    "cron",
+    "doctor",
+    "gateway",
+    "onboard",
+    "plugins",
+    "provider",
+    "sandbox",
+    "sentinel",
+    "sessions",
+    "skill",
+    "status",
+    "tui",
+}
+
+
+def test_no_logs_subcommand_registered() -> None:
+    """There is no ``raven logs`` command; adding one must break this test."""
+    assert "logs" not in _registered_command_names()
+
+
+def test_registered_command_set_is_pinned() -> None:
+    """Pin the exact command surface so any add/remove trips a test."""
+    assert _registered_command_names() == REGISTERED_COMMAND_NAMES

--- a/tests/test_litellm_provider_attribution.py
+++ b/tests/test_litellm_provider_attribution.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from raven.providers.litellm_provider import LiteLLMProvider
+from raven.providers.litellm_provider import _ANTHROPIC_EXTRA_KEYS, LiteLLMProvider
 
 
 def _make_provider(provider_name: str, extra_headers: dict | None = None) -> LiteLLMProvider:
@@ -38,3 +38,27 @@ def test_non_openrouter_provider_has_no_attribution():
     assert "X-OpenRouter-Title" not in provider.extra_headers
     assert "HTTP-Referer" not in provider.extra_headers
     assert "X-OpenRouter-Categories" not in provider.extra_headers
+
+
+# --- anthropic wire-format branch of _extra_msg_keys (keyless, no live call) ---
+# Pins the branch at litellm_provider.py `_extra_msg_keys`: the anthropic
+# spec / a "claude" model / an "anthropic/"-prefixed resolved model preserves
+# the `thinking_blocks` message key; everything else preserves nothing.
+
+
+def test_extra_msg_keys_anthropic_spec_preserves_thinking_blocks():
+    keys = LiteLLMProvider._extra_msg_keys("anthropic/claude-opus-4-5", "anthropic/claude-opus-4-5")
+    assert keys == _ANTHROPIC_EXTRA_KEYS
+    assert keys == frozenset({"thinking_blocks"})
+
+
+def test_extra_msg_keys_matches_on_claude_in_original_model():
+    assert LiteLLMProvider._extra_msg_keys("claude-3", "openai/claude-3") == _ANTHROPIC_EXTRA_KEYS
+
+
+def test_extra_msg_keys_matches_on_resolved_anthropic_prefix():
+    assert LiteLLMProvider._extra_msg_keys("some-alias", "anthropic/foo") == _ANTHROPIC_EXTRA_KEYS
+
+
+def test_extra_msg_keys_non_anthropic_preserves_nothing():
+    assert LiteLLMProvider._extra_msg_keys("gpt-4o", "gpt-4o") == frozenset()

--- a/tests/test_no_otel_tracing.py
+++ b/tests/test_no_otel_tracing.py
@@ -1,0 +1,27 @@
+"""Pin the absence of centralized OpenTelemetry tracing / exporter.
+
+Raven has no OTEL dependency and no `raven/**` module imports opentelemetry.
+Adding an OTEL exporter dependency (or an import) later must break this test so
+the decision is revisited deliberately.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import raven
+
+
+def test_opentelemetry_is_not_a_dependency():
+    assert importlib.util.find_spec("opentelemetry") is None
+
+
+def test_no_raven_module_imports_opentelemetry():
+    root = Path(raven.__file__).resolve().parent
+    offenders = [
+        str(path.relative_to(root))
+        for path in root.rglob("*.py")
+        if "opentelemetry" in path.read_text(encoding="utf-8")
+    ]
+    assert offenders == []

--- a/tests/test_openai_codex_provider.py
+++ b/tests/test_openai_codex_provider.py
@@ -1,0 +1,34 @@
+"""Shape tests for OpenAICodexProvider (Responses API), no live call / no key.
+
+Pins that this provider targets the OpenAI Responses endpoint and sends the
+experimental Responses beta header — so a switch away from the Responses API
+trips a test.
+"""
+
+from __future__ import annotations
+
+from raven.providers.openai_codex_provider import (
+    DEFAULT_CODEX_URL,
+    OpenAICodexProvider,
+    _build_headers,
+)
+
+
+def test_default_url_targets_codex_responses_endpoint():
+    assert DEFAULT_CODEX_URL == "https://chatgpt.com/backend-api/codex/responses"
+    assert DEFAULT_CODEX_URL.endswith("/codex/responses")
+
+
+def test_headers_declare_experimental_responses_beta():
+    headers = _build_headers(account_id="acct-123", token="tok-abc")
+    assert headers["OpenAI-Beta"] == "responses=experimental"
+    assert headers["Authorization"] == "Bearer tok-abc"
+    assert headers["chatgpt-account-id"] == "acct-123"
+    assert headers["accept"] == "text/event-stream"
+
+
+def test_provider_default_model_is_codex():
+    provider = OpenAICodexProvider(default_model="openai-codex/gpt-5.1-codex")
+    assert provider.get_default_model() == "openai-codex/gpt-5.1-codex"
+    # OAuth-based: constructed without an API key.
+    assert provider.api_key is None

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -1,0 +1,88 @@
+"""Catalog-shape tests for the LLM provider registry and backend classes.
+
+These pin the *current* shape so that adding / removing a provider spec or a
+concrete backend class trips a test instead of silently drifting.
+"""
+
+from __future__ import annotations
+
+from raven.providers.base import LLMProvider
+from raven.providers.registry import PROVIDERS
+
+# The Confluence "Providers" page claims 19 providers. This pins the current
+# registry so any drift (add/remove a ProviderSpec) is caught here.
+EXPECTED_PROVIDER_NAMES = {
+    "custom",
+    "azure_openai",
+    "openrouter",
+    "aihubmix",
+    "siliconflow",
+    "volcengine",
+    "anthropic",
+    "openai",
+    "openai_codex",
+    "github_copilot",
+    "deepseek",
+    "gemini",
+    "zhipu",
+    "dashscope",
+    "moonshot",
+    "minimax",
+    "vllm",
+    "ollama",
+    "groq",
+}
+
+
+def test_registry_has_exactly_19_providers() -> None:
+    assert len(PROVIDERS) == 19
+    assert len(EXPECTED_PROVIDER_NAMES) == 19
+
+
+def test_registry_provider_name_set_is_pinned() -> None:
+    assert {spec.name for spec in PROVIDERS} == EXPECTED_PROVIDER_NAMES
+
+
+def test_provider_names_are_unique() -> None:
+    names = [spec.name for spec in PROVIDERS]
+    assert len(names) == len(set(names))
+
+
+def _concrete_provider_subclasses() -> set[type]:
+    """All non-abstract LLMProvider subclasses defined in raven.providers."""
+    # Import each backend module so its subclass is registered on LLMProvider.
+    import raven.providers.azure_openai_provider  # noqa: F401
+    import raven.providers.custom_provider  # noqa: F401
+    import raven.providers.litellm_provider  # noqa: F401
+    import raven.providers.openai_codex_provider  # noqa: F401
+
+    seen: set[type] = set()
+    stack = list(LLMProvider.__subclasses__())
+    while stack:
+        cls = stack.pop()
+        stack.extend(cls.__subclasses__())
+        if getattr(cls, "__abstractmethods__", frozenset()):
+            continue
+        if cls.__module__.startswith("raven.providers"):
+            seen.add(cls)
+    return seen
+
+
+def test_exactly_four_concrete_backend_classes() -> None:
+    # Only 3 are runtime-dispatched via cli/_helpers.py `_get_provider`
+    # (LiteLLM / AzureOpenAI / OpenAICodex); CustomProvider is legacy and not
+    # wired. This asserts class existence only, not the dispatch wiring.
+    from raven.providers.azure_openai_provider import AzureOpenAIProvider
+    from raven.providers.custom_provider import CustomProvider
+    from raven.providers.litellm_provider import LiteLLMProvider
+    from raven.providers.openai_codex_provider import OpenAICodexProvider
+
+    expected = {
+        LiteLLMProvider,
+        AzureOpenAIProvider,
+        OpenAICodexProvider,
+        CustomProvider,
+    }
+    assert _concrete_provider_subclasses() == expected
+    for cls in expected:
+        assert issubclass(cls, LLMProvider)

--- a/tests/test_subagent_manager.py
+++ b/tests/test_subagent_manager.py
@@ -170,6 +170,32 @@ async def test_cancel_by_session_clears_spawn_history(monkeypatch):
     assert "sessA" not in mgr._session_spawn_times
 
 
+async def test_cancel_by_session_cancels_live_task(monkeypatch):
+    """cancel_by_session cancels a still-running asyncio.Task registered under
+    the session (not just the rate-limit bookkeeping)."""
+    mgr = _make_manager(max_concurrent=1)
+    monkeypatch.setattr(manager_mod, "build_executor", lambda *a, **k: _DummyExecutor())
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _blocking_inner(task_id, task, label, origin, executor) -> None:
+        entered.set()
+        await release.wait()  # never set — keeps the task live until cancelled
+
+    monkeypatch.setattr(mgr, "_run_subagent_inner", _blocking_inner)
+
+    assert "started" in await mgr.spawn(task="long", session_key="sessLive")
+    await _settle(entered.is_set)
+    assert mgr.get_running_count() == 1
+    (live_task,) = list(mgr._running_tasks.values())
+
+    cancelled = await mgr.cancel_by_session("sessLive")
+    assert cancelled == 1
+    assert live_task.cancelled()
+    await _settle(lambda: mgr.get_running_count() == 0)
+
+
 async def test_announce_result_routes_to_tui_session_key(monkeypatch):
     """TUI origins pass an authoritative session_key distinct from channel:chat_id
     (chat_id falls back to "default" while the live subscription is keyed by

--- a/tests/test_tui_rpc_stubs.py
+++ b/tests/test_tui_rpc_stubs.py
@@ -99,6 +99,43 @@ async def test_stub_handler_callable_raises_directly(method: str, _msg: str, _hi
         await handler({})
 
 
+def test_no_per_task_progress_rpc_method() -> None:
+    """R7 negative pin: the full production dispatcher exposes NO per-task
+    "progress" RPC method (spawn_tree topology is stub-only). Wiring a real
+    ``task.progress`` / ``spawn_tree.progress`` endpoint later must break here.
+    """
+    from raven.tui_rpc.methods import register_aligned_methods
+
+    d = Dispatcher()
+    register_aligned_methods(d)
+    progress_methods = [m for m in d.methods() if "progress" in m.lower()]
+    assert progress_methods == [], f"unexpected progress RPC method(s): {progress_methods}"
+
+
+def test_process_stop_is_not_supported_stub_exact_shape() -> None:
+    """R8 pin: single-task stop (``process.stop``) is a not-supported stub, not a
+    real endpoint. Assert the EXACT error/hint shape so promoting it to a real
+    per-task stop handler breaks this test."""
+    assert "process.stop" in HERMES_ONLY_STUB_METHODS
+
+    from raven.tui_rpc.methods import register_aligned_methods
+
+    d = Dispatcher()
+    register_aligned_methods(d)
+    assert "process.stop" in d.methods()
+
+
+async def test_process_stop_stub_error_and_hint_exact() -> None:
+    d = Dispatcher()
+    register_stub_methods(d)
+    resp = await d.dispatch({"jsonrpc": "2.0", "id": 1, "method": "process.stop", "params": {}})
+    err = resp["error"]
+    assert err["code"] == -32012
+    assert err["message"] == "not_supported_in_v01"
+    assert err["data"]["error"] == "process.stop not supported; use Ctrl+C"
+    assert err["data"]["hint"] == "Press Ctrl+C in the TUI to interrupt a running turn."
+
+
 async def test_stub_calls_do_not_mutate_dispatcher_state() -> None:
     """Calling stubs repeatedly must not corrupt subsequent dispatches."""
     d = Dispatcher()

--- a/ui-tui/src/__tests__/inputHistory.test.ts
+++ b/ui-tui/src/__tests__/inputHistory.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 EverMind.
+// See NOTICES.md.
+//
+// R14: the composer's up/down history cycling (cycleHistory in
+// useInputHandlers.ts) is a closure inside the hook and not exported, so it
+// walks the backing store returned by useInputHistory -> lib/history.ts. These
+// tests pin that store's contract: insertion order (oldest first, newest last),
+// consecutive dedup, and the on-disk `+`-prefixed round-trip that load() parses
+// back. cycleHistory relies on this ordering: dir<0 starts at the last index
+// (newest) and walks toward index 0 (oldest); dir>0 walks forward again.
+
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import type { append, load } from '../lib/history.js'
+
+interface HistoryModule {
+  append: typeof append
+  load: typeof load
+}
+
+let history: HistoryModule
+
+beforeAll(async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'raven-hist-'))
+
+  vi.stubEnv('RAVEN_HOME', dir)
+  history = await import('../lib/history.js')
+})
+
+afterAll(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('input history store (backs cycleHistory)', () => {
+  it('starts empty when no history file exists', () => {
+    expect(history.load()).toEqual([])
+  })
+
+  it('appends entries in insertion order with newest last', () => {
+    history.append('first command')
+    history.append('second command')
+    history.append('third command')
+
+    const entries = history.load()
+
+    expect(entries).toEqual(['first command', 'second command', 'third command'])
+    // cycle-up (dir<0) surfaces the newest first...
+    expect(entries.at(-1)).toBe('third command')
+    // ...and walks down to the oldest at index 0.
+    expect(entries[0]).toBe('first command')
+  })
+
+  it('deduplicates a repeat of the most recent entry', () => {
+    history.append('third command')
+
+    expect(history.load()).toEqual(['first command', 'second command', 'third command'])
+  })
+
+  it('trims leading/trailing whitespace and ignores blank input', () => {
+    history.append('   ')
+    history.append('  spaced command  ')
+
+    const entries = history.load()
+
+    expect(entries.at(-1)).toBe('spaced command')
+    expect(entries).not.toContain('   ')
+  })
+
+  it('round-trips a multi-line entry through the on-disk format', async () => {
+    history.append('line a\nline b')
+
+    vi.resetModules()
+    const reloaded: HistoryModule = await import('../lib/history.js')
+
+    expect(reloaded.load().at(-1)).toBe('line a\nline b')
+    expect(reloaded.load()).toEqual([
+      'first command',
+      'second command',
+      'third command',
+      'spaced command',
+      'line a\nline b'
+    ])
+  })
+})

--- a/ui-tui/src/__tests__/todoPanel.test.tsx
+++ b/ui-tui/src/__tests__/todoPanel.test.tsx
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 EverMind.
+// See NOTICES.md.
+
+import { render } from 'ink-testing-library'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import type { TodoItem } from '../types.js'
+
+import { TodoPanel } from '../components/todoPanel.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const frameOf = (node: React.ReactElement): string => stripAnsi(render(node).lastFrame() ?? '')
+
+const mixed: TodoItem[] = [
+  { content: 'done item', id: '1', status: 'completed' },
+  { content: 'active item', id: '2', status: 'in_progress' },
+  { content: 'todo item', id: '3', status: 'pending' },
+  { content: 'skip item', id: '4', status: 'cancelled' }
+]
+
+describe('TodoPanel', () => {
+  it('renders each todo item text (R9)', () => {
+    const frame = frameOf(<TodoPanel t={DEFAULT_THEME} todos={mixed} />)
+
+    for (const todo of mixed) {
+      expect(frame).toContain(todo.content)
+    }
+  })
+
+  it('shows a completed / total count (R10)', () => {
+    const frame = frameOf(<TodoPanel t={DEFAULT_THEME} todos={mixed} />)
+
+    // Only `completed` counts toward done; the four-item list has exactly one.
+    expect(frame).toContain('(1/4)')
+  })
+
+  it('renders the per-status glyph on each row (R11)', () => {
+    const frame = frameOf(<TodoPanel t={DEFAULT_THEME} todos={mixed} />)
+
+    expect(frame).toContain('[x] done item')
+    expect(frame).toContain('[>] active item')
+    expect(frame).toContain('[ ] todo item')
+    expect(frame).toContain('[-] skip item')
+  })
+
+  it('renders nothing for an empty list', () => {
+    expect(frameOf(<TodoPanel t={DEFAULT_THEME} todos={[]} />).trim()).toBe('')
+  })
+
+  it('hides rows when collapsed and shows them when expanded (R12)', () => {
+    const collapsed = frameOf(<TodoPanel collapsed t={DEFAULT_THEME} todos={mixed} />)
+    const expanded = frameOf(<TodoPanel collapsed={false} t={DEFAULT_THEME} todos={mixed} />)
+
+    // The header + count survive in both states; only the rows toggle.
+    expect(collapsed).toContain('Todo')
+    expect(collapsed).toContain('(1/4)')
+    expect(collapsed).not.toContain('done item')
+
+    expect(expanded).toContain('done item')
+    expect(expanded).toContain('todo item')
+  })
+
+  it('respects defaultCollapsed for the uncontrolled path (R12)', () => {
+    const frame = frameOf(<TodoPanel defaultCollapsed t={DEFAULT_THEME} todos={mixed} />)
+
+    expect(frame).toContain('Todo')
+    expect(frame).not.toContain('done item')
+  })
+
+  it('updates the completed count when item status changes (R13)', () => {
+    const before: TodoItem[] = [
+      { content: 'a', id: 'a', status: 'completed' },
+      { content: 'b', id: 'b', status: 'pending' },
+      { content: 'c', id: 'c', status: 'pending' }
+    ]
+    const { lastFrame, rerender } = render(<TodoPanel t={DEFAULT_THEME} todos={before} />)
+
+    expect(stripAnsi(lastFrame() ?? '')).toContain('(1/3)')
+
+    const after = before.map(todo => (todo.id === 'b' ? { ...todo, status: 'completed' as const } : todo))
+    rerender(<TodoPanel t={DEFAULT_THEME} todos={after} />)
+
+    expect(stripAnsi(lastFrame() ?? '')).toContain('(2/3)')
+  })
+})

--- a/ui-tui/src/__tests__/useCompletion.test.ts
+++ b/ui-tui/src/__tests__/useCompletion.test.ts
@@ -35,6 +35,22 @@ describe('completionRequestForInput', () => {
     expect(completionRequestForInput('hello there')).toBeNull()
   })
 
+  it('routes a bare @ token through path completion (R16)', () => {
+    expect(completionRequestForInput('@notes.md')).toMatchObject({
+      method: 'complete.path',
+      params: { word: '@notes.md' },
+      replaceFrom: 0
+    })
+  })
+
+  it('routes a trailing @ token after leading text (R16)', () => {
+    expect(completionRequestForInput('read @docs/plan.md')).toMatchObject({
+      method: 'complete.path',
+      params: { word: '@docs/plan.md' },
+      replaceFrom: 5
+    })
+  })
+
   it('returns null for /model (preserved short-circuit)', () => {
     expect(completionRequestForInput('/model')).toBeNull()
     expect(completionRequestForInput('/model ')).toBeNull()


### PR DESCRIPTION
## Summary

Automated test coverage for the automatable rows of the Raven 1.0 acceptance test set (Confluence page "Raven1.0 special test"). Tests only — no product code changed.

Python:
- Session: fork empty-source CLI nonzero exit; live-task cancel via `SubagentManager.cancel_by_session`; `/stop` dual-dispatch pin (scheduler + subagents); tui_rpc stub absence pins (no per-task progress endpoint, no single-task stop).
- Providers: registry count (19) + pinned name set + 4 backend classes; anthropic wire-format keys; codex responses-endpoint shape; bedrock warning-suppress stub with no converse path.
- Logging: no `logs` subcommand pin; no `opentelemetry` dependency pin.

ui-tui:
- TodoPanel render / completed-total count / status glyph / collapse; input-history store; `@`-path completion.

Rows describing superseded behaviour are deliberately not asserted, because current `main` refutes them and existing tests already pin the corrected behaviour:
- session lock-free write / data loss (writes take a cross-process advisory lock and append),
- single global lock serializing all sessions (per-conversation lanes + independent semaphore pools),
- tui_rpc todo server-push (no todo tool is emitted by the RPC server),
- external-editor fill-back (editor content is submitted directly on exit).

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other (tests only)

## Verification

Ran in a clean worktree built with `uv sync --extra channels --extra tools` and a real `npm ci` + hermes-ink/ui-tui builds:

- `uv run pytest <10 touched files>` -> 169 passed
- `uv run ruff check <10 touched files>` -> all checks passed
- ui-tui `npx vitest run <3 touched files>` -> 42 passed
- ui-tui `tsc --noEmit` -> clean
- Re-run green after rebase onto latest `origin/main`.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered (tests only, no runtime or dependency change)
- [x] Backward compatibility considered (no product code touched)
- [x] Rollback path is clear for risky changes (revert the single test commit)

## Related Issues

N/A
