### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raven"
-version = "0.1.2"
+version = "0.1.3"
 description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "Apache-2.0"

--- a/raven/__init__.py
+++ b/raven/__init__.py
@@ -42,5 +42,5 @@ class _LiteLLMBotocorePreloadFilter(_logging.Filter):
 
 _logging.getLogger("LiteLLM").addFilter(_LiteLLMBotocorePreloadFilter())
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 __logo__ = "🐦‍⬛"

--- a/uv.lock
+++ b/uv.lock
@@ -3196,7 +3196,7 @@ wheels = [
 
 [[package]]
 name = "raven"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Prepare Raven 0.1.3 by updating the package version, runtime version, and lockfile project entry from 0.1.2 to 0.1.3.

After this change is merged, a `v0.1.3` tag can pass the release workflow version guard and create a draft GitHub Release with wheel and source distribution assets. This pull request does not create a tag or publish a release.

### Proposed release notes

Raven 0.1.3 makes setup and TUI use more dependable with working EverOS memory, verified model onboarding, curated model choices, and stronger session reliability.

#### Highlights

- EverOS memory now works out of the box in the TUI, with managed embedded-backend startup and shutdown.
- `raven onboard` now verifies real chat, embedding, rerank, and multimodal requests, offers safer recovery paths, and upgrades EverOS to 1.1.2 with automatic first-run config and LanceDB schema migration.
- The TUI `/model` picker now includes curated choices for OpenRouter and the DeepSeek, OpenAI, Anthropic, Gemini, Zhipu, Groq, and DashScope direct providers.
- Large tool catalogs can opt into progressive tool disclosure, keeping per-turn tool payloads bounded while models search and call hidden tools on demand.
- Subagent results now return to the session that launched them, and repeated spawns no longer leak skill file watchers.
- Cancelling a streamed TUI turn now keeps partial assistant output in the transcript, and CLI shutdown avoids a LanceDB-related exit crash.
- Thinking-mode conversations now preserve reasoning fields across trimmed history, fixing DeepSeek follow-up turns that include tool calls.
- Standard macOS, Linux, and Windows installers now include channel SDKs by default and show install-mode-aware recovery guidance for missing dependencies.

#### Install

```bash
curl -fsSL https://raven.evermind.ai/install.sh | bash
```

Then reload your shell and run:

```bash
raven onboard
```

#### Release status

- Version: `0.1.3`
- Tag: `v0.1.3`
- Stability: public preview patch
- Assets: wheel and source distribution attached to the release

#### Notes

- Raven is still pre-1.0; CLI surfaces, plugin contracts, and runtime internals may continue to evolve.
- PyPI publishing is not enabled yet; the supported public install path uses the GitHub Release wheel asset.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

## Verification

- `uv lock --check`
- Version consistency check confirms `pyproject.toml`, `raven.__version__`, and `uv.lock` use `0.1.3`.
- `git diff --check`
- The full test suite is not marked passing: the local baseline includes environment-dependent EverOS integration failures and unrelated host-state failures.

- [ ] Relevant tests pass locally
- [ ] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

This is a metadata-only version bump. Rollback is a revert before tagging.

## Related Issues

N/A
