### PR TITLE
fix(cli): open browser for onboard oauth login

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     # OAuth provider login (Codex / GitHub Copilot) imports this during onboard,
     # so it must be a runtime dep -- otherwise `uv tool install raven` users hit
     # "oauth_cli_kit not installed" the moment they pick an OAuth provider.
-    "oauth-cli-kit>=0.1.3,<1.0.0",
+    "oauth-cli-kit>=0.1.6,<1.0.0",
     "portalocker>=3.2.0",
     "mcp>=1.27.0",
 ]
@@ -91,7 +91,7 @@ channels = [
 ]
 tools = [
     "readability-lxml>=0.8.4,<1.0.0",
-    "oauth-cli-kit>=0.1.3,<1.0.0",
+    "oauth-cli-kit>=0.1.6,<1.0.0",
 ]
 retrieval = [
     "torch>=2.0.0",
@@ -232,7 +232,7 @@ markers = [
 [dependency-groups]
 dev = [
     "json-repair>=0.59.5",
-    "oauth-cli-kit>=0.1.3",
+    "oauth-cli-kit>=0.1.6",
     "pexpect>=4.9",
     "pip-audit>=2.10.0",
     "pre-commit>=4.6.0",

--- a/raven/cli/provider_commands.py
+++ b/raven/cli/provider_commands.py
@@ -25,6 +25,8 @@ Architecture: write operations go ONLY through
 
 from __future__ import annotations
 
+import os
+import sys
 from typing import Any
 
 import typer
@@ -88,6 +90,11 @@ def _login_openai_codex() -> None:
             token = login_oauth_interactive(
                 print_fn=lambda s: console.print(s),
                 prompt_fn=lambda s: typer.prompt(s),
+                open_browser=(
+                    bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+                    if sys.platform.startswith("linux")
+                    else None
+                ),
             )
         if not (token and token.access):
             console.print("[red]✗ Authentication failed[/red]")

--- a/raven/cli/provider_commands.py
+++ b/raven/cli/provider_commands.py
@@ -78,24 +78,18 @@ def provider_login(
 @_register_login("openai_codex")
 def _login_openai_codex() -> None:
     try:
-        from oauth_cli_kit import get_token, login_oauth_interactive
+        from oauth_cli_kit import login_oauth_interactive
 
-        token = None
-        try:
-            token = get_token()
-        except Exception:
-            pass
-        if not (token and token.access):
-            console.print("[cyan]Starting interactive OAuth login...[/cyan]\n")
-            token = login_oauth_interactive(
-                print_fn=lambda s: console.print(s),
-                prompt_fn=lambda s: typer.prompt(s),
-                open_browser=(
-                    bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
-                    if sys.platform.startswith("linux")
-                    else None
-                ),
-            )
+        console.print("[cyan]Starting interactive OAuth login...[/cyan]\n")
+        token = login_oauth_interactive(
+            print_fn=lambda s: console.print(s),
+            prompt_fn=lambda s: typer.prompt(s),
+            open_browser=(
+                bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+                if sys.platform.startswith("linux")
+                else None
+            ),
+        )
         if not (token and token.access):
             console.print("[red]✗ Authentication failed[/red]")
             raise typer.Exit(1)

--- a/tests/test_cli_provider_commands.py
+++ b/tests/test_cli_provider_commands.py
@@ -52,19 +52,26 @@ def test_provider_login_unknown_provider_exits_1() -> None:
 
 
 def test_provider_login_openai_codex_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Happy path: mocked oauth_cli_kit returns a token → exit 0."""
+    """Login starts an interactive flow even when a cached token exists."""
     from types import SimpleNamespace
 
     fake_token = SimpleNamespace(access="fake-access-token", account_id="user@example.com")
+    login_calls = 0
+
+    def fake_login(**_):
+        nonlocal login_calls
+        login_calls += 1
+        return fake_token
 
     fake_module = SimpleNamespace(
         get_token=lambda: fake_token,
-        login_oauth_interactive=lambda **_: fake_token,
+        login_oauth_interactive=fake_login,
     )
     monkeypatch.setitem(__import__("sys").modules, "oauth_cli_kit", fake_module)
 
     r = runner.invoke(app, ["provider", "login", "openai-codex"])
     assert r.exit_code == 0
+    assert login_calls == 1
     assert "Authenticated with OpenAI Codex" in r.stdout
 
 

--- a/tests/test_cli_provider_commands.py
+++ b/tests/test_cli_provider_commands.py
@@ -85,6 +85,34 @@ def test_provider_login_openai_codex_failure_exits_1(monkeypatch: pytest.MonkeyP
     assert "Authentication failed" in r.stdout
 
 
+def test_provider_login_openai_codex_disables_browser_without_linux_display(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    empty_token = SimpleNamespace(access=None, account_id=None)
+    authenticated_token = SimpleNamespace(access="fake-access-token", account_id="user@example.com")
+    login_kwargs: dict[str, object] = {}
+
+    def fake_login(**kwargs):
+        login_kwargs.update(kwargs)
+        return authenticated_token
+
+    fake_module = SimpleNamespace(
+        get_token=lambda: empty_token,
+        login_oauth_interactive=fake_login,
+    )
+    monkeypatch.setitem(__import__("sys").modules, "oauth_cli_kit", fake_module)
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+
+    r = runner.invoke(app, ["provider", "login", "openai-codex"])
+
+    assert r.exit_code == 0
+    assert login_kwargs["open_browser"] is False
+
+
 def test_provider_login_github_copilot_success(monkeypatch: pytest.MonkeyPatch) -> None:
     """github-copilot login triggers an acompletion → mock it returning OK."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -2369,15 +2369,15 @@ wheels = [
 
 [[package]]
 name = "oauth-cli-kit"
-version = "0.1.3"
+version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/84/c6b1030669266378e2f286a4e3e8c020e7f2d537b711a2ad30a789e97097/oauth_cli_kit-0.1.3.tar.gz", hash = "sha256:6612b3dea1a97c4de4a7d3b828767d42f0a78eae93be56b90c55d3ab668ebfb8", size = 8551, upload-time = "2026-02-13T10:21:19.046Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/65/db8768844cff218ae2bb19305ec1abe95e414c9953af205fe1b75a5e2300/oauth_cli_kit-0.1.6.tar.gz", hash = "sha256:7252f57e1a2f9dba7a94894c11b979f83884b3c88af3b4fe0206370a2b120499", size = 8529, upload-time = "2026-06-30T06:18:35.295Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/55/a4abfc5f9be60ffd7fedf0e808ffd0a1d35f3ecd6f7b2fc782b7948a8329/oauth_cli_kit-0.1.3-py3-none-any.whl", hash = "sha256:09aabde83fbb823b38de3b8c220f6c256df2d771bf31dccdb2680a5fbe383836", size = 11504, upload-time = "2026-02-13T10:21:18.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/9f/53555ec2543e6ba5f6eeff4331cca43842a2c48983c793c97560500b6764/oauth_cli_kit-0.1.6-py3-none-any.whl", hash = "sha256:d4a73beae7333ae642a9e5766ab0a04de53279667fefdf064c23db77a3494e7f", size = 11490, upload-time = "2026-06-30T06:18:34.467Z" },
 ]
 
 [[package]]
@@ -3332,8 +3332,8 @@ requires-dist = [
     { name = "mistune", marker = "extra == 'channel-matrix'", specifier = ">=3.0.0,<4.0.0" },
     { name = "msgpack", marker = "extra == 'channel-mochat'", specifier = ">=1.2.1,<2.0.0" },
     { name = "nh3", marker = "extra == 'channel-matrix'", specifier = ">=0.2.17,<1.0.0" },
-    { name = "oauth-cli-kit", specifier = ">=0.1.3,<1.0.0" },
-    { name = "oauth-cli-kit", marker = "extra == 'tools'", specifier = ">=0.1.3,<1.0.0" },
+    { name = "oauth-cli-kit", specifier = ">=0.1.6,<1.0.0" },
+    { name = "oauth-cli-kit", marker = "extra == 'tools'", specifier = ">=0.1.6,<1.0.0" },
     { name = "portalocker", specifier = ">=3.2.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.0" },
     { name = "pycryptodome", marker = "extra == 'channel-weixin'", specifier = ">=3.20.0" },
@@ -3381,7 +3381,7 @@ provides-extras = ["channel-telegram", "channel-slack", "channel-discord", "chan
 [package.metadata.requires-dev]
 dev = [
     { name = "json-repair", specifier = ">=0.59.5" },
-    { name = "oauth-cli-kit", specifier = ">=0.1.3" },
+    { name = "oauth-cli-kit", specifier = ">=0.1.6" },
     { name = "pexpect", specifier = ">=4.9" },
     { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pre-commit", specifier = ">=4.6.0" },


### PR DESCRIPTION
## Summary

- Always start the interactive Codex OAuth flow when the user explicitly selects OAuth login, even when a cached token exists.
- Upgrade `oauth-cli-kit` from 0.1.3 to 0.1.6 for headless browser detection and manual callback fallback.
- Pass Raven's Linux graphical-session detection into the OAuth login flow.
- Add regression coverage for cached-token reauthentication and headless Linux sessions.

The login handler previously read a cached Codex token before starting OAuth. When that token was valid, Raven skipped `login_oauth_interactive()` entirely, so selecting Codex OAuth during onboarding did not open a browser. The handler now treats an explicit login action as a request to authenticate interactively and launches the browser flow every time.

Headless Linux sessions still use the manual authorization URL and redirect-URL prompt instead of waiting for a browser callback that cannot arrive.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_cli_provider_commands.py tests/test_cli_onboard_commands.py -q` (`87 passed`)
- `uv run pre-commit run --files pyproject.toml raven/cli/provider_commands.py tests/test_cli_provider_commands.py uv.lock`
- `make lint-python && make test-python` (`18 passed`)
- Local commit-message and PR-title lint scripts
- Manual macOS verification through `raven onboard`: selecting `Codex (OAuth)` opened the OpenAI authorization page in the default browser with an existing cached token. The flow was cancelled before account authorization.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Normal provider usage continues to reuse stored OAuth credentials. Only an explicit login action now forces the interactive authorization flow.

## Related Issues

Fixes #108
