### PR TITLE
ci: skip merge commits in commit-message lint

### DIFF
--- a/scripts/check_commit_messages.py
+++ b/scripts/check_commit_messages.py
@@ -45,7 +45,7 @@ def _default_range() -> str | None:
 
 def _commit_messages(revision_range: str) -> list[tuple[str, str]]:
     output = subprocess.check_output(
-        ["git", "log", "--format=%H%x00%B%x00", revision_range],
+        ["git", "log", "--no-merges", "--format=%H%x00%B%x00", revision_range],
         text=True,
     )
     chunks = output.rstrip("\0").split("\0")

--- a/tests/test_check_commit_messages.py
+++ b/tests/test_check_commit_messages.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from scripts import check_commit_messages
+
+
+def _git(cwd: Path, *args: str) -> str:
+    env = {
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "PATH": os.environ["PATH"],
+    }
+    return subprocess.check_output(["git", *args], cwd=cwd, text=True, env=env).strip()
+
+
+def _init_repo(root: Path) -> None:
+    _git(root, "init", "-q", "-b", "main")
+    (root / "a.txt").write_text("a\n")
+    _git(root, "add", "a.txt")
+    _git(root, "commit", "-qm", "feat: seed initial file")
+
+
+def test_range_with_merge_commit_passes(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    base = _git(repo, "rev-parse", "HEAD")
+
+    _git(repo, "checkout", "-q", "-b", "feature")
+    (repo / "b.txt").write_text("b\n")
+    _git(repo, "add", "b.txt")
+    _git(repo, "commit", "-qm", "feat: add feature file")
+
+    _git(repo, "checkout", "-q", "main")
+    (repo / "c.txt").write_text("c\n")
+    _git(repo, "add", "c.txt")
+    _git(repo, "commit", "-qm", "feat: add main file")
+
+    _git(repo, "checkout", "-q", "feature")
+    _git(repo, "merge", "--no-ff", "-m", "Merge branch 'main' into feature", "main")
+
+    cwd = Path.cwd()
+    try:
+        os.chdir(repo)
+        exit_code = check_commit_messages.main([f"{base}..HEAD"])
+    finally:
+        os.chdir(cwd)
+
+    assert exit_code == 0


### PR DESCRIPTION
## Summary

The commit-message lint rejects any `Merge ...` commit in the PR range
(`scripts/commit_lint.py`: "merge commits are not allowed in PR ranges").
But this repository is squash-only (rebase/merge disabled), so a merge
commit created by syncing `main` into a feature branch is squashed away at
merge time and never reaches `main`. The rule therefore guards nothing while
failing the CI check for every PR that synced `main` via a merge commit
(observed on #82).

The fix makes `scripts/check_commit_messages.py` gather only non-merge
commits by passing `--no-merges` to its `git log` call, mirroring
commitlint's own default of ignoring merge commits. The `Merge ` rule in
`commit_lint.py` is left intact as belt-and-suspenders (it is also reused by
the PR-title path), so no lint behavior is removed.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [x] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_check_commit_messages.py tests/test_commit_lint.py -q` -> 10 passed
- `uv run ruff check scripts/check_commit_messages.py tests/test_check_commit_messages.py` -> All checks passed
- Added TDD coverage in `tests/test_check_commit_messages.py`: builds a real
  temporary repo with a `--no-ff` merge commit and asserts the range passes
  (red before the fix, green after).

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Backward compatible: real commit messages are still linted exactly as
before; only merge commits are now skipped. Rollback is a one-line revert of
the `--no-merges` flag.

## Related Issues

N/A

Co-authored-by: Claude (claude-opus-4-8) <noreply@anthropic.com>