### PR TITLE
feat(agent): progressive tool disclosure for large tool catalogs

### DIFF
--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -260,6 +260,7 @@ class AgentLoop:
         max_subagent_spawns_per_hour: int = 30,
         media_config: Any = None,
         disabled_tools: list[str] | None = None,
+        tool_search_config: Any = None,
         # AG-1: optional plugin-provided MemoryBackend. When supplied,
         # the after-turn pipeline gains a third peer step ``backend.store``
         # (alongside the existing ``maybe_consolidate`` and the implicit
@@ -362,6 +363,7 @@ class AgentLoop:
         # registration and after MCP connect so it can blacklist either group.
         # Used by eval harnesses (e.g. BCP) that need a strict tool subset.
         self._disabled_tools = set(disabled_tools or [])
+        self._tool_search_config = tool_search_config
         self.tools = ToolRegistry()
 
         # Context engine — the single ContextAssembler.
@@ -636,6 +638,41 @@ class AgentLoop:
                         registry=skill_registry,
                     ),
                 )
+
+        # Progressive tool disclosure. Registered last so the catalog it
+        # searches covers every built-in/plugin tool above; MCP tools join
+        # later (registered in ``_connect_mcp``) and the strategy picks them up
+        # since it re-reads the registry each turn.
+        cfg = self._tool_search_config
+        if cfg is not None and cfg.enabled:
+            from raven.agent.tools.tool_search import (
+                DEFAULT_ALWAYS_VISIBLE,
+                ToolCallTool,
+                ToolDescribeTool,
+                ToolSearchController,
+                ToolSearchStrategy,
+                ToolSearchTool,
+            )
+
+            always = set(DEFAULT_ALWAYS_VISIBLE) | set(cfg.always_visible)
+            self.tool_search_controller = ToolSearchController(
+                self.tools,
+                always_visible=always,
+                search_result_limit=cfg.search_result_limit,
+            )
+            self.tools.register(ToolSearchTool(self.tool_search_controller))
+            self.tools.register(ToolDescribeTool(self.tool_search_controller))
+            self.tools.register(ToolCallTool(self.tool_search_controller))
+            # ``first=True``: filter the tool list before CacheOptimizer marks
+            # the final tool with ``cache_control`` (else the marked tool may be
+            # filtered out and the breakpoint lost).
+            self.strategies.register(
+                ToolSearchStrategy(
+                    self.tool_search_controller,
+                    compaction_threshold=cfg.compaction_threshold,
+                ),
+                first=True,
+            )
 
     @staticmethod
     def _build_skill_hub_client(

--- a/raven/agent/tools/tool_index.py
+++ b/raven/agent/tools/tool_index.py
@@ -1,0 +1,102 @@
+"""BM25 keyword index over the agent's tool catalog.
+
+Backs ``tool_search``: ranks tools by a query over their name and description,
+reusing the shared Okapi BM25 in :mod:`raven.utils.bm25` (CJK-aware, so
+Chinese queries match). The name is repeated in the indexed text so a hit on
+the tool name outranks an incidental description hit — the same field-weighting
+idea as the skill ``LocalPool``.
+
+The index rebuilds only when the catalog's ``(name, description)`` set changes
+(startup + each MCP connect is one burst); steady-state ``search`` is one
+query-side tokenize plus a BM25 dot product over precomputed ``doc_freqs``.
+
+A single process-level slot caches the most recently built index keyed by that
+same signature, so the many short-lived agent loops a resident process spins up
+over one fixed tool set reuse one prebuilt BM25 rather than each rebuilding an
+identical one. A single slot suffices because only the main loop feeds this
+index (subagents run a separate minimal tool set), so one signature dominates;
+keying on description (not just name) also forces a rebuild when a tool's
+description changes under hot-reload.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+from raven.utils.bm25 import BM25Okapi, tokenize
+
+if TYPE_CHECKING:
+    from raven.agent.tools.base import Tool
+
+# Catalog signature: the exact inputs to the BM25 build (name + description).
+_Signature = frozenset[tuple[str, str]]
+# A built index: the names list paired with the BM25 built from it (same
+# ordering). Read-only for searchers, so safe to share across loops.
+_BuiltIndex = tuple[list[str], BM25Okapi]
+
+# Single process-level slot, guarded by its own lock. The expensive build runs
+# outside the lock; the lock only guards the slot read/write. A rare concurrent
+# double-build on first miss is harmless — the build is pure, so last-writer-
+# wins yields an identical index (same tolerance as ``LocalPool``).
+_cache_lock = threading.Lock()
+_cached_sig: _Signature = frozenset()
+_cached_index: _BuiltIndex | None = None
+
+
+def _format_tool_text(tool: "Tool") -> str:
+    """Indexed text for one tool. name ×3, description ×1 — TF-based field
+    weighting so a query term on the name dominates a description hit."""
+    name = tool.name
+    desc = tool.description or ""
+    return f"{name} {name} {name} {desc}"
+
+
+def _get_or_build(sig: _Signature, tools: "list[Tool]") -> _BuiltIndex:
+    """Return the shared prebuilt index for ``sig``, building it once on miss."""
+    global _cached_sig, _cached_index
+    with _cache_lock:
+        if sig == _cached_sig and _cached_index is not None:
+            return _cached_index
+    names = [t.name for t in tools]
+    corpus = [tokenize(_format_tool_text(t)) for t in tools]
+    built: _BuiltIndex = (names, BM25Okapi(corpus))
+    with _cache_lock:
+        _cached_sig, _cached_index = sig, built
+    return built
+
+
+class ToolIndex:
+    """Prebuilt BM25 over a tool catalog, rebuilt on (name, description) change.
+
+    Thread-safety: a lock guards the ``(names, BM25Okapi)`` pair. The expensive
+    build is delegated to the shared ``_get_or_build`` slot; the lock here is
+    held only for the atomic swap and for capturing references in ``search``.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._names: list[str] = []
+        self._sig: _Signature = frozenset()
+        self._bm25: BM25Okapi | None = None
+
+    def ensure(self, tools: "list[Tool]") -> None:
+        """Adopt the shared index iff the (name, description) set changed."""
+        sig: _Signature = frozenset((t.name, t.description or "") for t in tools)
+        with self._lock:
+            if sig == self._sig and self._bm25 is not None:
+                return
+        names, bm25 = _get_or_build(sig, tools)
+        with self._lock:
+            self._names, self._bm25, self._sig = names, bm25, sig
+
+    def search(self, query: str, limit: int) -> list[str]:
+        """Return up to ``limit`` tool names ranked by BM25, zero-score dropped."""
+        tokens = tokenize(query)
+        with self._lock:
+            bm25, names = self._bm25, self._names
+        if bm25 is None or not tokens:
+            return []
+        scores = bm25.get_scores(tokens)
+        ranked = sorted(zip(names, scores), key=lambda x: x[1], reverse=True)
+        return [name for name, score in ranked if score > 0.0][:limit]

--- a/raven/agent/tools/tool_search.py
+++ b/raven/agent/tools/tool_search.py
@@ -36,7 +36,11 @@ if TYPE_CHECKING:
     from raven.agent.tools.registry import ToolRegistry
 
 # Core tools kept exposed every turn — the agent would be crippled having to
-# search for these. Config ``tools.tool_search.always_visible`` extends this.
+# search for these. Beyond the file/search/exec primitives, ``message``,
+# ``ask_user`` and ``spawn`` are interaction/orchestration primitives the agent
+# must reach on any turn (reply, unblock via a question, delegate a subagent) —
+# hiding them risks the model not thinking to search for them at all. Config
+# ``tools.tool_search.always_visible`` extends this set.
 DEFAULT_ALWAYS_VISIBLE: tuple[str, ...] = (
     "read_file",
     "write_file",
@@ -46,6 +50,8 @@ DEFAULT_ALWAYS_VISIBLE: tuple[str, ...] = (
     "find",
     "exec",
     "message",
+    "ask_user",
+    "spawn",
 )
 
 TOOL_CALL_NAME: str = "tool_call"

--- a/raven/agent/tools/tool_search.py
+++ b/raven/agent/tools/tool_search.py
@@ -1,0 +1,289 @@
+"""Progressive tool disclosure for large catalogs.
+
+When built-ins + plugins + MCP push the tool count past a threshold, injecting
+every schema into each request burns context that scales with tool count. This
+module withholds most schemas and exposes three meta-tools instead:
+
+  - ``tool_search``   — BM25 keyword search over the hidden catalog; compact
+                        hits (name + description, no parameters).
+  - ``tool_describe`` — one tool's full parameter schema (so the model knows
+                        the argument shape before calling it).
+  - ``tool_call``     — invoke a cataloged tool by name; forwards through the
+                        registry, which still validates arguments.
+
+The tool list sent to the model never changes turn-to-turn (always the core
+set + these three meta-tools), so the prompt cache stays stable across the
+whole session — tools sit ahead of system+messages in the cached prefix, so a
+changing tool list would invalidate everything after it. The cost is that
+cataloged tools are invoked through ``tool_call`` rather than native
+function-calling.
+
+Two visibility tiers per turn (see :class:`ToolSearchStrategy`):
+  - always-visible: a core set + the meta-tools (full schema every turn);
+  - cataloged:      everything else — searchable, schema withheld until asked.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from raven.agent.tools.base import Tool
+from raven.agent.tools.tool_index import ToolIndex
+from raven.token_wise.base import TokenStrategy
+
+if TYPE_CHECKING:
+    from raven.agent.tools.registry import ToolRegistry
+
+# Core tools kept exposed every turn — the agent would be crippled having to
+# search for these. Config ``tools.tool_search.always_visible`` extends this.
+DEFAULT_ALWAYS_VISIBLE: tuple[str, ...] = (
+    "read_file",
+    "write_file",
+    "edit_file",
+    "list_dir",
+    "grep",
+    "find",
+    "exec",
+    "message",
+)
+
+TOOL_CALL_NAME: str = "tool_call"
+# The meta-tools: always registered when the feature is on, never cataloged.
+META_TOOL_NAMES: frozenset[str] = frozenset({"tool_search", "tool_describe", TOOL_CALL_NAME})
+
+
+class ToolSearchController:
+    """Shared state between the meta-tools and the strategy.
+
+    Holds the live registry (the catalog source of truth) and the BM25 index.
+    The visible set is constant (core + meta-tools), which keeps the per-turn
+    tool list — and thus the prompt cache — stable.
+    """
+
+    def __init__(
+        self,
+        registry: "ToolRegistry",
+        *,
+        always_visible: set[str],
+        search_result_limit: int = 10,
+    ) -> None:
+        self._registry = registry
+        self.always_visible = set(always_visible) | META_TOOL_NAMES
+        self.search_result_limit = search_result_limit
+        self._index = ToolIndex()
+
+    def _catalog_tools(self) -> list[Tool]:
+        """All registered tools except the meta-tools (never self-searchable)."""
+        out = []
+        for name in self._registry.tool_names:
+            if name in META_TOOL_NAMES:
+                continue
+            tool = self._registry.get(name)
+            if tool is not None:
+                out.append(tool)
+        return out
+
+    def refresh(self) -> None:
+        """Sync the BM25 index with the current registry (no-op if unchanged)."""
+        self._index.ensure(self._catalog_tools())
+
+    def visible_names(self) -> set[str]:
+        return self.always_visible
+
+    def search(self, query: str, limit: int | None = None) -> list[dict[str, Any]]:
+        """Compact hits: name + description, never parameters."""
+        names = self._index.search(query, limit or self.search_result_limit)
+        hits = []
+        for name in names:
+            tool = self._registry.get(name)
+            if tool is None:
+                continue
+            hits.append({"name": name, "description": tool.description})
+        return hits
+
+    def describe(self, name: str) -> dict[str, Any] | None:
+        """Return the tool's full function schema (for argument shape)."""
+        tool = self._registry.get(name)
+        if tool is None or name in META_TOOL_NAMES:
+            return None
+        return tool.to_schema()["function"]
+
+    async def call(self, name: str, arguments: dict[str, Any] | None) -> str:
+        """Invoke a cataloged tool: forward to the registry (validates args).
+
+        Models sometimes emit the nested ``arguments`` as a JSON string rather
+        than an object; parse that case so the call still goes through.
+        """
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                return "Error: 'arguments' must be a JSON object."
+        if name in META_TOOL_NAMES:
+            return f"Error: '{name}' cannot be invoked via tool_call."
+        if not self._registry.has(name):
+            return f"Error: tool '{name}' not found. Use tool_search to find it."
+        return await self._registry.execute(name, arguments or {})
+
+
+class ToolSearchTool(Tool):
+    """Keyword search over tools whose schemas are not currently loaded."""
+
+    def __init__(self, controller: ToolSearchController) -> None:
+        self._ctrl = controller
+
+    @property
+    def name(self) -> str:
+        return "tool_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search the catalog of additional tools that are available but not "
+            "currently loaded. Returns matching tool names with a short "
+            "description (no parameters). Use tool_describe to see a tool's "
+            "arguments, then tool_call to invoke it. Query with task keywords, "
+            "e.g. 'create github issue' or '生成图片'."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Task keywords describing the capability you need.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max number of results.",
+                    "minimum": 1,
+                    "maximum": 25,
+                },
+            },
+            "required": ["query"],
+        }
+
+    async def execute(self, query: str, limit: int | None = None) -> str:
+        hits = self._ctrl.search(query, limit)
+        if not hits:
+            return f"No tools matched '{query}'. Try broader or different keywords."
+        return json.dumps(hits, ensure_ascii=False)
+
+
+class ToolDescribeTool(Tool):
+    """Return a cataloged tool's full parameter schema."""
+
+    def __init__(self, controller: ToolSearchController) -> None:
+        self._ctrl = controller
+
+    @property
+    def name(self) -> str:
+        return "tool_describe"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Show the full parameter schema of a tool found via tool_search, so "
+            "you know its arguments. Invoke the tool afterwards with tool_call."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Exact tool name from a tool_search result.",
+                },
+            },
+            "required": ["name"],
+        }
+
+    async def execute(self, name: str) -> str:
+        schema = self._ctrl.describe(name)
+        if schema is None:
+            return f"Tool '{name}' not found. Use tool_search to find available tools."
+        return json.dumps(schema, ensure_ascii=False)
+
+
+class ToolCallTool(Tool):
+    """Invoke a cataloged tool by name. Arguments are validated by the registry."""
+
+    def __init__(self, controller: ToolSearchController) -> None:
+        self._ctrl = controller
+
+    @property
+    def name(self) -> str:
+        return TOOL_CALL_NAME
+
+    @property
+    def description(self) -> str:
+        return (
+            "Invoke a tool found via tool_search by name, passing its arguments. "
+            "Use tool_describe first to learn the argument shape."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Exact tool name from a tool_search result.",
+                },
+                "arguments": {
+                    "type": "object",
+                    "description": "Arguments object for the target tool.",
+                },
+            },
+            "required": ["name"],
+        }
+
+    async def execute(self, name: str, arguments: dict[str, Any] | None = None) -> str:
+        return await self._ctrl.call(name, arguments)
+
+
+class ToolSearchStrategy(TokenStrategy):
+    """``before_llm_call`` hook that compacts the tool list for large catalogs.
+
+    At or below ``compaction_threshold`` tools it passes through unchanged (and
+    drops the meta-tools, so small setups are byte-for-byte as before). Above
+    it, only the always-visible core + meta-tools keep their schema in the
+    request; the rest stay reachable via ``tool_search`` / ``tool_call``.
+    """
+
+    def __init__(self, controller: ToolSearchController, *, compaction_threshold: int = 50) -> None:
+        self._ctrl = controller
+        self._compaction_threshold = compaction_threshold
+
+    @property
+    def name(self) -> str:
+        return "tool_search"
+
+    async def before_llm_call(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        model: str,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]] | None, str]:
+        if not tools:
+            return messages, tools, model
+        self._ctrl.refresh()
+        catalog_size = sum(1 for t in tools if t["function"]["name"] not in META_TOOL_NAMES)
+        if catalog_size <= self._compaction_threshold:
+            out = [t for t in tools if t["function"]["name"] not in META_TOOL_NAMES]
+            return messages, out, model
+        present = {t["function"]["name"] for t in tools}
+        if not META_TOOL_NAMES <= present:
+            # Meta-tools unavailable (e.g. removed via disabled_tools): expose
+            # everything rather than strand the cataloged tools behind a search
+            # the model cannot invoke.
+            return messages, tools, model
+        visible = self._ctrl.visible_names()
+        out = [t for t in tools if t["function"]["name"] in visible]
+        return messages, out, model

--- a/raven/cli/agent_commands.py
+++ b/raven/cli/agent_commands.py
@@ -343,6 +343,7 @@ def register(app: typer.Typer) -> None:
             session_manager=session_manager,
             mcp_servers=config.tools.mcp_servers,
             disabled_tools=config.tools.disabled_tools,
+            tool_search_config=config.tools.tool_search,
             sandbox_config=config.tools.sandbox,
             channels_config=config.channels,
             skill_forge_config=skill_forge_cfg,

--- a/raven/cli/gateway_commands.py
+++ b/raven/cli/gateway_commands.py
@@ -223,6 +223,7 @@ def register(app: typer.Typer) -> None:
             session_manager=session_manager,
             mcp_servers=config.tools.mcp_servers,
             disabled_tools=config.tools.disabled_tools,
+            tool_search_config=config.tools.tool_search,
             sandbox_config=config.tools.sandbox,
             channels_config=config.channels,
             router=router,

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -391,6 +391,7 @@ def _build_tui_agent_loop():
             restrict_to_workspace=config.tools.restrict_to_workspace,
             session_manager=session_manager,
             mcp_servers=config.tools.mcp_servers,
+            tool_search_config=config.tools.tool_search,
             sandbox_config=config.tools.sandbox,
             channels_config=config.channels,
             skill_forge_config=skill_forge_cfg,

--- a/raven/config/schema.py
+++ b/raven/config/schema.py
@@ -499,6 +499,28 @@ class MCPServerConfig(Base):
     tool_timeout: int = 30  # seconds before a tool call is cancelled
 
 
+class ToolSearchConfig(Base):
+    """Progressive tool disclosure.
+
+    When the live tool catalog (built-ins + plugins + MCP) grows past
+    ``compaction_threshold``, most tool schemas are withheld from each request and reached
+    on demand through the ``tool_search`` / ``tool_describe`` / ``tool_call``
+    meta-tools, so context cost stops scaling with tool count and the per-turn
+    tool list (and thus the prompt cache) stays stable. At or below the
+    threshold every tool is exposed directly (unchanged behavior) and the
+    meta-tools are omitted.
+    """
+
+    enabled: bool = False
+    compaction_threshold: int = 50
+    """Tool-catalog size that triggers compaction: at or below this many tools
+    everything is exposed directly; above it, schemas are withheld."""
+    search_result_limit: int = 10
+    """Default number of hits ``tool_search`` returns per query."""
+    always_visible: list[str] = Field(default_factory=list)
+    """Extra tool names kept exposed every turn, on top of the core set."""
+
+
 class ToolsConfig(Base):
     """Tools configuration."""
 
@@ -508,6 +530,7 @@ class ToolsConfig(Base):
     restrict_to_workspace: bool = False  # If true, restrict all tool access to workspace directory
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
     sandbox: SandboxConfig = Field(default_factory=SandboxConfig)
+    tool_search: ToolSearchConfig = Field(default_factory=ToolSearchConfig)
     disabled_tools: list[str] = Field(default_factory=list)
     """Tool names to unregister after default-tool registration and MCP connect.
     Used by eval harnesses (e.g. BrowseComp-Plus) that need to constrain the

--- a/raven/memory_engine/skill_local/local_pool.py
+++ b/raven/memory_engine/skill_local/local_pool.py
@@ -21,85 +21,22 @@ costs one query-side tokenize + one BM25 dot-product over precomputed
 ``doc_freqs``; the per-doc tokenize and IDF accumulation only run when
 files actually changed.
 
-A self-contained BM25Okapi implementation (no ``rank_bm25`` / ``jieba`` /
-``nltk`` dependency) keeps the install footprint small. Tokenization is
-regex-based, splitting on word boundaries and treating Chinese characters
-as single tokens — sufficient for skill names + descriptions, which are
-mostly short English domain terms.
+BM25 + tokenization come from :mod:`raven.utils.bm25` (a self-contained
+Okapi BM25, no ``rank_bm25`` / ``jieba`` / ``nltk`` dependency, with CJK-aware
+tokenization) — shared with the agent tool catalog.
 """
 
 from __future__ import annotations
 
-import math
-import re
 import threading
 from typing import TYPE_CHECKING
 
 from raven.memory_engine.skill_local.types import ScoredSkill, SkillMeta
+from raven.utils.bm25 import BM25Okapi as _BM25Okapi
+from raven.utils.bm25 import tokenize as _tokenize
 
 if TYPE_CHECKING:
     from raven.memory_engine.skill_local.registry import SkillRegistry
-
-
-# Match length-≥2 alphanumeric runs OR a single CJK ideograph.
-# ``re`` precompile is module-level to dodge per-call regex setup.
-_TOKEN_RE = re.compile(r"[a-z0-9]{2,}|[一-鿿]")
-
-
-def _tokenize(text: str) -> list[str]:
-    return _TOKEN_RE.findall(text.lower())
-
-
-class _BM25Okapi:
-    """Minimal Okapi BM25 — same formula as rank_bm25 / Lucene defaults.
-
-    ``score(D, Q) = Σ idf(q_i) * f(q_i, D) * (k1 + 1)
-                          / (f(q_i, D) + k1 * (1 - b + b * |D| / avgdl))``
-    """
-
-    def __init__(
-        self,
-        tokenized_corpus: list[list[str]],
-        k1: float = 1.5,
-        b: float = 0.75,
-    ) -> None:
-        self.k1 = k1
-        self.b = b
-        self.corpus_size = len(tokenized_corpus)
-        self.doc_lens = [len(d) for d in tokenized_corpus]
-        self.avgdl = sum(self.doc_lens) / self.corpus_size if self.corpus_size else 0.0
-
-        self.doc_freqs: list[dict[str, int]] = []
-        df: dict[str, int] = {}
-        for doc in tokenized_corpus:
-            freqs: dict[str, int] = {}
-            for tok in doc:
-                freqs[tok] = freqs.get(tok, 0) + 1
-            self.doc_freqs.append(freqs)
-            for tok in freqs:
-                df[tok] = df.get(tok, 0) + 1
-
-        n = self.corpus_size
-        # ``log(1 + (N - n + 0.5) / (n + 0.5))`` — Robertson-Spärck-Jones
-        # weighting; the ``1 +`` guard keeps it non-negative when n ≈ N.
-        self.idf = {term: math.log(1 + (n - count + 0.5) / (count + 0.5)) for term, count in df.items()}
-
-    def get_scores(self, query_tokens: list[str]) -> list[float]:
-        scores = [0.0] * self.corpus_size
-        if not query_tokens or self.corpus_size == 0:
-            return scores
-        for term in query_tokens:
-            idf = self.idf.get(term, 0.0)
-            if idf <= 0.0:
-                continue
-            for i, freqs in enumerate(self.doc_freqs):
-                f = freqs.get(term, 0)
-                if f == 0:
-                    continue
-                dl = self.doc_lens[i]
-                norm = self.k1 * (1 - self.b + self.b * dl / (self.avgdl or 1.0))
-                scores[i] += idf * f * (self.k1 + 1) / (f + norm)
-        return scores
 
 
 def _format_skill_text(meta: SkillMeta, body_max: int = 4000) -> str:

--- a/raven/token_wise/registry.py
+++ b/raven/token_wise/registry.py
@@ -48,9 +48,17 @@ class StrategyRegistry:
                 return s
         return None
 
-    def register(self, strategy: TokenStrategy) -> None:
-        """Append a strategy. Order matters — see class docstring."""
-        self._strategies.append(strategy)
+    def register(self, strategy: TokenStrategy, *, first: bool = False) -> None:
+        """Add a strategy. Order matters — see class docstring.
+
+        ``first=True`` inserts at the front so it runs before the others (e.g.
+        a tool-list filter must run before CacheOptimizer marks the final tool
+        with ``cache_control``); default appends to the end.
+        """
+        if first:
+            self._strategies.insert(0, strategy)
+        else:
+            self._strategies.append(strategy)
 
     # ---- Hooks ----
 

--- a/raven/utils/bm25.py
+++ b/raven/utils/bm25.py
@@ -1,0 +1,74 @@
+"""Dependency-free BM25 keyword retrieval over small in-memory corpora.
+
+A self-contained Okapi BM25 (no ``rank_bm25`` / ``jieba`` / ``nltk``) plus a
+CJK-aware tokenizer, shared by anything that needs cheap keyword ranking over
+a few hundred short documents — file-based skills, tool catalogs, etc.
+
+Tokenization splits on word boundaries and treats each Chinese ideograph as a
+single token, so Chinese queries match instead of collapsing to empty.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+
+# Match length-≥2 alphanumeric runs OR a single CJK ideograph.
+# ``re`` precompile is module-level to dodge per-call regex setup.
+_TOKEN_RE = re.compile(r"[a-z0-9]{2,}|[一-鿿]")
+
+
+def tokenize(text: str) -> list[str]:
+    return _TOKEN_RE.findall(text.lower())
+
+
+class BM25Okapi:
+    """Minimal Okapi BM25 — same formula as rank_bm25 / Lucene defaults.
+
+    ``score(D, Q) = Σ idf(q_i) * f(q_i, D) * (k1 + 1)
+                          / (f(q_i, D) + k1 * (1 - b + b * |D| / avgdl))``
+    """
+
+    def __init__(
+        self,
+        tokenized_corpus: list[list[str]],
+        k1: float = 1.5,
+        b: float = 0.75,
+    ) -> None:
+        self.k1 = k1
+        self.b = b
+        self.corpus_size = len(tokenized_corpus)
+        self.doc_lens = [len(d) for d in tokenized_corpus]
+        self.avgdl = sum(self.doc_lens) / self.corpus_size if self.corpus_size else 0.0
+
+        self.doc_freqs: list[dict[str, int]] = []
+        df: dict[str, int] = {}
+        for doc in tokenized_corpus:
+            freqs: dict[str, int] = {}
+            for tok in doc:
+                freqs[tok] = freqs.get(tok, 0) + 1
+            self.doc_freqs.append(freqs)
+            for tok in freqs:
+                df[tok] = df.get(tok, 0) + 1
+
+        n = self.corpus_size
+        # ``log(1 + (N - n + 0.5) / (n + 0.5))`` — Robertson-Spärck-Jones
+        # weighting; the ``1 +`` guard keeps it non-negative when n ≈ N.
+        self.idf = {term: math.log(1 + (n - count + 0.5) / (count + 0.5)) for term, count in df.items()}
+
+    def get_scores(self, query_tokens: list[str]) -> list[float]:
+        scores = [0.0] * self.corpus_size
+        if not query_tokens or self.corpus_size == 0:
+            return scores
+        for term in query_tokens:
+            idf = self.idf.get(term, 0.0)
+            if idf <= 0.0:
+                continue
+            for i, freqs in enumerate(self.doc_freqs):
+                f = freqs.get(term, 0)
+                if f == 0:
+                    continue
+                dl = self.doc_lens[i]
+                norm = self.k1 * (1 - self.b + self.b * dl / (self.avgdl or 1.0))
+                scores[i] += idf * f * (self.k1 + 1) / (f + norm)
+        return scores

--- a/tests/test_agent_loop_tool_search.py
+++ b/tests/test_agent_loop_tool_search.py
@@ -1,0 +1,94 @@
+"""Wiring tests for tool-search registration inside AgentLoop.__init__.
+
+Covers the ``_register_default_tools`` block: the meta-tools land in the
+registry and the strategy is inserted *first* (so it filters before
+CacheOptimizer marks the final tool), and the whole thing is a no-op when the
+feature is disabled.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from raven.agent.loop import AgentLoop
+from raven.config.schema import ToolSearchConfig
+from raven.providers.base import LLMProvider, LLMResponse
+from raven.token_wise.base import TokenStrategy
+from raven.token_wise.registry import StrategyRegistry
+
+
+class _StubProvider(LLMProvider):
+    def __init__(self) -> None:
+        super().__init__(api_key="test")
+
+    async def chat(
+        self,
+        messages,
+        tools=None,
+        model=None,
+        max_tokens=4096,
+        temperature=0.7,
+        reasoning_effort=None,
+        tool_choice=None,
+    ):
+        return LLMResponse(content="stub", finish_reason="stop")
+
+    def get_default_model(self) -> str:
+        return "stub"
+
+
+class _MarkerStrategy(TokenStrategy):
+    @property
+    def name(self) -> str:
+        return "marker"
+
+
+@pytest.fixture
+def workspace():
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td)
+
+
+def _make_loop(workspace: Path, cfg, strategies=None) -> AgentLoop:
+    return AgentLoop(
+        provider=_StubProvider(),
+        workspace=workspace,
+        model="stub",
+        max_iterations=2,
+        restrict_to_workspace=True,
+        tool_search_config=cfg,
+        strategies=strategies,
+    )
+
+
+def test_enabled_registers_meta_tools(workspace) -> None:
+    loop = _make_loop(workspace, ToolSearchConfig(enabled=True))
+    for name in ("tool_search", "tool_describe", "tool_call"):
+        assert loop.tools.has(name), f"{name} should be registered"
+    assert loop.strategies.get("tool_search") is not None
+
+
+def test_strategy_registered_first(workspace) -> None:
+    # A pre-existing strategy must end up *after* tool_search (which is inserted
+    # first so it filters tools before any cache-marking strategy runs).
+    registry = StrategyRegistry([_MarkerStrategy()])
+    loop = _make_loop(workspace, ToolSearchConfig(enabled=True), strategies=registry)
+    names = [s.name for s in loop.strategies.strategies]
+    assert names[0] == "tool_search", f"tool_search must run first, got {names}"
+    assert "marker" in names
+
+
+def test_disabled_registers_nothing(workspace) -> None:
+    loop = _make_loop(workspace, ToolSearchConfig(enabled=False))
+    for name in ("tool_search", "tool_describe", "tool_call"):
+        assert not loop.tools.has(name)
+    assert loop.strategies.get("tool_search") is None
+
+
+def test_none_config_registers_nothing(workspace) -> None:
+    loop = _make_loop(workspace, None)
+    assert not loop.tools.has("tool_search")
+    assert loop.strategies.get("tool_search") is None

--- a/tests/test_agent_loop_tool_search.py
+++ b/tests/test_agent_loop_tool_search.py
@@ -92,3 +92,19 @@ def test_none_config_registers_nothing(workspace) -> None:
     loop = _make_loop(workspace, None)
     assert not loop.tools.has("tool_search")
     assert loop.strategies.get("tool_search") is None
+
+
+@pytest.mark.asyncio
+async def test_enabled_loop_keeps_interaction_primitives_visible(workspace) -> None:
+    # Above the threshold the strategy compacts the real loop's tool list: the
+    # file/interaction/orchestration primitives (read_file / message / ask_user /
+    # spawn) and the meta-tools keep their schema, while a cataloged domain tool
+    # (web_search) is withheld and reachable only via tool_search.
+    loop = _make_loop(workspace, ToolSearchConfig(enabled=True, compaction_threshold=5))
+    assert loop.tools.has("ask_user") and loop.tools.has("spawn") and loop.tools.has("web_search")
+    tools = loop.tools.get_definitions()
+    _, out, _ = await loop.strategies.before_llm_call([], tools, "stub")
+    names = {t["function"]["name"] for t in out}
+    assert {"read_file", "message", "ask_user", "spawn"} <= names, "primitives must stay visible"
+    assert {"tool_search", "tool_describe", "tool_call"} <= names, "meta-tools must stay visible"
+    assert "web_search" not in names, "cataloged domain tools are withheld above threshold"

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -1,0 +1,65 @@
+"""Tests for the shared BM25 retrieval kernel (raven.utils.bm25)."""
+
+from raven.utils.bm25 import BM25Okapi, tokenize
+
+
+def test_tokenize_alphanumeric_lowercased() -> None:
+    assert tokenize("Generate PDF Report") == ["generate", "pdf", "report"]
+
+
+def test_tokenize_drops_one_char_words() -> None:
+    assert tokenize("a ai OK x y") == ["ai", "ok"]
+
+
+def test_tokenize_handles_chinese_per_char() -> None:
+    # CJK ideographs each become one token; a plain word-boundary regex
+    # would drop them entirely.
+    out = tokenize("生成图片 image")
+    assert "生" in out and "成" in out and "图" in out and "片" in out
+    assert "image" in out
+
+
+def test_tokenize_empty_returns_empty() -> None:
+    assert tokenize("") == []
+    assert tokenize("   ") == []
+
+
+def test_bm25_empty_corpus_scores_empty() -> None:
+    bm25 = BM25Okapi([])
+    assert bm25.get_scores(["foo"]) == []
+
+
+def test_bm25_ranks_matching_doc_highest() -> None:
+    corpus = [
+        tokenize("create github issue tracker"),
+        tokenize("send slack message channel"),
+        tokenize("read local file path"),
+    ]
+    bm25 = BM25Okapi(corpus)
+    scores = bm25.get_scores(tokenize("github issue"))
+    assert scores[0] == max(scores)
+    assert scores[0] > 0.0
+
+
+def test_bm25_idf_suppresses_common_term() -> None:
+    # 'tool' appears in every doc → near-zero IDF; 'weather' is rare → high.
+    corpus = [
+        tokenize("tool weather forecast"),
+        tokenize("tool github issue"),
+        tokenize("tool slack message"),
+    ]
+    bm25 = BM25Okapi(corpus)
+    common = bm25.get_scores(tokenize("tool"))
+    rare = bm25.get_scores(tokenize("weather"))
+    assert max(rare) > max(common)
+
+
+def test_bm25_chinese_query_matches() -> None:
+    corpus = [
+        tokenize("生成图片 image generate"),
+        tokenize("读取文件 read file"),
+    ]
+    bm25 = BM25Okapi(corpus)
+    scores = bm25.get_scores(tokenize("生成图片"))
+    assert scores[0] == max(scores)
+    assert scores[0] > 0.0

--- a/tests/test_cli_tui_commands.py
+++ b/tests/test_cli_tui_commands.py
@@ -86,6 +86,7 @@ def patched_tui_loop_deps(monkeypatch: pytest.MonkeyPatch, tmp_path):
     captured["fake_registry"] = fake_registry
     captured["fake_backend"] = fake_backend
     captured["fake_tools"] = fake_tools
+    captured["config"] = config
     return captured
 
 
@@ -122,6 +123,25 @@ def test_tui_agent_loop_receives_plugin_tools(patched_tui_loop_deps) -> None:
     kwargs = patched_tui_loop_deps["agent_loop_kwargs"]
     assert "plugin_tools" in kwargs, "AgentLoop must receive plugin_tools kwarg"
     assert kwargs["plugin_tools"] is patched_tui_loop_deps["fake_tools"]
+
+
+# ---------------------------------------------------------------------------
+# tool_search config wired into AgentLoop
+# ---------------------------------------------------------------------------
+
+
+def test_tui_agent_loop_receives_tool_search_config(patched_tui_loop_deps) -> None:
+    """``_build_tui_agent_loop`` must forward ``tool_search_config=`` so the
+    interactive TUI honors ``tools.tool_search`` (progressive disclosure) at
+    parity with the ``agent`` / ``gateway`` entrypoints; else the feature is
+    silently unavailable in the primary interactive surface."""
+    from raven.cli.tui_commands import _build_tui_agent_loop
+
+    _build_tui_agent_loop()
+
+    kwargs = patched_tui_loop_deps["agent_loop_kwargs"]
+    assert "tool_search_config" in kwargs, "AgentLoop must receive tool_search_config kwarg"
+    assert kwargs["tool_search_config"] is patched_tui_loop_deps["config"].tools.tool_search
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -1,0 +1,305 @@
+"""Tests for progressive tool disclosure (tool_index + tool_search)."""
+
+import json
+from typing import Any
+
+import pytest
+
+from raven.agent.tools.base import Tool
+from raven.agent.tools.registry import ToolRegistry
+from raven.agent.tools.tool_index import ToolIndex
+from raven.agent.tools.tool_search import (
+    DEFAULT_ALWAYS_VISIBLE,
+    META_TOOL_NAMES,
+    TOOL_CALL_NAME,
+    ToolCallTool,
+    ToolDescribeTool,
+    ToolSearchController,
+    ToolSearchStrategy,
+    ToolSearchTool,
+)
+
+
+class _FakeTool(Tool):
+    def __init__(self, name: str, description: str) -> None:
+        self._name = name
+        self._description = description
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, **kwargs: Any) -> str:
+        return f"ran {self._name}"
+
+
+# ---- ToolIndex ----
+
+
+def test_index_ranks_name_match_first() -> None:
+    idx = ToolIndex()
+    tools = [
+        _FakeTool("create_issue", "open a github issue"),
+        _FakeTool("send_message", "post to a slack channel"),
+    ]
+    idx.ensure(tools)
+    assert idx.search("issue", limit=5)[0] == "create_issue"
+
+
+def test_index_chinese_query_hits() -> None:
+    idx = ToolIndex()
+    tools = [
+        _FakeTool("image_generate", "生成图片 from a text prompt"),
+        _FakeTool("read_file", "读取文件 contents"),
+    ]
+    idx.ensure(tools)
+    assert idx.search("生成图片", limit=5)[0] == "image_generate"
+
+
+def test_index_search_before_ensure_returns_empty() -> None:
+    assert ToolIndex().search("anything", limit=5) == []
+
+
+def test_index_rebuilds_on_name_or_description_change() -> None:
+    idx = ToolIndex()
+    idx.ensure([_FakeTool("a", "alpha")])
+    first = idx._bm25
+    idx.ensure([_FakeTool("a", "alpha")])  # identical catalog
+    assert idx._bm25 is first, "should not rebuild when (name, description) is unchanged"
+    idx.ensure([_FakeTool("a", "alpha changed")])  # description changed
+    assert idx._bm25 is not first, "should rebuild when a description changes"
+    idx.ensure([_FakeTool("a", "alpha changed"), _FakeTool("b", "beta")])  # name set grew
+    assert idx._bm25 is not first, "should rebuild when the name set changes"
+
+
+def test_index_reused_across_instances_for_same_catalog() -> None:
+    tools = [_FakeTool("x", "xray"), _FakeTool("y", "yankee")]
+    first = ToolIndex()
+    first.ensure(tools)
+    second = ToolIndex()
+    second.ensure([_FakeTool("x", "xray"), _FakeTool("y", "yankee")])
+    assert second._bm25 is first._bm25, "same catalog should reuse the cached BM25"
+
+
+# ---- ToolSearchController ----
+
+
+def _controller(registry: ToolRegistry) -> ToolSearchController:
+    return ToolSearchController(
+        registry,
+        always_visible={"read_file"},
+        search_result_limit=10,
+    )
+
+
+def test_controller_search_compact_has_no_parameters() -> None:
+    reg = ToolRegistry()
+    reg.register(_FakeTool("create_issue", "open a github issue"))
+    ctrl = _controller(reg)
+    ctrl.refresh()
+    hits = ctrl.search("github issue")
+    assert hits[0]["name"] == "create_issue"
+    assert "parameters" not in hits[0]
+
+
+def test_controller_describe_returns_full_schema() -> None:
+    reg = ToolRegistry()
+    reg.register(_FakeTool("create_issue", "open a github issue"))
+    ctrl = _controller(reg)
+    fn = ctrl.describe("create_issue")
+    assert fn is not None and fn["name"] == "create_issue" and "parameters" in fn
+
+
+def test_controller_describe_unknown_returns_none() -> None:
+    ctrl = _controller(ToolRegistry())
+    assert ctrl.describe("nope") is None
+
+
+def test_controller_describe_rejects_meta() -> None:
+    assert _controller(ToolRegistry()).describe("tool_search") is None
+
+
+def test_meta_includes_tool_call() -> None:
+    assert TOOL_CALL_NAME in META_TOOL_NAMES
+
+
+def test_visible_names_are_stable_and_include_meta() -> None:
+    ctrl = ToolSearchController(ToolRegistry(), always_visible={"read_file"})
+    assert META_TOOL_NAMES <= ctrl.visible_names()
+    assert ctrl.visible_names() == ctrl.visible_names()
+
+
+def test_meta_tools_not_self_searchable() -> None:
+    reg = ToolRegistry()
+    ctrl = _controller(reg)
+    reg.register(ToolSearchTool(ctrl))
+    reg.register(ToolDescribeTool(ctrl))
+    reg.register(ToolCallTool(ctrl))
+    reg.register(_FakeTool("create_issue", "open a github issue"))
+    ctrl.refresh()
+    names = [h["name"] for h in ctrl.search("tool search describe call")]
+    assert not (META_TOOL_NAMES & set(names))
+
+
+# ---- meta-tools execute ----
+
+
+@pytest.mark.asyncio
+async def test_tool_search_tool_returns_json_hits() -> None:
+    reg = ToolRegistry()
+    reg.register(_FakeTool("create_issue", "open a github issue"))
+    ctrl = _controller(reg)
+    ctrl.refresh()
+    out = await ToolSearchTool(ctrl).execute(query="github issue")
+    assert json.loads(out)[0]["name"] == "create_issue"
+
+
+@pytest.mark.asyncio
+async def test_tool_search_tool_no_match_message() -> None:
+    reg = ToolRegistry()
+    reg.register(_FakeTool("create_issue", "open a github issue"))
+    ctrl = _controller(reg)
+    ctrl.refresh()
+    out = await ToolSearchTool(ctrl).execute(query="zzzznomatch")
+    assert "No tools matched" in out
+
+
+@pytest.mark.asyncio
+async def test_tool_describe_tool_returns_schema() -> None:
+    reg = ToolRegistry()
+    reg.register(_FakeTool("create_issue", "open a github issue"))
+    ctrl = _controller(reg)
+    out = await ToolDescribeTool(ctrl).execute(name="create_issue")
+    assert json.loads(out)["name"] == "create_issue"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_forwards_to_registry() -> None:
+    reg = ToolRegistry()
+    reg.register(_FakeTool("create_issue", "open a github issue"))
+    ctrl = _controller(reg)
+    out = await ToolCallTool(ctrl).execute(name="create_issue", arguments={})
+    assert out == "ran create_issue"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_rejects_meta_and_missing() -> None:
+    ctrl = _controller(ToolRegistry())
+    assert "cannot be invoked" in await ctrl.call("tool_search", {})
+    assert "not found" in await ctrl.call("nope", {})
+
+
+@pytest.mark.asyncio
+async def test_tool_call_parses_stringified_arguments() -> None:
+    reg = ToolRegistry()
+    reg.register(_FakeTool("create_issue", "open a github issue"))
+    ctrl = _controller(reg)
+    # Model emitted the nested arguments as a JSON string instead of an object.
+    out = await ctrl.call("create_issue", '{"x": 1}')
+    assert out == "ran create_issue"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_rejects_unparseable_arguments() -> None:
+    ctrl = _controller(ToolRegistry())
+    assert "must be a JSON object" in await ctrl.call("anything", "not json {")
+
+
+# ---- ToolSearchStrategy ----
+
+
+def _registry_with_n(n: int) -> tuple[ToolRegistry, ToolSearchController]:
+    reg = ToolRegistry()
+    for i in range(n):
+        reg.register(_FakeTool(f"extra_{i}", f"extra tool number {i}"))
+    ctrl = ToolSearchController(
+        reg,
+        always_visible=set(DEFAULT_ALWAYS_VISIBLE),
+        search_result_limit=10,
+    )
+    reg.register(ToolSearchTool(ctrl))
+    reg.register(ToolDescribeTool(ctrl))
+    reg.register(ToolCallTool(ctrl))
+    return reg, ctrl
+
+
+@pytest.mark.asyncio
+async def test_strategy_small_catalog_passthrough_drops_meta() -> None:
+    reg, ctrl = _registry_with_n(3)
+    strat = ToolSearchStrategy(ctrl, compaction_threshold=25)
+    tools = reg.get_definitions()
+    _, out, _ = await strat.before_llm_call([], tools, "m")
+    out_names = {t["function"]["name"] for t in out}
+    assert not (META_TOOL_NAMES & out_names), "meta-tools dropped below threshold"
+    assert "extra_0" in out_names, "all real tools exposed below threshold"
+
+
+@pytest.mark.asyncio
+async def test_strategy_large_catalog_compacts_to_visible() -> None:
+    reg, ctrl = _registry_with_n(40)
+    strat = ToolSearchStrategy(ctrl, compaction_threshold=25)
+    tools = reg.get_definitions()
+    _, out, _ = await strat.before_llm_call([], tools, "m")
+    out_names = {t["function"]["name"] for t in out}
+    assert META_TOOL_NAMES <= out_names, "meta-tools stay visible above threshold"
+    assert "extra_0" not in out_names, "cataloged tools are withheld above threshold"
+
+
+@pytest.mark.asyncio
+async def test_strategy_tool_list_stable_across_turns() -> None:
+    # Core guarantee: the compacted tool list never changes turn-to-turn, so the
+    # prompt cache stays valid (tools sit ahead of system+messages in the prefix).
+    reg, ctrl = _registry_with_n(40)
+    strat = ToolSearchStrategy(ctrl, compaction_threshold=25)
+    first = {t["function"]["name"] for t in (await strat.before_llm_call([], reg.get_definitions(), "m"))[1]}
+    second = {t["function"]["name"] for t in (await strat.before_llm_call([], reg.get_definitions(), "m"))[1]}
+    assert first == second
+    assert META_TOOL_NAMES <= first and "extra_0" not in first
+
+
+@pytest.mark.asyncio
+async def test_strategy_none_tools_passthrough() -> None:
+    _, ctrl = _registry_with_n(40)
+    strat = ToolSearchStrategy(ctrl, compaction_threshold=25)
+    msgs, out, model = await strat.before_llm_call([{"role": "user"}], None, "m")
+    assert out is None and model == "m"
+
+
+@pytest.mark.asyncio
+async def test_strategy_passthrough_when_meta_tools_absent() -> None:
+    # Above threshold but meta-tools missing (e.g. removed via disabled_tools):
+    # expose everything rather than strand cataloged tools.
+    reg, ctrl = _registry_with_n(40)
+    reg.unregister("tool_search")
+    reg.unregister("tool_describe")
+    reg.unregister(TOOL_CALL_NAME)
+    strat = ToolSearchStrategy(ctrl, compaction_threshold=25)
+    tools = reg.get_definitions()
+    _, out, _ = await strat.before_llm_call([], tools, "m")
+    assert {t["function"]["name"] for t in out} == {t["function"]["name"] for t in tools}
+
+
+def test_registry_register_first_runs_before_others() -> None:
+    from raven.token_wise.base import TokenStrategy
+    from raven.token_wise.registry import StrategyRegistry
+
+    class _Noop(TokenStrategy):
+        def __init__(self, tag: str) -> None:
+            self._tag = tag
+
+        @property
+        def name(self) -> str:
+            return self._tag
+
+    reg = StrategyRegistry([_Noop("a"), _Noop("b")])
+    reg.register(_Noop("front"), first=True)
+    reg.register(_Noop("back"))
+    assert [s.name for s in reg.strategies] == ["front", "a", "b", "back"]

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -131,6 +131,24 @@ def test_meta_includes_tool_call() -> None:
     assert TOOL_CALL_NAME in META_TOOL_NAMES
 
 
+def test_default_always_visible_covers_core_and_interaction_primitives() -> None:
+    # File/search/exec primitives plus the interaction/orchestration primitives
+    # (message / ask_user / spawn) the agent must reach on any turn. Guards
+    # against silently dropping one (which would strand it behind tool_search).
+    assert set(DEFAULT_ALWAYS_VISIBLE) >= {
+        "read_file",
+        "write_file",
+        "edit_file",
+        "list_dir",
+        "grep",
+        "find",
+        "exec",
+        "message",
+        "ask_user",
+        "spawn",
+    }
+
+
 def test_visible_names_are_stable_and_include_meta() -> None:
     ctrl = ToolSearchController(ToolRegistry(), always_visible={"read_file"})
     assert META_TOOL_NAMES <= ctrl.visible_names()
@@ -251,6 +269,20 @@ async def test_strategy_large_catalog_compacts_to_visible() -> None:
     out_names = {t["function"]["name"] for t in out}
     assert META_TOOL_NAMES <= out_names, "meta-tools stay visible above threshold"
     assert "extra_0" not in out_names, "cataloged tools are withheld above threshold"
+
+
+@pytest.mark.asyncio
+async def test_strategy_keeps_interaction_primitives_visible_above_threshold() -> None:
+    # ask_user / spawn are in DEFAULT_ALWAYS_VISIBLE, so above the threshold they
+    # keep their schema while ordinary cataloged tools are withheld.
+    reg, ctrl = _registry_with_n(40)
+    reg.register(_FakeTool("ask_user", "ask the user a clarifying question"))
+    reg.register(_FakeTool("spawn", "spawn a subagent to handle a subtask"))
+    strat = ToolSearchStrategy(ctrl, compaction_threshold=25)
+    _, out, _ = await strat.before_llm_call([], reg.get_definitions(), "m")
+    out_names = {t["function"]["name"] for t in out}
+    assert {"ask_user", "spawn"} <= out_names, "interaction primitives must stay visible"
+    assert "extra_0" not in out_names, "ordinary cataloged tools are still withheld"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

<!-- What changed, and why? -->

Adds **progressive tool disclosure** so the per-request tool payload stops
scaling with the tool count. When built-ins + plugins + MCP push the catalog
past a threshold, most tool schemas are withheld and reached on demand through
three meta-tools; the tool list sent to the model stays constant turn-to-turn,
so the prompt cache prefix stays valid.

**Two commits, logically orthogonal:**

1. `refactor(utils)` — lift the self-contained Okapi BM25 + CJK-aware tokenizer
   out of the skill `LocalPool` into `raven.utils.bm25`, so it can also back
   the agent tool catalog. `LocalPool` imports the shared kernel; behavior is
   byte-for-byte unchanged.
2. `feat(agent)` — the feature itself:
   - `tool_index.py` — BM25 index over the tool catalog, rebuilt only on a
     `(name, description)` change, with a process-level single-slot cache shared
     across agent loops.
   - `tool_search.py` — three meta-tools (`tool_search` / `tool_describe` /
     `tool_call`) plus a `TokenStrategy` that compacts the tool list above the
     threshold and passes through unchanged at/below it.
   - `ToolSearchConfig` (`enabled=False`, `compaction_threshold=50`,
     `search_result_limit`, `always_visible`); wired into the `agent`,
     `gateway`, and `tui` entrypoints.
   - `StrategyRegistry.register(first=...)` so the tool-list filter runs before
     any cache-marking strategy.

**Opt-in and inert when off:** the entire registration block is guarded by
`if cfg is not None and cfg.enabled:`, and the default is `enabled=False`. When
disabled, no meta-tools and no strategy are registered, the `tool_search`
module is never imported, and the tool list sent to the model is identical to
before. The only always-on change is the BM25 relocation, which is
behavior-preserving.

## Type

- [ ] Fix
- [x] Feature
- [ ] Docs
- [ ] CI / tooling
- [x] Refactor
- [ ] Other

## Verification

<!-- List the exact commands you ran and the result. -->

- Unit tests for the feature — `uv run pytest tests/test_bm25.py
  tests/test_tool_search.py tests/test_agent_loop_tool_search.py
  tests/test_cli_tui_commands.py -q` → all pass (49 tests).
- Regression scope — ran the core Python suite with and without this change
  (via `git stash`); the pre-existing environmental failures (sandbox VM / TUI
  binary / sentinel) are identical in both, so this change adds zero new
  failures.
- The TUI wiring is a real regression guard — verified the new
  `test_tui_agent_loop_receives_tool_search_config` fails when the wiring line
  is removed and passes when restored.
- Live end-to-end with a real LLM (deepseek-v3.2 via OpenRouter): drove both
  the `agent`-style loop and the production `_build_tui_agent_loop()` path with
  the feature enabled and a 31-tool catalog whose useful tool is hidden; the
  model ran `tool_search` -> `tool_describe` -> `tool_call` and returned the
  secret from the hidden tool. Both PASS.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Backward compatibility: opt-in and off by default; the disabled path is inert
(proven above). The BM25 relocation is the only always-on change and is
behavior-preserving. Rollback is a clean revert of the two commits.

## Related Issues

<!-- Fixes #123, closes #123, or N/A -->

N/A