### PR TITLE
feat(*): add required/optional dimension to channel field specs

### DIFF
--- a/raven/cli/channel_commands.py
+++ b/raven/cli/channel_commands.py
@@ -65,6 +65,7 @@ def _print_schema_table(name: str) -> None:
     table.add_column("Flag", style="cyan", no_wrap=True)
     table.add_column("Type", overflow="fold")
     table.add_column("Default", no_wrap=True)
+    table.add_column("Required?", no_wrap=True, justify="center")
     table.add_column("Secret?", no_wrap=True, justify="center")
     table.add_column("Description", overflow="fold")
     for path, spec in specs.items():
@@ -75,6 +76,7 @@ def _print_schema_table(name: str) -> None:
             flag,
             spec["type"],
             default_str,
+            "✓" if spec.get("required") else "",
             "✓" if spec["is_secret"] else "",
             spec.get("description", "") or "",
         )

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -376,6 +376,20 @@ def _back_placeholder(allow_back: bool) -> Any:
     return [("fg:#6c6c6c italic", _t("empty ↵ to go back", "留空回车返回上一步"))]
 
 
+def _field_placeholder(allow_back: bool, required: bool) -> Any:
+    """In-field hint for a channel credential prompt.
+
+    First field: empty submit rewinds to the channel picker (back). Later
+    optional fields: empty submit skips them. Required later fields get no
+    hint — an empty submit there silently drops a value the channel needs.
+    """
+    if allow_back:
+        return _back_placeholder(True)
+    if not required:
+        return [("fg:#6c6c6c italic", _t("empty ↵ to skip", "留空回车跳过"))]
+    return None
+
+
 def _collect_fields(prompts: list[Callable[[], Any]]) -> Optional[list[Any]]:
     """Run text-prompt callables in order with empty-submit = back.
 
@@ -1547,23 +1561,26 @@ def _prompt_channel_fields(channel: str) -> Any:
 
     fields: dict[str, Any] = {}
     for idx, (path, spec) in enumerate(promptable):
+        required = bool(spec.get("required"))
         description = spec.get("description", "")
-        prompt_label = f"{path}" + (f" — {description}" if description else "") + ":"
-        # First field: an empty submit rewinds to the channel picker. Later
-        # fields keep the "empty = skip this optional field" semantics, so the
-        # back hint only shows on the first one.
+        opt_tag = "" if required else _t(" (optional)", " (可选)")
+        prompt_label = f"{path}{opt_tag}" + (f" — {description}" if description else "") + ":"
+        # First field's empty submit rewinds to the channel picker; later
+        # optional fields' empty submit skips them. Required later fields get
+        # no skip hint so we don't invite dropping a value the channel needs.
         allow_back = idx == 0
+        placeholder = _field_placeholder(allow_back, required)
         if spec.get("is_secret"):
             value = questionary.password(
                 prompt_label,
-                placeholder=_back_placeholder(allow_back),
+                placeholder=placeholder,
                 style=RAVEN_STYLE,
                 qmark=_QMARK,
             ).ask()
         else:
             value = questionary.text(
                 prompt_label,
-                placeholder=_back_placeholder(allow_back),
+                placeholder=placeholder,
                 style=RAVEN_STYLE,
                 qmark=_QMARK,
             ).ask()

--- a/raven/config/schema.py
+++ b/raven/config/schema.py
@@ -30,7 +30,7 @@ class TelegramConfig(Base):
     """Telegram channel configuration."""
 
     enabled: bool = False
-    token: str = ""  # Bot token from @BotFather
+    token: str = Field(default="", json_schema_extra={"required": True})  # Bot token from @BotFather
     allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Allowed user IDs or usernames; ['*'] = anyone
     proxy: str | None = None  # HTTP/SOCKS5 proxy URL, e.g. "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
     reply_to_message: bool = False  # If true, bot replies quote the original message
@@ -43,10 +43,10 @@ class FeishuConfig(Base):
     """Feishu/Lark channel configuration using WebSocket long connection."""
 
     enabled: bool = False
-    app_id: str = ""  # App ID from Feishu Open Platform
-    app_secret: str = ""  # App Secret from Feishu Open Platform
-    encrypt_key: str = ""  # Encrypt Key for event subscription (optional)
-    verification_token: str = ""  # Verification Token for event subscription (optional)
+    app_id: str = Field(default="", json_schema_extra={"required": True})  # App ID from Feishu Open Platform
+    app_secret: str = Field(default="", json_schema_extra={"required": True})  # App Secret from Feishu Open Platform
+    encrypt_key: str = ""  # Encrypt Key for event subscription
+    verification_token: str = ""  # Verification Token for event subscription
     allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Allowed user open_ids; ['*'] = anyone
     react_emoji: str = "THUMBSUP"  # Emoji type for message reactions (e.g. THUMBSUP, OK, DONE, SMILE)
     group_policy: Literal["open", "mention"] = "mention"  # "mention" responds when @mentioned, "open" responds to all
@@ -56,8 +56,8 @@ class DingTalkConfig(Base):
     """DingTalk channel configuration using Stream mode."""
 
     enabled: bool = False
-    client_id: str = ""  # AppKey
-    client_secret: str = ""  # AppSecret
+    client_id: str = Field(default="", json_schema_extra={"required": True})  # AppKey
+    client_secret: str = Field(default="", json_schema_extra={"required": True})  # AppSecret
     allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Allowed staff_ids; ['*'] = anyone
 
 
@@ -65,7 +65,7 @@ class DiscordConfig(Base):
     """Discord channel configuration."""
 
     enabled: bool = False
-    token: str = ""  # Bot token from Discord Developer Portal
+    token: str = Field(default="", json_schema_extra={"required": True})  # Bot token from Discord Developer Portal
     allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Allowed user IDs; ['*'] = anyone
     gateway_url: str = "wss://gateway.discord.gg/?v=10&encoding=json"
     intents: int = 37377  # GUILDS + GUILD_MESSAGES + DIRECT_MESSAGES + MESSAGE_CONTENT
@@ -77,8 +77,8 @@ class MatrixConfig(Base):
 
     enabled: bool = False
     homeserver: str = "https://matrix.org"
-    access_token: str = ""
-    user_id: str = ""  # @bot:matrix.org
+    access_token: str = Field(default="", json_schema_extra={"required": True})
+    user_id: str = Field(default="", json_schema_extra={"required": True})  # @bot:matrix.org
     device_id: str = ""
     e2ee_enabled: bool = True  # Enable Matrix E2EE support (encryption + encrypted room handling).
     sync_stop_grace_seconds: int = (
@@ -100,18 +100,18 @@ class EmailConfig(Base):
     consent_granted: bool = False  # Explicit owner permission to access mailbox data
 
     # IMAP (receive)
-    imap_host: str = ""
+    imap_host: str = Field(default="", json_schema_extra={"required": True})
     imap_port: int = 993
-    imap_username: str = ""
-    imap_password: str = ""
+    imap_username: str = Field(default="", json_schema_extra={"required": True})
+    imap_password: str = Field(default="", json_schema_extra={"required": True})
     imap_mailbox: str = "INBOX"
     imap_use_ssl: bool = True
 
     # SMTP (send)
-    smtp_host: str = ""
+    smtp_host: str = Field(default="", json_schema_extra={"required": True})
     smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
+    smtp_username: str = Field(default="", json_schema_extra={"required": True})
+    smtp_password: str = Field(default="", json_schema_extra={"required": True})
     smtp_use_tls: bool = True
     smtp_use_ssl: bool = False
     from_address: str = ""
@@ -153,7 +153,7 @@ class MochatConfig(Base):
     watch_limit: int = 100
     retry_delay_ms: int = 500
     max_retry_attempts: int = 0  # 0 means unlimited retries
-    claw_token: str = ""
+    claw_token: str = Field(default="", json_schema_extra={"required": True})
     agent_user_id: str = ""
     sessions: list[str] = Field(default_factory=list)
     panels: list[str] = Field(default_factory=list)
@@ -178,8 +178,8 @@ class SlackConfig(Base):
     enabled: bool = False
     mode: str = "socket"  # "socket" supported
     webhook_path: str = "/slack/events"
-    bot_token: str = ""  # xoxb-...
-    app_token: str = ""  # xapp-...
+    bot_token: str = Field(default="", json_schema_extra={"required": True})  # xoxb-...
+    app_token: str = Field(default="", json_schema_extra={"required": True})  # xapp-...
     user_token_read_only: bool = True
     reply_in_thread: bool = True
     react_emoji: str = "eyes"
@@ -195,8 +195,8 @@ class QQConfig(Base):
     """QQ channel configuration using botpy SDK."""
 
     enabled: bool = False
-    app_id: str = ""  # bot AppID from q.qq.com
-    secret: str = ""  # bot AppSecret from q.qq.com
+    app_id: str = Field(default="", json_schema_extra={"required": True})  # bot AppID from q.qq.com
+    secret: str = Field(default="", json_schema_extra={"required": True})  # bot AppSecret from q.qq.com
     allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Allowed user openids; ['*'] = public access
 
 
@@ -204,8 +204,8 @@ class WecomConfig(Base):
     """WeCom (Enterprise WeChat) AI Bot channel configuration."""
 
     enabled: bool = False
-    bot_id: str = ""  # Bot ID from WeCom AI Bot platform
-    secret: str = ""  # Bot Secret from WeCom AI Bot platform
+    bot_id: str = Field(default="", json_schema_extra={"required": True})  # Bot ID from WeCom AI Bot platform
+    secret: str = Field(default="", json_schema_extra={"required": True})  # Bot Secret from WeCom AI Bot platform
     allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Allowed user IDs; ['*'] = anyone
     welcome_message: str = ""  # Welcome message for enter_chat event
 

--- a/raven/config/update_channels.py
+++ b/raven/config/update_channels.py
@@ -129,6 +129,16 @@ def _is_secret_field(field_name: str, field_info: Any) -> bool:
     return any(field_name.endswith(suf) for suf in _SECRET_SUFFIXES)
 
 
+def _is_required_field(field_info: Any) -> bool:
+    """A field is required when explicitly marked ``json_schema_extra={'required': True}``.
+
+    Every channel field carries a Pydantic default (so partial/disabled configs load),
+    so pydantic's own required flag is always False; requiredness is an explicit UX marker.
+    """
+    extra = getattr(field_info, "json_schema_extra", None)
+    return isinstance(extra, dict) and extra.get("required") is True
+
+
 def _walk_nested_path(model_cls: type[BaseModel], dotted_key: str) -> tuple[type[BaseModel], str]:
     """Walk ``a.b.c`` into nested ``BaseModel`` classes.
 
@@ -243,6 +253,7 @@ def _flatten_fields(cls: type[BaseModel], prefix: str = "") -> dict[str, dict[st
             "type": _annotation_str(ann),
             "default": _field_default(finfo),
             "is_secret": _is_secret_field(fname, finfo),
+            "required": _is_required_field(finfo),
             "description": description,
         }
     return out
@@ -284,7 +295,7 @@ def _set_nested(dotted_key: str, value: Any, target: dict[str, Any]) -> Any:
 def channel_field_specs(name: str) -> dict[str, dict[str, Any]]:
     """Reflect a channel schema into a flat ``dotted-path -> spec`` map.
 
-    Each entry has keys: ``type``, ``default``, ``is_secret``, ``description``.
+    Each entry has keys: ``type``, ``default``, ``is_secret``, ``required``, ``description``.
     Used by CLI parsers, the ``channels help`` command, and ``get_channel_config``
     to know which fields exist and which to redact.
     """

--- a/tests/test_channels_required_marker.py
+++ b/tests/test_channels_required_marker.py
@@ -1,0 +1,45 @@
+"""Guard: channel ``required`` markers stay aligned with adapter ``start()`` guards.
+
+Each channel's required set below is the audited truth — the credentials whose
+absence makes the adapter bail on startup (see the referenced guard). The schema
+markers (``Field(json_schema_extra={"required": True})``) must match this table
+exactly. When an adapter changes what it enforces, update the adapter, the schema
+marker, and this table in the same change.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from raven.config.update_channels import channel_field_specs
+
+# channel -> required fields, each backed by the adapter guard that proves it.
+EXPECTED_REQUIRED: dict[str, set[str]] = {
+    "feishu": {"app_id", "app_secret"},  # feishu/channel.py: if not app_id or not app_secret: return
+    "telegram": {"token"},  # telegram/channel.py: if not self.config.token
+    "discord": {"token"},  # discord/channel.py: if not self.config.token
+    "dingtalk": {"client_id", "client_secret"},  # dingtalk/channel.py: if not client_id or not client_secret
+    "qq": {"app_id", "secret"},  # qq/channel.py: if not app_id or not secret
+    "slack": {"bot_token", "app_token"},  # slack/channel.py: if not bot_token or not app_token
+    "wecom": {"bot_id", "secret"},  # wecom/channel.py: if not bot_id or not secret
+    "mochat": {"claw_token"},  # mochat/channel.py: if not self.config.claw_token
+    "email": {  # email/channel.py _validate_config(): all six must be set
+        "imap_host",
+        "imap_username",
+        "imap_password",
+        "smtp_host",
+        "smtp_username",
+        "smtp_password",
+    },
+    # Judgment calls (no hard start() guard) — see the plan for rationale.
+    "matrix": {"access_token", "user_id"},  # fed into AsyncClient; effectively required to connect
+    "whatsapp": set(),  # local bridge; bridge_token auto-generated when empty
+    "weixin": set(),  # credentials arrive via `raven channels login weixin`
+}
+
+
+@pytest.mark.parametrize("channel, expected", sorted(EXPECTED_REQUIRED.items()))
+def test_required_markers_match_audit(channel: str, expected: set[str]) -> None:
+    specs = channel_field_specs(channel)
+    marked = {path for path, spec in specs.items() if spec.get("required")}
+    assert marked == expected

--- a/tests/test_cli_channel_commands.py
+++ b/tests/test_cli_channel_commands.py
@@ -120,6 +120,14 @@ def test_show_lists_all_flags(tmp_config: Path) -> None:
     assert "--group-policy" in out
 
 
+def test_show_has_required_column(tmp_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Widen the render so the extra column's header is not truncated.
+    monkeypatch.setenv("COLUMNS", "200")
+    r = runner.invoke(app, ["channels", "show", "feishu"])
+    assert r.exit_code == 0, r.stdout
+    assert "Required?" in r.stdout
+
+
 def test_help_alias_no_longer_exists(tmp_config: Path) -> None:
     """`channels help <name>` was renamed to `channels show <name>` — verify the
     old verb is gone (no hidden alias).

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1548,3 +1548,45 @@ def test_bootstrap_backfills_preexisting_config(tmp_env: Path, monkeypatch: pyte
     assert data["memory"]["userId"] == "default"
     assert data["plugins"]["config"]["everos-memory"]["mode"] == "embedded"
     assert data["skillForge"]["router"]["hub"]["endpoint"] == "https://skillhub.evermind.ai"
+
+
+def test_prompt_channel_fields_gates_skip_on_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Optional fields get an ``(optional)`` label + skip hint; a required field
+    that is not the first prompt (feishu ``app_secret``) must NOT show a skip
+    hint. Regression guard for the ``idx>0`` heuristic that told users they
+    could skip a required credential.
+    """
+    import questionary
+
+    monkeypatch.setattr(onboard_commands, "_LANG", "en")
+    captured: list[tuple[str, Any]] = []
+
+    class _Prompt:
+        def __init__(self, label: str, placeholder: Any = None, **_: Any) -> None:
+            self._label = label
+            self._placeholder = placeholder
+
+        def ask(self) -> str:
+            captured.append((self._label, self._placeholder))
+            return "x"  # non-empty: records the field without triggering back/skip
+
+    monkeypatch.setattr(questionary, "text", lambda label, **kw: _Prompt(label, **kw))
+    monkeypatch.setattr(questionary, "password", lambda label, **kw: _Prompt(label, **kw))
+
+    onboard_commands._prompt_channel_fields("feishu")
+
+    # promptable order: app_id, app_secret (both required), encrypt_key, verification_token (optional)
+    def _ph_text(placeholder: Any) -> Any:
+        return placeholder[0][1] if placeholder else None
+
+    app_id_lbl, app_id_ph = captured[0]
+    app_secret_lbl, app_secret_ph = captured[1]
+    encrypt_lbl, encrypt_ph = captured[2]
+
+    assert "(optional)" not in app_id_lbl
+    assert "(optional)" not in app_secret_lbl
+    assert "(optional)" in encrypt_lbl
+
+    assert "back" in _ph_text(app_id_ph)  # first field: rewind affordance
+    assert app_secret_ph is None  # required later field: no skip hint
+    assert "skip" in _ph_text(encrypt_ph)  # optional field: skip hint

--- a/tests/test_config_update_channels.py
+++ b/tests/test_config_update_channels.py
@@ -221,6 +221,20 @@ def test_field_specs_marks_known_secrets() -> None:
     assert channel_field_specs("slack")["dm.policy"]["is_secret"] is False
 
 
+def test_field_specs_marks_required() -> None:
+    fs = channel_field_specs("feishu")
+    assert fs["app_id"]["required"] is True
+    assert fs["app_secret"]["required"] is True
+    # Optional credential fields must NOT be marked required.
+    assert fs["encrypt_key"]["required"] is False
+    assert fs["verification_token"]["required"] is False
+    # Non-credential fields (defaults / lists / literals) are optional too.
+    assert fs["allow_from"]["required"] is False
+    assert channel_field_specs("telegram")["token"]["required"] is True
+    # Channels with no hard-required field carry no required marker.
+    assert all(not s["required"] for s in channel_field_specs("whatsapp").values())
+
+
 def test_field_specs_unknown_channel_raises() -> None:
     with pytest.raises(KeyError, match="Unknown channel 'foobar'"):
         channel_field_specs("foobar")


### PR DESCRIPTION
## Summary

Give channel field specs a single source of truth for required/optional: the schema
declares it, `channels show` displays it, and the onboard wizard uses it.

This fixes the onboard wizard's `idx>0` heuristic, which showed an "empty to skip" hint
on required non-first fields (e.g. feishu `app_secret`) — inviting users to skip a
credential the channel needs to start.

- Mark required fields with `Field(json_schema_extra={"required": True})`, mirroring the
  existing `is_secret` escape hatch. Defaults are kept, so `ChannelsConfig`'s
  `default_factory` construction of every channel still loads (no config migration).
- `_flatten_fields` exposes a `required` spec key; `channels show` gains a `Required?` column.
- The wizard gates the skip hint on the marker. This drops the misleading hint only —
  empty submits are still silently ignored as before (no new enforcement added).

Required sets were audited against each adapter's `start()` guard across all 12 channels.
matrix / whatsapp / weixin have no hard guard and are marked by product judgment.

Scope is channels only; providers share the spec model but their table is left unchanged.

## Type

- [x] Feature

## Verification

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally

```
uv run pytest tests/test_config_update_channels.py tests/test_cli_channel_commands.py \
  tests/test_cli_onboard_commands.py tests/test_channels_required_marker.py -q
# 183 passed

uv run ruff check <changed files>           # All checks passed
uv run ruff format --check <changed files>  # already formatted
```

## Risk

- [x] Backward compatibility considered

`json_schema_extra` is inert metadata: no change to validation, serialization, or how
config.json is read/written. Existing configs load unchanged.

## Related Issues

Fixes #84