### PR TITLE
build: pin fresh-install deps to the release lockfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,16 @@ jobs:
           uv build --wheel
           uv build --sdist
 
+      # Export the exact dependency set from uv.lock so install.sh can pin a
+      # fresh install to it (--constraint). The wheel only carries loose ranges,
+      # so without this a curl|sh install resolves whatever upstream published
+      # latest, drifting off the versions CI actually tested.
+      - name: Export locked dependency constraints
+        run: |
+          uv export --frozen --no-emit-project --no-dev --all-extras --no-hashes \
+            --format requirements-txt -o dist/requirements.txt
+          test -s dist/requirements.txt  # fail fast if the export is empty
+
       # 4) Sanity gate: the wheel MUST contain the bundle and MUST NOT carry
       #    node_modules or ui-tui sources (keeps the wheel lean and the smoke honest).
       - name: Verify wheel contents
@@ -121,7 +131,7 @@ jobs:
             id=""
           fi
           if [ -z "$id" ]; then
-            gh release create "$tag" dist/*.whl dist/*.tar.gz \
+            gh release create "$tag" dist/*.whl dist/*.tar.gz dist/requirements.txt \
               --title "Raven $ver ($today)" --notes-file "$RUNNER_TEMP/notes.md" --draft $pre
           else
             echo "Release $tag already published (id=$id); leaving as-is."

--- a/install.sh
+++ b/install.sh
@@ -182,18 +182,41 @@ install_raven() {
     # the prebuilt ui-tui/dist/entry.js (built by CI). We deliberately do NOT
     # install from git here -- the TUI bundle is a gitignored build artifact,
     # so a git install would yield a raven whose `raven tui` cannot start.
-    # Override RAVEN_WHEEL_URL to pin a specific wheel.
+    # Override RAVEN_WHEEL_URL to pin a specific wheel (and RAVEN_CONSTRAINT_URL
+    # to pin its dependency set).
     wheel_url="${RAVEN_WHEEL_URL:-}"
+    constraint_url="${RAVEN_CONSTRAINT_URL:-}"
     if [ -z "$wheel_url" ]; then
       info "Resolving the latest raven release from GitHub..."
-      wheel_url="$(curl -fsSL "https://api.github.com/repos/EverMind-AI/raven/releases/latest" 2>/dev/null \
-        | grep -oE 'https://[^"]*/raven-[^"]*\.whl' | head -n1)"
+      release_json="$(curl -fsSL "https://api.github.com/repos/EverMind-AI/raven/releases/latest" 2>/dev/null || true)"
+      wheel_url="$(printf '%s' "$release_json" | grep -oE 'https://[^"]*/raven-[^"]*\.whl' | head -n1)"
+      # The release ships a requirements.txt exported from CI's uv.lock. Pinning
+      # against it stops a fresh install from resolving newer, untested upstream
+      # versions (the wheel only carries loose ranges, so without this the deps
+      # drift the moment upstream publishes a new release).
+      [ -n "$constraint_url" ] || constraint_url="$(printf '%s' "$release_json" | grep -oE 'https://[^"]*/requirements\.txt' | head -n1)"
     fi
     [ -n "$wheel_url" ] || die "Could not resolve the latest raven release wheel from GitHub (check network, or set RAVEN_WHEEL_URL to a wheel URL)."
+
+    # Download the constraint set if the release provides one; older releases
+    # without it simply install unpinned (backward compatible).
+    constraint_arg=""
+    if [ -n "$constraint_url" ]; then
+      con_file="$(mktemp)"
+      if curl -fsSL "$constraint_url" -o "$con_file" 2>/dev/null; then
+        info "  pinning dependencies from $constraint_url"
+        constraint_arg="--constraint $con_file"
+      else
+        warn "Could not download the dependency lock; installing without version pins."
+      fi
+    fi
+
     info "  installing $wheel_url"
-    if ! uv tool install --force "raven[channels] @ $wheel_url"; then
+    # shellcheck disable=SC2086 # $constraint_arg must word-split into 0 or 2 args.
+    if ! uv tool install --force $constraint_arg "raven[channels] @ $wheel_url"; then
       warn "Channel dependencies failed to install; installed base raven only. Some channels stay unavailable (see: raven channels list)."
-      uv tool install --force "$wheel_url"
+      # shellcheck disable=SC2086
+      uv tool install --force $constraint_arg "$wheel_url"
     fi
   fi
   # Ensure ~/.local/bin (uv tool bin dir) is on PATH for future shells.


### PR DESCRIPTION
## Change description

Make a fresh `curl | sh` / `uv tool install` install resolve the exact dependency
set that CI locked and tested, instead of whatever upstream published latest.

**Why:** the wheel only carries loose ranges (e.g. `litellm>=1.82.1,<2.0.0`), and
neither the wheel nor `uv tool install` consults `uv.lock`. So a fresh install
resolves the newest in-range versions at install time. That is exactly how the
missing-`orjson` breakage (issue #113) reached users: litellm silently moved
`1.85 -> 1.92`, and 1.92's request path needs `orjson`, which the older locked
1.85 did not.

**What:**
- `release.yml` exports the locked set from `uv.lock` (`uv export --frozen
  --no-emit-project --no-dev --all-extras --no-hashes`) and ships it as a
  `requirements.txt` release asset alongside the wheel.
- `install.sh` (remote mode) resolves that asset next to the wheel and installs
  with `--constraint`, pinning transitive deps to the tested versions.
- Backward compatible: releases without the asset install unpinned (current
  behavior). `RAVEN_CONSTRAINT_URL` overrides for a custom wheel.

**Verified locally** with a freshly built wheel:

| install | resolved litellm |
| --- | --- |
| unpinned (current) | 1.92.0 (drifts to latest) |
| `--constraint requirements.txt` (this PR) | 1.85.0 (matches uv.lock) |

Note: this is the distribution-side guard. It complements #116 (declare orjson)
and does not pin litellm's range in `pyproject.toml` (that stays flexible for
`uv sync` / dev).

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Document
- [x] Others (build / release + install reproducibility)

## Checklists

### Development
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security
- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review
- [x] Pull request has a descriptive title and context useful to a reviewer