### PR TITLE
feat(providers): seed model shortlists for direct providers

### DIFF
--- a/raven/providers/common_models.py
+++ b/raven/providers/common_models.py
@@ -9,9 +9,8 @@ configured in ``config.providers.<slug>.models``; users can always type any
 model id by hand (``model.add_model``), so this list only needs to cover the
 common case, not every model.
 
-Model ids drift as providers ship releases — update this list as needed. Only
-``openrouter`` (the default provider) is seeded today; other providers fall
-back to their configured list until curated here.
+Model ids drift as providers ship releases — update this list as needed.
+Providers not listed here fall back to their configured list.
 """
 
 from __future__ import annotations
@@ -19,19 +18,86 @@ from __future__ import annotations
 COMMON_MODELS: dict[str, list[str]] = {
     "openrouter": [
         "anthropic/claude-opus-4.8",
+        "anthropic/claude-opus-4.7",
         "anthropic/claude-sonnet-5",
         "anthropic/claude-fable-5",
         "openai/gpt-5.5",
-        "openai/gpt-5.5-pro",
         "openai/gpt-5.4-mini",
         "google/gemini-3.5-flash",
-        "deepseek/deepseek-v4-pro",
-        "deepseek/deepseek-v4-flash",
+        "google/gemini-3-flash-preview",
         "x-ai/grok-4.3",
-        "qwen/qwen3.7-max",
-        "moonshotai/kimi-k2-thinking",
         "meta-llama/llama-4-maverick",
         "mistralai/mistral-medium-3-5",
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-pro",
+        "xiaomi/mimo-v2.5",
+        "minimax/minimax-m3",
+        "z-ai/glm-5.2",
+        "tencent/hy3",
+        "moonshotai/kimi-k2.6",
+        "qwen/qwen3.7-max",
+    ],
+    "openai": [
+        "openai/gpt-5.5",
+        "openai/gpt-5.5-pro",
+        "openai/gpt-5.4",
+        "openai/gpt-5.4-mini",
+        "openai/gpt-5.4-nano",
+        "openai/gpt-5.3-codex",
+        "openai/gpt-4.1",
+        "openai/gpt-4o-mini",
+    ],
+    "anthropic": [
+        "anthropic/claude-sonnet-5",
+        "anthropic/claude-opus-4-8",
+        "anthropic/claude-opus-4-7",
+        "anthropic/claude-sonnet-4-6",
+        "anthropic/claude-haiku-4-5",
+        "anthropic/claude-fable-5",
+    ],
+    "gemini": [
+        "gemini/gemini-3.5-flash",
+        "gemini/gemini-2.5-pro",
+        "gemini/gemini-2.5-flash",
+        "gemini/gemini-2.5-flash-lite",
+        "gemini/gemini-3.1-pro-preview",
+        "gemini/gemini-3.1-flash-lite",
+        "gemini/gemini-3-flash-preview",
+    ],
+    "groq": [
+        "groq/openai/gpt-oss-120b",
+        "groq/openai/gpt-oss-20b",
+        "groq/llama-3.3-70b-versatile",
+        "groq/llama-3.1-8b-instant",
+        "groq/qwen/qwen3.6-27b",
+    ],
+    "deepseek": [
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-pro",
+    ],
+    "zhipu": [
+        "zai/glm-5.2",
+        "zai/glm-5.1",
+        "zai/glm-5",
+        "zai/glm-4.7",
+        "zai/glm-4.6",
+        "zai/glm-4.5-air",
+        "zai/glm-4.5",
+        "zai/glm-4.7-flash",
+        "zai/glm-4.5-flash",
+    ],
+    "dashscope": [
+        "dashscope/qwen-plus",
+        "dashscope/qwen-max",
+        "dashscope/qwen-flash",
+        "dashscope/qwen-turbo",
+        "dashscope/qwen3.5-plus",
+        "dashscope/qwen3.6-plus",
+        "dashscope/qwen3.7-max",
+        "dashscope/qwq-plus",
+        "dashscope/qwen3-coder-plus",
+        "dashscope/qwen3-coder-flash",
+        "dashscope/qwen3-vl-plus",
     ],
 }
 

--- a/raven/providers/registry.py
+++ b/raven/providers/registry.py
@@ -189,7 +189,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         strip_model_prefix=False,
         model_overrides=(),
         supports_prompt_caching=True,
-        default_model="anthropic/claude-sonnet-4-5",
+        default_model="anthropic/claude-sonnet-5",
     ),
     # OpenAI: LiteLLM recognizes "gpt-*" natively, no prefix needed.
     ProviderSpec(
@@ -207,7 +207,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="",
         strip_model_prefix=False,
         model_overrides=(),
-        default_model="openai/gpt-4o-mini",
+        default_model="openai/gpt-5.5",
     ),
     # OpenAI Codex: uses OAuth, not API key.
     ProviderSpec(
@@ -263,7 +263,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="",
         strip_model_prefix=False,
         model_overrides=(),
-        default_model="deepseek/deepseek-chat",
+        default_model="deepseek/deepseek-v4-flash",
     ),
     # Gemini: needs "gemini/" prefix for LiteLLM.
     ProviderSpec(
@@ -301,6 +301,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="",
         strip_model_prefix=False,
         model_overrides=(),
+        default_model="zai/glm-4.6",
     ),
     # DashScope: Qwen models, needs "dashscope/" prefix.
     ProviderSpec(
@@ -318,6 +319,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="",
         strip_model_prefix=False,
         model_overrides=(),
+        default_model="dashscope/qwen-plus",
     ),
     # Moonshot: Kimi models, needs "moonshot/" prefix.
     # LiteLLM requires MOONSHOT_API_BASE env var to find the endpoint.
@@ -410,6 +412,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="",
         strip_model_prefix=False,
         model_overrides=(),
+        default_model="groq/openai/gpt-oss-120b",
     ),
 )
 

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -187,7 +187,7 @@ def test_onboard_non_interactive_minimum_flags(tmp_env: Path, stub_verify, stub_
 
     data = json.loads(tmp_env.read_text())
     assert data["providers"]["openai"]["apiKey"] == "sk-fake-test-key"
-    assert data["agents"]["defaults"]["model"] == "openai/gpt-4o-mini"
+    assert data["agents"]["defaults"]["model"] == "openai/gpt-5.5"
 
 
 def test_onboard_non_interactive_skips_optional_steps(
@@ -473,7 +473,7 @@ def test_onboard_interactive_uses_stubbed_pickers(
 
     data = json.loads(tmp_env.read_text())
     assert data["providers"]["anthropic"]["apiKey"] == "sk-int-test"
-    assert data["agents"]["defaults"]["model"] == "anthropic/claude-sonnet-4-5"
+    assert data["agents"]["defaults"]["model"] == "anthropic/claude-sonnet-5"
 
 
 # --------------------------------------------------------------------------- unit-level
@@ -559,7 +559,7 @@ def test_step1_falls_back_to_spec_default_in_non_interactive(tmp_env: Path, stub
     )
     assert r.exit_code == 0, r.stdout
     data = json.loads(tmp_env.read_text())
-    assert data["agents"]["defaults"]["model"] == "anthropic/claude-sonnet-4-5"
+    assert data["agents"]["defaults"]["model"] == "anthropic/claude-sonnet-5"
 
 
 def test_step1_picker_uses_catalog_when_available(tmp_env: Path, monkeypatch: pytest.MonkeyPatch, stub_step3) -> None:
@@ -1376,7 +1376,7 @@ def test_first_screen_back_does_not_skip_step1(
     # so the gate would NOT re-trigger (no infinite loop).
     data = json.loads(tmp_env.read_text())
     assert data["providers"]["openai"]["apiKey"] == "sk-back-test"
-    assert data["agents"]["defaults"]["model"] == "openai/gpt-4o-mini"
+    assert data["agents"]["defaults"]["model"] == "openai/gpt-5.5"
     assert onboard_commands._is_config_populated() is True
 
 
@@ -1420,7 +1420,7 @@ def test_switch_provider_returns_to_picker_keeps_steps(
     data = json.loads(tmp_env.read_text())
     # Switched to openai; its key written, default model is openai's.
     assert data["providers"]["openai"]["apiKey"] == "sk-openai"
-    assert data["agents"]["defaults"]["model"] == "openai/gpt-4o-mini"
+    assert data["agents"]["defaults"]["model"] == "openai/gpt-5.5"
 
 
 def test_add_provider_keeps_existing(tmp_env: Path, monkeypatch: pytest.MonkeyPatch, stub_verify, stub_step3) -> None:

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -6,8 +6,11 @@ concrete backend class trips a test instead of silently drifting.
 
 from __future__ import annotations
 
+import pytest
+
 from raven.providers.base import LLMProvider
-from raven.providers.registry import PROVIDERS
+from raven.providers.common_models import common_models_for
+from raven.providers.registry import PROVIDERS, find_by_name
 
 # The Confluence "Providers" page claims 19 providers. This pins the current
 # registry so any drift (add/remove a ProviderSpec) is caught here.
@@ -46,6 +49,27 @@ def test_registry_provider_name_set_is_pinned() -> None:
 def test_provider_names_are_unique() -> None:
     names = [spec.name for spec in PROVIDERS]
     assert len(names) == len(set(names))
+
+
+# Direct providers seeded in the model picker (issue #100). Each must expose a
+# non-empty default_model drawn from its curated shortlist, so the onboarding
+# fallback and the picker stay in sync and no provider defaults to empty.
+_SEEDED_DIRECT_PROVIDERS = [
+    "deepseek",
+    "openai",
+    "anthropic",
+    "gemini",
+    "zhipu",
+    "dashscope",
+    "groq",
+]
+
+
+@pytest.mark.parametrize("slug", _SEEDED_DIRECT_PROVIDERS)
+def test_seeded_provider_default_model_in_shortlist(slug: str) -> None:
+    default = find_by_name(slug).default_model
+    assert default, f"{slug} has no default_model"
+    assert default in common_models_for(slug)
 
 
 def _concrete_provider_subclasses() -> set[type]:

--- a/tests/test_tui_rpc_model.py
+++ b/tests/test_tui_rpc_model.py
@@ -64,8 +64,9 @@ async def test_options_authed_provider_lists_models(fake_home: Path) -> None:
     result = await model_options({})
     entry = _entry(result, "anthropic")
     assert entry["authenticated"] is True
-    assert entry["models"] == ["claude-opus-4-8", "claude-sonnet-4-5"]
-    assert entry["total_models"] == 2
+    # Configured models rank first; the curated shortlist follows (deduped).
+    assert entry["models"][:2] == ["claude-opus-4-8", "claude-sonnet-4-5"]
+    assert entry["total_models"] == 2 + len(common_models_for("anthropic"))
     assert entry["auth_type"] == "api_key"
     assert entry["key_env"] == "ANTHROPIC_API_KEY"
 
@@ -75,8 +76,10 @@ async def test_options_unauthed_provider_marked(fake_home: Path) -> None:
     result = await model_options({})
     entry = _entry(result, "openai")
     assert entry["authenticated"] is False
-    assert entry["models"] == []
-    assert entry["total_models"] == 0
+    # Curated shortlist is shown regardless of auth (as openrouter always has),
+    # so the picker is never empty; the unauthed state is conveyed separately.
+    assert entry["models"] == common_models_for("openai")
+    assert entry["total_models"] == len(common_models_for("openai"))
 
 
 async def test_options_current_provider_marked(fake_home: Path) -> None:
@@ -287,3 +290,41 @@ async def test_options_config_models_rank_before_common_and_dedup(fake_home: Pat
     assert models[:2] == ["my/custom-model", dup]
     assert models.count(dup) == 1
     assert set(common_models_for("openrouter")).issubset(set(models))
+
+
+# Direct providers seeded for issue #100 (keyed provider, empty config models,
+# used to show an empty picker). ``prefix`` is the litellm-routing form each id
+# must carry so a picked id drops straight into ``agents.defaults.model``.
+_SEEDED_DIRECT_PROVIDERS = [
+    ("deepseek", "deepseek/"),
+    ("openai", "openai/"),
+    ("anthropic", "anthropic/"),
+    ("gemini", "gemini/"),
+    ("zhipu", "zai/"),
+    ("groq", "groq/"),
+    ("dashscope", "dashscope/"),
+]
+
+
+@pytest.mark.parametrize("slug, prefix", _SEEDED_DIRECT_PROVIDERS)
+def test_common_models_seeded_for_direct_providers(slug: str, prefix: str) -> None:
+    models = common_models_for(slug)
+    assert models, f"{slug} common-model shortlist is empty"
+    assert all(m.startswith(prefix) for m in models), models
+    assert len(models) == len(set(models)), "duplicate ids in shortlist"
+
+
+@pytest.mark.parametrize("slug, prefix", _SEEDED_DIRECT_PROVIDERS)
+async def test_options_direct_provider_lists_common_models_when_unconfigured(
+    fake_home: Path, slug: str, prefix: str
+) -> None:
+    _write_config(
+        fake_home,
+        {
+            "agents": {"defaults": {"model": "openrouter/anthropic/claude-opus-4.8"}},
+            "providers": {slug: {"apiKey": "sk-test-xxxxxxx", "models": []}},
+        },
+    )
+    entry = _entry(await model_options({}), slug)
+    assert entry["total_models"] > 0
+    assert entry["models"] == common_models_for(slug)


### PR DESCRIPTION
## Change description

The TUI `/model` picker showed an empty model list for direct providers
(DeepSeek, OpenAI, Anthropic, Gemini, Zhipu, Groq, DashScope): their config
`models` default to `[]` and `COMMON_MODELS` seeded only openrouter, so the
curated fallback the picker reads was empty.

This seeds a curated, chat-only shortlist for each of those providers,
refreshes the openrouter shortlist from real usage rankings, and gives each
seeded provider a non-empty `default_model`:

- deepseek moves off the soon-deprecated `deepseek-chat` (its official
  successor is `deepseek-v4-flash`, same economy tier);
- zhipu, dashscope and groq previously had no `default_model` at all;
- openai and anthropic move to current-generation flagships.

Model ids were verified against litellm 1.85.0, provider docs, and OpenRouter
usage data, not guessed. Live dynamic model fetching (hermes-style per-provider
`/v1/models`) was evaluated and deferred as a separate follow-up: litellm gives
no clean live catalog for the direct providers, so it does not solve this case.

Note: unauthenticated providers now also surface the curated shortlist in the
picker, consistent with openrouter's existing behavior; the auth state is
conveyed separately.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Document
- [ ] Others

## Related issues

Fixes #100

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [ ] Code follows security best practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary