### PR TITLE
feat(cli): add raven upgrade command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,21 @@ jobs:
       - name: Focused Python tests
         run: make test-python
 
+  windows-upgrade:
+    name: Windows self-upgrade
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Test real uv self-upgrade
+        run: uvx --python 3.12 --from "pytest>=8,<10" pytest tests/integration/test_cli_upgrade_real_uv.py -q
+
   tui:
     name: TUI checks
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Test real uv self-upgrade
-        run: uvx --python 3.12 --from "pytest>=8,<10" pytest tests/integration/test_cli_upgrade_real_uv.py -q
+        run: uvx --python 3.12 --from "pytest>=8,<10" pytest --noconftest tests/integration/test_cli_upgrade_real_uv.py -q
 
   tui:
     name: TUI checks

--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ If setup fails or a provider is not ready, run:
 raven doctor
 ```
 
+### Upgrade an existing installation
+
+Check for the latest published stable release:
+
+    raven upgrade --check
+
+Upgrade Raven without resetting configuration, sessions, or memory:
+
+    raven upgrade
+
+Raven upgrades are user-triggered, not automatic. Editable source installs are
+not overwritten; update the checkout and rerun its development setup instead.
+
 ## What You Can Do in 2 Minutes
 
 - Start the Raven harness in a terminal-native TUI with `raven` or `raven tui`.
@@ -263,6 +276,8 @@ official endorsement unless explicitly approved by EverMind.
 | Show plugins and memory backend | `raven plugins` |
 | Debug sandbox VMs | `raven sandbox list` |
 | Show local status | `raven status` |
+| Check for Raven updates | `raven upgrade --check` |
+| Upgrade Raven | `raven upgrade` |
 | Diagnose setup | `raven doctor` |
 
 ## Docs by Goal

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Upgrade Raven without resetting configuration, sessions, or memory:
 
 Raven upgrades are user-triggered, not automatic. Editable source installs are
 not overwritten; update the checkout and rerun its development setup instead.
+On POSIX systems, the command stays synchronous until the helper reports its
+final result. On native Windows, it schedules an external helper so the running
+executable can exit; wait for the helper's completion message before running
+Raven again.
 
 ## What You Can Do in 2 Minutes
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,6 +99,19 @@ OpenAI Codex OAuth，以及自定义 OpenAI-compatible endpoints。
 raven doctor
 ```
 
+### 升级现有安装
+
+检查最新发布的稳定版本：
+
+    raven upgrade --check
+
+升级 Raven，同时保留现有配置、sessions 和 memory：
+
+    raven upgrade
+
+Raven 升级需要由用户主动触发，不会自动进行。Raven 会拒绝覆盖 editable source
+installs；请更新源码 checkout，并重新运行对应的开发环境配置。
+
 ## 2 分钟能做什么
 
 - 用 `raven` 或 `raven tui` 启动 Raven 的终端原生 harness。
@@ -257,6 +270,8 @@ digital worker。
 | 查看 plugins 和 memory backend | `raven plugins` |
 | 调试 sandbox VMs | `raven sandbox list` |
 | 查看本地状态 | `raven status` |
+| 检查 Raven 更新 | `raven upgrade --check` |
+| 升级 Raven | `raven upgrade` |
 | 诊断配置 | `raven doctor` |
 
 ## 按目标阅读文档

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -111,6 +111,8 @@ raven doctor
 
 Raven 升级需要由用户主动触发，不会自动进行。Raven 会拒绝覆盖 editable source
 installs；请更新源码 checkout，并重新运行对应的开发环境配置。
+在 POSIX 系统上，命令会同步等待 helper 输出最终结果。原生 Windows 会先调度外部
+helper，让当前运行的可执行文件退出；请等 helper 输出完成消息后再运行 Raven。
 
 ## 2 分钟能做什么
 

--- a/docs/superpowers/plans/2026-07-12-raven-upgrade-command.md
+++ b/docs/superpowers/plans/2026-07-12-raven-upgrade-command.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a safe `raven upgrade` command that checks and installs the latest published stable Raven Release without requiring users to rerun the public installer.
 
-**Architecture:** A focused top-level CLI module resolves and validates GitHub Release metadata, compares strict Raven semantic versions, and protects editable or malformed installations. For mutation, a standard-library-only helper runs on the external base Python: POSIX replaces the current process synchronously, while Windows starts a breakaway helper that waits for the uv trampoline to exit before replacing the locked entrypoint. The helper restores the active uv tool/bin directories and performs the installer-compatible fallback only after the Raven executable is no longer active. TUI dispatch remains unable to run self-upgrade, while dormant update copy points to the real command.
+**Architecture:** A focused top-level CLI module resolves and validates GitHub Release metadata, compares strict Raven semantic versions, and protects editable or malformed installations. For mutation, a standard-library-only helper runs on the external base Python: POSIX replaces the current process synchronously, while Windows starts an external helper that waits for the uv trampoline to exit before replacing the locked entrypoint. uv's trampoline job silently releases child processes, so no explicit breakaway flag is needed. The helper restores the active uv tool/bin directories and performs the installer-compatible fallback only after the Raven executable is no longer active. TUI dispatch remains unable to run self-upgrade, while dormant update copy points to the real command.
 
 **Tech Stack:** Python 3.12, Typer, Rich, httpx, importlib.metadata, uv, pytest, React/Ink, TypeScript, Vitest.
 
@@ -275,10 +275,12 @@ argv = [base_python, "-I", "-c", bootstrap, uv_path, wheel_url, current, latest]
 
 On POSIX, flush inherited output and call `os.execve(base_python, argv, env)`.
 On Windows, append `os.getppid()` to `argv`, start the helper with
-`subprocess.Popen(..., creationflags=CREATE_BREAKAWAY_FROM_JOB)`, and return
-after printing that the user must wait for the final completion message. The
-helper opens the trampoline process with `SYNCHRONIZE`, waits for it with a
-bounded `WaitForSingleObject`, and only then invokes uv.
+`subprocess.Popen(argv, env=env)`, and return after printing that the user must
+wait for the final completion message. uv configures its trampoline job with
+`JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK`, so this child is not terminated when
+the trampoline exits. The helper opens the trampoline process with
+`SYNCHRONIZE`, waits for it with a bounded `WaitForSingleObject`, and only then
+invokes uv.
 
 The helper must use only the standard library and trusted argument arrays. It
 runs the channels requirement first, falls back to the base wheel, warns only
@@ -488,10 +490,10 @@ git commit -m "docs: explain raven upgrade workflow"
 - [ ] **Step 1: Add failing Windows transport and scheduling tests**
 
 Extend `tests/test_cli_upgrade_commands.py` so a simulated Windows handoff uses
-paths containing spaces, calls `subprocess.Popen` with the external base Python
-and the breakaway creation flag, appends a fixed `os.getppid()` value, and never
-calls `os.execve`. Assert that the `-c` bootstrap contains no whitespace and
-that a spawn `OSError` becomes `UpgradeError`.
+paths containing spaces, calls `subprocess.Popen` with the external base Python,
+appends a fixed `os.getppid()` value, and never calls `os.execve`. Assert that
+the `-c` bootstrap contains no whitespace and that a spawn `OSError` becomes
+`UpgradeError`.
 
 - [ ] **Step 2: Add failing helper parent-wait tests**
 
@@ -513,17 +515,16 @@ Expected: the new Windows tests fail because `_handoff_upgrade()` still calls
 
 - [ ] **Step 4: Implement the minimal cross-platform handoff**
 
-Add `base64` and `subprocess` imports, define a portable
-`CREATE_BREAKAWAY_FROM_JOB = 0x01000000` constant, and generate a one-line
-bootstrap equivalent to:
+Add `base64` and `subprocess` imports and generate a one-line bootstrap
+equivalent to:
 
 ```python
 exec(compile(__import__("base64").b64decode(encoded), "<raven-upgrade>", "exec"))
 ```
 
 Keep `os.execve` for POSIX. On Windows, append `str(os.getppid())`, call
-`subprocess.Popen(argv, env=env, creationflags=CREATE_BREAKAWAY_FROM_JOB)`, and
-print `Raven upgrade started. Wait for the completion message before running Raven again.`
+`subprocess.Popen(argv, env=env)`, and print
+`Raven upgrade started. Wait for the completion message before running Raven again.`
 
 Inside `_UPGRADE_HELPER_SOURCE`, accept the optional fifth PID argument. Open
 that process with Windows `SYNCHRONIZE`, wait at most 30 seconds with

--- a/docs/superpowers/plans/2026-07-12-raven-upgrade-command.md
+++ b/docs/superpowers/plans/2026-07-12-raven-upgrade-command.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a safe `raven upgrade` command that checks and installs the latest published stable Raven Release without requiring users to rerun the public installer.
 
-**Architecture:** A focused top-level CLI module resolves and validates GitHub Release metadata, compares strict Raven semantic versions, protects editable and non-uv installations, and delegates replacement to the same `uv tool install --force` flow used by the public installers. TUI dispatch remains unable to run self-upgrade, while dormant update copy points to the real command.
+**Architecture:** A focused top-level CLI module resolves and validates GitHub Release metadata, compares strict Raven semantic versions, and protects editable or malformed installations. For mutation, Raven replaces itself with an isolated, standard-library-only helper running on the external base Python; the helper restores the active uv tool/bin directories and performs the installer-compatible fallback only after the Raven executable is no longer active. TUI dispatch remains unable to run self-upgrade, while dormant update copy points to the real command.
 
 **Tech Stack:** Python 3.12, Typer, Rich, httpx, importlib.metadata, uv, pytest, React/Ink, TypeScript, Vitest.
 
@@ -24,7 +24,9 @@
 ## File map
 
 - Create `raven/cli/upgrade_commands.py`: release lookup, validation, install-mode guards, uv execution, and Typer registration.
-- Create `tests/test_cli_upgrade_commands.py`: focused unit and command tests with no real network or subprocess calls.
+- Create `tests/test_cli_upgrade_commands.py`: focused unit and command tests with no real network or tool mutation.
+- Create `tests/integration/test_cli_upgrade_real_uv.py`: bounded uv self-replacement test using temporary custom directories.
+- Modify `.github/workflows/ci.yml`: run the real self-replacement test on Windows.
 - Modify `raven/cli/commands.py`: register the new top-level command.
 - Modify `tests/test_cli_smoke.py`: pin `upgrade` in the root command surface.
 - Modify `raven/tui_rpc/methods/cli_dispatch.py`: reject upgrades from an active TUI RPC process.
@@ -190,7 +192,7 @@ git commit -m "feat(cli): resolve raven release upgrades"
 
 **Interfaces:**
 - Consumes: `ReleaseInfo`, `_version_key`, `_fetch_latest_release`, `_current_version` from Task 1.
-- Produces: `_is_editable_install() -> bool`, `_is_uv_tool_install() -> bool`, `_run_uv(uv_path: str, requirement: str) -> int`, `_install_release(release: ReleaseInfo) -> None`, `register(app: typer.Typer) -> None`.
+- Produces: `_is_editable_install() -> bool`, `_uv_tool_target() -> ToolInstallTarget | None`, `_handoff_upgrade(release, current_version, target) -> NoReturn`, an inline standard-library helper, and `register(app: typer.Typer) -> None`.
 
 - [ ] **Step 1: Write failing command and install-mode tests**
 
@@ -216,15 +218,15 @@ def test_upgrade_check_reports_available_without_install(monkeypatch: pytest.Mon
         "_fetch_latest_release",
         lambda: upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL),
     )
-    install = Mock()
-    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+    handoff = Mock()
+    monkeypatch.setattr(upgrade_commands, "_handoff_upgrade", handoff)
 
     result = runner.invoke(app, ["upgrade", "--check"])
 
     assert result.exit_code == 0
     assert "0.1.3 -> 0.1.4" in result.stdout
     assert "raven upgrade" in result.stdout
-    install.assert_not_called()
+    handoff.assert_not_called()
 ```
 
 Cover equal versions, a newer local version with no downgrade, editable refusal, unsupported install refusal, missing uv, successful channel install, channel failure followed by base success, both attempts failing, and network/release errors returning exit code 1.
@@ -248,68 +250,34 @@ uv run pytest tests/test_cli_upgrade_commands.py tests/test_cli_smoke.py -q
 
 Expected: failures because `upgrade` is not registered and install helpers do not exist.
 
-- [ ] **Step 3: Implement PEP 610 and uv-receipt guards**
+- [ ] **Step 3: Implement strict PEP 610 and uv-receipt guards**
 
-Use standard-library metadata only:
+Distinguish an absent `direct_url.json` from a malformed present file. Require
+a nonempty URL and exactly one valid `archive_info`, `dir_info`, or `vcs_info`
+record. Treat `dir_info.editable` as optional with a false default, but require
+it to be boolean when present; require the PEP 610 VCS fields.
 
-```python
-import json
-import sys
-import tomllib
-from pathlib import Path
+Parse `sys.prefix/uv-receipt.toml` into an immutable `ToolInstallTarget`.
+Require a Raven requirement and exactly one Raven entrypoint with an absolute
+`install-path`. Derive `UV_TOOL_DIR` from `Path(sys.prefix).parent` and
+`UV_TOOL_BIN_DIR` from the entrypoint parent. Missing receipts remain an
+unsupported install; present malformed receipts fail closed.
 
+- [ ] **Step 4: Implement post-exit uv execution with the installer-compatible fallback**
 
-def _direct_url_data() -> dict[str, object]:
-    raw = metadata.distribution("raven").read_text("direct_url.json")
-    if not raw:
-        return {}
-    data = json.loads(raw)
-    return data if isinstance(data, dict) else {}
-
-
-def _is_editable_install() -> bool:
-    data = _direct_url_data()
-    directory = data.get("dir_info")
-    return isinstance(directory, dict) and directory.get("editable") is True
-
-
-def _is_uv_tool_install() -> bool:
-    receipt_path = Path(sys.prefix) / "uv-receipt.toml"
-    if not receipt_path.is_file():
-        return False
-    receipt = tomllib.loads(receipt_path.read_text(encoding="utf-8"))
-    requirements = receipt.get("tool", {}).get("requirements", [])
-    return any(isinstance(item, dict) and item.get("name") == "raven" for item in requirements)
-```
-
-Treat malformed metadata or receipts as unsupported installation errors instead of tracebacks.
-
-- [ ] **Step 4: Implement uv execution with the installer-compatible fallback**
-
-Use inherited output and argument arrays:
+Resolve uv and `sys._base_executable` to files outside the active Raven tool
+prefix. Override `UV_TOOL_DIR` and `UV_TOOL_BIN_DIR` in a copied environment,
+flush inherited output, and call `os.execve` with:
 
 ```python
-import shutil
-import subprocess
-
-
-def _run_uv(uv_path: str, requirement: str) -> int:
-    completed = subprocess.run(
-        [uv_path, "tool", "install", "--force", requirement],
-        check=False,
-    )
-    return completed.returncode
-
-
-def _install_release(release: ReleaseInfo) -> None:
-    uv_path = shutil.which("uv")
-    if uv_path is None:
-        raise UpgradeError("uv was not found on PATH")
-    if _run_uv(uv_path, f"raven[channels] @ {release.wheel_url}") == 0:
-        return
-    if _run_uv(uv_path, release.wheel_url) != 0:
-        raise UpgradeError("uv could not install the Raven release wheel")
+[base_python, "-I", "-c", helper_source, uv_path, wheel_url, current, latest]
 ```
+
+The inline helper must use only the standard library and trusted argument
+arrays. It runs the channels requirement first, falls back to the base wheel,
+warns only when that fallback succeeds, prints the final success itself, catches
+uv execution `OSError`, and returns the final uv status when both attempts fail.
+Because the helper is inline, no temporary artifact needs cleanup.
 
 - [ ] **Step 5: Register and orchestrate the top-level command**
 
@@ -319,11 +287,16 @@ Add `upgrade_commands` to the import and registration list in `raven/cli/command
 2. Compare current and latest version keys.
 3. Exit zero for equal or newer-local versions.
 4. Print `current -> latest` and exit zero for `--check`.
-5. Refuse editable and non-uv installs before invoking `_install_release`.
-6. Print success plus restart guidance after installation.
+5. Refuse editable, malformed, and non-uv installs before invoking `_handoff_upgrade`.
+6. Do not print success in the parent; the post-exit helper owns final status.
 7. Catch `UpgradeError`, `httpx.HTTPError`, JSON errors, and metadata errors, print one actionable red error, and raise `typer.Exit(1)`.
 
 Register `upgrade` in both `TOP_LEVEL_COMMANDS` and `REGISTERED_COMMAND_NAMES` in `tests/test_cli_smoke.py`.
+
+Add `tests/integration/test_cli_upgrade_real_uv.py` to install an old temporary
+uv tool in custom directories, invoke its own handoff, and verify the same
+entrypoint reports the new version. Run this bounded test in a dedicated
+Windows CI job to cover executable locking.
 
 - [ ] **Step 6: Run focused tests and commit the working CLI**
 

--- a/docs/superpowers/plans/2026-07-12-raven-upgrade-command.md
+++ b/docs/superpowers/plans/2026-07-12-raven-upgrade-command.md
@@ -1,0 +1,602 @@
+# Raven Upgrade Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a safe `raven upgrade` command that checks and installs the latest published stable Raven Release without requiring users to rerun the public installer.
+
+**Architecture:** A focused top-level CLI module resolves and validates GitHub Release metadata, compares strict Raven semantic versions, protects editable and non-uv installations, and delegates replacement to the same `uv tool install --force` flow used by the public installers. TUI dispatch remains unable to run self-upgrade, while dormant update copy points to the real command.
+
+**Tech Stack:** Python 3.12, Typer, Rich, httpx, importlib.metadata, uv, pytest, React/Ink, TypeScript, Vitest.
+
+## Global Constraints
+
+- Only `GET https://api.github.com/repos/EverMind-AI/Raven/releases/latest` defines an available stable update.
+- Never advertise unpublished commits, tags without Releases, draft Releases, or prereleases.
+- Do not add background or silent automatic updates.
+- Do not overwrite editable source checkouts or unsupported package-manager installations.
+- Do not modify Raven state under `~/.raven`.
+- Use uv for all Python dependency and command execution; never use pip.
+- Run Python tests with `uv run pytest`.
+- Keep repository comments necessary and English-only.
+- Do not add report assets, standalone web artifacts, or files over 1 MiB.
+- Use Conventional Commits with ASCII-only English messages.
+
+## File map
+
+- Create `raven/cli/upgrade_commands.py`: release lookup, validation, install-mode guards, uv execution, and Typer registration.
+- Create `tests/test_cli_upgrade_commands.py`: focused unit and command tests with no real network or subprocess calls.
+- Modify `raven/cli/commands.py`: register the new top-level command.
+- Modify `tests/test_cli_smoke.py`: pin `upgrade` in the root command surface.
+- Modify `raven/tui_rpc/methods/cli_dispatch.py`: reject upgrades from an active TUI RPC process.
+- Modify `tests/test_tui_rpc_cli_dispatch.py`: pin the expanded dispatch blacklist.
+- Modify `ui-tui/src/components/branding.tsx`: replace the nonexistent fallback command.
+- Modify `ui-tui/src/demo/gallery.tsx`: keep demo data aligned with production copy.
+- Modify `ui-tui/src/__tests__/branding.test.tsx`: render and verify the fallback upgrade hint.
+- Modify `README.md` and `README.zh-CN.md`: document checks, upgrades, state preservation, and source-install behavior.
+
+---
+
+### Task 1: Release discovery and version comparison
+
+**Files:**
+- Create: `raven/cli/upgrade_commands.py`
+- Create: `tests/test_cli_upgrade_commands.py`
+
+**Interfaces:**
+- Consumes: `httpx.Client`, `importlib.metadata.version("raven")`.
+- Produces: `ReleaseInfo(version: str, wheel_url: str)`, `_version_key(value: str) -> tuple[int, int, int]`, `_parse_release_payload(payload: object) -> ReleaseInfo`, `_fetch_latest_release() -> ReleaseInfo`, `_current_version() -> str`.
+
+- [ ] **Step 1: Write failing tests for strict Raven versions and release metadata**
+
+Add tests with exact stable and invalid examples:
+
+```python
+import pytest
+
+from raven.cli import upgrade_commands
+
+
+def test_version_key_accepts_documented_stable_versions() -> None:
+    assert upgrade_commands._version_key("0.1.3") == (0, 1, 3)
+    assert upgrade_commands._version_key("v2.10.4") == (2, 10, 4)
+
+
+@pytest.mark.parametrize("value", ["0.1", "0.1.3-rc1", "latest", "01.2.3"])
+def test_version_key_rejects_nonstable_versions(value: str) -> None:
+    with pytest.raises(upgrade_commands.UpgradeError):
+        upgrade_commands._version_key(value)
+
+
+def test_parse_release_payload_selects_exact_release_wheel() -> None:
+    release = upgrade_commands._parse_release_payload(
+        {
+            "tag_name": "v0.1.4",
+            "draft": False,
+            "prerelease": False,
+            "assets": [
+                {
+                    "name": "raven-0.1.4-py3-none-any.whl",
+                    "browser_download_url": "https://github.com/EverMind-AI/Raven/releases/download/v0.1.4/raven-0.1.4-py3-none-any.whl",
+                }
+            ],
+        }
+    )
+    assert release.version == "0.1.4"
+```
+
+Also cover draft, prerelease, malformed payload, wrong wheel filename, duplicate exact wheels, HTTP URL, wrong host, and wrong repository path.
+
+- [ ] **Step 2: Run the focused tests and confirm the red state**
+
+Run:
+
+```bash
+uv run pytest tests/test_cli_upgrade_commands.py -q
+```
+
+Expected: collection or import failure because `raven.cli.upgrade_commands` does not exist.
+
+- [ ] **Step 3: Implement the immutable release record and strict parsing**
+
+Create the module with these boundaries:
+
+```python
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from importlib import metadata
+from urllib.parse import urlparse
+
+import httpx
+
+LATEST_RELEASE_API = "https://api.github.com/repos/EverMind-AI/Raven/releases/latest"
+_VERSION_RE = re.compile(r"^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+
+
+class UpgradeError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ReleaseInfo:
+    version: str
+    wheel_url: str
+
+
+def _version_key(value: str) -> tuple[int, int, int]:
+    match = _VERSION_RE.fullmatch(value)
+    if match is None:
+        raise UpgradeError(f"Unsupported Raven version: {value}")
+    major, minor, patch = match.groups()
+    return int(major), int(minor), int(patch)
+
+
+def _current_version() -> str:
+    return metadata.version("raven")
+```
+
+Implement `_parse_release_payload` so it validates booleans, the exact `raven-X.Y.Z-py3-none-any.whl` asset, HTTPS, host `github.com`, and path `/EverMind-AI/Raven/releases/download/vX.Y.Z/<wheel>` before returning `ReleaseInfo`.
+
+- [ ] **Step 4: Implement the HTTP boundary with deterministic errors**
+
+Use an injectable client and the public API headers:
+
+```python
+def _fetch_latest_release(client: httpx.Client | None = None) -> ReleaseInfo:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": f"raven/{_current_version()}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if client is not None:
+        response = client.get(LATEST_RELEASE_API, headers=headers)
+        response.raise_for_status()
+        return _parse_release_payload(response.json())
+    with httpx.Client(timeout=10.0, follow_redirects=True) as owned_client:
+        response = owned_client.get(LATEST_RELEASE_API, headers=headers)
+        response.raise_for_status()
+        return _parse_release_payload(response.json())
+```
+
+Extend tests with `httpx.MockTransport` for success, timeout, non-2xx, and invalid JSON. The command layer will translate `httpx.HTTPError`, `ValueError`, and `UpgradeError` into user-facing failures.
+
+- [ ] **Step 5: Run focused tests and commit the release-discovery unit**
+
+Run:
+
+```bash
+uv run pytest tests/test_cli_upgrade_commands.py -q
+uv run ruff check raven/cli/upgrade_commands.py tests/test_cli_upgrade_commands.py
+uv run ruff format --check raven/cli/upgrade_commands.py tests/test_cli_upgrade_commands.py
+```
+
+Expected: all Task 1 tests pass and lint exits zero.
+
+Commit:
+
+```bash
+git add raven/cli/upgrade_commands.py tests/test_cli_upgrade_commands.py
+git commit -m "feat(cli): resolve raven release upgrades"
+```
+
+### Task 2: Installation guards and upgrade command
+
+**Files:**
+- Modify: `raven/cli/upgrade_commands.py`
+- Modify: `tests/test_cli_upgrade_commands.py`
+- Modify: `raven/cli/commands.py:104-118`
+- Modify: `tests/test_cli_smoke.py:44-73,154-181`
+
+**Interfaces:**
+- Consumes: `ReleaseInfo`, `_version_key`, `_fetch_latest_release`, `_current_version` from Task 1.
+- Produces: `_is_editable_install() -> bool`, `_is_uv_tool_install() -> bool`, `_run_uv(uv_path: str, requirement: str) -> int`, `_install_release(release: ReleaseInfo) -> None`, `register(app: typer.Typer) -> None`.
+
+- [ ] **Step 1: Write failing command and install-mode tests**
+
+Add CLI tests that monkeypatch all external boundaries:
+
+```python
+from unittest.mock import Mock
+
+import pytest
+from typer.testing import CliRunner
+
+from raven.cli import upgrade_commands
+from raven.cli.commands import app
+
+WHEEL_URL = "https://github.com/EverMind-AI/Raven/releases/download/v0.1.4/raven-0.1.4-py3-none-any.whl"
+runner = CliRunner()
+
+
+def test_upgrade_check_reports_available_without_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_commands, "_current_version", lambda: "0.1.3")
+    monkeypatch.setattr(
+        upgrade_commands,
+        "_fetch_latest_release",
+        lambda: upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL),
+    )
+    install = Mock()
+    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+
+    result = runner.invoke(app, ["upgrade", "--check"])
+
+    assert result.exit_code == 0
+    assert "0.1.3 -> 0.1.4" in result.stdout
+    assert "raven upgrade" in result.stdout
+    install.assert_not_called()
+```
+
+Cover equal versions, a newer local version with no downgrade, editable refusal, unsupported install refusal, missing uv, successful channel install, channel failure followed by base success, both attempts failing, and network/release errors returning exit code 1.
+
+For exact uv behavior, capture these calls:
+
+```python
+assert calls == [
+    ("/usr/bin/uv", f"raven[channels] @ {WHEEL_URL}"),
+    ("/usr/bin/uv", WHEEL_URL),
+]
+```
+
+- [ ] **Step 2: Run tests and confirm command registration is red**
+
+Run:
+
+```bash
+uv run pytest tests/test_cli_upgrade_commands.py tests/test_cli_smoke.py -q
+```
+
+Expected: failures because `upgrade` is not registered and install helpers do not exist.
+
+- [ ] **Step 3: Implement PEP 610 and uv-receipt guards**
+
+Use standard-library metadata only:
+
+```python
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+
+def _direct_url_data() -> dict[str, object]:
+    raw = metadata.distribution("raven").read_text("direct_url.json")
+    if not raw:
+        return {}
+    data = json.loads(raw)
+    return data if isinstance(data, dict) else {}
+
+
+def _is_editable_install() -> bool:
+    data = _direct_url_data()
+    directory = data.get("dir_info")
+    return isinstance(directory, dict) and directory.get("editable") is True
+
+
+def _is_uv_tool_install() -> bool:
+    receipt_path = Path(sys.prefix) / "uv-receipt.toml"
+    if not receipt_path.is_file():
+        return False
+    receipt = tomllib.loads(receipt_path.read_text(encoding="utf-8"))
+    requirements = receipt.get("tool", {}).get("requirements", [])
+    return any(isinstance(item, dict) and item.get("name") == "raven" for item in requirements)
+```
+
+Treat malformed metadata or receipts as unsupported installation errors instead of tracebacks.
+
+- [ ] **Step 4: Implement uv execution with the installer-compatible fallback**
+
+Use inherited output and argument arrays:
+
+```python
+import shutil
+import subprocess
+
+
+def _run_uv(uv_path: str, requirement: str) -> int:
+    completed = subprocess.run(
+        [uv_path, "tool", "install", "--force", requirement],
+        check=False,
+    )
+    return completed.returncode
+
+
+def _install_release(release: ReleaseInfo) -> None:
+    uv_path = shutil.which("uv")
+    if uv_path is None:
+        raise UpgradeError("uv was not found on PATH")
+    if _run_uv(uv_path, f"raven[channels] @ {release.wheel_url}") == 0:
+        return
+    if _run_uv(uv_path, release.wheel_url) != 0:
+        raise UpgradeError("uv could not install the Raven release wheel")
+```
+
+- [ ] **Step 5: Register and orchestrate the top-level command**
+
+Add `upgrade_commands` to the import and registration list in `raven/cli/commands.py`. The Typer callback must:
+
+1. Fetch and validate the latest Release.
+2. Compare current and latest version keys.
+3. Exit zero for equal or newer-local versions.
+4. Print `current -> latest` and exit zero for `--check`.
+5. Refuse editable and non-uv installs before invoking `_install_release`.
+6. Print success plus restart guidance after installation.
+7. Catch `UpgradeError`, `httpx.HTTPError`, JSON errors, and metadata errors, print one actionable red error, and raise `typer.Exit(1)`.
+
+Register `upgrade` in both `TOP_LEVEL_COMMANDS` and `REGISTERED_COMMAND_NAMES` in `tests/test_cli_smoke.py`.
+
+- [ ] **Step 6: Run focused tests and commit the working CLI**
+
+Run:
+
+```bash
+uv run pytest tests/test_cli_upgrade_commands.py tests/test_cli_smoke.py -q
+uv run ruff check raven/cli/upgrade_commands.py raven/cli/commands.py tests/test_cli_upgrade_commands.py tests/test_cli_smoke.py
+uv run ruff format --check raven/cli/upgrade_commands.py raven/cli/commands.py tests/test_cli_upgrade_commands.py tests/test_cli_smoke.py
+```
+
+Expected: all focused tests and lint pass.
+
+Commit:
+
+```bash
+git add raven/cli/upgrade_commands.py raven/cli/commands.py tests/test_cli_upgrade_commands.py tests/test_cli_smoke.py
+git commit -m "feat(cli): add raven upgrade command"
+```
+
+### Task 3: TUI upgrade safety and accurate hint
+
+**Files:**
+- Modify: `raven/tui_rpc/methods/cli_dispatch.py:66-103`
+- Modify: `tests/test_tui_rpc_cli_dispatch.py:232-257`
+- Modify: `ui-tui/src/components/branding.tsx:415-435`
+- Modify: `ui-tui/src/demo/gallery.tsx:102-104`
+- Modify: `ui-tui/src/__tests__/branding.test.tsx`
+
+**Interfaces:**
+- Consumes: the registered `upgrade` command from Task 2.
+- Produces: `("upgrade",)` in `_DISPATCH_BLACKLIST`; TUI fallback text `raven upgrade`.
+
+- [ ] **Step 1: Write failing Python and TypeScript safety tests**
+
+Extend the Python blacklist expectation and probe:
+
+```python
+expected_entries = {
+    ("gateway",),
+    ("provider", "login"),
+    ("channels", "login", "weixin"),
+    ("channels", "login", "whatsapp"),
+    ("sandbox", "shell"),
+    ("tui",),
+    ("onboard",),
+    ("upgrade",),
+}
+assert _is_dispatch_compatible(["upgrade"]) is False
+assert _is_dispatch_compatible(["upgrade", "--check"]) is False
+```
+
+Render the real session panel in `branding.test.tsx`:
+
+```tsx
+it('recommends the real raven upgrade command', () => {
+  const info: SessionInfo = {
+    model: 'anthropic/claude-sonnet-4-6',
+    skills: {},
+    tools: {},
+    update_behind: 1
+  }
+  const { lastFrame } = render(<SessionPanel info={info} maxCols={80} sid="test" t={DEFAULT_THEME} />)
+  expect(lastFrame()).toContain('raven upgrade')
+  expect(lastFrame()).not.toContain('raven update')
+})
+```
+
+Import `SessionPanel` and `SessionInfo` explicitly.
+
+- [ ] **Step 2: Run both tests and confirm the red state**
+
+Run:
+
+```bash
+uv run pytest tests/test_tui_rpc_cli_dispatch.py -q
+npm test --prefix ui-tui -- src/__tests__/branding.test.tsx
+```
+
+Expected: Python blacklist mismatch and TypeScript fallback text assertion failure.
+
+- [ ] **Step 3: Add the TUI blacklist entry and correct both literals**
+
+Add `("upgrade",)` with an English why-comment stating that replacing the active Raven process is terminal-only. Update blacklist count comments and assertions from seven to eight entries.
+
+Change both dormant literals:
+
+```tsx
+{info.update_command || 'raven upgrade'}
+```
+
+```tsx
+update_command: 'raven upgrade'
+```
+
+- [ ] **Step 4: Run TUI and RPC tests and commit**
+
+Run:
+
+```bash
+uv run pytest tests/test_tui_rpc_cli_dispatch.py tests/test_tui_rpc_commands_catalog.py -q
+npm test --prefix ui-tui -- src/__tests__/branding.test.tsx
+npm run lint --prefix ui-tui
+npm run type-check --prefix ui-tui
+```
+
+Expected: all commands exit zero.
+
+Commit:
+
+```bash
+git add raven/tui_rpc/methods/cli_dispatch.py tests/test_tui_rpc_cli_dispatch.py ui-tui/src/components/branding.tsx ui-tui/src/demo/gallery.tsx ui-tui/src/__tests__/branding.test.tsx
+git commit -m "fix(cli): keep upgrades outside active tui"
+```
+
+### Task 4: User documentation
+
+**Files:**
+- Modify: `README.md:52-90`
+- Modify: `README.zh-CN.md:56-94`
+
+**Interfaces:**
+- Consumes: the final CLI behavior from Task 2.
+- Produces: matching English and Chinese upgrade instructions.
+
+- [ ] **Step 1: Add an existing-install upgrade section to both READMEs**
+
+The English section must include these exact commands and boundaries:
+
+```markdown
+### Upgrade an existing installation
+
+Check for the latest published stable release:
+
+    raven upgrade --check
+
+Upgrade Raven without resetting configuration, sessions, or memory:
+
+    raven upgrade
+
+Raven upgrades are user-triggered, not automatic. Editable source installs are
+not overwritten; update the checkout and rerun its development setup instead.
+```
+
+Add the equivalent Chinese section with the same commands and meaning. Also add `raven upgrade --check` and `raven upgrade` to each useful-command table.
+
+- [ ] **Step 2: Verify documentation scope and commit**
+
+Run:
+
+```bash
+rg -n "raven upgrade" README.md README.zh-CN.md
+git diff --check
+PYTHONPATH=. uv run --extra dev python scripts/check_large_files.py origin/main
+```
+
+Expected: both READMEs contain check and upgrade guidance; checks exit zero.
+
+Commit:
+
+```bash
+git add README.md README.zh-CN.md
+git commit -m "docs: explain raven upgrade workflow"
+```
+
+### Task 5: Full verification and pull request
+
+**Files:**
+- Verify all files changed by Tasks 1-4.
+- Create: `/tmp/raven-upgrade-pr.md` outside the repository.
+
+**Interfaces:**
+- Consumes: all implementation commits.
+- Produces: pushed branch and draft pull request closing issue #111.
+
+- [ ] **Step 1: Run the complete relevant verification matrix**
+
+Run:
+
+```bash
+uv run pytest tests/test_cli_upgrade_commands.py tests/test_cli_smoke.py tests/test_tui_rpc_cli_dispatch.py tests/test_tui_rpc_commands_catalog.py -q
+uv run pytest -q
+uv run ruff check raven/cli/upgrade_commands.py raven/cli/commands.py raven/tui_rpc/methods/cli_dispatch.py tests/test_cli_upgrade_commands.py tests/test_cli_smoke.py tests/test_tui_rpc_cli_dispatch.py
+uv run ruff format --check raven/cli/upgrade_commands.py raven/cli/commands.py raven/tui_rpc/methods/cli_dispatch.py tests/test_cli_upgrade_commands.py tests/test_cli_smoke.py tests/test_tui_rpc_cli_dispatch.py
+npm test --prefix ui-tui
+npm run lint --prefix ui-tui
+npm run lint:rpc --prefix ui-tui
+npm run type-check --prefix ui-tui
+make check-large-files
+```
+
+Expected: every command exits zero with no failures.
+
+- [ ] **Step 2: Rebase onto the latest main and rerun focused tests**
+
+Run:
+
+```bash
+git fetch origin main
+git merge-tree --write-tree HEAD origin/main
+git rebase origin/main
+uv run pytest tests/test_cli_upgrade_commands.py tests/test_cli_smoke.py tests/test_tui_rpc_cli_dispatch.py tests/test_tui_rpc_commands_catalog.py -q
+npm test --prefix ui-tui -- src/__tests__/branding.test.tsx
+```
+
+Expected: the merge-tree and rebase are clean, then focused tests pass.
+
+- [ ] **Step 3: Run repository message and title lint**
+
+Run:
+
+```bash
+make check-commits
+PR_TITLE='feat(cli): add raven upgrade command' make check-pr-title
+```
+
+Expected: both lint gates pass.
+
+- [ ] **Step 4: Draft and validate the PR description**
+
+Write `/tmp/raven-upgrade-pr.md` with the repository template and these facts:
+
+```markdown
+## Change description
+
+> Add `raven upgrade --check` and `raven upgrade` using the latest published stable GitHub Release wheel. Protect editable and unsupported installs, preserve `~/.raven` state, keep self-upgrade outside the active TUI process, and document the user workflow.
+
+Closes #111
+
+## Type of change
+- [ ] Bug fix
+- [x] New feature
+- [x] Document
+- [ ] Others
+
+## Related issues (if there is)
+
+> Closes #111
+
+## Checklists
+
+### Development
+
+- [x] Lint rules pass locally
+- [x] Application changes have been tested thoroughly
+- [x] Automated tests covering modified code pass
+
+### Security
+
+- [x] Security impact of change has been considered
+- [x] Code follows security best practices and guidelines
+
+### Code review
+
+- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
+```
+
+Validate:
+
+```bash
+if LC_ALL=C rg -n '[^\x00-\x7F]' /tmp/raven-upgrade-pr.md; then exit 1; fi
+cat /tmp/raven-upgrade-pr.md
+```
+
+Expected: no non-ASCII matches and the full body matches verified work.
+
+- [ ] **Step 5: Push and open the draft PR**
+
+Run:
+
+```bash
+git push -u origin feat/raven_upgrade_command
+gh pr create --repo EverMind-AI/Raven --base main --head feat/raven_upgrade_command --draft --title 'feat(cli): add raven upgrade command' --body-file /tmp/raven-upgrade-pr.md
+```
+
+Expected: GitHub prints the new draft PR URL.

--- a/docs/superpowers/plans/2026-07-12-raven-upgrade-command.md
+++ b/docs/superpowers/plans/2026-07-12-raven-upgrade-command.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a safe `raven upgrade` command that checks and installs the latest published stable Raven Release without requiring users to rerun the public installer.
 
-**Architecture:** A focused top-level CLI module resolves and validates GitHub Release metadata, compares strict Raven semantic versions, and protects editable or malformed installations. For mutation, Raven replaces itself with an isolated, standard-library-only helper running on the external base Python; the helper restores the active uv tool/bin directories and performs the installer-compatible fallback only after the Raven executable is no longer active. TUI dispatch remains unable to run self-upgrade, while dormant update copy points to the real command.
+**Architecture:** A focused top-level CLI module resolves and validates GitHub Release metadata, compares strict Raven semantic versions, and protects editable or malformed installations. For mutation, a standard-library-only helper runs on the external base Python: POSIX replaces the current process synchronously, while Windows starts a breakaway helper that waits for the uv trampoline to exit before replacing the locked entrypoint. The helper restores the active uv tool/bin directories and performs the installer-compatible fallback only after the Raven executable is no longer active. TUI dispatch remains unable to run self-upgrade, while dormant update copy points to the real command.
 
 **Tech Stack:** Python 3.12, Typer, Rich, httpx, importlib.metadata, uv, pytest, React/Ink, TypeScript, Vitest.
 
@@ -263,21 +263,31 @@ Require a Raven requirement and exactly one Raven entrypoint with an absolute
 `UV_TOOL_BIN_DIR` from the entrypoint parent. Missing receipts remain an
 unsupported install; present malformed receipts fail closed.
 
-- [ ] **Step 4: Implement post-exit uv execution with the installer-compatible fallback**
+- [ ] **Step 4: Implement platform-specific post-exit uv execution**
 
 Resolve uv and `sys._base_executable` to files outside the active Raven tool
-prefix. Override `UV_TOOL_DIR` and `UV_TOOL_BIN_DIR` in a copied environment,
-flush inherited output, and call `os.execve` with:
+prefix. Encode the multiline helper source into a whitespace-free bootstrap,
+override `UV_TOOL_DIR` and `UV_TOOL_BIN_DIR` in a copied environment, and build:
 
 ```python
-[base_python, "-I", "-c", helper_source, uv_path, wheel_url, current, latest]
+argv = [base_python, "-I", "-c", bootstrap, uv_path, wheel_url, current, latest]
 ```
 
-The inline helper must use only the standard library and trusted argument
-arrays. It runs the channels requirement first, falls back to the base wheel,
-warns only when that fallback succeeds, prints the final success itself, catches
-uv execution `OSError`, and returns the final uv status when both attempts fail.
-Because the helper is inline, no temporary artifact needs cleanup.
+On POSIX, flush inherited output and call `os.execve(base_python, argv, env)`.
+On Windows, append `os.getppid()` to `argv`, start the helper with
+`subprocess.Popen(..., creationflags=CREATE_BREAKAWAY_FROM_JOB)`, and return
+after printing that the user must wait for the final completion message. The
+helper opens the trampoline process with `SYNCHRONIZE`, waits for it with a
+bounded `WaitForSingleObject`, and only then invokes uv.
+
+The helper must use only the standard library and trusted argument arrays. It
+runs the channels requirement first, falls back to the base wheel, warns only
+when that fallback succeeds, prints the final success itself, catches uv
+execution `OSError`, and returns the final uv status when both attempts fail.
+Because the helper is inline, no temporary artifact needs cleanup. Unit tests
+must cover bootstrap transport, Windows process scheduling, parent waiting, and
+spawn failures. The real integration test must use uv tool/bin paths containing
+spaces and verify the installed version after the helper finishes.
 
 - [ ] **Step 5: Register and orchestrate the top-level command**
 
@@ -462,7 +472,85 @@ git add README.md README.zh-CN.md
 git commit -m "docs: explain raven upgrade workflow"
 ```
 
-### Task 5: Full verification and pull request
+### Task 5: Correct Windows handoff semantics
+
+**Files:**
+- Modify: `raven/cli/upgrade_commands.py`
+- Modify: `tests/test_cli_upgrade_commands.py`
+- Modify: `tests/integration/test_cli_upgrade_real_uv.py`
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+
+**Interfaces:**
+- Consumes: `_UPGRADE_HELPER_SOURCE`, `_handoff_upgrade()`, and `ToolInstallTarget` from Task 2.
+- Produces: `_upgrade_helper_bootstrap() -> str`; POSIX synchronous handoff; Windows breakaway handoff that waits for the uv trampoline before mutation.
+
+- [ ] **Step 1: Add failing Windows transport and scheduling tests**
+
+Extend `tests/test_cli_upgrade_commands.py` so a simulated Windows handoff uses
+paths containing spaces, calls `subprocess.Popen` with the external base Python
+and the breakaway creation flag, appends a fixed `os.getppid()` value, and never
+calls `os.execve`. Assert that the `-c` bootstrap contains no whitespace and
+that a spawn `OSError` becomes `UpgradeError`.
+
+- [ ] **Step 2: Add failing helper parent-wait tests**
+
+Load `_UPGRADE_HELPER_SOURCE`, replace its `wait_for_parent` global with a mock,
+and call `main()` with a fifth parent-PID argument. Assert that the parent wait
+completes before the first uv subprocess call and that a nonzero wait result
+prevents uv from running.
+
+- [ ] **Step 3: Run the new unit tests and verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_cli_upgrade_commands.py -q
+```
+
+Expected: the new Windows tests fail because `_handoff_upgrade()` still calls
+`os.execve` with the multiline source and the helper has no parent wait.
+
+- [ ] **Step 4: Implement the minimal cross-platform handoff**
+
+Add `base64` and `subprocess` imports, define a portable
+`CREATE_BREAKAWAY_FROM_JOB = 0x01000000` constant, and generate a one-line
+bootstrap equivalent to:
+
+```python
+exec(compile(__import__("base64").b64decode(encoded), "<raven-upgrade>", "exec"))
+```
+
+Keep `os.execve` for POSIX. On Windows, append `str(os.getppid())`, call
+`subprocess.Popen(argv, env=env, creationflags=CREATE_BREAKAWAY_FROM_JOB)`, and
+print `Raven upgrade started. Wait for the completion message before running Raven again.`
+
+Inside `_UPGRADE_HELPER_SOURCE`, accept the optional fifth PID argument. Open
+that process with Windows `SYNCHRONIZE`, wait at most 30 seconds with
+`WaitForSingleObject`, close the handle, and refuse to invoke uv when opening or
+waiting fails.
+
+- [ ] **Step 5: Strengthen the real integration test and documentation**
+
+Copy the discovered uv executable into `external tools`, use `custom tools` and
+`custom bin` for the uv installation, and keep the success-output and final
+`--version == 2.0.0` assertions. Explain in both READMEs that POSIX completion
+is synchronous while Windows users must wait for the helper's completion
+message.
+
+- [ ] **Step 6: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_cli_upgrade_commands.py tests/integration/test_cli_upgrade_real_uv.py -q
+uv run ruff check raven/cli/upgrade_commands.py tests/test_cli_upgrade_commands.py tests/integration/test_cli_upgrade_real_uv.py
+uv run ruff format --check raven/cli/upgrade_commands.py tests/test_cli_upgrade_commands.py tests/integration/test_cli_upgrade_real_uv.py
+```
+
+Expected: all focused tests and lint pass.
+
+### Task 6: Full verification and pull request
 
 **Files:**
 - Verify all files changed by Tasks 1-4.

--- a/docs/superpowers/specs/2026-07-12-raven-upgrade-command-design.md
+++ b/docs/superpowers/specs/2026-07-12-raven-upgrade-command-design.md
@@ -1,0 +1,151 @@
+# Raven Upgrade Command Design
+
+## Status
+
+Approved for implementation on 2026-07-12. Tracks GitHub issue #111.
+
+## Context
+
+Raven's public installers resolve the wheel attached to the latest published
+GitHub Release and install it as a global uv tool. Raven does not currently
+expose a user-facing update command, so existing users must rerun the original
+installer to receive a new release. The TUI also retains dormant Hermes-era
+fields that refer to commit counts and a nonexistent `raven update` command.
+
+## Goals
+
+- Add `raven upgrade --check` for a read-only release check.
+- Add `raven upgrade` for upgrading a supported uv-tool installation.
+- Use the latest published stable GitHub Release as the only update source.
+- Preserve Raven state under `~/.raven`.
+- Refuse to overwrite editable or unsupported installations.
+- Keep upgrade execution out of the running TUI process.
+- Document the upgrade workflow for all supported operating systems.
+
+## Non-goals
+
+- Background or silent automatic updates.
+- Updating from an unpublished commit, tag, draft Release, or prerelease.
+- Updating a developer's source checkout automatically.
+- Enabling PyPI distribution.
+- Adding a synchronous network check to TUI startup.
+
+## Considered approaches
+
+### Native Python updater (selected)
+
+The CLI queries GitHub's latest-release endpoint, validates the release wheel,
+compares versions, and invokes uv with an argument list. This path is testable,
+does not execute downloaded shell code, and can protect nonstandard installs.
+
+### Installer wrapper
+
+The CLI could rerun `install.sh` or `install.ps1`. This would reuse the current
+installer but would execute remote scripts, repeat first-install runtime checks,
+depend on platform shells, and be harder to test reliably.
+
+### Check-only assistant
+
+The CLI could report an available version and print the existing installer
+command. This is the smallest change, but it leaves the manual reinstall step
+that the feature is intended to remove.
+
+## Architecture
+
+### CLI module
+
+Add `raven/cli/upgrade_commands.py` with the same `register(app)` boundary used
+by the other top-level command modules. Keep orchestration in the command
+callback and isolate network, metadata, version, and subprocess behavior behind
+small functions that unit tests can replace.
+
+The module will expose a small immutable release record containing the stable
+version and wheel URL. Version comparison will accept Raven's documented
+`MAJOR.MINOR.PATCH` format and will not treat commit distance as a release.
+
+### Release resolution
+
+Use `GET https://api.github.com/repos/EverMind-AI/Raven/releases/latest` through
+the existing `httpx` runtime dependency. Require:
+
+- a stable `vMAJOR.MINOR.PATCH` tag;
+- a non-draft, non-prerelease response;
+- exactly one Raven `.whl` asset for that version;
+- an HTTPS download URL under the Raven GitHub Release path.
+
+Malformed responses, timeouts, rate limits, missing assets, and non-success
+responses must produce actionable errors and a nonzero exit code.
+
+### Installation-mode protection
+
+Read the installed distribution's PEP 610 `direct_url.json` metadata. An
+editable installation may run `raven upgrade --check`, but `raven upgrade`
+must stop and explain that the source checkout should be pulled and rebuilt.
+
+Before mutation, require the uv tool receipt in the active environment. A
+non-editable installation that is not managed by uv must receive the official
+installer guidance instead of being overwritten.
+
+### Upgrade execution
+
+When a newer release exists, locate `uv` on `PATH` and mirror the supported
+installer flow:
+
+1. Run `uv tool install --force "raven[channels] @ <wheel-url>"`.
+2. If optional channel dependencies fail, retry the base wheel.
+3. If both attempts fail, return the final uv failure status with recovery
+   guidance. Raven state under `~/.raven` remains untouched.
+
+Subprocesses receive argument arrays and inherited terminal output. The command
+does not modify `~/.raven`, so configuration, sessions, memory, and runtime state
+remain intact. On success, the user is told to restart any running Raven process.
+
+### TUI boundary
+
+Add `upgrade` to the TUI RPC dispatch blacklist because replacing Raven from an
+active TUI process is unsafe. Correct dormant fallback/demo text from
+`raven update` to `raven upgrade`, but do not add a startup network request or a
+new RPC version contract in this PR.
+
+A future TUI update notice should use release-oriented fields such as
+`update_available` and `latest_version`, populated asynchronously or from a
+cache, rather than the current `update_behind` commit count.
+
+## User-visible behavior
+
+- Current version equals latest: report that Raven is up to date and exit zero.
+- Current version is newer than latest: report a development/newer build and
+  exit zero without downgrading.
+- New stable release with `--check`: report `current -> latest`, print
+  `Run raven upgrade`, and exit zero without a subprocess.
+- New stable release without `--check`: run the uv installation flow.
+- Editable or unsupported install with `--check`: perform the release comparison
+  without changing the environment.
+- Editable or unsupported install without `--check`: explain the correct update
+  path and exit nonzero without attempting uv installation.
+
+## Tests
+
+Add `tests/test_cli_upgrade_commands.py` and update the pinned CLI smoke surface.
+All network and subprocess behavior will be mocked. Cover:
+
+- command help and root registration;
+- up-to-date, newer-local, and update-available comparisons;
+- `--check` never invoking uv;
+- exact uv argument arrays and the channel-to-base fallback;
+- missing uv and both installation attempts failing;
+- editable and unsupported installation refusal;
+- HTTP, malformed metadata, invalid URL, and missing-wheel failures;
+- TUI dispatch blacklist and corrected fallback command text.
+
+Run the focused Python suite, CLI/TUI RPC tests, TUI type/lint/tests, repository
+lint, commit-message lint, PR-title lint, and the large-file check before the PR.
+
+## Documentation
+
+Update both README files so existing users understand that:
+
+- `raven upgrade --check` checks the latest stable Release;
+- `raven upgrade` replaces the installed Raven tool without resetting state;
+- the command is manual, not a background auto-update service;
+- source installations follow the developer update workflow.

--- a/docs/superpowers/specs/2026-07-12-raven-upgrade-command-design.md
+++ b/docs/superpowers/specs/2026-07-12-raven-upgrade-command-design.md
@@ -94,27 +94,39 @@ official installer guidance instead of being overwritten.
 
 ### Upgrade execution
 
-When a newer release exists, locate `uv` on `PATH`, require both uv and
-`sys._base_executable` to be outside the active Raven tool environment, and
-replace the current process with that external Python via `os.execve`. The
-inline helper is passed through `python -I -c`, uses only the standard library,
-inherits the console, and receives explicit `UV_TOOL_DIR` and
-`UV_TOOL_BIN_DIR` values. There is no temporary helper file to clean up.
+When a newer release exists, locate `uv` on `PATH` and require both uv and
+`sys._base_executable` to be outside the active Raven tool environment. The
+standard-library-only helper receives explicit `UV_TOOL_DIR` and
+`UV_TOOL_BIN_DIR` values through a copied environment. Its source is encoded
+into a single whitespace-free `python -I -c` bootstrap, so Windows argument
+marshalling cannot split the multiline program.
 
-Only after Raven has been replaced does the helper mirror the supported
-installer flow:
+On POSIX, replace the current process with the external base Python via
+`os.execve`, preserving synchronous completion and the helper's final status.
+Windows cannot provide the same exec semantics: the uv-generated `raven.exe`
+trampoline remains locked until it exits. Launch the external helper with a
+breakaway process flag, pass the trampoline PID, return only after the helper
+has been scheduled, and have the helper wait for that parent process to exit
+before invoking uv. The helper inherits the console so it can print its final
+result. There is no temporary helper file to clean up.
+
+Only after the active Raven entrypoint is no longer running does the helper
+mirror the supported installer flow:
 
 1. Run `uv tool install --force "raven[channels] @ <wheel-url>"`.
 2. If optional channel dependencies fail, retry the base wheel.
 3. If the base fallback succeeds, warn that channel adapters may be
    unavailable.
-4. If both attempts fail, return the final uv failure status with recovery
-   guidance. Raven state under `~/.raven` remains untouched.
+4. If both attempts fail, print the final uv failure status with recovery
+   guidance. On POSIX that status is returned synchronously; on Windows the
+   original command reports only whether the detached handoff was scheduled.
+   Raven state under `~/.raven` remains untouched.
 
 All process calls receive trusted argument arrays without a shell. The command
 does not modify `~/.raven`, so configuration, sessions, memory, and runtime
 state remain intact. The helper prints the final success or failure after uv
-finishes and preserves the final uv exit status.
+finishes. Windows users must wait for that completion message before running
+Raven again.
 
 ### TUI boundary
 
@@ -148,17 +160,20 @@ and update the pinned CLI smoke surface. Cover:
 - command help and root registration;
 - up-to-date, newer-local, and update-available comparisons;
 - `--check` never invoking uv;
-- exact helper argument arrays, custom uv tool/bin targets, and process handoff;
+- exact helper argument arrays, custom uv tool/bin targets, and platform-specific
+  process handoff;
+- whitespace-safe helper transport and Windows trampoline waiting;
 - the channel-to-base fallback warning and final uv exit status;
 - missing uv and both installation attempts failing;
 - editable, malformed, and unsupported installation refusal;
 - HTTP, malformed metadata, invalid URL, and missing-wheel failures;
 - TUI dispatch blacklist and corrected fallback command text.
 
-The integration test installs a temporary old uv tool in custom directories,
-runs its own upgrade handoff, and verifies that the same entrypoint reports the
-new version. A dedicated Windows CI job runs this test to protect the executable
-locking scenario that motivated the external helper.
+The integration test installs a temporary old uv tool in custom directories
+whose paths contain spaces, runs its own upgrade handoff, and verifies that the
+same entrypoint reports the new version. A dedicated Windows CI job runs this
+test to protect the argument-marshalling and executable-locking scenarios that
+motivate the external helper.
 
 Run the focused Python suite, CLI/TUI RPC tests, TUI type/lint/tests, repository
 lint, commit-message lint, PR-title lint, and the large-file check before the PR.

--- a/docs/superpowers/specs/2026-07-12-raven-upgrade-command-design.md
+++ b/docs/superpowers/specs/2026-07-12-raven-upgrade-command-design.md
@@ -104,11 +104,13 @@ marshalling cannot split the multiline program.
 On POSIX, replace the current process with the external base Python via
 `os.execve`, preserving synchronous completion and the helper's final status.
 Windows cannot provide the same exec semantics: the uv-generated `raven.exe`
-trampoline remains locked until it exits. Launch the external helper with a
-breakaway process flag, pass the trampoline PID, return only after the helper
-has been scheduled, and have the helper wait for that parent process to exit
-before invoking uv. The helper inherits the console so it can print its final
-result. There is no temporary helper file to clean up.
+trampoline remains locked until it exits. Launch the external helper with
+`subprocess.Popen`, pass the trampoline PID, return only after the helper has
+been scheduled, and have the helper wait for that parent process to exit before
+invoking uv. uv's trampoline job is configured for silent child breakaway, so
+an explicit Windows breakaway creation flag is unnecessary and could conflict
+with an enclosing job. The helper inherits the console so it can print its
+final result. There is no temporary helper file to clean up.
 
 Only after the active Raven entrypoint is no longer running does the helper
 mirror the supported installer flow:

--- a/docs/superpowers/specs/2026-07-12-raven-upgrade-command-design.md
+++ b/docs/superpowers/specs/2026-07-12-raven-upgrade-command-design.md
@@ -35,8 +35,10 @@ fields that refer to commit counts and a nonexistent `raven update` command.
 ### Native Python updater (selected)
 
 The CLI queries GitHub's latest-release endpoint, validates the release wheel,
-compares versions, and invokes uv with an argument list. This path is testable,
-does not execute downloaded shell code, and can protect nonstandard installs.
+compares versions, and replaces itself with a standard-library-only helper
+running on the tool environment's external base Python. This path is testable,
+does not execute downloaded shell code, and releases the active Raven
+executable before uv replaces the installation on Windows.
 
 ### Installer wrapper
 
@@ -78,27 +80,41 @@ responses must produce actionable errors and a nonzero exit code.
 
 ### Installation-mode protection
 
-Read the installed distribution's PEP 610 `direct_url.json` metadata. An
-editable installation may run `raven upgrade --check`, but `raven upgrade`
-must stop and explain that the source checkout should be pulled and rebuilt.
+Read the installed distribution's PEP 610 `direct_url.json` metadata. When the
+file is present, require a nonempty URL and exactly one valid archive,
+directory, or VCS origin record. An editable installation may run
+`raven upgrade --check`, but `raven upgrade` must stop and explain that the
+source checkout should be pulled and rebuilt.
 
-Before mutation, require the uv tool receipt in the active environment. A
-non-editable installation that is not managed by uv must receive the official
-installer guidance instead of being overwritten.
+Before mutation, require the uv tool receipt in the active environment. Derive
+the active `UV_TOOL_DIR` from `sys.prefix` and `UV_TOOL_BIN_DIR` from the Raven
+entrypoint's absolute `install-path`; malformed or ambiguous targets fail
+closed. A non-editable installation that is not managed by uv must receive the
+official installer guidance instead of being overwritten.
 
 ### Upgrade execution
 
-When a newer release exists, locate `uv` on `PATH` and mirror the supported
+When a newer release exists, locate `uv` on `PATH`, require both uv and
+`sys._base_executable` to be outside the active Raven tool environment, and
+replace the current process with that external Python via `os.execve`. The
+inline helper is passed through `python -I -c`, uses only the standard library,
+inherits the console, and receives explicit `UV_TOOL_DIR` and
+`UV_TOOL_BIN_DIR` values. There is no temporary helper file to clean up.
+
+Only after Raven has been replaced does the helper mirror the supported
 installer flow:
 
 1. Run `uv tool install --force "raven[channels] @ <wheel-url>"`.
 2. If optional channel dependencies fail, retry the base wheel.
-3. If both attempts fail, return the final uv failure status with recovery
+3. If the base fallback succeeds, warn that channel adapters may be
+   unavailable.
+4. If both attempts fail, return the final uv failure status with recovery
    guidance. Raven state under `~/.raven` remains untouched.
 
-Subprocesses receive argument arrays and inherited terminal output. The command
-does not modify `~/.raven`, so configuration, sessions, memory, and runtime state
-remain intact. On success, the user is told to restart any running Raven process.
+All process calls receive trusted argument arrays without a shell. The command
+does not modify `~/.raven`, so configuration, sessions, memory, and runtime
+state remain intact. The helper prints the final success or failure after uv
+finishes and preserves the final uv exit status.
 
 ### TUI boundary
 
@@ -126,17 +142,23 @@ cache, rather than the current `update_behind` commit count.
 
 ## Tests
 
-Add `tests/test_cli_upgrade_commands.py` and update the pinned CLI smoke surface.
-All network and subprocess behavior will be mocked. Cover:
+Add `tests/test_cli_upgrade_commands.py`, a bounded real-uv integration test,
+and update the pinned CLI smoke surface. Cover:
 
 - command help and root registration;
 - up-to-date, newer-local, and update-available comparisons;
 - `--check` never invoking uv;
-- exact uv argument arrays and the channel-to-base fallback;
+- exact helper argument arrays, custom uv tool/bin targets, and process handoff;
+- the channel-to-base fallback warning and final uv exit status;
 - missing uv and both installation attempts failing;
-- editable and unsupported installation refusal;
+- editable, malformed, and unsupported installation refusal;
 - HTTP, malformed metadata, invalid URL, and missing-wheel failures;
 - TUI dispatch blacklist and corrected fallback command text.
+
+The integration test installs a temporary old uv tool in custom directories,
+runs its own upgrade handoff, and verifies that the same entrypoint reports the
+new version. A dedicated Windows CI job runs this test to protect the executable
+locking scenario that motivated the external helper.
 
 Run the focused Python suite, CLI/TUI RPC tests, TUI type/lint/tests, repository
 lint, commit-message lint, PR-title lint, and the large-file check before the PR.

--- a/raven/cli/commands.py
+++ b/raven/cli/commands.py
@@ -9,6 +9,7 @@ group. The actual implementations live in per-feature modules:
     - ``gateway``  → ``raven/cli/gateway_commands.py``
     - ``onboard``  → ``raven/cli/onboard_commands.py``
     - ``status``   → ``raven/cli/status_commands.py``
+    - ``upgrade``  → ``raven/cli/upgrade_commands.py``
 
 - Subcommand groups (each exposes a typer ``*_app`` instance):
     - ``channels`` → ``raven/cli/channel_commands.py``
@@ -108,6 +109,7 @@ from raven.cli import (
     onboard_commands,
     plugin_commands,
     status_commands,
+    upgrade_commands,
 )
 
 onboard_commands.register(app)
@@ -116,6 +118,7 @@ agent_commands.register(app)
 status_commands.register(app)
 doctor_commands.register(app)
 plugin_commands.register(app)
+upgrade_commands.register(app)
 
 
 # ============================================================================

--- a/raven/cli/upgrade_commands.py
+++ b/raven/cli/upgrade_commands.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
+import json
 import re
+import shutil
+import subprocess
+import sys
+import tomllib
 from dataclasses import dataclass
 from importlib import metadata
+from pathlib import Path
 from urllib.parse import urlparse
 
 import httpx
+import typer
+from rich.console import Console
 
 LATEST_RELEASE_API = "https://api.github.com/repos/EverMind-AI/Raven/releases/latest"
 _VERSION_RE = re.compile(r"^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+console = Console()
 
 
 class UpgradeError(RuntimeError):
@@ -91,3 +100,106 @@ def _fetch_latest_release(client: httpx.Client | None = None) -> ReleaseInfo:
         response = owned_client.get(LATEST_RELEASE_API, headers=headers)
         response.raise_for_status()
         return _parse_release_payload(response.json())
+
+
+def _direct_url_data() -> dict[str, object]:
+    raw = metadata.distribution("raven").read_text("direct_url.json")
+    if not raw:
+        return {}
+    data = json.loads(raw)
+    return data if isinstance(data, dict) else {}
+
+
+def _is_editable_install() -> bool:
+    data = _direct_url_data()
+    directory = data.get("dir_info")
+    return isinstance(directory, dict) and directory.get("editable") is True
+
+
+def _is_uv_tool_install() -> bool:
+    receipt_path = Path(sys.prefix) / "uv-receipt.toml"
+    if not receipt_path.is_file():
+        return False
+    receipt = tomllib.loads(receipt_path.read_text(encoding="utf-8"))
+    tool = receipt.get("tool")
+    if not isinstance(tool, dict):
+        return False
+    requirements = tool.get("requirements")
+    if not isinstance(requirements, list):
+        return False
+    return any(isinstance(item, dict) and item.get("name") == "raven" for item in requirements)
+
+
+def _run_uv(uv_path: str, requirement: str) -> int:
+    completed = subprocess.run(
+        [uv_path, "tool", "install", "--force", requirement],
+        check=False,
+    )
+    return completed.returncode
+
+
+def _install_release(release: ReleaseInfo) -> None:
+    uv_path = shutil.which("uv")
+    if uv_path is None:
+        raise UpgradeError("uv was not found on PATH")
+    if _run_uv(uv_path, f"raven[channels] @ {release.wheel_url}") == 0:
+        return
+    if _run_uv(uv_path, release.wheel_url) != 0:
+        raise UpgradeError("uv could not install the Raven release wheel")
+
+
+def register(app: typer.Typer) -> None:
+    @app.command()
+    def upgrade(
+        check: bool = typer.Option(
+            False,
+            "--check",
+            help="Check for a newer stable Raven release without installing it.",
+        ),
+    ) -> None:
+        """Check for and install the latest stable Raven release."""
+        try:
+            current_version = _current_version()
+            release = _fetch_latest_release()
+            current_key = _version_key(current_version)
+            latest_key = _version_key(release.version)
+
+            if current_key == latest_key:
+                console.print(f"Raven {current_version} is up to date.")
+                return
+            if current_key > latest_key:
+                console.print(
+                    f"Raven {current_version} is newer than the latest release "
+                    f"{release.version}; no downgrade was performed."
+                )
+                return
+            if check:
+                console.print(f"Raven upgrade available: {current_version} -> {release.version}")
+                console.print("Run [cyan]raven upgrade[/cyan] to install it.")
+                return
+            if _is_editable_install():
+                raise UpgradeError(
+                    "Editable Raven installations cannot be upgraded automatically. "
+                    "Pull the source checkout and rebuild Raven."
+                )
+            if not _is_uv_tool_install():
+                raise UpgradeError(
+                    "This Raven installation is not managed by uv. "
+                    "Reinstall Raven with the official installer, then run raven upgrade."
+                )
+
+            _install_release(release)
+            console.print(f"[green]Raven upgraded: {current_version} -> {release.version}[/green]")
+            console.print("Restart any running Raven process to use the new version.")
+        except (
+            UpgradeError,
+            httpx.HTTPError,
+            ValueError,
+            metadata.PackageNotFoundError,
+        ) as exc:
+            console.print(
+                f"[red]Unable to upgrade Raven:[/red] {exc}. "
+                "Check your network and try again; if the problem persists, "
+                "rerun the official installer."
+            )
+            raise typer.Exit(1) from exc

--- a/raven/cli/upgrade_commands.py
+++ b/raven/cli/upgrade_commands.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
+import base64
 import json
 import os
 import re
 import shutil
+import subprocess
 import sys
 import tomllib
 from dataclasses import dataclass
 from importlib import metadata
 from pathlib import Path
-from typing import NoReturn
 from urllib.parse import urlparse
 
 import httpx
@@ -41,13 +42,73 @@ _UPGRADE_HELPER_SOURCE = r"""import subprocess
 import sys
 
 
+def wait_for_parent(parent_pid):
+    import ctypes
+    from ctypes import wintypes
+
+    synchronize = 0x00100000
+    wait_object_0 = 0x00000000
+    wait_timeout = 0x00000102
+    wait_failed = 0xFFFFFFFF
+    error_invalid_parameter = 87
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = ctypes.c_void_p
+    kernel32.WaitForSingleObject.argtypes = [ctypes.c_void_p, wintypes.DWORD]
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    handle = kernel32.OpenProcess(synchronize, False, parent_pid)
+    if not handle:
+        error = ctypes.get_last_error()
+        if error == error_invalid_parameter:
+            return 0
+        print(
+            f"Unable to upgrade Raven: could not wait for Raven to exit "
+            f"(Windows error {error}).",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        wait_status = kernel32.WaitForSingleObject(handle, 30_000)
+        wait_error = ctypes.get_last_error()
+    finally:
+        kernel32.CloseHandle(handle)
+
+    if wait_status == wait_object_0:
+        return 0
+    if wait_status == wait_timeout:
+        detail = "timed out"
+    elif wait_status == wait_failed:
+        detail = f"failed with Windows error {wait_error}"
+    else:
+        detail = f"returned unexpected status {wait_status}"
+    print(f"Unable to upgrade Raven: waiting for Raven to exit {detail}.", file=sys.stderr)
+    return 1
+
+
 def main(argv=None):
     args = sys.argv[1:] if argv is None else argv
-    if len(args) != 4:
+    if len(args) not in (4, 5):
         print("Unable to upgrade Raven: invalid upgrade helper arguments.", file=sys.stderr)
         return 2
 
-    uv_path, wheel_url, current_version, latest_version = args
+    uv_path, wheel_url, current_version, latest_version = args[:4]
+    if len(args) == 5:
+        try:
+            parent_pid = int(args[4])
+        except (TypeError, ValueError):
+            print("Unable to upgrade Raven: invalid upgrade helper arguments.", file=sys.stderr)
+            return 2
+        if parent_pid <= 0:
+            print("Unable to upgrade Raven: invalid upgrade helper arguments.", file=sys.stderr)
+            return 2
+        parent_status = wait_for_parent(parent_pid)
+        if parent_status != 0:
+            return parent_status
 
     def install(requirement):
         return subprocess.run(
@@ -82,6 +143,11 @@ def main(argv=None):
 if __name__ == "__main__":
     raise SystemExit(main())
 """
+
+
+def _upgrade_helper_bootstrap() -> str:
+    encoded = base64.b64encode(_UPGRADE_HELPER_SOURCE.encode("utf-8")).decode("ascii")
+    return f'exec(compile(__import__("base64").b64decode("{encoded}"),"<raven-upgrade>","exec"))'
 
 
 def _version_key(value: str) -> tuple[int, int, int]:
@@ -283,7 +349,7 @@ def _handoff_upgrade(
     release: ReleaseInfo,
     current_version: str,
     target: ToolInstallTarget,
-) -> NoReturn:
+) -> None:
     uv_value = shutil.which("uv")
     if uv_value is None:
         raise UpgradeError("uv was not found on PATH")
@@ -297,7 +363,7 @@ def _handoff_upgrade(
         str(base_python),
         "-I",
         "-c",
-        _UPGRADE_HELPER_SOURCE,
+        _upgrade_helper_bootstrap(),
         str(uv_path),
         release.wheel_url,
         current_version,
@@ -306,6 +372,11 @@ def _handoff_upgrade(
     sys.stdout.flush()
     sys.stderr.flush()
     try:
+        if sys.platform == "win32":
+            argv.append(str(os.getppid()))
+            subprocess.Popen(argv, env=env)
+            print("Raven upgrade started. Wait for the completion message before running Raven again.")
+            return
         os.execve(str(base_python), argv, env)
     except OSError as exc:
         raise UpgradeError(f"Could not start the Raven upgrade helper: {exc}") from exc

--- a/raven/cli/upgrade_commands.py
+++ b/raven/cli/upgrade_commands.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
-import subprocess
 import sys
 import tomllib
 from dataclasses import dataclass
 from importlib import metadata
 from pathlib import Path
+from typing import NoReturn
 from urllib.parse import urlparse
 
 import httpx
@@ -28,6 +29,59 @@ class UpgradeError(RuntimeError):
 class ReleaseInfo:
     version: str
     wheel_url: str
+
+
+@dataclass(frozen=True)
+class ToolInstallTarget:
+    tool_dir: Path
+    bin_dir: Path
+
+
+_UPGRADE_HELPER_SOURCE = r"""import subprocess
+import sys
+
+
+def main(argv=None):
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) != 4:
+        print("Unable to upgrade Raven: invalid upgrade helper arguments.", file=sys.stderr)
+        return 2
+
+    uv_path, wheel_url, current_version, latest_version = args
+
+    def install(requirement):
+        return subprocess.run(
+            [uv_path, "tool", "install", "--force", requirement],
+            check=False,
+        ).returncode
+
+    try:
+        channel_status = install(f"raven[channels] @ {wheel_url}")
+        if channel_status != 0:
+            base_status = install(wheel_url)
+            if base_status != 0:
+                print(
+                    f"Unable to upgrade Raven: uv exited with status {base_status}.",
+                    file=sys.stderr,
+                )
+                return base_status
+            print(
+                "Warning: Channel dependencies failed to install; installed base raven only. "
+                "Some channels stay unavailable (see: raven channels list).",
+                file=sys.stderr,
+            )
+    except OSError as exc:
+        print(f"Unable to upgrade Raven: could not run uv: {exc}.", file=sys.stderr)
+        return 1
+
+    print(f"Raven upgraded: {current_version} -> {latest_version}")
+    print("Restart any other running Raven process to use the new version.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+"""
 
 
 def _version_key(value: str) -> tuple[int, int, int]:
@@ -54,7 +108,7 @@ def _parse_release_payload(payload: object) -> ReleaseInfo:
         raise UpgradeError("Latest Raven release is not stable")
 
     tag_name = payload.get("tag_name")
-    if not isinstance(tag_name, str):
+    if not isinstance(tag_name, str) or not tag_name.startswith("v"):
         raise UpgradeError("Malformed GitHub release payload")
     version = ".".join(str(part) for part in _version_key(tag_name))
 
@@ -102,62 +156,160 @@ def _fetch_latest_release(client: httpx.Client | None = None) -> ReleaseInfo:
         return _parse_release_payload(response.json())
 
 
-def _direct_url_data() -> dict[str, object]:
+def _direct_url_data() -> dict[str, object] | None:
     raw = metadata.distribution("raven").read_text("direct_url.json")
     if raw is None:
-        return {}
+        return None
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as exc:
         raise UpgradeError("Malformed Raven installation metadata") from exc
     if not isinstance(data, dict):
         raise UpgradeError("Malformed Raven installation metadata")
+
+    url = data.get("url")
+    origins = [key for key in ("archive_info", "dir_info", "vcs_info") if key in data]
+    if not isinstance(url, str) or not url.strip() or not urlparse(url).scheme or len(origins) != 1:
+        raise UpgradeError("Malformed Raven installation metadata")
+
+    origin_name = origins[0]
+    origin = data[origin_name]
+    if not isinstance(origin, dict):
+        raise UpgradeError("Malformed Raven installation metadata")
+
+    if origin_name == "archive_info":
+        archive_hash = origin.get("hash")
+        hashes = origin.get("hashes")
+        if archive_hash is not None and (not isinstance(archive_hash, str) or not archive_hash.strip()):
+            raise UpgradeError("Malformed Raven installation metadata")
+        if hashes is not None and (
+            not isinstance(hashes, dict)
+            or any(
+                not isinstance(algorithm, str)
+                or not algorithm.strip()
+                or not isinstance(digest, str)
+                or not digest.strip()
+                for algorithm, digest in hashes.items()
+            )
+        ):
+            raise UpgradeError("Malformed Raven installation metadata")
+    elif origin_name == "dir_info":
+        editable = origin.get("editable", False)
+        if not isinstance(editable, bool):
+            raise UpgradeError("Malformed Raven installation metadata")
+    elif origin_name == "vcs_info":
+        vcs = origin.get("vcs")
+        commit_id = origin.get("commit_id")
+        requested_revision = origin.get("requested_revision")
+        if (
+            not isinstance(vcs, str)
+            or not vcs.strip()
+            or not isinstance(commit_id, str)
+            or not commit_id.strip()
+            or (requested_revision is not None and not isinstance(requested_revision, str))
+        ):
+            raise UpgradeError("Malformed Raven installation metadata")
     return data
 
 
 def _is_editable_install() -> bool:
     data = _direct_url_data()
-    if "dir_info" not in data:
+    if data is None or "dir_info" not in data:
         return False
     directory = data["dir_info"]
-    if not isinstance(directory, dict):
-        raise UpgradeError("Malformed Raven installation metadata")
     editable = directory.get("editable", False)
-    if not isinstance(editable, bool):
-        raise UpgradeError("Malformed Raven installation metadata")
     return editable
 
 
-def _is_uv_tool_install() -> bool:
-    receipt_path = Path(sys.prefix) / "uv-receipt.toml"
+def _uv_tool_target() -> ToolInstallTarget | None:
+    prefix = Path(sys.prefix)
+    if not prefix.is_absolute():
+        raise UpgradeError("Malformed Raven uv tool receipt")
+
+    receipt_path = prefix / "uv-receipt.toml"
     if not receipt_path.is_file():
-        return False
-    receipt = tomllib.loads(receipt_path.read_text(encoding="utf-8"))
+        return None
+    try:
+        receipt = tomllib.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise UpgradeError("Malformed Raven uv tool receipt") from exc
+
     tool = receipt.get("tool")
     if not isinstance(tool, dict):
-        return False
+        raise UpgradeError("Malformed Raven uv tool receipt")
     requirements = tool.get("requirements")
     if not isinstance(requirements, list):
-        return False
-    return any(isinstance(item, dict) and item.get("name") == "raven" for item in requirements)
+        raise UpgradeError("Malformed Raven uv tool receipt")
+    if any(not isinstance(item, dict) for item in requirements):
+        raise UpgradeError("Malformed Raven uv tool receipt")
+    if not any(item.get("name") == "raven" for item in requirements):
+        return None
+
+    entrypoints = tool.get("entrypoints")
+    if not isinstance(entrypoints, list) or any(not isinstance(item, dict) for item in entrypoints):
+        raise UpgradeError("Malformed Raven uv tool receipt")
+    raven_entrypoints = [item for item in entrypoints if item.get("name") == "raven"]
+    if len(raven_entrypoints) != 1:
+        raise UpgradeError("Malformed Raven uv tool receipt")
+
+    install_path_value = raven_entrypoints[0].get("install-path")
+    if not isinstance(install_path_value, str) or not install_path_value.strip():
+        raise UpgradeError("Malformed Raven uv tool receipt")
+    install_path = Path(install_path_value)
+    if not install_path.is_absolute():
+        raise UpgradeError("Malformed Raven uv tool receipt")
+
+    return ToolInstallTarget(tool_dir=prefix.parent, bin_dir=install_path.parent)
 
 
-def _run_uv(uv_path: str, requirement: str) -> int:
-    completed = subprocess.run(
-        [uv_path, "tool", "install", "--force", requirement],
-        check=False,
-    )
-    return completed.returncode
+def _is_uv_tool_install() -> bool:
+    return _uv_tool_target() is not None
 
 
-def _install_release(release: ReleaseInfo) -> None:
-    uv_path = shutil.which("uv")
-    if uv_path is None:
+def _external_executable(value: object, *, label: str) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise UpgradeError(f"{label} was not found")
+    try:
+        executable = Path(value).resolve(strict=True)
+        prefix = Path(sys.prefix).resolve(strict=True)
+    except OSError as exc:
+        raise UpgradeError(f"{label} is unavailable") from exc
+    if not executable.is_file() or executable.is_relative_to(prefix):
+        raise UpgradeError(f"{label} must be outside the active Raven tool environment")
+    return executable
+
+
+def _handoff_upgrade(
+    release: ReleaseInfo,
+    current_version: str,
+    target: ToolInstallTarget,
+) -> NoReturn:
+    uv_value = shutil.which("uv")
+    if uv_value is None:
         raise UpgradeError("uv was not found on PATH")
-    if _run_uv(uv_path, f"raven[channels] @ {release.wheel_url}") == 0:
-        return
-    if _run_uv(uv_path, release.wheel_url) != 0:
-        raise UpgradeError("uv could not install the Raven release wheel")
+    uv_path = _external_executable(uv_value, label="uv")
+    base_python = _external_executable(getattr(sys, "_base_executable", None), label="Raven base Python")
+
+    env = os.environ.copy()
+    env["UV_TOOL_DIR"] = str(target.tool_dir)
+    env["UV_TOOL_BIN_DIR"] = str(target.bin_dir)
+    argv = [
+        str(base_python),
+        "-I",
+        "-c",
+        _UPGRADE_HELPER_SOURCE,
+        str(uv_path),
+        release.wheel_url,
+        current_version,
+        release.version,
+    ]
+    sys.stdout.flush()
+    sys.stderr.flush()
+    try:
+        os.execve(str(base_python), argv, env)
+    except OSError as exc:
+        raise UpgradeError(f"Could not start the Raven upgrade helper: {exc}") from exc
+    raise UpgradeError("The Raven upgrade helper returned unexpectedly")
 
 
 def register(app: typer.Typer) -> None:
@@ -194,15 +346,14 @@ def register(app: typer.Typer) -> None:
                     "Editable Raven installations cannot be upgraded automatically. "
                     "Pull the source checkout and rebuild Raven."
                 )
-            if not _is_uv_tool_install():
+            target = _uv_tool_target()
+            if target is None:
                 raise UpgradeError(
                     "This Raven installation is not managed by uv. "
                     "Reinstall Raven with the official installer, then run raven upgrade."
                 )
 
-            _install_release(release)
-            console.print(f"[green]Raven upgraded: {current_version} -> {release.version}[/green]")
-            console.print("Restart any running Raven process to use the new version.")
+            _handoff_upgrade(release, current_version, target)
         except (
             UpgradeError,
             httpx.HTTPError,

--- a/raven/cli/upgrade_commands.py
+++ b/raven/cli/upgrade_commands.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from importlib import metadata
+from urllib.parse import urlparse
+
+import httpx
+
+LATEST_RELEASE_API = "https://api.github.com/repos/EverMind-AI/Raven/releases/latest"
+_VERSION_RE = re.compile(r"^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+
+
+class UpgradeError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ReleaseInfo:
+    version: str
+    wheel_url: str
+
+
+def _version_key(value: str) -> tuple[int, int, int]:
+    match = _VERSION_RE.fullmatch(value)
+    if match is None:
+        raise UpgradeError(f"Unsupported Raven version: {value}")
+    major, minor, patch = match.groups()
+    return int(major), int(minor), int(patch)
+
+
+def _current_version() -> str:
+    return metadata.version("raven")
+
+
+def _parse_release_payload(payload: object) -> ReleaseInfo:
+    if not isinstance(payload, dict):
+        raise UpgradeError("Malformed GitHub release payload")
+
+    draft = payload.get("draft")
+    prerelease = payload.get("prerelease")
+    if not isinstance(draft, bool) or not isinstance(prerelease, bool):
+        raise UpgradeError("Malformed GitHub release payload")
+    if draft or prerelease:
+        raise UpgradeError("Latest Raven release is not stable")
+
+    tag_name = payload.get("tag_name")
+    if not isinstance(tag_name, str):
+        raise UpgradeError("Malformed GitHub release payload")
+    version = ".".join(str(part) for part in _version_key(tag_name))
+
+    assets = payload.get("assets")
+    if not isinstance(assets, list):
+        raise UpgradeError("Malformed GitHub release payload")
+
+    wheel_name = f"raven-{version}-py3-none-any.whl"
+    exact_wheels: list[str] = []
+    for asset in assets:
+        if not isinstance(asset, dict):
+            raise UpgradeError("Malformed GitHub release payload")
+        name = asset.get("name")
+        wheel_url = asset.get("browser_download_url")
+        if not isinstance(name, str) or not isinstance(wheel_url, str):
+            raise UpgradeError("Malformed GitHub release payload")
+        if name == wheel_name:
+            exact_wheels.append(wheel_url)
+
+    if len(exact_wheels) != 1:
+        raise UpgradeError(f"Expected exactly one release wheel named {wheel_name}")
+
+    wheel_url = exact_wheels[0]
+    parsed_url = urlparse(wheel_url)
+    expected_path = f"/EverMind-AI/Raven/releases/download/v{version}/{wheel_name}"
+    if parsed_url.scheme != "https" or parsed_url.netloc != "github.com" or parsed_url.path != expected_path:
+        raise UpgradeError(f"Untrusted Raven release wheel URL: {wheel_url}")
+
+    return ReleaseInfo(version=version, wheel_url=wheel_url)
+
+
+def _fetch_latest_release(client: httpx.Client | None = None) -> ReleaseInfo:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": f"raven/{_current_version()}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if client is not None:
+        response = client.get(LATEST_RELEASE_API, headers=headers)
+        response.raise_for_status()
+        return _parse_release_payload(response.json())
+    with httpx.Client(timeout=10.0, follow_redirects=True) as owned_client:
+        response = owned_client.get(LATEST_RELEASE_API, headers=headers)
+        response.raise_for_status()
+        return _parse_release_payload(response.json())

--- a/raven/cli/upgrade_commands.py
+++ b/raven/cli/upgrade_commands.py
@@ -104,16 +104,28 @@ def _fetch_latest_release(client: httpx.Client | None = None) -> ReleaseInfo:
 
 def _direct_url_data() -> dict[str, object]:
     raw = metadata.distribution("raven").read_text("direct_url.json")
-    if not raw:
+    if raw is None:
         return {}
-    data = json.loads(raw)
-    return data if isinstance(data, dict) else {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise UpgradeError("Malformed Raven installation metadata") from exc
+    if not isinstance(data, dict):
+        raise UpgradeError("Malformed Raven installation metadata")
+    return data
 
 
 def _is_editable_install() -> bool:
     data = _direct_url_data()
-    directory = data.get("dir_info")
-    return isinstance(directory, dict) and directory.get("editable") is True
+    if "dir_info" not in data:
+        return False
+    directory = data["dir_info"]
+    if not isinstance(directory, dict):
+        raise UpgradeError("Malformed Raven installation metadata")
+    editable = directory.get("editable", False)
+    if not isinstance(editable, bool):
+        raise UpgradeError("Malformed Raven installation metadata")
+    return editable
 
 
 def _is_uv_tool_install() -> bool:

--- a/raven/tui_rpc/methods/cli_dispatch.py
+++ b/raven/tui_rpc/methods/cli_dispatch.py
@@ -93,12 +93,13 @@ _DISPATCH_BLACKLIST: set[tuple[str, ...]] = {
     ("channels", "login", "weixin"),  # QR long-poll loop — terminal-only
     ("channels", "login", "whatsapp"),  # npm subprocess owns the TTY — terminal-only
     ("sandbox", "shell"),  # interactive shell — hijacks stdin
-    # ---- harness-command-catalog-dynamic extensions (5 → 7) ----
-    # Both names were previously unreachable: not in the old _DISPATCH_WHITELIST,
-    # so dispatch never saw them. With Typer-reflection dispatch, both
-    # become reachable; the blacklist now hard-rejects to preserve safety.
+    # ---- harness-command-catalog-dynamic extensions (5 → 8) ----
+    # tui and onboard were unreachable under the old _DISPATCH_WHITELIST.
+    # Reflection makes them and the registered upgrade command reachable, so
+    # the blacklist hard-rejects all three to preserve safety.
     ("tui",),  # recursive Ink+Node spawn would deadlock + steal stdin
     ("onboard",),  # prompt_toolkit three-step wizard hijacks stdin
+    ("upgrade",),  # replacing the active Raven process is terminal-only
     # ``agent`` (no -m) — handled specially in _is_dispatch_compatible
 }
 

--- a/tests/integration/test_cli_upgrade_real_uv.py
+++ b/tests/integration/test_cli_upgrade_real_uv.py
@@ -12,7 +12,7 @@ import pytest
 UV_PATH = shutil.which("uv")
 
 
-def _build_fixture(source_root: Path, output_root: Path, version: str) -> Path:
+def _build_fixture(source_root: Path, output_root: Path, version: str, uv_path: Path) -> Path:
     package_root = source_root / "upgrade_fixture"
     package_root.mkdir(parents=True)
     (source_root / "pyproject.toml").write_text(
@@ -74,7 +74,7 @@ def _build_fixture(source_root: Path, output_root: Path, version: str) -> Path:
     )
     output_root.mkdir(parents=True, exist_ok=True)
     subprocess.run(
-        [UV_PATH, "build", "--wheel", "--out-dir", str(output_root)],
+        [str(uv_path), "build", "--wheel", "--out-dir", str(output_root)],
         cwd=source_root,
         check=True,
         capture_output=True,
@@ -86,14 +86,19 @@ def _build_fixture(source_root: Path, output_root: Path, version: str) -> Path:
 
 @pytest.mark.skipif(UV_PATH is None, reason="uv is required for the real self-upgrade test")
 def test_running_uv_tool_replaces_itself_in_custom_directories(tmp_path: Path) -> None:
+    external_tools = tmp_path / "external tools"
+    external_tools.mkdir()
+    external_uv = external_tools / Path(UV_PATH).name
+    shutil.copy2(UV_PATH, external_uv)
     wheels = tmp_path / "wheels"
-    old_wheel = _build_fixture(tmp_path / "old", wheels, "1.0.0")
-    new_wheel = _build_fixture(tmp_path / "new", wheels, "2.0.0")
-    tool_dir = tmp_path / "custom-tools"
-    bin_dir = tmp_path / "custom-bin"
+    old_wheel = _build_fixture(tmp_path / "old", wheels, "1.0.0", external_uv)
+    new_wheel = _build_fixture(tmp_path / "new", wheels, "2.0.0", external_uv)
+    tool_dir = tmp_path / "custom tools"
+    bin_dir = tmp_path / "custom bin"
     env = os.environ.copy()
     env.update(
         {
+            "PATH": str(external_tools) + os.pathsep + env["PATH"],
             "UV_TOOL_DIR": str(tool_dir),
             "UV_TOOL_BIN_DIR": str(bin_dir),
             "RAVEN_UPGRADE_SOURCE": str(Path(__file__).parents[2]),
@@ -101,7 +106,7 @@ def test_running_uv_tool_replaces_itself_in_custom_directories(tmp_path: Path) -
         }
     )
     subprocess.run(
-        [UV_PATH, "tool", "install", "--force", str(old_wheel)],
+        [str(external_uv), "tool", "install", "--force", str(old_wheel)],
         check=True,
         env=env,
         capture_output=True,

--- a/tests/integration/test_cli_upgrade_real_uv.py
+++ b/tests/integration/test_cli_upgrade_real_uv.py
@@ -130,3 +130,9 @@ def test_running_uv_tool_replaces_itself_in_custom_directories(tmp_path: Path) -
         timeout=30,
     )
     assert version.stdout.strip() == "2.0.0"
+
+
+def test_windows_workflow_isolates_upgrade_test_from_shared_conftests() -> None:
+    workflow = (Path(__file__).parents[2] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert "pytest --noconftest tests/integration/test_cli_upgrade_real_uv.py -q" in workflow

--- a/tests/integration/test_cli_upgrade_real_uv.py
+++ b/tests/integration/test_cli_upgrade_real_uv.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+UV_PATH = shutil.which("uv")
+
+
+def _build_fixture(source_root: Path, output_root: Path, version: str) -> Path:
+    package_root = source_root / "upgrade_fixture"
+    package_root.mkdir(parents=True)
+    (source_root / "pyproject.toml").write_text(
+        textwrap.dedent(
+            f"""
+            [project]
+            name = "raven"
+            version = "{version}"
+            requires-python = ">=3.12"
+            dependencies = ["httpx", "rich", "typer"]
+
+            [project.optional-dependencies]
+            channels = []
+
+            [project.scripts]
+            raven = "upgrade_fixture:main"
+
+            [build-system]
+            requires = ["hatchling"]
+            build-backend = "hatchling.build"
+
+            [tool.hatch.build.targets.wheel]
+            packages = ["upgrade_fixture"]
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    (package_root / "__init__.py").write_text(
+        textwrap.dedent(
+            f'''\
+            import os
+            import sys
+
+
+            VERSION = "{version}"
+
+
+            def main():
+                if sys.argv[1:] == ["--version"]:
+                    print(VERSION)
+                    return 0
+                if sys.argv[1:] != ["upgrade"]:
+                    return 2
+
+                sys.path.insert(0, os.environ["RAVEN_UPGRADE_SOURCE"])
+                from raven.cli import upgrade_commands
+
+                target = upgrade_commands._uv_tool_target()
+                if target is None:
+                    raise RuntimeError("fixture uv receipt was not detected")
+                release = upgrade_commands.ReleaseInfo(
+                    version="2.0.0",
+                    wheel_url=os.environ["RAVEN_UPGRADE_WHEEL"],
+                )
+                upgrade_commands._handoff_upgrade(release, VERSION, target)
+            '''
+        ),
+        encoding="utf-8",
+    )
+    output_root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [UV_PATH, "build", "--wheel", "--out-dir", str(output_root)],
+        cwd=source_root,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return next(output_root.glob(f"raven-{version}-*.whl"))
+
+
+@pytest.mark.skipif(UV_PATH is None, reason="uv is required for the real self-upgrade test")
+def test_running_uv_tool_replaces_itself_in_custom_directories(tmp_path: Path) -> None:
+    wheels = tmp_path / "wheels"
+    old_wheel = _build_fixture(tmp_path / "old", wheels, "1.0.0")
+    new_wheel = _build_fixture(tmp_path / "new", wheels, "2.0.0")
+    tool_dir = tmp_path / "custom-tools"
+    bin_dir = tmp_path / "custom-bin"
+    env = os.environ.copy()
+    env.update(
+        {
+            "UV_TOOL_DIR": str(tool_dir),
+            "UV_TOOL_BIN_DIR": str(bin_dir),
+            "RAVEN_UPGRADE_SOURCE": str(Path(__file__).parents[2]),
+            "RAVEN_UPGRADE_WHEEL": new_wheel.resolve().as_uri(),
+        }
+    )
+    subprocess.run(
+        [UV_PATH, "tool", "install", "--force", str(old_wheel)],
+        check=True,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    executable = bin_dir / ("raven.exe" if sys.platform == "win32" else "raven")
+
+    completed = subprocess.run(
+        [str(executable), "upgrade"],
+        check=False,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Raven upgraded: 1.0.0 -> 2.0.0" in completed.stdout
+    version = subprocess.run(
+        [str(executable), "--version"],
+        check=True,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert version.stdout.strip() == "2.0.0"

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -46,6 +46,7 @@ TOP_LEVEL_COMMANDS = [
     "gateway",
     "agent",
     "status",
+    "upgrade",
     "doctor",
     "channels",
     "cron",
@@ -168,6 +169,7 @@ REGISTERED_COMMAND_NAMES = {
     "skill",
     "status",
     "tui",
+    "upgrade",
 }
 
 

--- a/tests/test_cli_upgrade_commands.py
+++ b/tests/test_cli_upgrade_commands.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import tomllib
 from dataclasses import FrozenInstanceError
+from pathlib import Path
 from unittest.mock import Mock
 
 import httpx
@@ -17,8 +20,25 @@ WHEEL_URL = "https://github.com/EverMind-AI/Raven/releases/download/v0.1.4/raven
 MALFORMED_DIRECT_URL_METADATA = [
     pytest.param("", id="empty-document"),
     pytest.param("[]", id="top-level-list"),
-    pytest.param('{"dir_info": "editable"}', id="invalid-dir-info"),
-    pytest.param('{"dir_info": {"editable": "true"}}', id="invalid-editable-flag"),
+    pytest.param("{}", id="empty-object"),
+    pytest.param('{"url": "", "archive_info": {}}', id="empty-url"),
+    pytest.param('{"url": "not-a-url", "archive_info": {}}', id="invalid-url"),
+    pytest.param(
+        '{"url": "https://example.com/raven.whl", "archive_info": {"hashes": []}}',
+        id="invalid-archive-hashes",
+    ),
+    pytest.param('{"url": "https://example.com/raven.whl"}', id="missing-origin"),
+    pytest.param(
+        '{"url": "https://example.com/raven.whl", "archive_info": {}, "vcs_info": {}}',
+        id="multiple-origins",
+    ),
+    pytest.param('{"dir_info": {}}', id="missing-url"),
+    pytest.param('{"url": "https://example.com/repo.git", "vcs_info": {}}', id="missing-vcs-fields"),
+    pytest.param('{"url": "file:///checkout", "dir_info": "editable"}', id="invalid-dir-info"),
+    pytest.param(
+        '{"url": "file:///checkout", "dir_info": {"editable": "true"}}',
+        id="invalid-editable-flag",
+    ),
 ]
 runner = CliRunner()
 
@@ -118,6 +138,11 @@ def test_parse_release_payload_rejects_malformed_payloads(payload: object) -> No
         upgrade_commands._parse_release_payload(payload)
 
 
+def test_parse_release_payload_requires_v_prefixed_tag() -> None:
+    with pytest.raises(upgrade_commands.UpgradeError):
+        upgrade_commands._parse_release_payload(_release_payload(tag_name="0.1.4"))
+
+
 def test_parse_release_payload_rejects_wrong_wheel_filename() -> None:
     assets = [
         {
@@ -209,7 +234,7 @@ def _patch_available_release(monkeypatch: pytest.MonkeyPatch) -> upgrade_command
 
 def test_is_editable_install_reads_pep_610_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     distribution = Mock()
-    distribution.read_text.return_value = '{"dir_info": {"editable": true}}'
+    distribution.read_text.return_value = '{"url": "file:///checkout", "dir_info": {"editable": true}}'
     distribution_lookup = Mock(return_value=distribution)
     monkeypatch.setattr(upgrade_commands.metadata, "distribution", distribution_lookup)
 
@@ -222,9 +247,10 @@ def test_is_editable_install_reads_pep_610_metadata(monkeypatch: pytest.MonkeyPa
     "raw",
     [
         None,
-        "{}",
-        '{"dir_info": {}}',
-        '{"dir_info": {"editable": false}}',
+        '{"url": "https://example.com/raven.whl", "archive_info": {}}',
+        '{"url": "file:///checkout", "dir_info": {}}',
+        '{"url": "file:///checkout", "dir_info": {"editable": false}}',
+        '{"url": "https://github.com/example/raven", "vcs_info": {"vcs": "git", "commit_id": "abc123"}}',
     ],
 )
 def test_is_editable_install_returns_false_for_missing_or_noneditable_metadata(
@@ -252,8 +278,15 @@ def test_is_editable_install_rejects_malformed_metadata(
 
 
 def test_is_uv_tool_install_reads_raven_receipt(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    install_path = json.dumps(str(tmp_path / "bin" / "raven"))
     (tmp_path / "uv-receipt.toml").write_text(
-        '[tool]\nrequirements = [{ name = "raven" }]\n',
+        "\n".join(
+            [
+                "[tool]",
+                'requirements = [{ name = "raven" }]',
+                f'entrypoints = [{{ name = "raven", install-path = {install_path} }}]',
+            ]
+        ),
         encoding="utf-8",
     )
     monkeypatch.setattr(upgrade_commands.sys, "prefix", str(tmp_path))
@@ -277,89 +310,214 @@ def test_is_uv_tool_install_rejects_unrelated_receipt(monkeypatch: pytest.Monkey
     assert upgrade_commands._is_uv_tool_install() is False
 
 
-def test_run_uv_uses_force_install_with_inherited_output(monkeypatch: pytest.MonkeyPatch) -> None:
-    completed = Mock(returncode=17)
-    run = Mock(return_value=completed)
-    monkeypatch.setattr(upgrade_commands.subprocess, "run", run)
+def test_uv_tool_target_derives_custom_tool_and_bin_directories(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    tool_dir = tmp_path / "custom-tools"
+    prefix = tool_dir / "raven"
+    bin_dir = tmp_path / "custom-bin"
+    prefix.mkdir(parents=True)
+    bin_dir.mkdir()
+    install_path = json.dumps(str(bin_dir / "raven"))
+    (prefix / "uv-receipt.toml").write_text(
+        "\n".join(
+            [
+                "[tool]",
+                'requirements = [{ name = "raven" }]',
+                "entrypoints = [",
+                f'    {{ name = "raven", install-path = {install_path}, from = "raven" }},',
+                "]",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(upgrade_commands.sys, "prefix", str(prefix))
 
-    assert upgrade_commands._run_uv("/usr/bin/uv", WHEEL_URL) == 17
+    target = upgrade_commands._uv_tool_target()
+
+    assert target == upgrade_commands.ToolInstallTarget(tool_dir=tool_dir, bin_dir=bin_dir)
+
+
+@pytest.mark.parametrize(
+    "entrypoints",
+    [
+        "[]",
+        '[{ name = "raven" }]',
+        '[{ name = "raven", install-path = "relative/raven" }]',
+        '[{ name = "raven", install-path = "/tmp/bin/raven" }, { name = "raven", install-path = "/tmp/other/raven" }]',
+    ],
+    ids=["missing", "missing-install-path", "relative-install-path", "duplicate-raven-entrypoint"],
+)
+def test_uv_tool_target_rejects_malformed_target_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    entrypoints: str,
+) -> None:
+    prefix = tmp_path / "tools" / "raven"
+    prefix.mkdir(parents=True)
+    (prefix / "uv-receipt.toml").write_text(
+        f'[tool]\nrequirements = [{{ name = "raven" }}]\nentrypoints = {entrypoints}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(upgrade_commands.sys, "prefix", str(prefix))
+
+    with pytest.raises(upgrade_commands.UpgradeError, match="Malformed Raven uv tool receipt"):
+        upgrade_commands._uv_tool_target()
+
+
+def _load_upgrade_helper() -> object:
+    namespace: dict[str, object] = {"__name__": "raven_upgrade_helper_test"}
+    exec(upgrade_commands._UPGRADE_HELPER_SOURCE, namespace)
+    return namespace["main"]
+
+
+def test_upgrade_helper_stops_after_channel_install_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run = Mock(return_value=Mock(returncode=0))
+    monkeypatch.setattr(subprocess, "run", run)
+    helper_main = _load_upgrade_helper()
+
+    status = helper_main(["/usr/bin/uv", WHEEL_URL, "0.1.3", "0.1.4"])
+
+    assert status == 0
     run.assert_called_once_with(
-        ["/usr/bin/uv", "tool", "install", "--force", WHEEL_URL],
+        ["/usr/bin/uv", "tool", "install", "--force", f"raven[channels] @ {WHEEL_URL}"],
         check=False,
     )
+    assert "Raven upgraded: 0.1.3 -> 0.1.4" in capsys.readouterr().out
 
 
-def test_install_release_requires_uv(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(upgrade_commands.shutil, "which", lambda executable: None)
+def test_upgrade_helper_warns_when_base_fallback_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run = Mock(side_effect=[Mock(returncode=9), Mock(returncode=0)])
+    monkeypatch.setattr(subprocess, "run", run)
+    helper_main = _load_upgrade_helper()
 
-    with pytest.raises(upgrade_commands.UpgradeError, match="uv was not found on PATH"):
-        upgrade_commands._install_release(upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL))
+    status = helper_main(["/usr/bin/uv", WHEEL_URL, "0.1.3", "0.1.4"])
 
-
-def test_install_release_stops_after_channel_install_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[tuple[str, str]] = []
-    monkeypatch.setattr(upgrade_commands.shutil, "which", lambda executable: "/usr/bin/uv")
-
-    def run_uv(uv_path: str, requirement: str) -> int:
-        calls.append((uv_path, requirement))
-        return 0
-
-    monkeypatch.setattr(upgrade_commands, "_run_uv", run_uv)
-
-    upgrade_commands._install_release(upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL))
-
-    assert calls == [("/usr/bin/uv", f"raven[channels] @ {WHEEL_URL}")]
-
-
-def test_install_release_falls_back_to_base_wheel(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[tuple[str, str]] = []
-    return_codes = iter([1, 0])
-    monkeypatch.setattr(upgrade_commands.shutil, "which", lambda executable: "/usr/bin/uv")
-
-    def run_uv(uv_path: str, requirement: str) -> int:
-        calls.append((uv_path, requirement))
-        return next(return_codes)
-
-    monkeypatch.setattr(upgrade_commands, "_run_uv", run_uv)
-
-    upgrade_commands._install_release(upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL))
-
-    assert calls == [
-        ("/usr/bin/uv", f"raven[channels] @ {WHEEL_URL}"),
-        ("/usr/bin/uv", WHEEL_URL),
+    assert status == 0
+    assert run.call_args_list == [
+        ((["/usr/bin/uv", "tool", "install", "--force", f"raven[channels] @ {WHEEL_URL}"],), {"check": False}),
+        ((["/usr/bin/uv", "tool", "install", "--force", WHEEL_URL],), {"check": False}),
     ]
+    captured = capsys.readouterr()
+    assert "Channel dependencies failed to install" in captured.err
+    assert "Some channels stay unavailable" in captured.err
+    assert "Raven upgraded: 0.1.3 -> 0.1.4" in captured.out
 
 
-def test_install_release_reports_both_attempts_failing(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[tuple[str, str]] = []
-    monkeypatch.setattr(upgrade_commands.shutil, "which", lambda executable: "/usr/bin/uv")
+def test_upgrade_helper_returns_final_uv_status(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run = Mock(side_effect=[Mock(returncode=9), Mock(returncode=23)])
+    monkeypatch.setattr(subprocess, "run", run)
+    helper_main = _load_upgrade_helper()
 
-    def run_uv(uv_path: str, requirement: str) -> int:
-        calls.append((uv_path, requirement))
-        return 1
+    status = helper_main(["/usr/bin/uv", WHEEL_URL, "0.1.3", "0.1.4"])
 
-    monkeypatch.setattr(upgrade_commands, "_run_uv", run_uv)
+    assert status == 23
+    assert "Unable to upgrade Raven" in capsys.readouterr().err
 
-    with pytest.raises(upgrade_commands.UpgradeError, match="uv could not install"):
-        upgrade_commands._install_release(upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL))
 
-    assert calls == [
-        ("/usr/bin/uv", f"raven[channels] @ {WHEEL_URL}"),
-        ("/usr/bin/uv", WHEEL_URL),
-    ]
+def test_upgrade_helper_catches_uv_execution_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(subprocess, "run", Mock(side_effect=OSError("access denied")))
+    helper_main = _load_upgrade_helper()
+
+    status = helper_main(["/usr/bin/uv", WHEEL_URL, "0.1.3", "0.1.4"])
+
+    assert status == 1
+    assert "access denied" in capsys.readouterr().err
+
+
+def test_handoff_replaces_process_with_isolated_base_python(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    prefix = tmp_path / "tools" / "raven"
+    base_python = tmp_path / "python" / "python"
+    uv_path = tmp_path / "bin" / "uv"
+    base_python.parent.mkdir(parents=True)
+    uv_path.parent.mkdir()
+    prefix.mkdir(parents=True)
+    base_python.touch()
+    uv_path.touch()
+    target = upgrade_commands.ToolInstallTarget(tmp_path / "tools", tmp_path / "tool-bin")
+    monkeypatch.setattr(upgrade_commands.sys, "prefix", str(prefix))
+    monkeypatch.setattr(upgrade_commands.sys, "_base_executable", str(base_python))
+    monkeypatch.setattr(upgrade_commands.shutil, "which", lambda executable: str(uv_path))
+    monkeypatch.setenv("UV_TOOL_DIR", "/wrong/tools")
+    monkeypatch.setenv("UV_TOOL_BIN_DIR", "/wrong/bin")
+    execve = Mock(side_effect=OSError("handoff failed"))
+    monkeypatch.setattr(upgrade_commands.os, "execve", execve)
+
+    with pytest.raises(upgrade_commands.UpgradeError, match="handoff failed"):
+        upgrade_commands._handoff_upgrade(
+            upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL),
+            "0.1.3",
+            target,
+        )
+
+    executable, argv, env = execve.call_args.args
+    assert executable == str(base_python)
+    assert argv[:4] == [str(base_python), "-I", "-c", upgrade_commands._UPGRADE_HELPER_SOURCE]
+    assert argv[4:] == [str(uv_path), WHEEL_URL, "0.1.3", "0.1.4"]
+    assert env["UV_TOOL_DIR"] == str(target.tool_dir)
+    assert env["UV_TOOL_BIN_DIR"] == str(target.bin_dir)
+    assert env["PATH"] == os.environ["PATH"]
+
+
+@pytest.mark.parametrize("inside_prefix", ["uv", "base-python"])
+def test_handoff_rejects_executables_inside_active_tool(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    inside_prefix: str,
+) -> None:
+    prefix = tmp_path / "tools" / "raven"
+    prefix.mkdir(parents=True)
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    inside = prefix / "locked-executable"
+    outside = external_dir / "external-executable"
+    inside.touch()
+    outside.touch()
+    uv_path = inside if inside_prefix == "uv" else outside
+    base_python = inside if inside_prefix == "base-python" else outside
+    monkeypatch.setattr(upgrade_commands.sys, "prefix", str(prefix))
+    monkeypatch.setattr(upgrade_commands.sys, "_base_executable", str(base_python))
+    monkeypatch.setattr(upgrade_commands.shutil, "which", lambda executable: str(uv_path))
+    execve = Mock()
+    monkeypatch.setattr(upgrade_commands.os, "execve", execve)
+
+    with pytest.raises(upgrade_commands.UpgradeError, match="outside the active Raven tool environment"):
+        upgrade_commands._handoff_upgrade(
+            upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL),
+            "0.1.3",
+            upgrade_commands.ToolInstallTarget(tmp_path / "tools", tmp_path / "bin"),
+        )
+
+    execve.assert_not_called()
 
 
 def test_upgrade_check_reports_available_without_install(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_available_release(monkeypatch)
-    install = Mock()
-    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+    handoff = Mock()
+    monkeypatch.setattr(upgrade_commands, "_handoff_upgrade", handoff)
 
     result = runner.invoke(app, ["upgrade", "--check"])
 
     assert result.exit_code == 0
     assert "0.1.3 -> 0.1.4" in result.stdout
     assert "raven upgrade" in result.stdout
-    install.assert_not_called()
+    handoff.assert_not_called()
 
 
 def test_upgrade_reports_current_release_as_up_to_date(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -369,14 +527,14 @@ def test_upgrade_reports_current_release_as_up_to_date(monkeypatch: pytest.Monke
         "_fetch_latest_release",
         lambda: upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL),
     )
-    install = Mock()
-    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+    handoff = Mock()
+    monkeypatch.setattr(upgrade_commands, "_handoff_upgrade", handoff)
 
     result = runner.invoke(app, ["upgrade"])
 
     assert result.exit_code == 0
     assert "up to date" in result.stdout
-    install.assert_not_called()
+    handoff.assert_not_called()
 
 
 def test_upgrade_does_not_downgrade_newer_local_version(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -386,8 +544,8 @@ def test_upgrade_does_not_downgrade_newer_local_version(monkeypatch: pytest.Monk
         "_fetch_latest_release",
         lambda: upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL),
     )
-    install = Mock()
-    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+    handoff = Mock()
+    monkeypatch.setattr(upgrade_commands, "_handoff_upgrade", handoff)
 
     result = runner.invoke(app, ["upgrade"])
 
@@ -395,60 +553,52 @@ def test_upgrade_does_not_downgrade_newer_local_version(monkeypatch: pytest.Monk
     assert "newer than the latest release" in result.stdout
     assert "0.1.5" in result.stdout
     assert "0.1.4" in result.stdout
-    install.assert_not_called()
+    handoff.assert_not_called()
 
 
 def test_upgrade_refuses_editable_install(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_available_release(monkeypatch)
     monkeypatch.setattr(upgrade_commands, "_is_editable_install", lambda: True)
-    uv_install = Mock(return_value=True)
-    monkeypatch.setattr(upgrade_commands, "_is_uv_tool_install", uv_install)
-    install = Mock()
-    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+    target_lookup = Mock(return_value=upgrade_commands.ToolInstallTarget(Path.cwd(), Path.cwd()))
+    monkeypatch.setattr(upgrade_commands, "_uv_tool_target", target_lookup)
+    handoff = Mock()
+    monkeypatch.setattr(upgrade_commands, "_handoff_upgrade", handoff)
 
     result = runner.invoke(app, ["upgrade"])
 
     assert result.exit_code == 1
     assert "editable" in result.stdout.lower()
     assert "source checkout" in result.stdout.lower()
-    uv_install.assert_not_called()
-    install.assert_not_called()
+    target_lookup.assert_not_called()
+    handoff.assert_not_called()
 
 
 def test_upgrade_refuses_unsupported_install(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_available_release(monkeypatch)
     monkeypatch.setattr(upgrade_commands, "_is_editable_install", lambda: False)
-    monkeypatch.setattr(upgrade_commands, "_is_uv_tool_install", lambda: False)
-    install = Mock()
-    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+    monkeypatch.setattr(upgrade_commands, "_uv_tool_target", lambda: None)
+    handoff = Mock()
+    monkeypatch.setattr(upgrade_commands, "_handoff_upgrade", handoff)
 
     result = runner.invoke(app, ["upgrade"])
 
     assert result.exit_code == 1
     assert "not managed by uv" in result.stdout.lower()
     assert "official installer" in result.stdout.lower()
-    install.assert_not_called()
+    handoff.assert_not_called()
 
 
 @pytest.mark.parametrize("raw", MALFORMED_DIRECT_URL_METADATA)
 def test_upgrade_rejects_malformed_direct_url_before_install(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path,
     raw: str,
 ) -> None:
     _patch_available_release(monkeypatch)
     distribution = Mock()
     distribution.read_text.return_value = raw
     monkeypatch.setattr(upgrade_commands.metadata, "distribution", lambda name: distribution)
-    (tmp_path / "uv-receipt.toml").write_text(
-        '[tool]\nrequirements = [{ name = "raven" }]\n',
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(upgrade_commands.sys, "prefix", str(tmp_path))
-    install = Mock()
-    monkeypatch.setattr(upgrade_commands, "_install_release", install)
-
-    assert upgrade_commands._is_uv_tool_install() is True
+    handoff = Mock()
+    monkeypatch.setattr(upgrade_commands, "_handoff_upgrade", handoff)
 
     result = runner.invoke(app, ["upgrade"])
 
@@ -456,33 +606,38 @@ def test_upgrade_rejects_malformed_direct_url_before_install(
     assert result.exit_code == 1
     assert "malformed raven installation metadata" in output
     assert "official installer" in output
-    install.assert_not_called()
+    handoff.assert_not_called()
 
 
-def test_upgrade_installs_release_and_requests_restart(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_upgrade_hands_off_release_after_validation(monkeypatch: pytest.MonkeyPatch) -> None:
     release = _patch_available_release(monkeypatch)
     monkeypatch.setattr(upgrade_commands, "_is_editable_install", lambda: False)
-    monkeypatch.setattr(upgrade_commands, "_is_uv_tool_install", lambda: True)
-    install = Mock()
-    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+    target = upgrade_commands.ToolInstallTarget(Path.cwd() / "tools", Path.cwd() / "bin")
+    monkeypatch.setattr(upgrade_commands, "_uv_tool_target", lambda: target)
+    handoff = Mock(side_effect=SystemExit(0))
+    monkeypatch.setattr(upgrade_commands, "_handoff_upgrade", handoff)
 
     result = runner.invoke(app, ["upgrade"])
 
     assert result.exit_code == 0
-    assert "0.1.3 -> 0.1.4" in result.stdout
-    assert "restart" in result.stdout.lower()
-    install.assert_called_once_with(release)
+    assert "Raven upgraded" not in result.stdout
+    handoff.assert_called_once_with(release, "0.1.3", target)
 
 
 def test_upgrade_reports_missing_uv(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_available_release(monkeypatch)
     monkeypatch.setattr(upgrade_commands, "_is_editable_install", lambda: False)
-    monkeypatch.setattr(upgrade_commands, "_is_uv_tool_install", lambda: True)
+    target = upgrade_commands.ToolInstallTarget(Path.cwd() / "tools", Path.cwd() / "bin")
+    monkeypatch.setattr(upgrade_commands, "_uv_tool_target", lambda: target)
 
-    def install(release: upgrade_commands.ReleaseInfo) -> None:
+    def handoff(
+        release: upgrade_commands.ReleaseInfo,
+        current_version: str,
+        install_target: upgrade_commands.ToolInstallTarget,
+    ) -> None:
         raise upgrade_commands.UpgradeError("uv was not found on PATH")
 
-    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+    monkeypatch.setattr(upgrade_commands, "_handoff_upgrade", handoff)
 
     result = runner.invoke(app, ["upgrade"])
 
@@ -539,11 +694,11 @@ def test_upgrade_reports_malformed_installation_metadata(
     else:
         monkeypatch.setattr(upgrade_commands, "_is_editable_install", lambda: False)
 
-        def malformed_receipt() -> bool:
+        def malformed_receipt() -> upgrade_commands.ToolInstallTarget | None:
             tomllib.loads("[tool")
-            return False
+            return None
 
-        monkeypatch.setattr(upgrade_commands, "_is_uv_tool_install", malformed_receipt)
+        monkeypatch.setattr(upgrade_commands, "_uv_tool_target", malformed_receipt)
 
     result = runner.invoke(app, ["upgrade"])
 

--- a/tests/test_cli_upgrade_commands.py
+++ b/tests/test_cli_upgrade_commands.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+import json
+import tomllib
 from dataclasses import FrozenInstanceError
+from unittest.mock import Mock
 
 import httpx
 import pytest
+from typer.testing import CliRunner
 
 from raven.cli import upgrade_commands
+from raven.cli.commands import app
 
 WHEEL_NAME = "raven-0.1.4-py3-none-any.whl"
 WHEEL_URL = "https://github.com/EverMind-AI/Raven/releases/download/v0.1.4/raven-0.1.4-py3-none-any.whl"
+runner = CliRunner()
 
 
 def _release_payload(**overrides: object) -> dict[str, object]:
@@ -186,3 +192,316 @@ def test_fetch_latest_release_propagates_invalid_json() -> None:
     with httpx.Client(transport=httpx.MockTransport(handler)) as client:
         with pytest.raises(ValueError):
             upgrade_commands._fetch_latest_release(client)
+
+
+def _patch_available_release(monkeypatch: pytest.MonkeyPatch) -> upgrade_commands.ReleaseInfo:
+    release = upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL)
+    monkeypatch.setattr(upgrade_commands, "_current_version", lambda: "0.1.3")
+    monkeypatch.setattr(upgrade_commands, "_fetch_latest_release", lambda: release)
+    return release
+
+
+def test_is_editable_install_reads_pep_610_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    distribution = Mock()
+    distribution.read_text.return_value = '{"dir_info": {"editable": true}}'
+    distribution_lookup = Mock(return_value=distribution)
+    monkeypatch.setattr(upgrade_commands.metadata, "distribution", distribution_lookup)
+
+    assert upgrade_commands._is_editable_install() is True
+    distribution_lookup.assert_called_once_with("raven")
+    distribution.read_text.assert_called_once_with("direct_url.json")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        None,
+        "{}",
+        '{"dir_info": {"editable": false}}',
+        '{"dir_info": "editable"}',
+    ],
+)
+def test_is_editable_install_rejects_noneditable_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str | None,
+) -> None:
+    distribution = Mock()
+    distribution.read_text.return_value = raw
+    monkeypatch.setattr(upgrade_commands.metadata, "distribution", lambda name: distribution)
+
+    assert upgrade_commands._is_editable_install() is False
+
+
+def test_is_uv_tool_install_reads_raven_receipt(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    (tmp_path / "uv-receipt.toml").write_text(
+        '[tool]\nrequirements = [{ name = "raven" }]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(upgrade_commands.sys, "prefix", str(tmp_path))
+
+    assert upgrade_commands._is_uv_tool_install() is True
+
+
+def test_is_uv_tool_install_rejects_missing_receipt(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setattr(upgrade_commands.sys, "prefix", str(tmp_path))
+
+    assert upgrade_commands._is_uv_tool_install() is False
+
+
+def test_is_uv_tool_install_rejects_unrelated_receipt(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    (tmp_path / "uv-receipt.toml").write_text(
+        '[tool]\nrequirements = [{ name = "other" }]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(upgrade_commands.sys, "prefix", str(tmp_path))
+
+    assert upgrade_commands._is_uv_tool_install() is False
+
+
+def test_run_uv_uses_force_install_with_inherited_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    completed = Mock(returncode=17)
+    run = Mock(return_value=completed)
+    monkeypatch.setattr(upgrade_commands.subprocess, "run", run)
+
+    assert upgrade_commands._run_uv("/usr/bin/uv", WHEEL_URL) == 17
+    run.assert_called_once_with(
+        ["/usr/bin/uv", "tool", "install", "--force", WHEEL_URL],
+        check=False,
+    )
+
+
+def test_install_release_requires_uv(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_commands.shutil, "which", lambda executable: None)
+
+    with pytest.raises(upgrade_commands.UpgradeError, match="uv was not found on PATH"):
+        upgrade_commands._install_release(upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL))
+
+
+def test_install_release_stops_after_channel_install_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(upgrade_commands.shutil, "which", lambda executable: "/usr/bin/uv")
+
+    def run_uv(uv_path: str, requirement: str) -> int:
+        calls.append((uv_path, requirement))
+        return 0
+
+    monkeypatch.setattr(upgrade_commands, "_run_uv", run_uv)
+
+    upgrade_commands._install_release(upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL))
+
+    assert calls == [("/usr/bin/uv", f"raven[channels] @ {WHEEL_URL}")]
+
+
+def test_install_release_falls_back_to_base_wheel(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str]] = []
+    return_codes = iter([1, 0])
+    monkeypatch.setattr(upgrade_commands.shutil, "which", lambda executable: "/usr/bin/uv")
+
+    def run_uv(uv_path: str, requirement: str) -> int:
+        calls.append((uv_path, requirement))
+        return next(return_codes)
+
+    monkeypatch.setattr(upgrade_commands, "_run_uv", run_uv)
+
+    upgrade_commands._install_release(upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL))
+
+    assert calls == [
+        ("/usr/bin/uv", f"raven[channels] @ {WHEEL_URL}"),
+        ("/usr/bin/uv", WHEEL_URL),
+    ]
+
+
+def test_install_release_reports_both_attempts_failing(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(upgrade_commands.shutil, "which", lambda executable: "/usr/bin/uv")
+
+    def run_uv(uv_path: str, requirement: str) -> int:
+        calls.append((uv_path, requirement))
+        return 1
+
+    monkeypatch.setattr(upgrade_commands, "_run_uv", run_uv)
+
+    with pytest.raises(upgrade_commands.UpgradeError, match="uv could not install"):
+        upgrade_commands._install_release(upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL))
+
+    assert calls == [
+        ("/usr/bin/uv", f"raven[channels] @ {WHEEL_URL}"),
+        ("/usr/bin/uv", WHEEL_URL),
+    ]
+
+
+def test_upgrade_check_reports_available_without_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_available_release(monkeypatch)
+    install = Mock()
+    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+
+    result = runner.invoke(app, ["upgrade", "--check"])
+
+    assert result.exit_code == 0
+    assert "0.1.3 -> 0.1.4" in result.stdout
+    assert "raven upgrade" in result.stdout
+    install.assert_not_called()
+
+
+def test_upgrade_reports_current_release_as_up_to_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_commands, "_current_version", lambda: "0.1.4")
+    monkeypatch.setattr(
+        upgrade_commands,
+        "_fetch_latest_release",
+        lambda: upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL),
+    )
+    install = Mock()
+    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+
+    result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 0
+    assert "up to date" in result.stdout
+    install.assert_not_called()
+
+
+def test_upgrade_does_not_downgrade_newer_local_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_commands, "_current_version", lambda: "0.1.5")
+    monkeypatch.setattr(
+        upgrade_commands,
+        "_fetch_latest_release",
+        lambda: upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL),
+    )
+    install = Mock()
+    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+
+    result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 0
+    assert "newer than the latest release" in result.stdout
+    assert "0.1.5" in result.stdout
+    assert "0.1.4" in result.stdout
+    install.assert_not_called()
+
+
+def test_upgrade_refuses_editable_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_available_release(monkeypatch)
+    monkeypatch.setattr(upgrade_commands, "_is_editable_install", lambda: True)
+    uv_install = Mock(return_value=True)
+    monkeypatch.setattr(upgrade_commands, "_is_uv_tool_install", uv_install)
+    install = Mock()
+    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+
+    result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 1
+    assert "editable" in result.stdout.lower()
+    assert "source checkout" in result.stdout.lower()
+    uv_install.assert_not_called()
+    install.assert_not_called()
+
+
+def test_upgrade_refuses_unsupported_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_available_release(monkeypatch)
+    monkeypatch.setattr(upgrade_commands, "_is_editable_install", lambda: False)
+    monkeypatch.setattr(upgrade_commands, "_is_uv_tool_install", lambda: False)
+    install = Mock()
+    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+
+    result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 1
+    assert "not managed by uv" in result.stdout.lower()
+    assert "official installer" in result.stdout.lower()
+    install.assert_not_called()
+
+
+def test_upgrade_installs_release_and_requests_restart(monkeypatch: pytest.MonkeyPatch) -> None:
+    release = _patch_available_release(monkeypatch)
+    monkeypatch.setattr(upgrade_commands, "_is_editable_install", lambda: False)
+    monkeypatch.setattr(upgrade_commands, "_is_uv_tool_install", lambda: True)
+    install = Mock()
+    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+
+    result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 0
+    assert "0.1.3 -> 0.1.4" in result.stdout
+    assert "restart" in result.stdout.lower()
+    install.assert_called_once_with(release)
+
+
+def test_upgrade_reports_missing_uv(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_available_release(monkeypatch)
+    monkeypatch.setattr(upgrade_commands, "_is_editable_install", lambda: False)
+    monkeypatch.setattr(upgrade_commands, "_is_uv_tool_install", lambda: True)
+
+    def install(release: upgrade_commands.ReleaseInfo) -> None:
+        raise upgrade_commands.UpgradeError("uv was not found on PATH")
+
+    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+
+    result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 1
+    assert "uv was not found on PATH" in result.stdout
+    assert "Traceback" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        upgrade_commands.UpgradeError("release unavailable"),
+        httpx.ReadTimeout("timed out"),
+        json.JSONDecodeError("malformed release JSON", "{", 0),
+        ValueError("malformed release JSON"),
+        upgrade_commands.metadata.PackageNotFoundError("raven"),
+    ],
+    ids=["release", "network", "json", "value-error", "package-metadata"],
+)
+def test_upgrade_reports_release_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+) -> None:
+    monkeypatch.setattr(upgrade_commands, "_current_version", lambda: "0.1.3")
+
+    def fetch() -> upgrade_commands.ReleaseInfo:
+        raise error
+
+    monkeypatch.setattr(upgrade_commands, "_fetch_latest_release", fetch)
+
+    result = runner.invoke(app, ["upgrade"])
+
+    output = " ".join(result.stdout.lower().split())
+    assert result.exit_code == 1
+    assert "Unable to upgrade Raven" in result.stdout
+    assert "try again" in output
+    assert "official installer" in output
+    assert "Traceback" not in result.stdout
+
+
+@pytest.mark.parametrize("guard", ["editable", "receipt"])
+def test_upgrade_reports_malformed_installation_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    guard: str,
+) -> None:
+    _patch_available_release(monkeypatch)
+    if guard == "editable":
+
+        def malformed_editable_metadata() -> bool:
+            json.loads("{")
+            return False
+
+        monkeypatch.setattr(upgrade_commands, "_is_editable_install", malformed_editable_metadata)
+    else:
+        monkeypatch.setattr(upgrade_commands, "_is_editable_install", lambda: False)
+
+        def malformed_receipt() -> bool:
+            tomllib.loads("[tool")
+            return False
+
+        monkeypatch.setattr(upgrade_commands, "_is_uv_tool_install", malformed_receipt)
+
+    result = runner.invoke(app, ["upgrade"])
+
+    output = " ".join(result.stdout.lower().split())
+    assert result.exit_code == 1
+    assert "Unable to upgrade Raven" in result.stdout
+    assert "try again" in output
+    assert "official installer" in output
+    assert "Traceback" not in result.stdout

--- a/tests/test_cli_upgrade_commands.py
+++ b/tests/test_cli_upgrade_commands.py
@@ -14,6 +14,12 @@ from raven.cli.commands import app
 
 WHEEL_NAME = "raven-0.1.4-py3-none-any.whl"
 WHEEL_URL = "https://github.com/EverMind-AI/Raven/releases/download/v0.1.4/raven-0.1.4-py3-none-any.whl"
+MALFORMED_DIRECT_URL_METADATA = [
+    pytest.param("", id="empty-document"),
+    pytest.param("[]", id="top-level-list"),
+    pytest.param('{"dir_info": "editable"}', id="invalid-dir-info"),
+    pytest.param('{"dir_info": {"editable": "true"}}', id="invalid-editable-flag"),
+]
 runner = CliRunner()
 
 
@@ -217,11 +223,11 @@ def test_is_editable_install_reads_pep_610_metadata(monkeypatch: pytest.MonkeyPa
     [
         None,
         "{}",
+        '{"dir_info": {}}',
         '{"dir_info": {"editable": false}}',
-        '{"dir_info": "editable"}',
     ],
 )
-def test_is_editable_install_rejects_noneditable_metadata(
+def test_is_editable_install_returns_false_for_missing_or_noneditable_metadata(
     monkeypatch: pytest.MonkeyPatch,
     raw: str | None,
 ) -> None:
@@ -230,6 +236,19 @@ def test_is_editable_install_rejects_noneditable_metadata(
     monkeypatch.setattr(upgrade_commands.metadata, "distribution", lambda name: distribution)
 
     assert upgrade_commands._is_editable_install() is False
+
+
+@pytest.mark.parametrize("raw", MALFORMED_DIRECT_URL_METADATA)
+def test_is_editable_install_rejects_malformed_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+) -> None:
+    distribution = Mock()
+    distribution.read_text.return_value = raw
+    monkeypatch.setattr(upgrade_commands.metadata, "distribution", lambda name: distribution)
+
+    with pytest.raises(upgrade_commands.UpgradeError, match="Malformed Raven installation metadata"):
+        upgrade_commands._is_editable_install()
 
 
 def test_is_uv_tool_install_reads_raven_receipt(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
@@ -408,6 +427,35 @@ def test_upgrade_refuses_unsupported_install(monkeypatch: pytest.MonkeyPatch) ->
     assert result.exit_code == 1
     assert "not managed by uv" in result.stdout.lower()
     assert "official installer" in result.stdout.lower()
+    install.assert_not_called()
+
+
+@pytest.mark.parametrize("raw", MALFORMED_DIRECT_URL_METADATA)
+def test_upgrade_rejects_malformed_direct_url_before_install(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    raw: str,
+) -> None:
+    _patch_available_release(monkeypatch)
+    distribution = Mock()
+    distribution.read_text.return_value = raw
+    monkeypatch.setattr(upgrade_commands.metadata, "distribution", lambda name: distribution)
+    (tmp_path / "uv-receipt.toml").write_text(
+        '[tool]\nrequirements = [{ name = "raven" }]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(upgrade_commands.sys, "prefix", str(tmp_path))
+    install = Mock()
+    monkeypatch.setattr(upgrade_commands, "_install_release", install)
+
+    assert upgrade_commands._is_uv_tool_install() is True
+
+    result = runner.invoke(app, ["upgrade"])
+
+    output = " ".join(result.stdout.lower().split())
+    assert result.exit_code == 1
+    assert "malformed raven installation metadata" in output
+    assert "official installer" in output
     install.assert_not_called()
 
 

--- a/tests/test_cli_upgrade_commands.py
+++ b/tests/test_cli_upgrade_commands.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import ctypes
 import json
 import os
 import subprocess
+import sys
 import tomllib
 from dataclasses import FrozenInstanceError
 from pathlib import Path
@@ -372,6 +374,22 @@ def _load_upgrade_helper() -> object:
     return namespace["main"]
 
 
+def test_upgrade_helper_bootstrap_runs_in_isolated_python() -> None:
+    bootstrap = upgrade_commands._upgrade_helper_bootstrap()
+
+    completed = subprocess.run(
+        [sys.executable, "-I", "-c", bootstrap],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert not any(character.isspace() for character in bootstrap)
+    assert completed.returncode == 2
+    assert completed.stdout == ""
+    assert completed.stderr == "Unable to upgrade Raven: invalid upgrade helper arguments.\n"
+
+
 def test_upgrade_helper_stops_after_channel_install_succeeds(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -438,6 +456,142 @@ def test_upgrade_helper_catches_uv_execution_errors(
     assert "access denied" in capsys.readouterr().err
 
 
+def test_upgrade_helper_waits_for_parent_before_running_uv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[str, object]] = []
+
+    def wait_for_parent(parent_pid: int) -> int:
+        events.append(("wait", parent_pid))
+        return 0
+
+    def run(argv: list[str], *, check: bool) -> Mock:
+        events.append(("run", argv))
+        return Mock(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", run)
+    helper_main = _load_upgrade_helper()
+    helper_main.__globals__["wait_for_parent"] = wait_for_parent
+
+    status = helper_main(["/path with spaces/uv", WHEEL_URL, "0.1.3", "0.1.4", "4321"])
+
+    assert status == 0
+    assert events[0] == ("wait", 4321)
+    assert events[1][0] == "run"
+
+
+def test_upgrade_helper_stops_when_parent_wait_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = Mock()
+    monkeypatch.setattr(subprocess, "run", run)
+    helper_main = _load_upgrade_helper()
+    helper_main.__globals__["wait_for_parent"] = Mock(return_value=19)
+
+    status = helper_main(["/usr/bin/uv", WHEEL_URL, "0.1.3", "0.1.4", "4321"])
+
+    assert status == 19
+    run.assert_not_called()
+
+
+def _mock_windows_process_api(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    handle: int | None,
+    wait_status: int = 0,
+    error: int = 0,
+) -> tuple[Mock, Mock, Mock]:
+    open_process = Mock(return_value=handle)
+    wait_for_single_object = Mock(return_value=wait_status)
+    close_handle = Mock(return_value=True)
+    kernel32 = Mock(
+        OpenProcess=open_process,
+        WaitForSingleObject=wait_for_single_object,
+        CloseHandle=close_handle,
+    )
+    monkeypatch.setattr(ctypes, "WinDLL", Mock(return_value=kernel32), raising=False)
+    monkeypatch.setattr(ctypes, "get_last_error", Mock(return_value=error), raising=False)
+    return open_process, wait_for_single_object, close_handle
+
+
+def test_upgrade_helper_waits_on_parent_process_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    open_process, wait_for_single_object, close_handle = _mock_windows_process_api(
+        monkeypatch,
+        handle=1234,
+    )
+    helper_main = _load_upgrade_helper()
+    wait_for_parent = helper_main.__globals__["wait_for_parent"]
+
+    status = wait_for_parent(4321)
+
+    assert status == 0
+    open_process.assert_called_once_with(0x00100000, False, 4321)
+    wait_for_single_object.assert_called_once_with(1234, 30_000)
+    close_handle.assert_called_once_with(1234)
+    assert open_process.restype is ctypes.c_void_p
+    assert wait_for_single_object.argtypes[0] is ctypes.c_void_p
+    assert close_handle.argtypes == [ctypes.c_void_p]
+
+
+def test_upgrade_helper_treats_missing_parent_as_already_exited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    open_process, wait_for_single_object, close_handle = _mock_windows_process_api(
+        monkeypatch,
+        handle=None,
+        error=87,
+    )
+    helper_main = _load_upgrade_helper()
+    wait_for_parent = helper_main.__globals__["wait_for_parent"]
+
+    status = wait_for_parent(4321)
+
+    assert status == 0
+    open_process.assert_called_once_with(0x00100000, False, 4321)
+    wait_for_single_object.assert_not_called()
+    close_handle.assert_not_called()
+
+
+@pytest.mark.parametrize("wait_status", [258, 0xFFFFFFFF], ids=["timeout", "failed"])
+def test_upgrade_helper_closes_parent_handle_when_wait_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    wait_status: int,
+) -> None:
+    _, wait_for_single_object, close_handle = _mock_windows_process_api(
+        monkeypatch,
+        handle=1234,
+        wait_status=wait_status,
+    )
+    helper_main = _load_upgrade_helper()
+    wait_for_parent = helper_main.__globals__["wait_for_parent"]
+
+    status = wait_for_parent(4321)
+
+    assert status == 1
+    wait_for_single_object.assert_called_once_with(1234, 30_000)
+    close_handle.assert_called_once_with(1234)
+
+
+def test_upgrade_helper_rejects_parent_open_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, wait_for_single_object, close_handle = _mock_windows_process_api(
+        monkeypatch,
+        handle=None,
+        error=5,
+    )
+    helper_main = _load_upgrade_helper()
+    wait_for_parent = helper_main.__globals__["wait_for_parent"]
+
+    status = wait_for_parent(4321)
+
+    assert status == 1
+    wait_for_single_object.assert_not_called()
+    close_handle.assert_not_called()
+
+
 def test_handoff_replaces_process_with_isolated_base_python(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -451,6 +605,7 @@ def test_handoff_replaces_process_with_isolated_base_python(
     base_python.touch()
     uv_path.touch()
     target = upgrade_commands.ToolInstallTarget(tmp_path / "tools", tmp_path / "tool-bin")
+    monkeypatch.setattr(upgrade_commands.sys, "platform", "linux")
     monkeypatch.setattr(upgrade_commands.sys, "prefix", str(prefix))
     monkeypatch.setattr(upgrade_commands.sys, "_base_executable", str(base_python))
     monkeypatch.setattr(upgrade_commands.shutil, "which", lambda executable: str(uv_path))
@@ -468,11 +623,91 @@ def test_handoff_replaces_process_with_isolated_base_python(
 
     executable, argv, env = execve.call_args.args
     assert executable == str(base_python)
-    assert argv[:4] == [str(base_python), "-I", "-c", upgrade_commands._UPGRADE_HELPER_SOURCE]
+    assert argv[:3] == [str(base_python), "-I", "-c"]
+    assert not any(character.isspace() for character in argv[3])
+    helper_namespace: dict[str, object] = {"__name__": "raven_upgrade_helper_test"}
+    exec(argv[3], helper_namespace)
+    assert "main" in helper_namespace
     assert argv[4:] == [str(uv_path), WHEEL_URL, "0.1.3", "0.1.4"]
     assert env["UV_TOOL_DIR"] == str(target.tool_dir)
     assert env["UV_TOOL_BIN_DIR"] == str(target.bin_dir)
     assert env["PATH"] == os.environ["PATH"]
+
+
+def test_windows_handoff_starts_external_helper(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    prefix = tmp_path / "custom tools" / "raven"
+    base_python = tmp_path / "external python" / "python.exe"
+    uv_path = tmp_path / "external tools" / "uv.exe"
+    prefix.mkdir(parents=True)
+    base_python.parent.mkdir(parents=True)
+    uv_path.parent.mkdir(parents=True)
+    base_python.touch()
+    uv_path.touch()
+    target = upgrade_commands.ToolInstallTarget(tmp_path / "custom tools", tmp_path / "custom bin")
+    monkeypatch.setattr(upgrade_commands.sys, "platform", "win32")
+    monkeypatch.setattr(upgrade_commands.sys, "prefix", str(prefix))
+    monkeypatch.setattr(upgrade_commands.sys, "_base_executable", str(base_python))
+    monkeypatch.setattr(upgrade_commands.shutil, "which", lambda executable: str(uv_path))
+    monkeypatch.setattr(upgrade_commands.os, "getppid", lambda: 4321)
+    execve = Mock(side_effect=OSError("execve was called"))
+    monkeypatch.setattr(upgrade_commands.os, "execve", execve)
+    popen = Mock()
+    monkeypatch.setattr(subprocess, "Popen", popen)
+
+    upgrade_commands._handoff_upgrade(
+        upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL),
+        "0.1.3",
+        target,
+    )
+
+    execve.assert_not_called()
+    popen.assert_called_once()
+    (argv,) = popen.call_args.args
+    env = popen.call_args.kwargs["env"]
+    assert popen.call_args.kwargs == {"env": env}
+    assert argv[:3] == [str(base_python), "-I", "-c"]
+    assert not any(character.isspace() for character in argv[3])
+    assert argv[4:] == [str(uv_path), WHEEL_URL, "0.1.3", "0.1.4", "4321"]
+    assert env["UV_TOOL_DIR"] == str(target.tool_dir)
+    assert env["UV_TOOL_BIN_DIR"] == str(target.bin_dir)
+    assert (
+        "Raven upgrade started. Wait for the completion message before running Raven again." in capsys.readouterr().out
+    )
+
+
+def test_windows_handoff_reports_spawn_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    prefix = tmp_path / "custom tools" / "raven"
+    base_python = tmp_path / "external python" / "python.exe"
+    uv_path = tmp_path / "external tools" / "uv.exe"
+    prefix.mkdir(parents=True)
+    base_python.parent.mkdir(parents=True)
+    uv_path.parent.mkdir(parents=True)
+    base_python.touch()
+    uv_path.touch()
+    monkeypatch.setattr(upgrade_commands.sys, "platform", "win32")
+    monkeypatch.setattr(upgrade_commands.sys, "prefix", str(prefix))
+    monkeypatch.setattr(upgrade_commands.sys, "_base_executable", str(base_python))
+    monkeypatch.setattr(upgrade_commands.shutil, "which", lambda executable: str(uv_path))
+    monkeypatch.setattr(upgrade_commands.os, "getppid", lambda: 4321)
+    execve = Mock(side_effect=OSError("execve was called"))
+    monkeypatch.setattr(upgrade_commands.os, "execve", execve)
+    monkeypatch.setattr(subprocess, "Popen", Mock(side_effect=OSError("spawn denied")))
+
+    with pytest.raises(upgrade_commands.UpgradeError, match="spawn denied"):
+        upgrade_commands._handoff_upgrade(
+            upgrade_commands.ReleaseInfo("0.1.4", WHEEL_URL),
+            "0.1.3",
+            upgrade_commands.ToolInstallTarget(tmp_path / "custom tools", tmp_path / "custom bin"),
+        )
+
+    execve.assert_not_called()
 
 
 @pytest.mark.parametrize("inside_prefix", ["uv", "base-python"])

--- a/tests/test_cli_upgrade_commands.py
+++ b/tests/test_cli_upgrade_commands.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import httpx
+import pytest
+
+from raven.cli import upgrade_commands
+
+WHEEL_NAME = "raven-0.1.4-py3-none-any.whl"
+WHEEL_URL = "https://github.com/EverMind-AI/Raven/releases/download/v0.1.4/raven-0.1.4-py3-none-any.whl"
+
+
+def _release_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "tag_name": "v0.1.4",
+        "draft": False,
+        "prerelease": False,
+        "assets": [
+            {
+                "name": WHEEL_NAME,
+                "browser_download_url": WHEEL_URL,
+            }
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_release_info_is_immutable() -> None:
+    release = upgrade_commands.ReleaseInfo(version="0.1.4", wheel_url=WHEEL_URL)
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(release, "version", "0.1.5")
+
+
+def test_version_key_accepts_documented_stable_versions() -> None:
+    assert upgrade_commands._version_key("0.1.3") == (0, 1, 3)
+    assert upgrade_commands._version_key("v2.10.4") == (2, 10, 4)
+
+
+@pytest.mark.parametrize("value", ["0.1", "0.1.3-rc1", "latest", "01.2.3"])
+def test_version_key_rejects_nonstable_versions(value: str) -> None:
+    with pytest.raises(upgrade_commands.UpgradeError):
+        upgrade_commands._version_key(value)
+
+
+def test_current_version_reads_raven_package_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    requested: list[str] = []
+
+    def package_version(distribution_name: str) -> str:
+        requested.append(distribution_name)
+        return "0.1.3"
+
+    monkeypatch.setattr(upgrade_commands.metadata, "version", package_version)
+
+    assert upgrade_commands._current_version() == "0.1.3"
+    assert requested == ["raven"]
+
+
+def test_parse_release_payload_selects_exact_release_wheel() -> None:
+    release = upgrade_commands._parse_release_payload(
+        {
+            "tag_name": "v0.1.4",
+            "draft": False,
+            "prerelease": False,
+            "assets": [
+                {
+                    "name": "raven-0.1.4-py3-none-any.whl",
+                    "browser_download_url": "https://github.com/EverMind-AI/Raven/releases/download/v0.1.4/raven-0.1.4-py3-none-any.whl",
+                }
+            ],
+        }
+    )
+    assert release.version == "0.1.4"
+    assert release.wheel_url == WHEEL_URL
+
+
+@pytest.mark.parametrize("field", ["draft", "prerelease"])
+def test_parse_release_payload_rejects_unstable_releases(field: str) -> None:
+    with pytest.raises(upgrade_commands.UpgradeError):
+        upgrade_commands._parse_release_payload(_release_payload(**{field: True}))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("draft", 0), ("prerelease", "false")],
+)
+def test_parse_release_payload_requires_boolean_release_flags(field: str, value: object) -> None:
+    with pytest.raises(upgrade_commands.UpgradeError):
+        upgrade_commands._parse_release_payload(_release_payload(**{field: value}))
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        {},
+        _release_payload(tag_name=1),
+        _release_payload(assets={}),
+        _release_payload(assets=[None]),
+    ],
+)
+def test_parse_release_payload_rejects_malformed_payloads(payload: object) -> None:
+    with pytest.raises(upgrade_commands.UpgradeError):
+        upgrade_commands._parse_release_payload(payload)
+
+
+def test_parse_release_payload_rejects_wrong_wheel_filename() -> None:
+    assets = [
+        {
+            "name": "raven-0.1.5-py3-none-any.whl",
+            "browser_download_url": WHEEL_URL,
+        }
+    ]
+
+    with pytest.raises(upgrade_commands.UpgradeError):
+        upgrade_commands._parse_release_payload(_release_payload(assets=assets))
+
+
+def test_parse_release_payload_rejects_duplicate_exact_wheels() -> None:
+    asset = {"name": WHEEL_NAME, "browser_download_url": WHEEL_URL}
+
+    with pytest.raises(upgrade_commands.UpgradeError):
+        upgrade_commands._parse_release_payload(_release_payload(assets=[asset, asset.copy()]))
+
+
+@pytest.mark.parametrize(
+    "wheel_url",
+    [
+        WHEEL_URL.replace("https://", "http://"),
+        WHEEL_URL.replace("github.com", "downloads.example.com"),
+        WHEEL_URL.replace("/EverMind-AI/Raven/", "/EverMind-AI/Other/"),
+    ],
+    ids=["http-url", "wrong-host", "wrong-repository-path"],
+)
+def test_parse_release_payload_rejects_untrusted_wheel_urls(wheel_url: str) -> None:
+    assets = [{"name": WHEEL_NAME, "browser_download_url": wheel_url}]
+
+    with pytest.raises(upgrade_commands.UpgradeError):
+        upgrade_commands._parse_release_payload(_release_payload(assets=assets))
+
+
+def test_fetch_latest_release_uses_github_api_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_commands, "_current_version", lambda: "0.1.3")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == upgrade_commands.LATEST_RELEASE_API
+        assert request.headers["Accept"] == "application/vnd.github+json"
+        assert request.headers["User-Agent"] == "raven/0.1.3"
+        assert request.headers["X-GitHub-Api-Version"] == "2022-11-28"
+        return httpx.Response(200, json=_release_payload())
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        release = upgrade_commands._fetch_latest_release(client)
+
+    assert release == upgrade_commands.ReleaseInfo(version="0.1.4", wheel_url=WHEEL_URL)
+
+
+def test_fetch_latest_release_propagates_timeout() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("timed out", request=request)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(httpx.ReadTimeout):
+            upgrade_commands._fetch_latest_release(client)
+
+
+def test_fetch_latest_release_propagates_non_2xx_response() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"message": "unavailable"})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            upgrade_commands._fetch_latest_release(client)
+
+
+def test_fetch_latest_release_propagates_invalid_json() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b"{not-json",
+            headers={"Content-Type": "application/json"},
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(ValueError):
+            upgrade_commands._fetch_latest_release(client)

--- a/tests/test_tui_rpc_cli_dispatch.py
+++ b/tests/test_tui_rpc_cli_dispatch.py
@@ -230,11 +230,11 @@ def test_channels_login_normal_channels_dispatch():
 
 
 def test_blacklist_full_coverage():
-    """7-entry blacklist (5 original + tui + onboard).
+    """8-entry blacklist (5 original + tui + onboard + upgrade).
 
     `tui` blocks recursive Ink+Node spawn; `onboard` blocks prompt_toolkit
-    wizard stdin hijack. Both necessary because reflection will otherwise
-    let them through.
+    wizard stdin hijack; `upgrade` blocks replacing the active Raven process.
+    All are necessary because reflection will otherwise let them through.
     """
     from raven.tui_rpc.methods.cli_dispatch import _DISPATCH_BLACKLIST
 
@@ -246,15 +246,18 @@ def test_blacklist_full_coverage():
         ("sandbox", "shell"),
         ("tui",),
         ("onboard",),
+        ("upgrade",),
     }
     assert _DISPATCH_BLACKLIST == expected_entries, (
-        f"blacklist drift; expected 7 prefix tuples (+ agent REPL special-case), got {_DISPATCH_BLACKLIST}"
+        f"blacklist drift; expected 8 prefix tuples (+ agent REPL special-case), got {_DISPATCH_BLACKLIST}"
     )
     # Hard-reject probe (prefix match)
     assert _is_dispatch_compatible(["tui"]) is False
     assert _is_dispatch_compatible(["tui", "--help"]) is False  # prefix
     assert _is_dispatch_compatible(["onboard"]) is False
     assert _is_dispatch_compatible(["onboard", "--reset"]) is False  # prefix
+    assert _is_dispatch_compatible(["upgrade"]) is False
+    assert _is_dispatch_compatible(["upgrade", "--check"]) is False  # prefix
 
 
 # ---------------------------------------------------------------------------

--- a/ui-tui/src/__tests__/branding.test.tsx
+++ b/ui-tui/src/__tests__/branding.test.tsx
@@ -6,8 +6,10 @@ import { render } from 'ink-testing-library'
 import React from 'react'
 import { describe, expect, it } from 'vitest'
 
+import type { SessionInfo } from '../types.js'
+
 import { ravenLogo, ravenLogoWord, RAVEN_WORD_WIDTH } from '../banner.js'
-import { Branding, formatProvider } from '../components/branding.js'
+import { Branding, formatProvider, SessionPanel } from '../components/branding.js'
 import { DEFAULT_THEME } from '../theme.js'
 
 describe('Branding', () => {
@@ -20,6 +22,20 @@ describe('Branding', () => {
     // The chosen layout (full / stacked / compact) depends on terminal width;
     // all three must render cleanly.
     expect(() => render(<Branding />)).not.toThrow()
+  })
+})
+
+describe('SessionPanel', () => {
+  it('recommends the real raven upgrade command', () => {
+    const info: SessionInfo = {
+      model: 'anthropic/claude-sonnet-4-6',
+      skills: {},
+      tools: {},
+      update_behind: 1
+    }
+    const { lastFrame } = render(<SessionPanel info={info} maxCols={80} sid="test" t={DEFAULT_THEME} />)
+    expect(lastFrame()).toContain('raven upgrade')
+    expect(lastFrame()).not.toContain('raven update')
   })
 })
 

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -426,7 +426,7 @@ export function SessionPanel({ info, maxCols, sid, t }: SessionPanelProps) {
                   - run{' '}
                 </Text>
                 <Text bold color={t.color.warn}>
-                  {info.update_command || 'raven update'}
+                  {info.update_command || 'raven upgrade'}
                 </Text>
                 <Text bold={false} color={t.color.warn} dimColor>
                   {' '}

--- a/ui-tui/src/demo/gallery.tsx
+++ b/ui-tui/src/demo/gallery.tsx
@@ -100,7 +100,7 @@ const sessionInfo: SessionInfo = {
     search_tools: ['grep', 'glob']
   },
   update_behind: 2,
-  update_command: 'raven update',
+  update_command: 'raven upgrade',
   version: '0.0.1'
 }
 


### PR DESCRIPTION
## Summary

- Add `raven upgrade --check` and `raven upgrade` for the latest stable GitHub Release wheel.
- Reject editable and unsupported installs, validate release and installation metadata, target the active uv tool directories, and preserve all state under `~/.raven`.
- Keep POSIX replacement synchronous. On Windows, launch a whitespace-safe external helper, wait for the uv trampoline to exit, and then replace the unlocked tool.
- Add a real uv self-upgrade integration test on Windows, block upgrades inside the active TUI, and document the manual user workflow in both READMEs.

Windows returns after scheduling the helper because the running `raven.exe` must exit before uv can replace it. Users must wait for the helper completion message before running Raven again.

## Type

- [ ] Fix
- [x] Feature
- [x] Docs
- [x] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_cli_upgrade_commands.py tests/integration/test_cli_upgrade_real_uv.py tests/test_cli_smoke.py tests/test_tui_rpc_cli_dispatch.py tests/test_tui_rpc_commands_catalog.py -q` - 187 passed
- `uv run ruff check raven/cli/upgrade_commands.py raven/cli/commands.py raven/tui_rpc/methods/cli_dispatch.py tests/test_cli_upgrade_commands.py tests/integration/test_cli_upgrade_real_uv.py tests/test_cli_smoke.py tests/test_tui_rpc_cli_dispatch.py` - passed
- `uv run ruff format --check raven/cli/upgrade_commands.py raven/cli/commands.py raven/tui_rpc/methods/cli_dispatch.py tests/test_cli_upgrade_commands.py tests/integration/test_cli_upgrade_real_uv.py tests/test_cli_smoke.py tests/test_tui_rpc_cli_dispatch.py` - passed
- `npm test --prefix ui-tui -- src/__tests__/branding.test.tsx` - 13 passed
- `npm run lint --prefix ui-tui` - passed with 0 errors and 22 existing warnings
- `npm run lint:rpc --prefix ui-tui && npm run type-check --prefix ui-tui` - passed
- `make check-commits && PR_TITLE='feat(cli): add raven upgrade command' make check-pr-title && make check-large-files` - passed
- Native Windows end-to-end confirmation is provided by the `Windows self-upgrade` PR check.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

Closes #111
