### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raven"
-version = "0.1.3"
+version = "0.1.4"
 description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3249,7 +3249,7 @@ wheels = [
 
 [[package]]
 name = "raven"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Bump project version 0.1.3 -> 0.1.4 to cut the next patch release. Ships the four fixes/features merged since v0.1.3: `raven upgrade` command (#112), onboard oauth browser login (#110), plugin dir on sys.path (#92), and orjson as a direct dependency (#116). Lockfile synced via `uv lock`.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

## Verification

- [x] Relevant lint / type checks pass locally

```
python3 scripts/check_commit_messages.py origin/main..HEAD   # pass
uv lock                                                       # raven 0.1.3 -> 0.1.4
```

## Risk

- [x] Backward compatibility considered

Version-only bump; no runtime code changed. The release tag (v0.1.4) is pushed after this merges.

## Related Issues

N/A