### PR TITLE
feat(tracing): in-tree tracing subsystem with decoupled adopter contract

### DIFF
--- a/docs/TRACING_STANDARD_API.md
+++ b/docs/TRACING_STANDARD_API.md
@@ -1,0 +1,216 @@
+# Tracing Standard API — v1 (draft)
+
+The contract between **raven** (and any other adopter) and **raven-tracing**.
+
+Principle: *tracing owns the standard, the app adopts it.* raven-tracing defines
+what a span is, which fields each span kind carries, and how it renders. An app
+(raven) instruments itself by calling one small, stable facade — `trace.span(...)`
+— at points it chooses. Neither side depends on the other's internals; the only
+coupling is this API's version + the semantic conventions below.
+
+This mirrors the OpenTelemetry model (library defines the API + data model; the
+app does manual instrumentation), so the same discipline applies: the API is
+tiny and slow-moving, the SDK behind it (storage, viewer, on-disk format) iterates
+freely without touching adopters.
+
+Related: the on-disk record shape (`audit.span.v1`) is defined in
+`raven/tracing/spans.py` (`build_span`) and summarized in §2; this document is
+the **write-side** standard that produces those records.
+
+---
+
+## 1. Public API
+
+One import, one primary call:
+
+```python
+from raven_tracing import trace
+
+with trace.span("llm.call", {"llm.provider": provider, "llm.model": model}) as s:
+    resp = do_call(...)
+    s.set({"llm.usage.total_tokens": resp.usage.total, "llm.finish_reason": resp.finish_reason})
+```
+
+### `trace.span(name, attributes=None, *, kind=None, **kw) -> Span`
+
+A context manager that opens a span on enter and finalizes + records it on exit.
+
+- `name` — dotted semantic name, `<domain>.<verb>` (e.g. `llm.call`). Drives the
+  default `kind` and the viewer's label/rendering (see §2).
+- `attributes` — a mapping of fully-qualified dotted keys (the standard form,
+  e.g. `{"llm.provider": p, "llm.model": m}`). Standard keys are dotted, so a
+  mapping is the primary form; `**kw` accepts bare keys for convenience (stored
+  verbatim, no auto-namespacing — the attribute namespace can differ from the
+  name domain, e.g. `session.turn` carries `turn.*`).
+- `kind` — optional override of the coarse category
+  (`session|model|tool|subagent|skill|memory|plugin`). Default derived from the
+  name's domain; pass explicitly for custom nodes (§3).
+
+Nesting is automatic via `contextvars`: a span opened while another is active
+becomes its child; context survives `await` and is snapshotted onto tasks. The
+root of a turn is a `session.turn` span; everything else nests beneath it.
+
+### `Span` handle
+
+| method | effect |
+|---|---|
+| `s.set(attrs=None, **kw)` | merge attributes onto the span (dotted-key mapping and/or bare kwargs) |
+| `s.artifact(key, payload, *, kind="json")` | persist a large payload out-of-line; attach `<key>.artifact_path/_sha1/_bytes` + a truncated `preview`. Use for prompts / tool IO / recall results. |
+| `s.event(name)` | append a timeline event `{time, name}` |
+| `s.error(exc)` | mark `status = ERROR` (done automatically if the block raises) |
+
+Read-only: `s.trace_id`, `s.span_id`, `s.name`.
+
+### Module helpers
+
+| call | returns |
+|---|---|
+| `trace.enabled()` | whether recording is on (config/env) |
+| `trace.current()` | the active `Span` or `None` |
+
+### Hard guarantees (why an adopter is safe)
+
+1. **No-op when off.** If disabled (config) or no SDK backend is active,
+   `trace.span(...)` yields a no-op handle: no I/O, near-zero overhead, the
+   `with` block runs normally.
+2. **Never breaks the caller.** The facade swallows *its own* failures (bad
+   attribute, disk error, SDK bug) and logs at debug level. It re-raises the
+   *application's* exception unchanged (after recording `status=ERROR`). A
+   tracing bug can never alter or crash the host's control flow.
+3. **Import-safe.** Importing `raven_tracing` and calling the API must succeed
+   even with no config present.
+
+### `@trace.instrument(...)` — the decorator (primary adopter mechanism)
+
+Adopters instrument a method by annotating it — the body is untouched, so this
+does not change core logic (only adds an observation wrapper)::
+
+    @trace.instrument("llm.call", extract=semconv.llm_call)
+    async def chat_with_retry(self, ...): ...
+
+`trace.instrument(name, *, kind=None, seed=None, on_open=None, extract=None)`
+wraps a sync **or** async method:
+
+- `extract(span, bound_args, result, exc)` — runs in `finally` (input captured
+  even on error); fills final attributes/artifacts. `bound_args` is the call's
+  arguments by name; `result` is the return (`None` on error); `exc` the raised
+  exception (`None` on success). The standard extractors live in
+  :mod:`raven.tracing.semconv` (`llm_call`, `tool_call`, `memory_*`, …).
+- `seed(bound_args) -> dict` — returns `session_key` / `channel` / `chat_id` to
+  open a *root* span (a turn) whose identity every child inherits.
+- `on_open(span, bound_args)` — runs right after open, before the body; used to
+  record input and `span.checkpoint()` an in-progress root for live viewing.
+
+Extra `Span` methods used by extractors: `span.retype(name, kind)` (a `tool.call`
+that turns out to be a `skill.read`), `span.cancel()` (drop a conditional span,
+e.g. `skill.inject` only when something was injected), `span.checkpoint()`,
+`span.elapsed_ms()`. Pass `detached=True` for a leaf marker that does NOT become
+the active parent — required for cancellable spans so a child that opened before
+the cancel doesn't dangle off an unemitted span.
+
+Every span family is instrumented this way — including `subagent.run`: a
+subagent runs the same decorated primitives (`chat_with_retry` / `tools.execute`),
+so its spans are captured by those decorators and nest under the `subagent.run`
+node automatically via the contextvars snapshot `asyncio.create_task` takes at
+spawn. No monkeypatch is used anywhere.
+
+---
+
+## 2. Semantic conventions (standard span kinds)
+
+`kind` is a single-word category (drives node coloring/grouping). `name` is the
+`<domain>.<verb>` identifier (drives the label + rendering). Attributes are
+namespaced by domain. Adopters SHOULD populate the "required" columns; "optional"
+adds richer rendering.
+
+| name | kind | required | optional attributes |
+|---|---|---|---|
+| `session.turn` | `session` | — | `turn.input_preview`, `turn.output_preview`, `turn.in_progress`, `turn.capabilities.{tools,plugins,skills}` |
+| `llm.call` | `model` | `llm.provider`, `llm.model` | `llm.provider_class`, `llm.finish_reason`, `llm.call_id`, `llm.invocation_source`, `llm.usage.{input,output,total,cache_read,cache_write}_tokens`, `llm.usage.cost_total`; artifacts `llm.input` (messages+tools), `llm.output` |
+| `tool.call` | `tool` | `tool.name` | `tool.call_id`, `tool.duration_ms`, `tool.error`; artifacts `tool.input` (params), `tool.output` (result) |
+| `subagent.run` / `subagent.call` | `subagent` | — | `subagent.id`, `subagent.label`, `subagent.task`, `subagent.session_id`, `subagent.parent_trace_id`, `subagent.parent_span_id`, `subagent.trace_id`, `subagent.status` |
+| `skill.read` / `skill.inject` | `skill` | — | `skill.name`, `skill.id`, `skill.source`, `skill.path`, `skill.scripts_dir` (present => a runnable bundle was materialized, vs instructions-only), `skill.read.via_tool` (`use_skill`/`read_skill`/`read_file`), `skill.inject.{names,count,via}` |
+| `memory.recall` / `.store` / `.feedback` / `.extract` / `.consolidate` / `.profile_refresh` | `memory` | — | `memory.scope`, `memory.hits`, `memory.message_count`, `memory.kind`, `memory.deposit_summary`, `memory.deposit_status`, `memory.surface`, `memory.sections_rewritten`; artifacts per op |
+| `plugin.load` / `tracing.bootstrap` | `plugin` | — | `plugin.name`, `plugin.contribution`, `plugin.id` |
+
+**Provider labeling:** `llm.provider` is the *logical backend* the call routes to
+(e.g. `openrouter`), derived from the model's gateway prefix; `llm.provider_class`
+is the concrete class (e.g. `LiteLLMProvider`) when it differs.
+
+Naming rules:
+- `name` = `<domain>.<verb>`, lowercase dotted.
+- attribute keys = `<domain>.<field>`, matching the span's domain.
+- kind is a closed vocabulary: `session|model|tool|subagent|skill|memory|plugin`.
+
+---
+
+## 3. Custom nodes
+
+Any adopter (or plugin) may record a custom span — no registration required:
+
+```python
+with trace.span("raven.sentinel.tick", {"sentinel.reason": r}, kind="plugin") as s:
+    s.set({"sentinel.fired": n})
+```
+
+Rules:
+- Use an **owned namespace** for `name` (`raven.<subsystem>.<verb>`) to avoid
+  clashing with the standard names in §2.
+- Pass `kind` explicitly (falls back to a generic node kind otherwise).
+- The viewer renders unknown names generically (title from `name`, subtitle from
+  a chosen attribute). For bespoke rendering, ship a **descriptor** entry
+  (`descriptors/*.json`, keyed by `name`) — the viewer's rendering standard,
+  shipped under `raven/tracing/viewer/descriptors/`.
+
+---
+
+## 4. Adopter integration contract (raven)
+
+1. Declare `raven-tracing` as a default dependency (default-on extra
+   `raven[tracing]`), so it ships with raven and survives `uv tool upgrade`.
+2. `from raven_tracing import trace` at instrumentation sites; wrap the operation
+   in `with trace.span(...)`. Instrumentation lives in the app's own code, moves
+   with refactors, and is visible in diffs (no external monkeypatch to silently
+   break).
+3. Enable/disable via `[tracing].enabled` (raven config) or `RAVEN_TRACING=0`
+   (env override). The API no-ops when disabled.
+4. The app never imports the SDK internals (storage/viewer) — only the facade.
+
+There is no monkeypatch / auto-instrumentation path: all instrumentation is the
+explicit `@trace.instrument` annotations in raven's own source, so it moves with
+the code and shows up in diffs (never silently breaks on a refactor).
+
+---
+
+## 5. Versioning & governance
+
+- The API + semantic conventions are versioned together as `standard-api.v1`,
+  independent of the app.
+- **Additive** changes (new optional attribute, new span name/kind) → minor bump,
+  backward compatible.
+- **Breaking** changes (rename/remove an attribute or the API signature) → major
+  bump + a migration note; adopters pin a supported range and warn (not silently
+  degrade) on mismatch.
+- A conformance snapshot test (frozen span names + required fields) guards the
+  contract in CI; changing it without a version bump fails the build.
+- On-disk record format is versioned separately as `audit.span.v1`
+  (defined in `raven/tracing/spans.py`); the two move independently.
+
+---
+
+## Status
+
+In-tree, complete. Every span family (turn / llm / tool / memory / skill.inject /
+plugin.load / subagent) is instrumented with `@trace.instrument` on raven's own
+methods; there is no monkeypatch and no `instrument.install()` — the auto-probe
+module was removed. `semconv.py` owns the standard attribute/artifact builders.
+
+Remaining for the standalone-OSS phase (P4), none blocking in-tree use:
+- Make the import optional: raven core hard-imports `raven.tracing` at module load
+  (decorators applied at class-definition time), so it must ship with raven; a
+  no-op fallback shim is needed before tracing can be a truly optional extra.
+- Move the raven-specific extractors (`semconv.py`) to raven's side; keep only the
+  generic API + schema + viewer in the standalone package.
+- Drop raven branding from the standalone package (`FRAMEWORK`, `RAVEN_*` env,
+  `~/.raven` paths) and the `raven.config`/`raven.token_wise` soft imports.
+- Freeze `standard-api.v1`; publish `raven-tracing`; raven default-depends on it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,11 @@ include = [
     "raven/templates/**/*.md",
     "raven/skills/**/*.md",
     "raven/skills/**/*.sh",
+    # Tracing dashboard viewer (dependency-free Node server + static client).
+    "raven/tracing/viewer/**/*.js",
+    "raven/tracing/viewer/**/*.css",
+    "raven/tracing/viewer/**/*.html",
+    "raven/tracing/viewer/**/*.json",
 ]
 
 [tool.hatch.build.targets.sdist]
@@ -182,6 +187,10 @@ ignore = ["E501"]
 # unused variables, deferred imports, ambiguous names — idiomatic in tests, not
 # product code. (Auto-fixable churn E702/F401/I001 is left for the reformat branch.)
 "tests/**" = ["E402", "E741", "F811", "F841", "N802", "N805", "N806", "N817", "N818", "S101", "S105", "S106", "S107", "S607"]
+
+# Tracing probe factories take the target class as an argument, named after
+# the class (e.g. `def _install_llm(LLMProvider: type)`) for readability.
+"raven/tracing/instrument.py" = ["N803"]
 
 # CLI startup-order / deferred imports, accepted long-term.
 "raven/cli/commands.py" = ["E402"]

--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -42,6 +42,7 @@ from raven.sandbox import SandboxConfig, SandboxExecutor, SandboxInitError, buil
 from raven.session.manager import Session, SessionManager
 from raven.spine.turn import Origin
 from raven.token_wise.pricing import resolve_context_window
+from raven.tracing import semconv, trace
 from raven.utils.helpers import estimate_prompt_tokens
 
 # NOTE: ``raven.context_engine`` is intentionally imported lazily (inside
@@ -861,6 +862,7 @@ class AgentLoop:
             return  # unexpected content shape → keep pending
         self._pending_recovery.pop(session_key, None)
 
+    @trace.instrument("memory.feedback", extract=semconv.memory_feedback)
     async def _dispatch_backend_feedback(
         self,
         session_key: str,
@@ -909,6 +911,7 @@ class AgentLoop:
                 session_key,
             )
 
+    @trace.instrument("memory.store", extract=semconv.memory_store)
     async def _dispatch_backend_store(
         self,
         session_key: str,
@@ -1176,6 +1179,7 @@ class AgentLoop:
             session_key=session_key or None,
         )
 
+    @trace.instrument("llm.call", extract=semconv.llm_call_stream)
     async def _llm_call_stream(
         self,
         messages: list[dict],
@@ -1765,6 +1769,7 @@ class AgentLoop:
         self._running = False
         logger.info("Agent loop stopping")
 
+    @trace.instrument("session.turn", seed=semconv.turn_seed, on_open=semconv.turn_open, extract=semconv.turn)
     async def _process_message(
         self,
         req: TurnRequest,

--- a/raven/agent/personalizer/personalizer.py
+++ b/raven/agent/personalizer/personalizer.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from raven.tracing import semconv, trace
+
 if TYPE_CHECKING:
     from raven.memory_engine.consolidate.consolidator import MemoryStore
     from raven.providers.base import LLMProvider
@@ -144,6 +146,7 @@ class Personalizer:
 
     # ── Step 1: request triage ────────────────────────────────────────────────
 
+    @trace.instrument("personalize.classify", kind="memory", extract=semconv.personalize)
     async def classify(self, message: str, history: list[dict] | None = None) -> dict:
         """Determine if the request needs a personalization clarification question.
 
@@ -184,6 +187,7 @@ class Personalizer:
 
     # ── Step 2a: generate a clarifying question ───────────────────────────────
 
+    @trace.instrument("personalize.question", kind="memory", extract=semconv.personalize)
     async def generate_question(self, message: str, domain: str) -> str:
         """Generate a single focused clarifying question for the given request.
 
@@ -215,6 +219,7 @@ class Personalizer:
 
     # ── Step 2b: extract preferences and write them to memory ─────────────────
 
+    @trace.instrument("personalize.extract", kind="memory", extract=semconv.personalize)
     async def extract_and_store_preference(self, original_message: str, question: str, answer: str) -> bool:
         """Extract reusable preferences from a Q&A pair and persist to MEMORY.md.
 
@@ -256,6 +261,7 @@ class Personalizer:
 
     # ── Step 4: post-action learning ──────────────────────────────────────────
 
+    @trace.instrument("personalize.postlearn", kind="memory", extract=semconv.personalize)
     async def post_learn(self, message: str, response_summary: str) -> bool:
         """Passively extract new preference signals from a completed interaction.
 

--- a/raven/agent/subagent/manager.py
+++ b/raven/agent/subagent/manager.py
@@ -18,6 +18,7 @@ from raven.config.schema import ExecToolConfig
 from raven.providers.base import LLMProvider
 from raven.sandbox import SandboxConfig, build_executor
 from raven.security.trust import wrap_untrusted
+from raven.tracing import semconv, trace
 from raven.utils.helpers import build_assistant_message
 
 # One hour: a runaway re-injection loop fires fast and trips the limit quickly,
@@ -119,6 +120,7 @@ class SubagentManager:
         logger.info("Spawned subagent [{}]: {}", task_id, display_label)
         return f"Subagent [{display_label}] started (id: {task_id}). I'll notify you when it completes."
 
+    @trace.instrument("subagent.run", extract=semconv.subagent)
     async def _run_subagent(
         self,
         task_id: str,

--- a/raven/agent/tools/registry.py
+++ b/raven/agent/tools/registry.py
@@ -4,6 +4,7 @@ import asyncio
 from typing import Any
 
 from raven.agent.tools.base import Tool
+from raven.tracing import semconv, trace
 
 
 class ToolRegistry:
@@ -41,6 +42,7 @@ class ToolRegistry:
         """Get all tool definitions in OpenAI format."""
         return [tool.to_schema() for tool in self._tools.values()]
 
+    @trace.instrument("tool.call", extract=semconv.tool_call)
     async def execute(self, name: str, params: dict[str, Any]) -> str:
         """Execute a tool by name with given parameters."""
         _hint = "\n\n[Analyze the error above and try a different approach.]"

--- a/raven/cli/commands.py
+++ b/raven/cli/commands.py
@@ -109,6 +109,7 @@ from raven.cli import (
     onboard_commands,
     plugin_commands,
     status_commands,
+    tracing_commands,
     upgrade_commands,
 )
 
@@ -118,6 +119,7 @@ agent_commands.register(app)
 status_commands.register(app)
 doctor_commands.register(app)
 plugin_commands.register(app)
+tracing_commands.register(app)
 upgrade_commands.register(app)
 
 

--- a/raven/cli/tracing_commands.py
+++ b/raven/cli/tracing_commands.py
@@ -1,0 +1,139 @@
+"""``raven tracing`` — open the tracing dashboard.
+
+The dashboard is a dependency-free Node viewer bundled under
+``raven/tracing/viewer/``. Instrumentation itself runs in-process (installed at
+CLI startup, see :mod:`raven.tracing`); this command only launches the viewer
+that reads the captured spans from ``~/.raven/traces``.
+
+``raven tracing`` (bare) lazily starts the viewer if it is not already running,
+then opens the browser. It reuses raven's own Node discovery (:func:`find_node`),
+so it needs the same Node >= 22 that ``raven tui`` already requires.
+
+Registered as a top-level leaf command (not a subcommand group) so the TUI
+command catalog lists it as a plain ``/tracing`` slash under "(top-level)".
+Foreground mode and port are options, not subcommands.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import time
+import webbrowser
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from raven.tracing import config as tracing_config
+
+console = Console()
+
+
+def _viewer_dir() -> Path:
+    return Path(__file__).resolve().parent.parent / "tracing" / "viewer"
+
+
+def _port_live(port: int) -> bool:
+    """True if something is already listening on 127.0.0.1:port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.25)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _viewer_env(port: int) -> dict:
+    env = dict(os.environ)
+    # Both server.js and log-store.js resolve the trace dir from this var.
+    env["TRACING_STATE_DIR"] = str(tracing_config.state_dir())
+    env["TRACING_UI_PORT"] = str(port)
+    return env
+
+
+def _resolve_node() -> str:
+    from raven.cli.tui_commands import find_node
+
+    node, _version = find_node()
+    if not node:
+        console.print(
+            "[red]Node (>= 22) not found.[/red] The tracing dashboard needs the "
+            "same Node runtime as the TUI.\n"
+            "Install: https://nodejs.org/  or  brew install node@22  or  nvm install 22"
+        )
+        raise typer.Exit(1)
+    return node
+
+
+def _server_js() -> Path:
+    server_js = _viewer_dir() / "server.js"
+    if not server_js.exists():
+        console.print(f"[red]Viewer not found at {server_js}[/red]")
+        raise typer.Exit(1)
+    return server_js
+
+
+def _open_dashboard(port: int) -> None:
+    url = f"http://127.0.0.1:{port}/"
+    if _port_live(port):
+        console.print(f"Tracing dashboard already running at [cyan]{url}[/cyan]")
+        webbrowser.open(url)
+        return
+
+    node = _resolve_node()
+    server_js = _server_js()
+    log_dir = tracing_config.state_dir()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = open(log_dir / "viewer.log", "a", encoding="utf-8")  # noqa: SIM115 — handed to the child
+    subprocess.Popen(
+        [node, str(server_js)],
+        cwd=str(_viewer_dir()),
+        env=_viewer_env(port),
+        stdout=log_file,
+        stderr=log_file,
+        start_new_session=True,
+    )
+
+    for _ in range(24):  # wait up to ~6s for the server to bind
+        if _port_live(port):
+            break
+        time.sleep(0.25)
+
+    console.print(f"Tracing dashboard at [cyan]{url}[/cyan]")
+    webbrowser.open(url)
+
+
+def _serve_foreground(port: int) -> None:
+    node = _resolve_node()
+    console.print(f"Serving tracing dashboard on http://127.0.0.1:{port}/  (Ctrl-C to stop)")
+    try:
+        subprocess.run(
+            [node, str(_server_js())],
+            cwd=str(_viewer_dir()),
+            env=_viewer_env(port),
+            check=False,
+        )
+    except KeyboardInterrupt:
+        pass
+
+
+def register(app: typer.Typer) -> None:
+    """Attach the ``tracing`` command to ``app``.
+
+    A top-level leaf command (not a subcommand group) so the TUI command
+    catalog surfaces it as a plain ``/tracing`` slash under "(top-level)",
+    the same as ``/status`` / ``/doctor``.
+    """
+
+    @app.command("tracing")
+    def tracing(
+        port: int = typer.Option(None, "--port", "-p", help="Port to bind (default: config or 4318)."),
+        foreground: bool = typer.Option(
+            False, "--foreground", "-f", help="Run the viewer in the foreground (blocks; Ctrl-C to stop)."
+        ),
+    ) -> None:
+        """Open the tracing dashboard (captured LLM/tool/memory spans)."""
+        bind_port = port if port is not None else tracing_config.port()
+        if foreground:
+            _serve_foreground(bind_port)
+        else:
+            _open_dashboard(bind_port)

--- a/raven/config/loader.py
+++ b/raven/config/loader.py
@@ -24,6 +24,8 @@ EXTENSION_KEYS = (
     "memory",
     # Bug2 / runtime-discipline 5th pillar — checkpoint policy etc.
     "runtime",
+    # In-tree observability tracing (raven.tracing).
+    "tracing",
 )
 
 # Global variable to store current config path (for multi-instance support)

--- a/raven/config/raven.py
+++ b/raven/config/raven.py
@@ -1255,6 +1255,20 @@ class RuntimeConfig(_Base):
     checkpoint: CheckpointConfig = Field(default_factory=CheckpointConfig)
 
 
+class TracingConfig(_Base):
+    """Observability tracing (in-tree ``raven.tracing``).
+
+    On by default; every ``raven`` command auto-installs non-invasive
+    instrumentation before any AgentLoop is built. ``RAVEN_TRACING=0`` is an
+    explicit env kill-switch that overrides this block. View captured traces
+    with ``raven tracing`` (or ``/tracing`` in the TUI).
+    """
+
+    enabled: bool = True
+    port: int = 4318
+    preview_len: int = 500
+
+
 # ---------------------------------------------------------------------------
 # Root
 # ---------------------------------------------------------------------------
@@ -1272,6 +1286,7 @@ class RavenConfig(_Base):
     # separate top-level ``skillRouter`` block.
     skill_forge: SkillForgeConfig = Field(default_factory=SkillForgeConfig)
     runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
+    tracing: TracingConfig = Field(default_factory=TracingConfig)
 
     # CFG-1: plugin system + memory backend.
     plugins: PluginsConfig = Field(default_factory=PluginsConfig)

--- a/raven/context_engine/segments/active_skills.py
+++ b/raven/context_engine/segments/active_skills.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from raven.context_engine.base import AssemblyContext, Segment
+from raven.tracing import semconv, trace
 
 if TYPE_CHECKING:
     from raven.memory_engine.skill_forge import LocalSkillCatalog
@@ -18,6 +19,7 @@ class ActiveSkillsSegmentBuilder:
     def __init__(self, skill_catalog: "LocalSkillCatalog") -> None:
         self._skills = skill_catalog
 
+    @trace.instrument("skill.inject", kind="skill", detached=True, extract=semconv.skill_inject_active)
     async def build(self, ctx: AssemblyContext) -> Segment | None:
         always_skills = self._skills.get_always_skills()
         if not always_skills:

--- a/raven/context_engine/segments/curator.py
+++ b/raven/context_engine/segments/curator.py
@@ -44,6 +44,7 @@ from raven.context_engine.curator import (
 )
 from raven.memory_engine.consolidate.consolidator import MemoryStore
 from raven.providers.base import LLMProvider
+from raven.tracing import semconv, trace
 
 
 class CuratorSegmentBuilder:
@@ -174,6 +175,7 @@ class CuratorSegmentBuilder:
     # Slow path (bounded internal Curator LLM loop)
     # ------------------------------------------------------------------
 
+    @trace.instrument("context.curate", kind="memory", extract=semconv.context_curate)
     async def _slow_path(self, state: CuratorState, turn_id: str) -> Segment | None:
         registry = self._make_tools(state, turn_id)
         messages = [

--- a/raven/context_engine/segments/memory.py
+++ b/raven/context_engine/segments/memory.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from raven.context_engine.base import AssemblyContext, Segment
 from raven.context_engine.segments import render
+from raven.tracing import semconv, trace
 
 if TYPE_CHECKING:
     from raven.memory_engine.backend import MemoryBackend
@@ -48,6 +49,7 @@ class MemorySegmentBuilder:
             return Segment(text="", meta=meta)
         return Segment(text="# Memory\n\n" + "\n\n".join(sections), meta=meta)
 
+    @trace.instrument("memory.recall", extract=semconv.memory_recall)
     async def _recall(self, query: str) -> list[Any]:
         if self._backend is None:
             return []

--- a/raven/context_engine/segments/skills.py
+++ b/raven/context_engine/segments/skills.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any
 from raven.context_engine.base import AssemblyContext, Segment
 from raven.context_engine.segments import render
 from raven.memory_engine.skill_forge.refs import resolve_refs
+from raven.tracing import semconv, trace
 
 if TYPE_CHECKING:
     from raven.memory_engine.skill_forge import SkillForgeRouter
@@ -72,6 +73,7 @@ class SkillsSegmentBuilder:
         self._hub_client = hub_client
         self._get_tool_definitions = get_tool_definitions
 
+    @trace.instrument("skill.inject", kind="skill", detached=True, extract=semconv.skill_inject_skills)
     async def build(self, ctx: AssemblyContext) -> Segment | None:
         if self._router is None:
             return Segment(

--- a/raven/memory_engine/consolidate/consolidator.py
+++ b/raven/memory_engine/consolidate/consolidator.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator
 
 from loguru import logger
 
+from raven.tracing import semconv, trace
 from raven.utils.helpers import ensure_dir, estimate_message_tokens, estimate_prompt_tokens_chain
 
 if TYPE_CHECKING:
@@ -1063,6 +1064,7 @@ class MemoryStore:
             )
         return "\n".join(lines)
 
+    @trace.instrument("memory.extract", extract=semconv.memory_extract)
     async def annotate(
         self,
         messages: list[dict],
@@ -1648,6 +1650,7 @@ section_body: full new content for that H2, every bullet ending with
                 self.write_long_term(new_content)
             return True
 
+    @trace.instrument("memory.profile_refresh", extract=semconv.memory_profile_refresh)
     async def maybe_refresh_hot_tags(
         self,
         provider: LLMProvider,
@@ -1798,6 +1801,7 @@ class MemoryConsolidator:
                 await self.maybe_refresh_hot_tags()
             return ok
 
+    @trace.instrument("memory.consolidate", extract=semconv.memory_consolidate)
     async def maybe_consolidate_by_tokens(self, session: Session) -> None:
         """Loop: archive old messages until prompt fits within half the context window."""
         if not session.messages or self.context_window_tokens <= 0:

--- a/raven/memory_engine/skill_forge/gate.py
+++ b/raven/memory_engine/skill_forge/gate.py
@@ -24,6 +24,7 @@ import time
 from typing import TYPE_CHECKING
 
 from raven.memory_engine.skill_forge.types import RouterHit
+from raven.tracing import semconv, trace
 
 if TYPE_CHECKING:
     from raven.providers.base import LLMProvider
@@ -60,6 +61,7 @@ class LLMGateFilter:
         self._temperature = temperature
         self._max_tokens = max_tokens
 
+    @trace.instrument("skill.gate", kind="skill", extract=semconv.skill_gate)
     async def filter(
         self,
         task: str,

--- a/raven/memory_engine/skill_forge/rewriter.py
+++ b/raven/memory_engine/skill_forge/rewriter.py
@@ -21,6 +21,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from raven.tracing import semconv, trace
+
 if TYPE_CHECKING:
     from raven.providers.base import LLMProvider
 
@@ -72,6 +74,7 @@ class QueryRewriter:
         self._max_tokens = max_tokens
         self._temperature = temperature
 
+    @trace.instrument("skill.rewrite", kind="skill", extract=semconv.skill_rewrite)
     async def analyze(self, query: str) -> RewriteResult:
         truncated = (query or "").strip()[:_QUERY_MAX_LENGTH]
         if not truncated:

--- a/raven/plugin/registry.py
+++ b/raven/plugin/registry.py
@@ -32,6 +32,7 @@ from typing import Any
 
 from raven.plugin.discover import DiscoveredPlugin, Source
 from raven.plugin.manifest import PluginManifest
+from raven.tracing import semconv, trace
 
 logger = logging.getLogger(__name__)
 
@@ -255,6 +256,7 @@ class PluginRegistry:
 
     # ── Build (PG-3 entry point) ──────────────────────────────────
 
+    @trace.instrument("plugin.load", extract=semconv.plugin_load("memory_backend"))
     def build_memory_backend(
         self,
         name: str,
@@ -280,6 +282,7 @@ class PluginRegistry:
         )
         return factory(ctx)
 
+    @trace.instrument("plugin.load", extract=semconv.plugin_load("tool"))
     def build_tool(
         self,
         name: str,

--- a/raven/providers/base.py
+++ b/raven/providers/base.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from loguru import logger
 
+from raven.tracing import semconv, trace
+
 
 @dataclass(frozen=True)
 class ErrorClassification:
@@ -486,6 +488,7 @@ class LLMProvider(ABC):
 
         return last_response  # type: ignore[return-value]  # loop always returns on the last attempt
 
+    @trace.instrument("llm.call", extract=semconv.llm_call)
     async def chat_with_retry(
         self,
         messages: list[dict[str, Any]],

--- a/raven/tracing/__init__.py
+++ b/raven/tracing/__init__.py
@@ -1,0 +1,22 @@
+"""Raven in-tree tracing: audit.span.v1 observability.
+
+Instrumentation is done by annotating raven's own methods with the
+``@trace.instrument(...)`` decorator (see :mod:`raven.tracing.trace` and the
+standard in ``docs/TRACING_STANDARD_API.md``). Nothing is monkeypatched — the
+decorators live in raven's source and are no-op when tracing is disabled, so a
+tracing failure can never alter the host's behavior.
+
+Turn off with ``RAVEN_TRACING=0`` or ``[tracing] enabled = false`` in the raven
+config. Spans land at ``~/.raven/traces/logs/audit-spans.log`` (override with
+``RAVEN_TRACING_DIR``). Open the dashboard with ``raven tracing`` or ``/tracing``.
+"""
+
+from __future__ import annotations
+
+from . import config, trace
+
+__all__ = ["enabled", "trace"]
+
+
+def enabled() -> bool:
+    return config.enabled()

--- a/raven/tracing/config.py
+++ b/raven/tracing/config.py
@@ -1,0 +1,84 @@
+"""Configuration for raven's in-tree tracing.
+
+Kept light and side-effect-free: read at process startup (from the CLI
+``main()`` callback) to decide whether to install instrumentation. Environment
+variables are explicit overrides; otherwise the ``[tracing]`` section of the
+raven config file drives behavior, defaulting to on.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_OFF = {"0", "false", "off", "no"}
+
+
+def _config_section() -> dict:
+    """Read the ``[tracing]`` block from the raven config file (best-effort).
+
+    Uses raven's own config-path resolver so a ``--config`` override is honored
+    once set. Never raises — tracing must not break startup.
+    """
+    try:
+        import json
+
+        from raven.config.loader import get_config_path
+
+        path = get_config_path()
+        if not path.exists():
+            return {}
+        data = json.loads(path.read_text(encoding="utf-8") or "{}")
+        section = data.get("tracing")
+        return section if isinstance(section, dict) else {}
+    except Exception:
+        return {}
+
+
+def enabled() -> bool:
+    """On by default. ``RAVEN_TRACING`` env wins; else ``[tracing].enabled``."""
+    env = os.environ.get("RAVEN_TRACING")
+    if env is not None:
+        return env.strip().lower() not in _OFF
+    return bool(_config_section().get("enabled", True))
+
+
+def state_dir() -> Path:
+    """Trace state dir (``~/.raven/traces``). Spans land at ``<dir>/logs/audit-spans.log``.
+
+    Overridable with ``RAVEN_TRACING_DIR`` (absolute) or ``RAVEN_HOME``.
+    """
+    override = os.environ.get("RAVEN_TRACING_DIR")
+    if override:
+        return Path(override).expanduser()
+    home = os.environ.get("RAVEN_HOME")
+    base = Path(home).expanduser() if home else Path.home() / ".raven"
+    return base / "traces"
+
+
+def port() -> int:
+    """Dashboard viewer port. ``TRACING_UI_PORT`` env wins; else ``[tracing].port``."""
+    env = os.environ.get("TRACING_UI_PORT")
+    if env is not None:
+        try:
+            return int(env)
+        except ValueError:
+            return 4318
+    try:
+        return int(_config_section().get("port", 4318))
+    except (ValueError, TypeError):
+        return 4318
+
+
+def preview_len() -> int:
+    """Max chars kept inline on a span; full payloads go to artifacts."""
+    env = os.environ.get("RAVEN_TRACING_PREVIEW")
+    if env is not None:
+        try:
+            return max(0, int(env))
+        except ValueError:
+            return 500
+    try:
+        return max(0, int(_config_section().get("previewLen", 500)))
+    except (ValueError, TypeError):
+        return 500

--- a/raven/tracing/context.py
+++ b/raven/tracing/context.py
@@ -1,0 +1,117 @@
+"""Per-turn trace context, propagated via contextvars.
+
+contextvars survive ``await`` and are snapshotted when ``asyncio.create_task``
+forks a child task — so a subagent spawned mid-turn (P1) inherits the turn's
+span as parent automatically, and nested LLM/tool calls hang off the right node.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import secrets
+import time
+from dataclasses import dataclass, replace
+from typing import Iterator
+
+
+@dataclass(frozen=True)
+class TraceCtx:
+    trace_id: str
+    session_key: str | None = None
+    channel: str | None = None
+    chat_id: str | None = None
+    parent_span_id: str | None = None
+    # Name of the nearest enclosing non-model span — the purpose a model call is
+    # made on behalf of (turn / memory.extract / skill.gate / ...). Model-kind
+    # spans inherit it rather than becoming a source themselves, so a nested
+    # ``llm.call`` can self-label without walking the tree. Generic: no adopter
+    # names are hard-coded here.
+    source: str | None = None
+
+
+_CTX: contextvars.ContextVar[TraceCtx | None] = contextvars.ContextVar("raven_tracing_ctx", default=None)
+
+
+def current() -> TraceCtx | None:
+    return _CTX.get()
+
+
+def new_trace_id() -> str:
+    return f"trace-{int(time.time() * 1000):x}-{secrets.token_hex(4)}"
+
+
+def new_span_id() -> str:
+    return f"span-{int(time.time() * 1000):x}-{secrets.token_hex(3)}"
+
+
+@contextlib.contextmanager
+def turn_scope(
+    *,
+    session_key: str | None,
+    channel: str | None,
+    chat_id: str | None,
+    root_span_id: str,
+) -> Iterator[TraceCtx]:
+    """Open a fresh trace for one turn; child spans parent onto ``root_span_id``."""
+    ctx = TraceCtx(
+        trace_id=new_trace_id(),
+        session_key=session_key,
+        channel=channel,
+        chat_id=chat_id,
+        parent_span_id=root_span_id,
+    )
+    token = _CTX.set(ctx)
+    try:
+        yield ctx
+    finally:
+        _CTX.reset(token)
+
+
+def push(
+    *,
+    trace_id: str,
+    span_id: str,
+    name: str | None = None,
+    kind: str | None = None,
+    session_key: str | None = None,
+    channel: str | None = None,
+    chat_id: str | None = None,
+):
+    """Set the active ctx so descendants parent onto ``span_id``; returns a reset token.
+
+    Used by the ``trace.span`` facade for manual instrumentation — it controls
+    enter/exit explicitly rather than via a ``with`` block. Pair with :func:`reset`.
+
+    ``name``/``kind`` propagate the enclosing ``source`` (see :class:`TraceCtx`):
+    a non-model span becomes the source for its descendants; a model span inherits
+    its parent's source (so it is never its own invocation source).
+    """
+    cur = _CTX.get()
+    parent_source = cur.source if cur else None
+    source = parent_source if (kind == "model" or not name) else name
+    return _CTX.set(
+        TraceCtx(
+            trace_id=trace_id,
+            session_key=session_key,
+            channel=channel,
+            chat_id=chat_id,
+            parent_span_id=span_id,
+            source=source,
+        )
+    )
+
+
+def reset(token) -> None:
+    _CTX.reset(token)
+
+
+@contextlib.contextmanager
+def child_scope(span_id: str) -> Iterator[TraceCtx]:
+    """Re-parent descendants onto ``span_id`` (used by the subagent probe, P1)."""
+    cur = _CTX.get() or TraceCtx(trace_id=new_trace_id())
+    token = _CTX.set(replace(cur, parent_span_id=span_id))
+    try:
+        yield _CTX.get()  # type: ignore[misc]
+    finally:
+        _CTX.reset(token)

--- a/raven/tracing/semconv.py
+++ b/raven/tracing/semconv.py
@@ -448,6 +448,17 @@ def context_curate(span, bound: dict[str, Any], result: Any, exc: BaseException 
     )
 
 
+def personalize(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    """Personalizer steps (classify / question / extract / post_learn). These call
+    ``provider.chat`` directly (not the instrumented ``chat_with_retry``), so the
+    step itself is the traced node: input = the call arguments, output = the step
+    result. The raw model round-trip is summarized here rather than a child span."""
+    args = {k: v for k, v in bound.items() if k != "self"}
+    span.set({"personalize.step": span.name.split(".", 1)[-1], "personalize.ok": exc is None})
+    span.artifact("personalize.input", args)
+    span.artifact("personalize.output", {"result": result})
+
+
 def memory_recall(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
     self = bound.get("self")
     span.set(

--- a/raven/tracing/semconv.py
+++ b/raven/tracing/semconv.py
@@ -1,0 +1,676 @@
+"""Semantic conventions for raven's tracing standard.
+
+Owns both the standard span attribute/artifact *builders* (low-level helpers)
+and the per-span-kind *extractors* used by ``@trace.instrument(extract=...)``.
+Extraction is duck-typed / by-name binding, so it stays framework-agnostic and
+survives raven refactors as long as the documented shapes hold.
+See ``docs/TRACING_STANDARD_API.md``.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from . import config
+from . import usage as usage_mod
+from .store import preview_text
+
+_SKILL_TOOLS = {"use_skill", "read_skill"}
+
+
+_FILE_READ_TOOLS = {"read_file"}
+
+
+def _preview(value: Any, n: int | None = None) -> str:
+    return preview_text(value, n if n is not None else config.preview_len())
+
+
+def _split_session_key(session_key: str | None) -> tuple[str | None, str | None]:
+    if session_key and ":" in session_key:
+        channel, _, chat_id = session_key.partition(":")
+        return channel or None, chat_id or None
+    return None, None
+
+
+def _turn_capabilities(loop: Any) -> dict[str, Any]:
+    """Snapshot what this turn's agent has loaded: tools, plugin backend +
+    plugin-contributed tools, and the available skills. Read off the AgentLoop
+    (``self``) at the turn probe. Each piece is best-effort — a missing attr
+    just omits that field, never breaks the turn span. This makes every trace
+    self-describing (e.g. a TUI trace plainly shows backend=null / no plugins)."""
+    caps: dict[str, Any] = {}
+    try:
+        names = loop.tools.tool_names
+        caps["turn.tools"] = list(names)
+        caps["turn.tool_count"] = len(names)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        backend = getattr(loop, "backend", None)
+        caps["turn.plugin.backend"] = type(backend).__name__ if backend is not None else None
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        ptools = getattr(loop, "plugin_tools", None) or []
+        caps["turn.plugin.tools"] = [getattr(t, "name", None) for t in ptools]
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        cat = getattr(getattr(loop, "context", None), "skills", None)
+        reg = getattr(cat, "registry", None) or getattr(cat, "_registry", None)
+        metas = list(reg.list_all()) if reg is not None else []
+        caps["turn.skills"] = [getattr(m, "name", None) for m in metas][:50]
+        caps["turn.skill_count"] = len(metas)
+    except Exception:  # noqa: BLE001
+        pass
+    return caps
+
+
+def _provider_label(model: str | None, provider_class: str | None) -> str | None:
+    """Logical routing backend for a call.
+
+    raven reaches every gateway through a single ``LiteLLMProvider`` class, so
+    the class name hides which backend actually served the call. LiteLLM encodes
+    that as the model prefix (``openrouter/anthropic/claude-...``), so the first
+    path segment is the backend (``openrouter``). Fall back to the provider class
+    name when the model carries no prefix (e.g. a native provider).
+    """
+    if model and "/" in model:
+        return model.split("/", 1)[0]
+    return provider_class
+
+
+def _llm_attrs(resp: Any, provider: str, model: str | None, provider_class: str | None = None) -> dict[str, Any]:
+    attrs: dict[str, Any] = {"llm.provider": provider, "llm.model": model}
+    if provider_class and provider_class != provider:
+        attrs["llm.provider_class"] = provider_class
+    if resp is None:
+        return attrs
+    attrs["llm.finish_reason"] = getattr(resp, "finish_reason", None)
+    attrs["llm.output_preview"] = _preview(getattr(resp, "content", None))
+    tool_calls = getattr(resp, "tool_calls", None) or []
+    attrs["llm.tool_call_count"] = len(tool_calls)
+    if tool_calls:
+        attrs["llm.tool_names"] = [getattr(t, "name", None) for t in tool_calls]
+    u = usage_mod.normalize(getattr(resp, "usage", None), model)
+    attrs["llm.usage.input_tokens"] = u["input_tokens"]
+    attrs["llm.usage.output_tokens"] = u["output_tokens"]
+    attrs["llm.usage.cache_read_tokens"] = u["cache_read_tokens"]
+    attrs["llm.usage.cache_write_tokens"] = u["cache_write_tokens"]
+    attrs["llm.usage.total_tokens"] = u["total_tokens"]
+    attrs["llm.usage.cost_total"] = u["cost_usd"]
+    reasoning = getattr(resp, "reasoning_content", None)
+    if reasoning:
+        attrs["llm.reasoning_preview"] = _preview(reasoning)
+    return attrs
+
+
+def _coerce_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        import json as _json
+
+        return _json.dumps(value, ensure_ascii=False)
+    except Exception:  # noqa: BLE001
+        return str(value)
+
+
+def _llm_input_payload(
+    provider: str, model: str | None, messages: Any, tools: Any, provider_class: str | None = None
+) -> dict:
+    """Artifact payload for the model-input card.
+
+    raven passes ONE flat ``messages`` list (system + prior turns + current).
+    We split it into three non-overlapping views for the viewer:
+      - ``systemPrompt``: the system message,
+      - ``prompt``: the latest user message (the current input to this call),
+      - ``historyMessages``: the prior turns only — everything EXCEPT the system
+        message and that latest user message (so it doesn't duplicate them).
+    ``messages`` keeps the full raw list as the ground truth of what was sent.
+    """
+    msgs = messages if isinstance(messages, list) else []
+    system_prompt = ""
+    user_prompt = ""
+    system_idxs: set[int] = set()
+    last_user_idx: int | None = None
+    for i, m in enumerate(msgs):
+        if isinstance(m, dict) and m.get("role") == "system":
+            system_idxs.add(i)
+            if not system_prompt:
+                system_prompt = _coerce_text(m.get("content"))
+    for i in range(len(msgs) - 1, -1, -1):
+        m = msgs[i]
+        if isinstance(m, dict) and m.get("role") == "user":
+            user_prompt = _coerce_text(m.get("content"))
+            last_user_idx = i
+            break
+    history = [m for i, m in enumerate(msgs) if i not in system_idxs and i != last_user_idx]
+    return {
+        "provider": provider,
+        "providerClass": provider_class,
+        "model": model,
+        "systemPrompt": system_prompt,
+        "prompt": user_prompt,
+        "historyMessages": history,
+        "messages": messages,
+        "tools": tools,
+    }
+
+
+def _llm_output_payload(resp: Any) -> Any:
+    if resp is None:
+        return None
+    content = getattr(resp, "content", None)
+    return {
+        "content": content,
+        "output": content,  # field the shared viewer's model-output card reads
+        "finish_reason": getattr(resp, "finish_reason", None),
+        "tool_calls": [
+            {"id": getattr(t, "id", None), "name": getattr(t, "name", None), "arguments": getattr(t, "arguments", None)}
+            for t in (getattr(resp, "tool_calls", None) or [])
+        ],
+        "reasoning_content": getattr(resp, "reasoning_content", None),
+        "usage": getattr(resp, "usage", None),
+    }
+
+
+def _parse_skill_name(result: Any) -> str | None:
+    """Skill tools return ``"## {name}\\n..."`` (hub: ``"## {name} ({version})"``)."""
+    if not isinstance(result, str) or not result.strip():
+        return None
+    first = result.lstrip().splitlines()[0]
+    if not first.startswith("## "):
+        return None
+    name = first[3:].strip()
+    if name.endswith(")") and " (" in name:
+        name = name[: name.rindex(" (")].strip()
+    return name or None
+
+
+def _skill_scripts_dir(result: Any) -> str | None:
+    """``use_skill`` embeds a ``scripts_dir: <path>`` line when it materialized a
+    runnable bundle; a plain body read (``read_skill`` / ``read_file``) never does.
+    Surface that path so "pulled a bundle" vs "just instructions" is a first-class
+    signal on the one Skill node, rather than buried in the output blob."""
+    if not isinstance(result, str):
+        return None
+    for line in result.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("scripts_dir:"):
+            return stripped[len("scripts_dir:") :].strip() or None
+    return None
+
+
+def _skill_attrs(tool_name: str, params: Any, result: Any) -> dict[str, Any]:
+    skill_id = params.get("skill_id") if isinstance(params, dict) else None
+    source = native = None
+    if isinstance(skill_id, str) and "/" in skill_id:
+        source, _, native = skill_id.partition("/")
+    attrs: dict[str, Any] = {
+        "skill.id": skill_id,
+        "skill.source": source,
+        "skill.native_id": native,
+        "skill.name": _parse_skill_name(result),
+        "skill.tool": tool_name,
+        "skill.read.via_tool": tool_name,
+        "skill.result_preview": _preview(result),
+    }
+    scripts_dir = _skill_scripts_dir(result)
+    if scripts_dir:
+        attrs["skill.scripts_dir"] = scripts_dir
+    return attrs
+
+
+def _skill_name_from_path(path: str | None) -> str | None:
+    """``…/skills/weather/SKILL.md`` → ``weather`` (the skill dir name)."""
+    if not path:
+        return None
+    parts = [p for p in str(path).replace("\\", "/").split("/") if p]
+    if len(parts) >= 2 and parts[-1].lower() == "skill.md":
+        return parts[-2]
+    return parts[-1] if parts else None
+
+
+def _skill_read_path(name: str, params: Any) -> str | None:
+    """If a read_file targets a SKILL.md, return that path; else ``None``.
+
+    This is the discovery→injection follow-through: raven's summary mode
+    tells the agent to ``read_file`` a skill's SKILL.md, and subagents (which
+    only get the skill *catalog*) do the same. Those reads carry the real body
+    into context but look like a plain file read — re-type them to skill.read.
+    """
+    if name not in _FILE_READ_TOOLS:
+        return None
+    path = params.get("path") if isinstance(params, dict) else (params if isinstance(params, str) else None)
+    if isinstance(path, str) and path.replace("\\", "/").lower().rstrip("/").endswith("skill.md"):
+        return path
+    return None
+
+
+# Public aliases (the standard's stable attribute/payload builders).
+provider_label = _provider_label
+llm_attrs = _llm_attrs
+llm_input_payload = _llm_input_payload
+llm_output_payload = _llm_output_payload
+
+
+__all__ = [
+    "llm_attrs",
+    "llm_input_payload",
+    "llm_output_payload",
+    "provider_label",
+    "llm_call",
+    "llm_call_stream",
+    "tool_call",
+    "turn_seed",
+    "turn_open",
+    "turn",
+    "memory_recall",
+    "memory_store",
+    "memory_feedback",
+    "memory_extract",
+    "memory_profile_refresh",
+    "memory_consolidate",
+    "plugin_load",
+    "skill_inject_active",
+    "skill_inject_skills",
+    "subagent",
+]
+
+
+def subagent(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    """Extractor for ``SubagentManager._run_subagent``.
+
+    The subagent runs the same decorated primitives (``chat_with_retry`` /
+    ``tools.execute``), so its llm/tool spans are captured automatically and — via
+    the contextvars snapshot ``asyncio.create_task`` takes at spawn — nest under
+    this node under the spawning turn. This node just describes the spawn.
+    """
+    origin = bound.get("origin") or {}
+    span.set(
+        {
+            "subagent.task_id": bound.get("task_id"),
+            "subagent.task": _preview(bound.get("task"), 300),
+            "subagent.label": bound.get("label"),
+            "subagent.origin_session": origin.get("session_key") if isinstance(origin, dict) else None,
+        }
+    )
+
+
+def plugin_load(contribution: str):
+    """Return an extractor for a sync ``PluginRegistry.build_*`` factory call."""
+
+    def _extract(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+        span.set(
+            {
+                "plugin.contribution": contribution,
+                "plugin.name": bound.get("name"),
+                "plugin.result_type": type(result).__name__ if result is not None else None,
+                "plugin.opt_out": exc is None and result is None,
+            }
+        )
+
+    return _extract
+
+
+def _skill_inject_fill(span, *, via: str, names: list, ids: list, sources: dict, body_len: int) -> None:
+    span.set(
+        {
+            "skill.inject.via": via,
+            "skill.inject.count": len(ids),
+            "skill.inject.names": names,
+            "skill.inject.ids": ids,
+            "skill.inject.sources": sources,
+            "skill.inject.body_len": body_len,
+        }
+    )
+    span.artifact(
+        "skill.inject",
+        {
+            "via": via,
+            "skills": [{"name": n, "id": i} for n, i in zip(names, ids)],
+            "sources": sources,
+            "body_len": body_len,
+        },
+    )
+
+
+def skill_inject_active(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    """``# Active Skills`` — emit only when always-on skills were force-injected."""
+    if result is not None and getattr(result, "text", ""):
+        self = bound.get("self")
+        metas = list(self._skills.get_always_skills() or [])
+        cfg = getattr(self._skills, "_config", None)
+        always_max = getattr(cfg, "always_max", 5) or 5
+        if always_max:
+            metas = metas[:always_max]
+        if metas:
+            _skill_inject_fill(
+                span,
+                via="active_skills",
+                names=[getattr(m, "name", None) for m in metas],
+                ids=[str(getattr(m, "id", "")) for m in metas],
+                sources=dict(Counter((getattr(m, "source", None) or "?") for m in metas)),
+                body_len=len(result.text),
+            )
+            return
+    span.cancel()
+
+
+def skill_inject_skills(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    """``# Skills`` — emit only when gate-selected skills' bodies were rendered."""
+    seg_meta = (getattr(result, "meta", None) or {}) if result is not None else {}
+    ids = list(seg_meta.get("injected_skill_ids") or [])
+    if ids:
+        _skill_inject_fill(
+            span,
+            via="skills_segment",
+            names=[str(i).split("/")[-1] for i in ids],
+            ids=ids,
+            sources=dict(seg_meta.get("skill_hits_by_source") or {}),
+            body_len=len(getattr(result, "text", "") or ""),
+        )
+    else:
+        span.cancel()
+
+
+def _hit_ref(hit: Any) -> dict[str, Any]:
+    """Light, serializable view of a RouterHit candidate (avoid dumping bodies)."""
+    return {
+        "id": getattr(hit, "id", None) or getattr(hit, "skill_id", None),
+        "name": getattr(hit, "name", None),
+        "source": getattr(hit, "source", None),
+        "score": getattr(hit, "score", None),
+    }
+
+
+def skill_rewrite(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    """``QueryRewriter.analyze`` — the need_retrieval judgment + query rewrite that
+    precedes skill retrieval. Its inner model call nests here (invocation source)."""
+    need = getattr(result, "need_retrieval", None)
+    rewritten = getattr(result, "rewritten_query", None)
+    span.set(
+        {
+            "skill.rewrite.query_preview": _preview(bound.get("query")),
+            "skill.rewrite.need_retrieval": need,
+            "skill.rewrite.rewritten": _preview(rewritten),
+        }
+    )
+    span.artifact("skill.rewrite.input", {"query": bound.get("query")})
+    span.artifact("skill.rewrite.output", {"need_retrieval": need, "rewritten_query": rewritten})
+
+
+def skill_gate(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    """``LLMGateFilter.filter`` — narrows the skill candidates to the selected few."""
+    candidates = bound.get("candidates") or []
+    selected = result if isinstance(result, list) else []
+    span.set(
+        {
+            "skill.gate.task_preview": _preview(bound.get("task")),
+            "skill.gate.candidate_count": len(candidates),
+            "skill.gate.selected_count": len(selected),
+        }
+    )
+    span.artifact(
+        "skill.gate.input",
+        {
+            "task": bound.get("task"),
+            "candidates": [_hit_ref(h) for h in candidates],
+            "available_tools": bound.get("available_tools"),
+        },
+    )
+    span.artifact("skill.gate.output", {"selected": [_hit_ref(h) for h in selected]})
+
+
+def context_curate(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    """``CuratorSegmentBuilder._slow_path`` — the bounded internal curator LLM loop
+    (its per-step model + tool calls nest under this one node)."""
+    seg = result
+    state = bound.get("state")
+    history = getattr(seg, "history", None) or [] if seg is not None else []
+    span.set(
+        {
+            "context.curate.produced": seg is not None,
+            "context.curate.history_len": len(history),
+        }
+    )
+    span.artifact(
+        "context.curate.input",
+        {"turn_id": bound.get("turn_id"), "session_key": getattr(state, "session_key", None)},
+    )
+    span.artifact(
+        "context.curate.output",
+        {"produced": seg is not None, "history_len": len(history), "working_state": getattr(seg, "text", None)},
+    )
+
+
+def memory_recall(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    self = bound.get("self")
+    span.set(
+        {
+            "memory.query": _preview(bound.get("query"), 300),
+            "memory.scope": "user",
+            "memory.user_id": getattr(self, "_user_id", None),
+            "memory.top_k": getattr(self, "_memory_top_k", None),
+        }
+    )
+    hits = list(result or [])
+    span.set({"memory.hits": len(hits)})
+    span.artifact(
+        "memory.recall",
+        [
+            {
+                "text": getattr(m, "text", None),
+                "score": getattr(m, "score", None),
+                "metadata": getattr(m, "metadata", None),
+            }
+            for m in hits
+        ],
+    )
+
+
+def memory_store(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    msgs = bound.get("messages_slice") or []
+    span.set({"memory.session_id": bound.get("session_key"), "memory.message_count": len(msgs)})
+    span.artifact("memory.store", {"session_id": bound.get("session_key"), "messages": msgs})
+
+
+def memory_feedback(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    span.set(
+        {
+            "memory.session_id": bound.get("session_key"),
+            "memory.injected": bound.get("injected_skill_ids"),
+            "memory.used": bound.get("used_skill_ids"),
+        }
+    )
+
+
+def memory_extract(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    msgs = bound.get("messages") or []
+    span.set(
+        {
+            "memory.surface": "host",
+            "memory.model": bound.get("model"),
+            "memory.message_count": len(msgs),
+            "memory.enable_foresight": bound.get("enable_foresight"),
+            "memory.annotated": bool(result),
+        }
+    )
+
+
+def memory_profile_refresh(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    span.set(
+        {
+            "memory.model": bound.get("model"),
+            "memory.threshold": bound.get("threshold"),
+            "memory.sections_rewritten": result if isinstance(result, int) else None,
+        }
+    )
+
+
+def memory_consolidate(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    session = bound.get("session")
+    span.set(
+        {
+            "memory.session_key": getattr(session, "key", None),
+            "memory.last_consolidated": getattr(session, "last_consolidated", None),
+            "memory.message_count": len(getattr(session, "messages", []) or []),
+        }
+    )
+
+
+def _turn_request(bound: dict[str, Any]) -> Any:
+    """The turn payload (``TurnRequest``) — first arg after ``self``, by name or position."""
+    for key in ("req", "msg"):
+        if key in bound:
+            return bound[key]
+    vals = list(bound.values())
+    return vals[1] if len(vals) > 1 else None
+
+
+def _turn_ids(bound: dict[str, Any]) -> tuple[Any, Any, Any]:
+    req = _turn_request(bound)
+    sk = bound.get("session_key") or getattr(req, "session_key", None)
+    channel = getattr(req, "channel", None)
+    chat_id = getattr(req, "chat_id", None)
+    if not channel or not chat_id:
+        ch2, cid2 = _split_session_key(sk)
+        channel = channel or ch2
+        chat_id = chat_id or cid2
+    return sk, channel, chat_id
+
+
+def _turn_input(bound: dict[str, Any]) -> Any:
+    req = _turn_request(bound)
+    text = getattr(req, "text", None)
+    return text if text is not None else getattr(req, "content", None)
+
+
+def turn_seed(bound: dict[str, Any]) -> dict[str, Any]:
+    """Seed the root turn span's session identity so every child span inherits it."""
+    sk, channel, chat_id = _turn_ids(bound)
+    return {"session_key": sk, "channel": channel, "chat_id": chat_id}
+
+
+def turn_open(span, bound: dict[str, Any]) -> None:
+    """Record turn input + emit an in-progress root so mid-turn children have a root."""
+    _, channel, chat_id = _turn_ids(bound)
+    user_input = _turn_input(bound)
+    req = _turn_request(bound)
+    span.set({"turn.input_preview": _preview(user_input), "turn.in_progress": True})
+    span.artifact(
+        "turn.input",
+        {"content": user_input, "channel": channel, "chat_id": chat_id, "media": getattr(req, "media", None)},
+    )
+    span.checkpoint()
+
+
+def turn(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    """Finalize the turn span: output + capabilities snapshot."""
+    user_input = _turn_input(bound)
+    out_content = getattr(result, "content", None) if result is not None else None
+    span.set(
+        {
+            "turn.input_preview": _preview(user_input),
+            "turn.output_preview": _preview(out_content),
+            "turn.in_progress": False,
+        }
+    )
+    span.set(_turn_capabilities(bound.get("self")))
+    span.artifact("turn.output", {"content": out_content})
+
+
+def _finish_error(span, result) -> None:
+    """Mark the span ERROR when the model returned a soft error response."""
+    if getattr(result, "finish_reason", None) == "error":
+        span.error((getattr(result, "content", "") or "")[:200])
+
+
+def llm_call(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    """Extractor for a non-streaming provider call (``self`` is the provider)."""
+    provider = bound.get("self")
+    messages = bound.get("messages")
+    tools = bound.get("tools")
+    model = bound.get("model")
+    provider_class = type(provider).__name__ if provider is not None else None
+    eff_model = model or getattr(provider, "default_model", None)
+    pname = provider_label(eff_model, provider_class)
+    span.artifact("llm.input", llm_input_payload(pname, eff_model, messages, tools, provider_class))
+    attrs = llm_attrs(result, pname, eff_model, provider_class)
+    if span.invocation_source:
+        attrs["llm.invocation_source"] = span.invocation_source
+    span.set(attrs)
+    span.artifact("llm.output", llm_output_payload(result))
+    _finish_error(span, result)
+
+
+def llm_call_stream(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    """Extractor for the streaming call (``self`` is the AgentLoop; provider = ``self.provider``)."""
+    loop = bound.get("self")
+    provider = getattr(loop, "provider", None)
+    messages = bound.get("messages")
+    tools = bound.get("tools")
+    model = bound.get("model")
+    provider_class = type(provider).__name__ if provider is not None else "stream"
+    eff_model = model or getattr(provider, "default_model", None)
+    pname = provider_label(eff_model, provider_class)
+    span.artifact("llm.input", llm_input_payload(pname, eff_model, messages, tools, provider_class))
+    attrs = llm_attrs(result, pname, eff_model, provider_class)
+    attrs["llm.stream"] = True
+    if span.invocation_source:
+        attrs["llm.invocation_source"] = span.invocation_source
+    span.set(attrs)
+    span.artifact("llm.output", llm_output_payload(result))
+    _finish_error(span, result)
+
+
+def tool_call(span, bound: dict[str, Any], result: Any, exc: BaseException | None) -> None:
+    """Extractor for ``ToolRegistry.execute``.
+
+    Retypes to ``skill.read`` when the tool is a skill tool (``use_skill`` /
+    ``read_skill``) or a ``read_file`` targeting a SKILL.md; otherwise stays
+    ``tool.call``. All skill accesses share the one ``skill.read`` node kind
+    (the tracing standard); the originating tool is preserved in
+    ``skill.read.via_tool`` (``use_skill`` / ``read_skill`` / ``read_file``).
+    """
+    name = bound.get("name")
+    params = bound.get("params")
+    skill_read_path = _skill_read_path(name, params)
+    if name in _SKILL_TOOLS:
+        span.retype("skill.read", "skill")
+        span.set(_skill_attrs(name, params, result))
+    elif skill_read_path:
+        span.retype("skill.read", "skill")
+        span.set(
+            {
+                "skill.tool": name,
+                "skill.read.via_tool": "read_file",
+                "skill.injected_via": "read_file",
+                "skill.path": skill_read_path,
+                "skill.name": _skill_name_from_path(skill_read_path),
+                "skill.result_preview": _preview(result),
+            }
+        )
+    else:
+        err = None
+        if exc is not None:
+            err = repr(exc)
+        elif isinstance(result, str) and result.startswith("Error"):
+            err = _preview(result, 200)
+        span.set(
+            {
+                "tool.name": name,
+                "tool.args_preview": _preview(params, 300),
+                "tool.result_preview": _preview(result),
+                "tool.error": err,
+            }
+        )
+    span.set({"tool.duration_ms": span.elapsed_ms()})
+    span.artifact("tool.input", {"name": name, "params": params})
+    span.artifact("tool.output", {"result": result})
+    if exc is None and isinstance(result, str) and result.startswith("Error"):
+        span.error(_preview(result, 200))

--- a/raven/tracing/spans.py
+++ b/raven/tracing/spans.py
@@ -1,0 +1,95 @@
+"""audit.span.v1 span construction + emission.
+
+One viewer renders any framework's traces because every collector writes this
+same schema. Raven adds ``span.type`` values beyond the original five
+(``memory``, ``plugin``, ``skill`` for skill.read/inject) — see the design doc.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from . import config
+from .store import TraceStore
+
+SCHEMA_VERSION = "audit.span.v1"
+FRAMEWORK = "raven"
+
+_store: TraceStore | None = None
+
+
+def _get_store() -> TraceStore:
+    global _store
+    if _store is None:
+        _store = TraceStore(config.state_dir())
+    return _store
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def build_span(
+    name: str,
+    span_type: str,
+    *,
+    trace_id: str,
+    span_id: str,
+    parent_span_id: str | None,
+    session_key: str | None = None,
+    channel: str | None = None,
+    chat_id: str | None = None,
+    start_time: str,
+    end_time: str | None = None,
+    status_code: str = "OK",
+    status_message: str = "",
+    attributes: dict[str, Any] | None = None,
+    events: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    attrs: dict[str, Any] = {
+        "span.type": span_type,
+        "framework": FRAMEWORK,
+        # session.id + channel.id are the keys the shared viewer groups on
+        # (audit.span.v1 common attrs). Mirror session_key/channel into them
+        # so raven traces group by conversation → turn like the others.
+        "session.id": session_key,
+        "session.key": session_key,
+        "channel": channel,
+        "channel.id": channel,
+        "chat_id": chat_id,
+        "audit.schema_version": SCHEMA_VERSION,
+    }
+    if attributes:
+        attrs.update(attributes)
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "traceId": trace_id,
+        "spanId": span_id,
+        "parentSpanId": parent_span_id,
+        "name": name,
+        "kind": "INTERNAL",
+        "startTime": start_time,
+        "endTime": end_time or start_time,
+        "status": {"code": status_code, "message": status_message},
+        "attributes": attrs,
+        "events": events or [],
+    }
+
+
+def emit(span: dict[str, Any]) -> None:
+    try:
+        _get_store().append_span(span)
+    except Exception:  # noqa: BLE001 — tracing must never break the host
+        pass
+
+
+def persist_artifact(kind: str, meta: dict[str, Any], payload: Any, *, label: str | None = None):
+    try:
+        return _get_store().persist_artifact(kind, meta, payload, label=label, preview_length=config.preview_len())
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def artifact_attributes(prefix: str, artifact: dict[str, Any] | None) -> dict[str, Any]:
+    return TraceStore.artifact_attributes(prefix, artifact)

--- a/raven/tracing/store.py
+++ b/raven/tracing/store.py
@@ -1,0 +1,177 @@
+"""JSONL + artifact storage for the trace core (audit.span.v1).
+
+Dependency-free (stdlib only). Copied from the shared tracing-plugin core so
+this package stays self-contained for a clean ``pip install``.
+
+Layout under the state dir::
+
+    <state_dir>/logs/audit-events.log      # one JSON event record per line
+    <state_dir>/logs/audit-spans.log       # one JSON span per line
+    <state_dir>/logs/audit-artifacts/...    # large payloads, SHA1-deduped
+    <state_dir>/logs/archive/<date>/...     # rotated logs
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MAX_BYTES = 50 * 1024 * 1024
+
+_KIND_FILES = {
+    "events": "audit-events.log",
+    "spans": "audit-spans.log",
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _date_key(dt: datetime | None = None) -> str:
+    return (dt or datetime.now(timezone.utc)).strftime("%Y-%m-%d")
+
+
+def to_json_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def hash_text(text: str) -> str:
+    return hashlib.sha1(text.encode("utf-8")).hexdigest()
+
+
+def preview_text(value: Any, max_len: int = 400) -> str:
+    text = value if isinstance(value, str) else to_json_text(value)
+    if not text:
+        return ""
+    return text if len(text) <= max_len else f"{text[:max_len]}..."
+
+
+def safe_segment(value: Any, fallback: str = "unknown") -> str:
+    normalized = re.sub(r"[^a-zA-Z0-9._-]+", "-", str("" if value is None else value).strip())
+    normalized = normalized.strip("-")
+    return (normalized or fallback)[:80]
+
+
+class TraceStore:
+    """Append-only JSONL store + artifact persistence for one state dir."""
+
+    def __init__(self, state_dir: str | os.PathLike[str], max_bytes: int | None = None) -> None:
+        self.state_dir = Path(state_dir).expanduser()
+        self.logs_dir = self.state_dir / "logs"
+        self.artifacts_dir = self.logs_dir / "audit-artifacts"
+        self.archive_dir = self.logs_dir / "archive"
+        self.max_bytes = max_bytes or int(os.environ.get("TRACE_LOG_MAX_BYTES", DEFAULT_MAX_BYTES))
+
+    # -- paths -------------------------------------------------------------
+
+    def _ensure(self, path: Path) -> Path:
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _active_log(self, kind: str) -> Path:
+        return self._ensure(self.logs_dir) / _KIND_FILES[kind]
+
+    # -- append + rotation -------------------------------------------------
+
+    def _rotate_if_needed(self, kind: str, next_text: str) -> Path:
+        path = self._active_log(kind)
+        if not path.exists():
+            return path
+        stat = path.stat()
+        current_day = _date_key(datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc))
+        next_bytes = len(next_text.encode("utf-8"))
+        rotate_by_date = current_day != _date_key()
+        rotate_by_size = stat.st_size + next_bytes > self.max_bytes
+        if not rotate_by_date and not rotate_by_size:
+            return path
+        day_dir = self._ensure(self.archive_dir / current_day)
+        suffix = datetime.now(timezone.utc).strftime("%H%M%S%f")
+        base = _KIND_FILES[kind].replace(".log", "")
+        path.rename(day_dir / f"{base}-{current_day}-{suffix}.log")
+        return path
+
+    def append(self, kind: str, record: dict[str, Any]) -> None:
+        text = f"{to_json_text(record)}\n"
+        path = self._rotate_if_needed(kind, text)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(text)
+
+    def append_event(self, record: dict[str, Any]) -> None:
+        try:
+            self.append("events", record)
+        except OSError:
+            pass
+
+    def append_span(self, span: dict[str, Any]) -> None:
+        try:
+            self.append("spans", span)
+        except OSError:
+            pass
+
+    # -- artifacts ---------------------------------------------------------
+
+    def persist_artifact(
+        self,
+        kind: str,
+        meta: dict[str, Any],
+        payload: Any,
+        *,
+        label: str | None = None,
+        preview_length: int = 400,
+    ) -> dict[str, Any]:
+        try:
+            if payload is None:
+                text, extension = "", "json"
+            elif isinstance(payload, str):
+                text, extension = payload, "txt"
+            else:
+                text, extension = json.dumps(payload, ensure_ascii=False, indent=2, default=str), "json"
+            sha1 = hash_text(text)
+            day = _date_key()
+            dir_path = self._ensure(self.artifacts_dir / safe_segment(kind) / day)
+            file_name = "-".join(
+                [
+                    datetime.now(timezone.utc).strftime("%H%M%S%f"),
+                    safe_segment(meta.get("traceId") or meta.get("runId") or "trace"),
+                    safe_segment(meta.get("sessionId") or meta.get("sessionKey") or "session"),
+                    safe_segment(label or kind),
+                    sha1[:10],
+                ]
+            )
+            file_path = dir_path / f"{file_name}.{extension}"
+            file_path.write_text(text, encoding="utf-8")
+            return {
+                "kind": kind,
+                "path": str(file_path),
+                "sha1": sha1,
+                "bytes": len(text.encode("utf-8")),
+                "preview": preview_text(text, preview_length),
+            }
+        except OSError as exc:
+            return {"kind": kind, "path": None, "sha1": None, "bytes": None, "preview": "", "error": str(exc)}
+
+    @staticmethod
+    def artifact_attributes(prefix: str, artifact: dict[str, Any] | None) -> dict[str, Any]:
+        if not artifact:
+            return {}
+        attrs = {
+            f"{prefix}.artifact_path": artifact.get("path"),
+            f"{prefix}.artifact_sha1": artifact.get("sha1"),
+            f"{prefix}.artifact_bytes": artifact.get("bytes"),
+        }
+        if artifact.get("error"):
+            attrs[f"{prefix}.artifact_error"] = artifact["error"]
+        return attrs

--- a/raven/tracing/trace.py
+++ b/raven/tracing/trace.py
@@ -1,0 +1,414 @@
+"""Public instrumentation API — the standard adopters call.
+
+See ``docs/TRACING_STANDARD_API.md``. A thin facade over ``context`` / ``spans`` /
+``store``: open a span on enter, finalize + emit on exit. Nesting is automatic
+via contextvars (a span opened inside another becomes its child).
+
+Guarantees (so an adopter is safe):
+- **No-op when disabled** — yields a no-op handle, no I/O.
+- **Never breaks the caller** — swallows tracing-internal failures; re-raises the
+  application's own exception (after recording ``status=ERROR``).
+- **Import-safe** — importing and calling never requires config to be present.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+from typing import Any, Iterator
+
+from . import config
+from . import context as _ctx
+from . import spans as _spans
+
+_log = logging.getLogger("raven.tracing")
+
+# name domain -> coarse kind (span.type). Custom nodes pass kind= explicitly.
+_KIND_BY_DOMAIN = {
+    "session": "session",
+    "llm": "model",
+    "tool": "tool",
+    "subagent": "subagent",
+    "skill": "skill",
+    "memory": "memory",
+    "plugin": "plugin",
+    "tracing": "plugin",
+}
+
+
+def _derive_kind(name: str) -> str:
+    domain = name.split(".", 1)[0]
+    return _KIND_BY_DOMAIN.get(domain, domain or "internal")
+
+
+class Span:
+    """Handle for an open span. Every method is no-throw and returns ``self``."""
+
+    __slots__ = (
+        "name",
+        "kind",
+        "trace_id",
+        "span_id",
+        "_parent",
+        "_start",
+        "_attrs",
+        "_events",
+        "_status_code",
+        "_status_message",
+        "_session_key",
+        "_channel",
+        "_chat_id",
+        "_perf0",
+        "_cancelled",
+        "_source",
+    )
+
+    def __init__(self, name, kind, *, trace_id, span_id, parent, session_key, channel, chat_id, start, source=None):
+        self.name = name
+        self.kind = kind
+        self.trace_id = trace_id
+        self.span_id = span_id
+        self._parent = parent
+        self._session_key = session_key
+        self._channel = channel
+        self._chat_id = chat_id
+        self._start = start
+        self._source = source
+        self._perf0 = time.monotonic()
+        self._cancelled = False
+        self._attrs: dict[str, Any] = {}
+        self._events: list[dict[str, Any]] = []
+        self._status_code = "OK"
+        self._status_message = ""
+
+    def set(self, attributes: dict[str, Any] | None = None, **kw) -> "Span":
+        """Merge attributes onto the span.
+
+        Standard keys are fully-qualified and dotted (``llm.provider``,
+        ``tool.name`` — see the semantic conventions doc), so pass them as a
+        mapping: ``s.set({"llm.provider": p})``. Bare keywords (``s.set(foo=1)``)
+        are accepted for convenience but are stored verbatim (no auto-namespacing).
+        """
+        if attributes:
+            self._attrs.update(attributes)
+        if kw:
+            self._attrs.update(kw)
+        return self
+
+    def artifact(self, key: str, payload: Any, *, kind: str = "json") -> "Span":
+        """Persist a large payload out-of-line; attach ``<key>.artifact_*`` + preview."""
+        try:
+            meta = {"traceId": self.trace_id, "sessionKey": self._session_key}
+            art = _spans.persist_artifact(key, meta, payload, label=key)
+            self._attrs.update(_spans.artifact_attributes(key, art))
+        except Exception:  # noqa: BLE001 — tracing must never break the host
+            _log.debug("tracing: artifact(%s) failed", key, exc_info=True)
+        return self
+
+    def event(self, name: str) -> "Span":
+        self._events.append({"time": _spans.now_iso(), "name": name})
+        return self
+
+    def error(self, exc: BaseException | str) -> "Span":
+        self._status_code = "ERROR"
+        self._status_message = repr(exc) if isinstance(exc, BaseException) else str(exc)
+        return self
+
+    def retype(self, name: str, kind: str | None = None) -> "Span":
+        """Change the span's name/kind at runtime (before emit).
+
+        For spans whose true type is only known after the call — e.g. a ``tool.call``
+        that turns out to be a ``skill.read`` (a ``use_skill`` / ``read_skill`` tool,
+        or a ``read_file`` of a SKILL.md). Nesting is unaffected (span_id is fixed).
+        """
+        self.name = name
+        if kind:
+            self.kind = kind
+        return self
+
+    @property
+    def invocation_source(self) -> str | None:
+        """Name of the nearest enclosing non-model span — the operation this span
+        runs on behalf of (``None`` at the root). Lets a model call self-label its
+        purpose without the extractor walking the tree."""
+        return self._source
+
+    def elapsed_ms(self) -> int:
+        return int((time.monotonic() - self._perf0) * 1000)
+
+    def cancel(self) -> "Span":
+        """Drop this span — nothing is emitted on close. For conditional spans
+        (e.g. skill.inject only when something was actually injected)."""
+        self._cancelled = True
+        return self
+
+    def checkpoint(self) -> "Span":
+        """Emit the span's current (in-progress) state now, without closing it.
+
+        Same ``span_id`` as the final emit — the viewer dedups by id and keeps
+        the last write. Used by long root spans (a turn) so mid-flight children
+        already have a root to group under while the turn is still open.
+        """
+        try:
+            _spans.emit(
+                _spans.build_span(
+                    self.name,
+                    self.kind,
+                    trace_id=self.trace_id,
+                    span_id=self.span_id,
+                    parent_span_id=self._parent,
+                    session_key=self._session_key,
+                    channel=self._channel,
+                    chat_id=self._chat_id,
+                    start_time=self._start,
+                    end_time=_spans.now_iso(),
+                    status_code=self._status_code,
+                    status_message=self._status_message,
+                    attributes=self._attrs,
+                    events=self._events,
+                )
+            )
+        except Exception:  # noqa: BLE001
+            _log.debug("tracing: checkpoint(%s) failed", self.name, exc_info=True)
+        return self
+
+
+class _NoopSpan:
+    """Returned when tracing is disabled or an internal open failed."""
+
+    trace_id = ""
+    span_id = ""
+    name = ""
+    invocation_source = None
+
+    def set(self, *_a, **_k):
+        return self
+
+    def artifact(self, *_a, **_k):
+        return self
+
+    def event(self, *_a):
+        return self
+
+    def error(self, *_a):
+        return self
+
+    def retype(self, *_a, **_k):
+        return self
+
+    def elapsed_ms(self):
+        return 0
+
+    def checkpoint(self, *_a, **_k):
+        return self
+
+    def cancel(self, *_a, **_k):
+        return self
+
+
+@contextlib.contextmanager
+def span(
+    name: str,
+    attributes: dict[str, Any] | None = None,
+    *,
+    kind: str | None = None,
+    session_key: str | None = None,
+    channel: str | None = None,
+    chat_id: str | None = None,
+    detached: bool = False,
+    **kw,
+) -> Iterator[Any]:
+    """Open a span for ``name`` (``<domain>.<verb>``). Yields a :class:`Span` handle.
+
+    ``attributes`` is a mapping of fully-qualified dotted keys (the standard form,
+    e.g. ``{"llm.provider": p, "llm.model": m}``); ``**kw`` accepts bare keys for
+    convenience. Children opened inside the ``with`` block nest under this span.
+    On exception the span is marked ``ERROR`` and the exception re-raised unchanged.
+    """
+    if not config.enabled():
+        yield _NoopSpan()
+        return
+
+    try:
+        cur = _ctx.current()
+        trace_id = cur.trace_id if cur else _ctx.new_trace_id()
+        parent = cur.parent_span_id if cur else None
+        # Passed session identity seeds a root span (the turn); otherwise inherit
+        # from the active context so children carry the turn's identity.
+        session_key = session_key if session_key is not None else (cur.session_key if cur else None)
+        channel = channel if channel is not None else (cur.channel if cur else None)
+        chat_id = chat_id if chat_id is not None else (cur.chat_id if cur else None)
+        span_id = _ctx.new_span_id()
+        handle = Span(
+            name,
+            kind or _derive_kind(name),
+            trace_id=trace_id,
+            span_id=span_id,
+            parent=parent,
+            session_key=session_key,
+            channel=channel,
+            chat_id=chat_id,
+            start=_spans.now_iso(),
+            source=cur.source if cur else None,
+        )
+        handle.set(attributes, **kw)
+        # A detached span is a leaf marker: it does NOT become the active parent,
+        # so work done inside it attaches to ITS parent, not to it. Required for
+        # cancellable spans (e.g. skill.inject) — otherwise a child that opened
+        # before the cancel would dangle off a span that never gets emitted.
+        token = (
+            None
+            if detached
+            else _ctx.push(
+                trace_id=trace_id,
+                span_id=span_id,
+                name=handle.name,
+                kind=handle.kind,
+                session_key=session_key,
+                channel=channel,
+                chat_id=chat_id,
+            )
+        )
+    except Exception:  # noqa: BLE001 — open must never break the host
+        _log.debug("tracing: span(%s) open failed", name, exc_info=True)
+        yield _NoopSpan()
+        return
+
+    try:
+        yield handle
+    except Exception as exc:
+        handle.error(exc)
+        raise
+    finally:
+        try:
+            if token is not None:
+                _ctx.reset(token)
+            if not handle._cancelled:
+                _spans.emit(
+                    _spans.build_span(
+                        handle.name,
+                        handle.kind,
+                        trace_id=handle.trace_id,
+                        span_id=handle.span_id,
+                        parent_span_id=handle._parent,
+                        session_key=handle._session_key,
+                        channel=handle._channel,
+                        chat_id=handle._chat_id,
+                        start_time=handle._start,
+                        end_time=_spans.now_iso(),
+                        status_code=handle._status_code,
+                        status_message=handle._status_message,
+                        attributes=handle._attrs,
+                        events=handle._events,
+                    )
+                )
+        except Exception:  # noqa: BLE001
+            _log.debug("tracing: span(%s) emit failed", name, exc_info=True)
+
+
+def instrument(name: str, *, kind: str | None = None, detached: bool = False, seed=None, on_open=None, extract=None):
+    """Decorator: wrap an async method so each call emits a ``name`` span.
+
+    The adopter's integration surface — annotate a method, leave its body
+    untouched::
+
+        @trace.instrument("llm.call", extract=semconv.llm_call)
+        async def chat_with_retry(self, ...): ...
+
+    Hooks (all optional, all get ``bound_args`` = the call's arguments by name):
+
+    - ``seed(bound) -> dict`` — returns ``session_key`` / ``channel`` / ``chat_id``
+      to open the span with, seeding a *root* span (a turn) whose identity every
+      child inherits.
+    - ``on_open(span, bound)`` — runs right after open, before the body. Used to
+      record input + ``span.checkpoint()`` an in-progress root for live viewing.
+    - ``extract(span, bound, result, exc)`` — runs in ``finally`` (so input is
+      captured even on error); fills final attributes/artifacts. ``result`` is the
+      return (``None`` on error); ``exc`` is the exception (``None`` on success).
+
+    All tracing work is no-throw and no-op when disabled — the wrapped method's
+    behavior is never altered.
+    """
+    import functools
+    import inspect
+
+    def decorate(func):
+        sig = inspect.signature(func)
+
+        def _bind(args, kwargs):
+            b = sig.bind(*args, **kwargs)
+            b.apply_defaults()
+            return b.arguments
+
+        def _seed(args, kwargs) -> dict:
+            if seed is None:
+                return {}
+            try:
+                return seed(_bind(args, kwargs)) or {}
+            except Exception:  # noqa: BLE001
+                _log.debug("tracing: seed for %s failed", name, exc_info=True)
+                return {}
+
+        def _open(s, args, kwargs) -> None:
+            if on_open is not None:
+                try:
+                    on_open(s, _bind(args, kwargs))
+                except Exception:  # noqa: BLE001
+                    _log.debug("tracing: on_open for %s failed", name, exc_info=True)
+
+        def _close(s, args, kwargs, result, exc) -> None:
+            if extract is not None:
+                try:
+                    extract(s, _bind(args, kwargs), result, exc)
+                except Exception:  # noqa: BLE001 — extraction must not break the host
+                    _log.debug("tracing: extract for %s failed", name, exc_info=True)
+
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def awrapper(*args, **kwargs):
+                if not config.enabled():
+                    return await func(*args, **kwargs)
+                with span(name, kind=kind, detached=detached, **_seed(args, kwargs)) as s:
+                    _open(s, args, kwargs)
+                    result = exc = None
+                    try:
+                        result = await func(*args, **kwargs)
+                        return result
+                    except BaseException as e:  # noqa: BLE001 — record + re-raise
+                        exc = e
+                        raise
+                    finally:
+                        _close(s, args, kwargs, result, exc)
+
+            return awrapper
+
+        @functools.wraps(func)
+        def swrapper(*args, **kwargs):
+            if not config.enabled():
+                return func(*args, **kwargs)
+            with span(name, kind=kind, detached=detached, **_seed(args, kwargs)) as s:
+                _open(s, args, kwargs)
+                result = exc = None
+                try:
+                    result = func(*args, **kwargs)
+                    return result
+                except BaseException as e:  # noqa: BLE001 — record + re-raise
+                    exc = e
+                    raise
+                finally:
+                    _close(s, args, kwargs, result, exc)
+
+        return swrapper
+
+    return decorate
+
+
+def current() -> Any | None:
+    """The active trace context (or None). Exposed for adopters that need it."""
+    return _ctx.current()
+
+
+def enabled() -> bool:
+    return config.enabled()

--- a/raven/tracing/usage.py
+++ b/raven/tracing/usage.py
@@ -1,0 +1,47 @@
+"""LLM usage normalization + best-effort cost.
+
+Mirrors ``AgentLoop._build_usage_snapshot`` semantics (fresh-vs-total prompt
+token convention differs by provider). Cost reuses raven's own pricing table
+when importable; if raven moves it, cost degrades to ``None`` — never raises.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize(usage: dict[str, Any] | None, model: str | None) -> dict[str, Any]:
+    usage = usage or {}
+    prompt_t = int(usage.get("prompt_tokens", 0) or 0)
+    out_toks = int(usage.get("completion_tokens", 0) or 0)
+    cache_read = int(usage.get("cache_read_input_tokens", 0) or 0)
+    cache_write = int(usage.get("cache_creation_input_tokens", 0) or 0)
+
+    # Normalize prompt tokens to *fresh* (non-cached): Anthropic reports
+    # fresh-only, OpenRouter/LiteLLM report total (already including cache).
+    if prompt_t >= cache_read + cache_write and (cache_read + cache_write) > 0:
+        fresh = prompt_t - cache_read - cache_write
+    else:
+        fresh = prompt_t
+
+    total = int(usage.get("total_tokens", 0) or 0) or (prompt_t + out_toks)
+    return {
+        "input_tokens": fresh,
+        "output_tokens": out_toks,
+        "cache_read_tokens": cache_read,
+        "cache_write_tokens": cache_write,
+        "total_tokens": total,
+        "cost_usd": _cost(model, fresh, out_toks, cache_read, cache_write),
+        "raw": dict(usage),
+    }
+
+
+def _cost(model: str | None, fresh: int, out: int, cache_read: int, cache_write: int):
+    if not model:
+        return None
+    try:
+        from raven.token_wise.pricing import estimate_cost_usd
+
+        return estimate_cost_usd(model, fresh, out, cache_read, cache_write)
+    except Exception:  # noqa: BLE001 — pricing is best-effort; never break tracing
+        return None

--- a/raven/tracing/viewer/descriptors/raven.json
+++ b/raven/tracing/viewer/descriptors/raven.json
@@ -1,0 +1,22 @@
+[
+  { "type": "session.turn", "label": "Turn", "render": "custom:sessionTurn" },
+  { "type": "llm.call", "label": "Model Call", "subtitle": "{llm.provider} / {llm.model}", "usage": true, "render": "custom:llmCall" },
+  {
+    "type": "tool.call",
+    "label": "Tool Call",
+    "subtitle": "{tool.name}",
+    "status": [{ "when": "attr:tool.error", "label": "Tool Error" }],
+    "panels": [
+      { "title": "Tool Input", "source": "artifact:tool.input", "pick": "params", "render": "json" },
+      { "title": "Tool Output", "source": "artifact:tool.output", "pick": "result", "render": "json" }
+    ]
+  },
+  { "type": "subagent.call", "label": "Subagent Dispatch", "render": "custom:subagentCall" },
+  { "type": "skill.read", "label": "Skill", "render": "custom:skillRead" },
+  { "type": "skill.rewrite", "label": "Query Rewrite", "subtitle": "{skill.rewrite.query_preview}" },
+  { "type": "skill.gate", "label": "Skill Gate", "subtitle": "{skill.gate.selected_count}/{skill.gate.candidate_count} selected" },
+  { "type": "context.curate", "label": "Context Curation" },
+  { "type": "memory.recall", "label": "Memory Recall", "render": "custom:memoryRecall" },
+  { "type": "memory.store", "label": "Memory Store", "render": "custom:memoryStore" },
+  { "type": "memory.feedback", "label": "Memory Feedback", "render": "custom:memoryFeedback" }
+]

--- a/raven/tracing/viewer/everos-deposits.js
+++ b/raven/tracing/viewer/everos-deposits.js
@@ -1,0 +1,173 @@
+'use strict';
+
+// Reads everos-derived memory (episode / atomic_fact / foresight / agent_case /
+// agent_skill) and indexes it so a `memory.store` span can be joined to the family
+// of memories that this turn's memcell was distilled into.
+//
+// Join key: (session_id, timestamp). raven's stored messages carry no ids/timestamps,
+// but every md entry header carries session_id + timestamp + parent_id, and the store
+// dispatch time matches the memcell/md timestamp to the millisecond. Entries of one
+// turn share one parent_id, so we group by parent_id and match the group whose
+// timestamp is nearest the store time within a tolerance. See STORE_DEPOSIT_DESIGN.md.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// dir basename -> derived memory type
+const DIR_TYPE = {
+  episodes: 'episode',
+  '.atomic_facts': 'atomic_fact',
+  '.foresights': 'foresight',
+  '.agent_cases': 'agent_case',
+  '.agent_skills': 'agent_skill'
+};
+
+function resolveEverosRoot(framework) {
+  if (process.env.EVEROS_ROOT) return process.env.EVEROS_ROOT;
+  const app = String(framework || 'raven').toLowerCase();
+  return path.join(os.homedir(), '.everos', app);
+}
+
+function walkFiles(root, out = []) {
+  let entries;
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const ent of entries) {
+    const full = path.join(root, ent.name);
+    if (ent.isDirectory()) {
+      if (ent.name === '.index' || ent.name === '.tmp') continue;
+      walkFiles(full, out);
+    } else if (ent.isFile() && ent.name.endsWith('.md')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function fileType(filePath) {
+  const dir = path.basename(path.dirname(filePath));
+  if (DIR_TYPE[dir]) return DIR_TYPE[dir];
+  const base = path.basename(filePath);
+  for (const [d, t] of Object.entries(DIR_TYPE)) {
+    if (base.startsWith(t)) return t;
+  }
+  return null;
+}
+
+// Parse `<!-- entry:ID -->...<!-- /entry:ID -->` blocks into structured entries.
+function parseEntries(text, type) {
+  const entries = [];
+  const re = /<!--\s*entry:([^\s]+)\s*-->([\s\S]*?)<!--\s*\/entry:\1\s*-->/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    const id = m[1];
+    const body = m[2];
+    const header = {};
+    const hre = /^\*\*([^*]+)\*\*:\s*(.+)$/gm;
+    let h;
+    while ((h = hre.exec(body)) !== null) header[h[1].trim()] = h[2].trim();
+    const sections = {};
+    const sre = /^###\s+(.+?)\s*\n([\s\S]*?)(?=\n###\s|\n<!--|\s*$)/gm;
+    let s;
+    while ((s = sre.exec(body)) !== null) sections[s[1].trim()] = s[2].trim();
+    const ts = header.timestamp ? Date.parse(header.timestamp) : NaN;
+    entries.push({
+      id,
+      type,
+      sessionId: header.session_id || null,
+      parentId: header.parent_id || null,
+      timestampMs: Number.isNaN(ts) ? null : ts,
+      timestamp: header.timestamp || null,
+      subject: sections.Subject || null,
+      text:
+        sections.Summary ||
+        sections.Fact ||
+        sections.Foresight ||
+        sections.Content ||
+        sections.Subject ||
+        null,
+      startTime: header.start_time || null,
+      endTime: header.end_time || null
+    });
+  }
+  return entries;
+}
+
+// Build: Map<sessionId, Array<familyGroup>> where a familyGroup is all entries
+// sharing one parent_id (one turn's memcell) grouped by type.
+function buildDepositIndex(everosRoot) {
+  const files = walkFiles(everosRoot);
+  const byParent = new Map();
+  for (const file of files) {
+    const type = fileType(file);
+    if (!type) continue;
+    let text;
+    try {
+      text = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const entry of parseEntries(text, type)) {
+      if (!entry.parentId) continue;
+      if (!byParent.has(entry.parentId)) {
+        byParent.set(entry.parentId, {
+          parentId: entry.parentId,
+          sessionId: entry.sessionId,
+          timestampMs: entry.timestampMs,
+          types: {}
+        });
+      }
+      const group = byParent.get(entry.parentId);
+      if (group.timestampMs == null && entry.timestampMs != null) group.timestampMs = entry.timestampMs;
+      if (!group.sessionId && entry.sessionId) group.sessionId = entry.sessionId;
+      if (!group.types[type]) group.types[type] = [];
+      group.types[type].push(entry);
+    }
+  }
+  const bySession = new Map();
+  for (const group of byParent.values()) {
+    const sid = group.sessionId || '__unknown__';
+    if (!bySession.has(sid)) bySession.set(sid, []);
+    bySession.get(sid).push(group);
+  }
+  return bySession;
+}
+
+// Resolve the deposit family for one store span.
+// Returns { parentId, timestamp, counts, types } or null (not yet distilled).
+function resolveDeposit(index, sessionId, storeTimeMs, toleranceMs = 20000) {
+  if (!sessionId || storeTimeMs == null) return null;
+  const groups = index.get(sessionId);
+  if (!groups || !groups.length) return null;
+  let best = null;
+  let bestDelta = Infinity;
+  for (const g of groups) {
+    if (g.timestampMs == null) continue;
+    const delta = Math.abs(g.timestampMs - storeTimeMs);
+    if (delta < bestDelta) {
+      bestDelta = delta;
+      best = g;
+    }
+  }
+  if (!best || bestDelta > toleranceMs) return null;
+  const counts = {};
+  for (const [t, arr] of Object.entries(best.types)) counts[t] = arr.length;
+  return { parentId: best.parentId, timestamp: best.timestampMs, deltaMs: bestDelta, counts, types: best.types };
+}
+
+function summarize(deposit) {
+  if (!deposit) return null;
+  const label = { episode: 'episode', atomic_fact: 'fact', foresight: 'foresight', agent_case: 'case', agent_skill: 'skill' };
+  const parts = [];
+  for (const [t, n] of Object.entries(deposit.counts)) {
+    const name = label[t] || t;
+    parts.push(`${n} ${name}${n === 1 ? '' : 's'}`);
+  }
+  return parts.join(' · ');
+}
+
+module.exports = { resolveEverosRoot, buildDepositIndex, resolveDeposit, summarize, parseEntries };

--- a/raven/tracing/viewer/log-store.js
+++ b/raven/tracing/viewer/log-store.js
@@ -1,0 +1,164 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const DEFAULT_MAX_BYTES = 50 * 1024 * 1024;
+
+const KIND_FILES = {
+  events: 'audit-events.log',
+  spans: 'audit-spans.log'
+};
+
+function getStateDir() {
+  // Generic across frameworks: TRACING_STATE_DIR wins (set from --state-dir
+  // by the entry scripts), then the legacy OpenClaw var, then ~/.openclaw.
+  return (
+    process.env.TRACING_STATE_DIR ||
+    process.env.OPENCLAW_STATE_DIR ||
+    path.join(os.homedir(), '.openclaw')
+  );
+}
+
+function getLogsDir() {
+  return path.join(getStateDir(), 'logs');
+}
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function getActiveLogPath(kind) {
+  return path.join(ensureDir(getLogsDir()), KIND_FILES[kind]);
+}
+
+function getArchiveDir() {
+  return ensureDir(path.join(getLogsDir(), 'archive'));
+}
+
+function getDateKey(date = new Date()) {
+  return date.toISOString().slice(0, 10);
+}
+
+function getMaxBytes() {
+  const raw = Number(process.env.TRACE_LOG_MAX_BYTES || DEFAULT_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MAX_BYTES;
+}
+
+function toJsonText(value) {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function readJsonlFile(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  return fs
+    .readFileSync(filePath, 'utf8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function walkFiles(rootDir) {
+  const result = [];
+  if (!fs.existsSync(rootDir)) return result;
+  const stack = [rootDir];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      result.push(full);
+    }
+  }
+  return result;
+}
+
+function listLogFiles(kind) {
+  const rootDir = getLogsDir();
+  const baseName = KIND_FILES[kind];
+  const files = walkFiles(rootDir).filter((filePath) => {
+    const name = path.basename(filePath);
+    if (name === baseName) return true;
+    if (!name.startsWith(baseName.replace('.log', ''))) return false;
+    return name.endsWith('.log');
+  });
+  files.sort((a, b) => {
+    const statA = fs.existsSync(a) ? fs.statSync(a) : null;
+    const statB = fs.existsSync(b) ? fs.statSync(b) : null;
+    const timeA = statA ? statA.mtimeMs : 0;
+    const timeB = statB ? statB.mtimeMs : 0;
+    if (timeA !== timeB) return timeA - timeB;
+    return a.localeCompare(b);
+  });
+  return files;
+}
+
+function readJsonl(kind) {
+  const records = [];
+  for (const filePath of listLogFiles(kind)) {
+    records.push(...readJsonlFile(filePath));
+  }
+  return records;
+}
+
+function rotateIfNeeded(kind, nextText = '') {
+  const filePath = getActiveLogPath(kind);
+  if (!fs.existsSync(filePath)) return filePath;
+
+  const stat = fs.statSync(filePath);
+  const currentDateKey = getDateKey(new Date(stat.mtimeMs));
+  const todayKey = getDateKey(new Date());
+  const maxBytes = getMaxBytes();
+  const nextBytes = Buffer.byteLength(String(nextText), 'utf8');
+  const shouldRotateByDate = currentDateKey !== todayKey;
+  const shouldRotateBySize = stat.size + nextBytes > maxBytes;
+  if (!shouldRotateByDate && !shouldRotateBySize) return filePath;
+
+  const archiveDayDir = ensureDir(path.join(getArchiveDir(), currentDateKey));
+  const suffix = `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+  const rotatedPath = path.join(archiveDayDir, `${KIND_FILES[kind].replace('.log', '')}-${currentDateKey}-${suffix}.log`);
+  fs.renameSync(filePath, rotatedPath);
+  return filePath;
+}
+
+function appendJsonl(kind, record) {
+  const text = `${toJsonText(record)}\n`;
+  const filePath = rotateIfNeeded(kind, text);
+  fs.appendFileSync(filePath, text, { encoding: 'utf8' });
+  return filePath;
+}
+
+module.exports = {
+  getStateDir,
+  getLogsDir,
+  getActiveLogPath,
+  getArchiveDir,
+  ensureDir,
+  readJsonl,
+  appendJsonl,
+  rotateIfNeeded,
+  getDateKey
+};

--- a/raven/tracing/viewer/server.js
+++ b/raven/tracing/viewer/server.js
@@ -1,0 +1,1017 @@
+#!/usr/bin/env node
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { URL } = require('url');
+const { applyStateDirArg } = require('./state-dir');
+applyStateDirArg();
+const { readJsonl, getLogsDir } = require('./log-store');
+const everosDeposits = require('./everos-deposits');
+
+const PORT = Number(process.env.TRACE_UI_PORT || process.env.TRACING_UI_PORT || 4318);
+const STATE_DIR =
+  process.env.TRACING_STATE_DIR ||
+  process.env.OPENCLAW_STATE_DIR ||
+  path.join(os.homedir(), '.openclaw');
+const LOGS_DIR = getLogsDir();
+const ARTIFACTS_DIR = path.join(LOGS_DIR, 'audit-artifacts');
+const STATIC_DIR = path.join(__dirname, 'ui');
+const SHELL_HTML = require('./ui/shell.js');
+const BUNDLED_DESCRIPTORS_DIR = path.join(__dirname, 'descriptors');
+const STATE_DESCRIPTORS_DIR = path.join(STATE_DIR, 'descriptors');
+const CLI_DESCRIPTORS = (() => {
+  const argv = process.argv;
+  const i = argv.indexOf('--descriptors');
+  if (i !== -1 && argv[i + 1]) return argv[i + 1];
+  const eq = argv.find((a) => a.startsWith('--descriptors='));
+  return eq ? eq.slice('--descriptors='.length) : null;
+})();
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store'
+  });
+  res.end(JSON.stringify(payload));
+}
+
+function sendText(res, statusCode, text, contentType = 'text/plain; charset=utf-8') {
+  res.writeHead(statusCode, {
+    'Content-Type': contentType,
+    'Cache-Control': 'no-store'
+  });
+  res.end(text);
+}
+
+function parseTime(value) {
+  const parsed = Date.parse(value || '');
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function shortId(value, len = 8) {
+  if (!value) return '';
+  const text = String(value);
+  return text.length <= len ? text : text.slice(0, len);
+}
+
+function durationMs(start, end) {
+  const a = parseTime(start);
+  const b = parseTime(end);
+  if (!a || !b) return 0;
+  return Math.max(0, b - a);
+}
+
+function compareSpansByTime(a, b) {
+  const timeDiff = parseTime(a.startTime) - parseTime(b.startTime);
+  if (timeDiff !== 0) return timeDiff;
+  const rank = (span) => {
+    if (span?.name === 'session.turn') return 0;
+    if (span?.name === 'llm.call') return 1;
+    if (span?.name === 'subagent.call') return 2;
+    return 3;
+  };
+  const rankDiff = rank(a) - rank(b);
+  if (rankDiff !== 0) return rankDiff;
+  return String(a?.spanId || '').localeCompare(String(b?.spanId || ''));
+}
+
+function pickMostFrequent(values) {
+  const counts = new Map();
+  for (const value of values || []) {
+    if (!value) continue;
+    counts.set(value, (counts.get(value) || 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1] || String(a[0]).localeCompare(String(b[0])))[0]?.[0] || null;
+}
+
+function parseJsonMaybe(value) {
+  if (value == null) return null;
+  if (typeof value === 'object') return value;
+  if (typeof value !== 'string') return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function readJsonFileMaybe(filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function dedupeSpans(spans) {
+  const byId = new Map();
+  for (const span of spans) {
+    if (!span || !span.spanId) continue;
+    byId.set(span.spanId, span);
+  }
+  return [...byId.values()];
+}
+
+function isUuidLike(value) {
+  return typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+function buildSessionIdentityIndex(spans) {
+  const countsBySessionKey = new Map();
+  const metaBySessionId = new Map();
+
+  for (const span of spans) {
+    if (span?.sessionKey) {
+      if (!countsBySessionKey.has(span.sessionKey)) countsBySessionKey.set(span.sessionKey, new Map());
+      const counts = countsBySessionKey.get(span.sessionKey);
+      const sessionId = span.sessionId || '';
+      counts.set(sessionId, (counts.get(sessionId) || 0) + 1);
+    }
+
+    if (span?.sessionId) {
+      const current = metaBySessionId.get(span.sessionId) || {
+        keyCounts: new Map(),
+        agentCounts: new Map(),
+        workspaceCounts: new Map()
+      };
+      if (span.sessionKey) current.keyCounts.set(span.sessionKey, (current.keyCounts.get(span.sessionKey) || 0) + 1);
+      if (span.agentId) current.agentCounts.set(span.agentId, (current.agentCounts.get(span.agentId) || 0) + 1);
+      if (span.workspaceDir) current.workspaceCounts.set(span.workspaceDir, (current.workspaceCounts.get(span.workspaceDir) || 0) + 1);
+      metaBySessionId.set(span.sessionId, current);
+    }
+  }
+
+  const canonicalIdBySessionKey = new Map();
+  for (const [sessionKey, counts] of countsBySessionKey.entries()) {
+    const entries = [...counts.entries()].filter(([sessionId]) => sessionId);
+    if (!entries.length) continue;
+    entries.sort((a, b) => {
+      const [idA, countA] = a;
+      const [idB, countB] = b;
+      const uuidBias = Number(isUuidLike(idB)) - Number(isUuidLike(idA));
+      if (uuidBias !== 0) return uuidBias;
+      if (countB !== countA) return countB - countA;
+      return idA.localeCompare(idB);
+    });
+    canonicalIdBySessionKey.set(sessionKey, entries[0][0]);
+  }
+
+  const preferredValue = (counts) =>
+    [...counts.entries()].sort((a, b) => b[1] - a[1] || String(a[0]).localeCompare(String(b[0])))[0]?.[0] || null;
+
+  const sessionMetaById = new Map();
+  for (const [sessionId, meta] of metaBySessionId.entries()) {
+    sessionMetaById.set(sessionId, {
+      sessionKey: preferredValue(meta.keyCounts),
+      agentId: preferredValue(meta.agentCounts),
+      workspaceDir: preferredValue(meta.workspaceCounts)
+    });
+  }
+
+  return { canonicalIdBySessionKey, sessionMetaById };
+}
+
+function projectSpanForDisplay(span, identityIndex) {
+  const { canonicalIdBySessionKey, sessionMetaById } = identityIndex;
+  const canonicalIdForKey = span.sessionKey ? canonicalIdBySessionKey.get(span.sessionKey) : null;
+  const canonicalMetaForSession = span.sessionId ? sessionMetaById.get(span.sessionId) || null : null;
+  const parentAliasSessionId = span.sessionId && !isUuidLike(span.sessionId)
+    ? canonicalIdBySessionKey.get(span.sessionId) || null
+    : null;
+  const resolvedSessionId = isUuidLike(span.sessionId)
+    ? span.sessionId
+    : span.sessionId || parentAliasSessionId || canonicalIdForKey || null;
+
+  if (span.name === 'subagent.call') {
+    const parentSessionId = isUuidLike(span.sessionId)
+      ? span.sessionId
+      : parentAliasSessionId || canonicalIdForKey || span.sessionId || null;
+    const parentMeta = (parentSessionId && sessionMetaById.get(parentSessionId)) || canonicalMetaForSession || {};
+    return {
+      ...span,
+      sessionId: parentSessionId,
+      sessionKey: parentMeta.sessionKey || span.sessionKey || null,
+      agentId: parentMeta.agentId || span.agentId || null,
+        workspaceDir: parentMeta.workspaceDir || span.workspaceDir || null
+    };
+  }
+
+  return {
+    ...span,
+    sessionId: resolvedSessionId,
+    sessionKey: span.sessionKey || canonicalMetaForSession?.sessionKey || null,
+    agentId: span.agentId || canonicalMetaForSession?.agentId || null,
+    workspaceDir: span.workspaceDir || canonicalMetaForSession?.workspaceDir || null
+  };
+}
+
+function normalizeSpan(span) {
+  const attrs = span.attributes || {};
+  const kind = attrs['span.type'] || 'internal';
+  const failure = detectSpanFailure(span, attrs);
+  return {
+    traceKey: null,
+    traceId: span.traceId,
+    spanId: span.spanId,
+    parentSpanId: span.parentSpanId || null,
+    name: span.name,
+    kind,
+    startTime: span.startTime,
+    endTime: span.endTime,
+    durationMs: durationMs(span.startTime, span.endTime),
+    status: span.status || { code: 'OK', message: '' },
+    isFailed: failure.isFailed,
+    failureLabel: failure.failureLabel,
+    attributes: attrs,
+    events: span.events || [],
+    sessionId: attrs['session.id'] || null,
+    sessionKey: attrs['session.key'] || null,
+    agentId: attrs['agent.id'] || null,
+    workspaceDir: attrs['workspace.dir'] || null,
+    runId: attrs['run.id'] || null,
+    trigger: attrs.trigger || null,
+    channelId: attrs['channel.id'] || null,
+    displayTitle: buildSpanTitle(span.name, attrs),
+    displaySubtitle: buildSpanSubtitle(span.name, attrs)
+  };
+}
+
+function detectSpanFailure(span, attrs) {
+  const statusCode = String(span?.status?.code || 'OK').toUpperCase();
+  if (statusCode && statusCode !== 'OK') {
+    return { isFailed: true, failureLabel: statusCode };
+  }
+
+  if (span?.name === 'llm.call') {
+    const outputPreview = parseJsonMaybe(attrs['llm.output_preview']);
+    const stopReason = outputPreview?.stopReason;
+    const errorMessage = outputPreview?.errorMessage;
+    if (stopReason && String(stopReason).toLowerCase() === 'error') {
+      return { isFailed: true, failureLabel: errorMessage ? 'model error' : 'error' };
+    }
+    if (errorMessage) {
+      return { isFailed: true, failureLabel: 'model error' };
+    }
+  }
+
+  if (span?.name === 'tool.call') {
+    const preview = parseJsonMaybe(attrs['tool.result_preview']);
+    const toolError = attrs['tool.error'];
+    if (toolError) return { isFailed: true, failureLabel: 'tool error' };
+    if (preview?.status && String(preview.status).toLowerCase() === 'error') {
+      return { isFailed: true, failureLabel: preview.error ? 'tool error' : 'error result' };
+    }
+    if (preview?.error) return { isFailed: true, failureLabel: 'tool error' };
+  }
+
+  if (span?.name === 'subagent.call') {
+    // Only genuine-failure statuses are failures. openclaw used 'accepted' for
+    // a successful spawn; raven uses 'ok' / 'completed' / 'ended'. Flagging
+    // anything != 'accepted' wrongly marked successful raven subagents red —
+    // the span's own status.code (checked above) is authoritative.
+    const subagentStatus = String(attrs['subagent.status'] || '').toLowerCase();
+    if (subagentStatus === 'error' || subagentStatus === 'failed') {
+      return { isFailed: true, failureLabel: subagentStatus };
+    }
+  }
+
+  if (span?.name === 'skill.read') {
+    // openclaw's skill.read signals success via skill.read.* byte/sha attrs;
+    // raven's read_file→skill.read signals it via skill.result_preview /
+    // skill.path / tool.output.artifact_bytes. Accept EITHER family as evidence
+    // of a real read so a successful raven read (status.code already OK above)
+    // isn't false-flagged "read failed" just because the openclaw attrs are absent.
+    const bytes = attrs['skill.read.file_bytes'];
+    const sha1 = attrs['skill.read.file_sha1'];
+    const preview = attrs['skill.read.preview'] || attrs['skill.result_preview'];
+    const artifactBytes = attrs['skill.read.artifact_bytes'] ?? attrs['tool.output.artifact_bytes'];
+    const artifactPath = attrs['skill.read.artifact_path'] || attrs['skill.path'];
+    if (
+      (bytes == null || bytes === 0) &&
+      !sha1 &&
+      !String(preview || '').trim() &&
+      !(artifactBytes > 0) &&
+      !artifactPath
+    ) {
+      return { isFailed: true, failureLabel: 'read failed' };
+    }
+  }
+
+  return { isFailed: false, failureLabel: '' };
+}
+
+function buildSpanTitle(name, attrs) {
+  if (name === 'llm.call') return 'Model Call';
+  if (name === 'tool.call') return 'Tool Call';
+  if (name === 'subagent.call') return 'Subagent Dispatch';
+  if (name === 'subagent.run') return 'Subagent Run';
+  if (name === 'skills.cataloged') return 'Skills Cataloged';
+  if (name === 'skills.catalog_read') return 'Skill Catalog Read';
+  if (name === 'skill.read') return 'Skill';
+  if (name === 'skills.scan') return 'Skills Scan';
+  if (name === 'session.turn') return 'Turn';
+  if (name === 'skill.inject') return 'Skill Inject';
+  if (name === 'skill.rewrite') return 'Query Rewrite';
+  if (name === 'skill.gate') return 'Skill Gate';
+  if (name === 'context.curate') return 'Context Curation';
+  if (name === 'memory.recall') return 'Memory Recall';
+  if (name === 'memory.store') return 'Memory Store';
+  if (name === 'memory.extract') return 'Memory Extract';
+  if (name === 'memory.consolidate') return 'Memory Consolidate';
+  if (name === 'memory.profile_refresh') return 'Profile Refresh';
+  if (name === 'memory.feedback') return 'Memory Feedback';
+  if (name === 'plugin.load') return 'Plugin Load';
+  if (name === 'tracing.bootstrap') return 'Tracing Bootstrap';
+  return name;
+}
+
+function buildSpanSubtitle(name, attrs) {
+  if (name === 'session.turn') {
+    const q = attrs['turn.input_preview'];
+    return q ? String(q).replace(/\s+/g, ' ').trim() : '';
+  }
+  if (name === 'llm.call') return [attrs['llm.provider'], attrs['llm.model']].filter(Boolean).join(' / ');
+  if (name === 'tool.call') return attrs['tool.name'] || '';
+  if (name === 'subagent.call') {
+    if (attrs['subagent.id']) return `named subagent / ${attrs['subagent.id']}`;
+    return attrs['subagent.label'] || 'derived subagent';
+  }
+  if (name === 'subagent.run') return attrs['subagent.label'] || attrs['subagent.task'] || 'subagent';
+  if (name === 'skills.cataloged') return `${attrs['skills.cataloged.count'] || 0} skills`;
+  if (name === 'skills.catalog_read') return attrs['skills.catalog_read.skill_name'] || '';
+  if (name === 'skill.read') {
+    const label = attrs['skill.name'] || attrs['skill.id'] || '';
+    return attrs['skill.scripts_dir'] ? `${label} + scripts`.trim() : label;
+  }
+  if (name === 'skills.scan') return `${attrs['skills.scan.total_count'] || 0} skills`;
+  if (name === 'skill.rewrite') {
+    const nr = attrs['skill.rewrite.need_retrieval'];
+    return nr === false ? 'no retrieval' : (attrs['skill.rewrite.query_preview'] || '');
+  }
+  if (name === 'skill.gate') {
+    return `${attrs['skill.gate.selected_count'] ?? 0}/${attrs['skill.gate.candidate_count'] ?? 0} selected`;
+  }
+  if (name === 'context.curate') return attrs['context.curate.produced'] ? 'curated' : '';
+  if (name === 'skill.inject') {
+    const names = attrs['skill.inject.names'];
+    const label = Array.isArray(names) && names.length ? names.join(', ') : `${attrs['skill.inject.count'] || 0} skills`;
+    return attrs['skill.inject.via'] ? `${label} (${attrs['skill.inject.via']})` : label;
+  }
+  if (name === 'memory.recall') {
+    return [attrs['memory.scope'], attrs['memory.hits'] != null ? `${attrs['memory.hits']} hits` : null]
+      .filter(Boolean).join(' / ');
+  }
+  if (name === 'memory.store') {
+    const base = attrs['memory.message_count'] != null ? `${attrs['memory.message_count']} msgs` : '';
+    if (attrs['memory.deposit_summary']) return base ? `${base} → ${attrs['memory.deposit_summary']}` : attrs['memory.deposit_summary'];
+    if (attrs['memory.deposit_status'] === 'pending') return base ? `${base} · not yet distilled` : 'not yet distilled';
+    return base;
+  }
+  if (name === 'memory.extract') return attrs['memory.surface'] || '';
+  if (name === 'memory.consolidate') return attrs['memory.message_count'] != null ? `${attrs['memory.message_count']} msgs` : '';
+  if (name === 'memory.profile_refresh') return attrs['memory.sections_rewritten'] != null ? `${attrs['memory.sections_rewritten']} sections` : '';
+  if (name === 'memory.feedback') return attrs['memory.kind'] || '';
+  if (name === 'plugin.load') return [attrs['plugin.name'], attrs['plugin.contribution']].filter(Boolean).join(' / ');
+  if (name === 'tracing.bootstrap') return attrs['plugin.id'] || '';
+  return attrs['hook.name'] || '';
+}
+
+function buildTraceTree(spans) {
+  const spanIds = new Set((spans || []).map((span) => span.spanId));
+  const byParent = new Map();
+  for (const span of spans) {
+    const effectiveParentId = span.displayParentSpanId ?? span.parentSpanId;
+    const parentKey = effectiveParentId && spanIds.has(effectiveParentId) ? effectiveParentId : '__root__';
+    if (!byParent.has(parentKey)) byParent.set(parentKey, []);
+    byParent.get(parentKey).push(span);
+  }
+
+  for (const [key, children] of byParent.entries()) {
+    children.sort(compareSpansByTime);
+    byParent.set(key, dedupeSiblingSpans(children));
+  }
+
+  function visit(node, depth) {
+    return {
+      ...node,
+      depth,
+      children: (byParent.get(node.spanId) || []).map((child) => visit(child, depth + 1))
+    };
+  }
+
+  return (byParent.get('__root__') || []).map((root) => visit(root, 0));
+}
+
+function dedupeSiblingSpans(spans) {
+  const seen = new Set();
+  const result = [];
+  for (const span of spans) {
+    const attrs = span.attributes || {};
+    const key = [
+      span.name,
+      span.displayParentSpanId || span.parentSpanId || '',
+      attrs['skills.cataloged.artifact_sha1'] || '',
+      attrs['skills.catalog_read.path'] || attrs['skills.load.path'] || '',
+      attrs['skill.path'] || '',
+      attrs['tool.call_id'] || '',
+      attrs['llm.input.artifact_sha1'] || '',
+      attrs['llm.output.artifact_sha1'] || '',
+      span.startTime || ''
+    ].join('|');
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(span);
+  }
+  return result;
+}
+
+function extractSessionsSpawnPayload(span, identityIndex) {
+  const attrs = span?.attributes || {};
+  if (String(attrs['tool.name'] || '').trim().toLowerCase() !== 'sessions_spawn') return null;
+
+  const inputArtifact = readJsonFileMaybe(attrs['tool.input.artifact_path']);
+  const outputArtifact = readJsonFileMaybe(attrs['tool.output.artifact_path']);
+  const persistedArtifact = readJsonFileMaybe(attrs['tool.persisted.artifact_path']);
+
+  const input =
+    inputArtifact?.params ||
+    inputArtifact?.input ||
+    inputArtifact?.payload ||
+    parseJsonMaybe(attrs['tool.args_preview']) ||
+    null;
+
+  const persistedText =
+    persistedArtifact?.message?.details?.status
+      ? persistedArtifact.message.details
+      : persistedArtifact?.message?.content?.find?.((part) => typeof part?.text === 'string')?.text ||
+        persistedArtifact?.result?.content?.find?.((part) => typeof part?.text === 'string')?.text ||
+        null;
+
+  const output =
+    parseJsonMaybe(persistedText) ||
+    persistedArtifact?.message?.details ||
+    outputArtifact?.result?.details ||
+    outputArtifact?.result ||
+    parseJsonMaybe(attrs['tool.result_preview']) ||
+    null;
+
+  if (!input || !output) return null;
+  if (String(input.runtime || '').trim().toLowerCase() !== 'subagent') return null;
+  if (String(output.status || '').trim().toLowerCase() !== 'accepted') return null;
+
+  const childSessionKey = output.childSessionKey || null;
+  const childSessionId =
+    output.childSessionId ||
+    (childSessionKey ? identityIndex.canonicalIdBySessionKey.get(childSessionKey) || null : null);
+
+  return {
+    input,
+    output,
+    childSessionKey,
+    childSessionId
+  };
+}
+
+function synthesizeSubagentCallSpans(spans, identityIndex) {
+  const existingToolCallIds = new Set(
+    spans
+      .filter((span) => span.name === 'subagent.call')
+      .map((span) => span.attributes?.['subagent.tool_call_id'])
+      .filter(Boolean)
+  );
+  const derived = [];
+
+  for (const span of spans) {
+    if (span.name !== 'tool.call') continue;
+    const attrs = span.attributes || {};
+    const toolCallId = attrs['tool.call_id'] || null;
+    if (toolCallId && existingToolCallIds.has(toolCallId)) continue;
+    const payload = extractSessionsSpawnPayload(span, identityIndex);
+    if (!payload) continue;
+    const { input, output, childSessionKey, childSessionId } = payload;
+    derived.push({
+      ...span,
+      spanId: `${span.spanId}::subagent`,
+      name: 'subagent.call',
+      kind: 'subagent',
+      startTime: span.startTime,
+      endTime: span.endTime,
+      durationMs: span.durationMs,
+      displayTitle: 'Subagent Dispatch',
+      displaySubtitle: input.agentId || input.label || '',
+      parentSpanId: span.spanId,
+      displayParentSpanId: span.spanId,
+      attributes: {
+        ...attrs,
+        'subagent.id': input.agentId || null,
+        'subagent.task': input.task || input.label || '',
+        'subagent.label': input.label || '',
+        'subagent.mode': input.mode || output.mode || null,
+        'subagent.session_key': childSessionKey,
+        'subagent.session_id': childSessionId,
+        'subagent.run_id': output.runId || null,
+        'subagent.status': 'accepted',
+        'subagent.source': 'sessions_spawn',
+        'subagent.tool_call_id': toolCallId
+      },
+      events: [...(span.events || []), { time: span.endTime || span.startTime, name: 'subagent_spawn_accepted' }]
+    });
+  }
+
+  return [...spans, ...derived];
+}
+
+function chooseTraceRoot(groups, traceId, timestamp) {
+  const candidates = (groups || [])
+    .filter((group) => group.root && (!traceId || group.traceId === traceId))
+    .sort((a, b) => compareSpansByTime(a.root, b.root));
+  if (!candidates.length) return null;
+  const targetTime = parseTime(timestamp);
+  const before = candidates.filter((group) => parseTime(group.root.startTime) <= targetTime);
+  return before[before.length - 1] || candidates[0];
+}
+
+function buildTraceGroups(sessionSpans) {
+  const spans = [...(sessionSpans || [])].sort(compareSpansByTime);
+  const spanById = new Map(spans.map((span) => [span.spanId, span]));
+  const childrenByParent = new Map();
+
+  for (const span of spans) {
+    if (!span.parentSpanId || !spanById.has(span.parentSpanId)) continue;
+    if (!childrenByParent.has(span.parentSpanId)) childrenByParent.set(span.parentSpanId, []);
+    childrenByParent.get(span.parentSpanId).push(span);
+  }
+
+  for (const children of childrenByParent.values()) {
+    children.sort(compareSpansByTime);
+  }
+
+  // session.turn roots the main trace; subagent.run roots a subagent's OWN
+  // trace (raven subagents run as a separate trace, linked via the dispatch
+  // node's subagent.trace_id). Both are first-class trace roots.
+  let rootCandidates = spans.filter((span) => (span.name === 'session.turn' || span.name === 'subagent.run') && (!span.parentSpanId || !spanById.has(span.parentSpanId)));
+  if (!rootCandidates.length) {
+    rootCandidates = spans.filter((span) => !span.parentSpanId || !spanById.has(span.parentSpanId));
+  }
+
+  const groups = rootCandidates
+    .sort(compareSpansByTime)
+    .map((root) => ({
+      id: root.spanId,
+      root,
+      traceId: root.traceId,
+      spans: [],
+      events: []
+    }));
+
+  const assignedGroupIdBySpanId = new Map();
+  const assignDescendants = (group, span) => {
+    if (!span || assignedGroupIdBySpanId.has(span.spanId)) return;
+    assignedGroupIdBySpanId.set(span.spanId, group.id);
+    group.spans.push({ ...span });
+    for (const child of childrenByParent.get(span.spanId) || []) {
+      assignDescendants(group, child);
+    }
+  };
+
+  for (const group of groups) {
+    assignDescendants(group, group.root);
+  }
+
+  const keptGroups = [];
+  for (const group of groups) {
+    const hasMeaningfulDescendant = group.spans.some(
+      (span) => span.spanId !== group.root.spanId && span.name !== 'session.turn'
+    );
+    const richerSiblingExists = groups.some(
+      (candidate) =>
+        candidate !== group &&
+        candidate.traceId === group.traceId &&
+        candidate.root.sessionKey === group.root.sessionKey &&
+        candidate.root.agentId === group.root.agentId &&
+        candidate.spans.length > group.spans.length
+    );
+    if (!hasMeaningfulDescendant && richerSiblingExists) {
+      for (const span of group.spans) {
+        assignedGroupIdBySpanId.delete(span.spanId);
+      }
+      continue;
+    }
+    keptGroups.push(group);
+  }
+
+  const syntheticGroups = [];
+  const unassignedSpans = spans.filter((span) => !assignedGroupIdBySpanId.has(span.spanId));
+  for (const span of unassignedSpans) {
+    if (
+      span.name === 'session.turn' &&
+      keptGroups.some(
+        (group) =>
+          group.root &&
+          group.traceId === span.traceId &&
+          group.root.sessionId === span.sessionId &&
+          group.root.sessionKey === span.sessionKey
+      )
+    ) {
+      continue;
+    }
+    let group = chooseTraceRoot(keptGroups, span.traceId, span.startTime);
+    if (!group) {
+      group = {
+        id: `synthetic::${span.spanId}`,
+        root: null,
+        traceId: span.traceId,
+        spans: [],
+        events: []
+      };
+      syntheticGroups.push(group);
+      keptGroups.push(group);
+    }
+    assignedGroupIdBySpanId.set(span.spanId, group.id);
+    group.spans.push({
+      ...span,
+      displayParentSpanId: group.root ? group.root.spanId : null
+    });
+  }
+
+  return keptGroups.map((group) => {
+    const spanIds = new Set(group.spans.map((span) => span.spanId));
+    const normalizedSpans = group.spans
+      .map((span) => {
+        const effectiveParent = span.displayParentSpanId ?? span.parentSpanId;
+        const displayParentSpanId =
+          effectiveParent && spanIds.has(effectiveParent)
+            ? effectiveParent
+            : group.root && span.spanId !== group.root.spanId
+              ? group.root.spanId
+              : null;
+        return {
+          ...span,
+          displayParentSpanId
+        };
+      })
+      .sort(compareSpansByTime);
+
+    return {
+      id: group.id,
+      root: group.root,
+      traceId: group.traceId,
+      startTime: normalizedSpans[0]?.startTime || group.root?.startTime || null,
+      endTime: normalizedSpans
+        .map((span) => span.endTime)
+        .sort((a, b) => parseTime(b) - parseTime(a))[0] || group.root?.endTime || null,
+      spans: normalizedSpans,
+      events: []
+    };
+  });
+}
+
+// Enrich memory.store spans with the everos deposit family (episode/fact/foresight/…)
+// distilled from that turn's memcell. Joined per-trace by (session_id, timestamp).
+// Read fresh each call so the view always reflects the latest async distillation.
+function enrichStoreDeposits(spans) {
+  const storeSpans = spans.filter((span) => span.name === 'memory.store');
+  if (!storeSpans.length) return;
+  let index;
+  try {
+    index = everosDeposits.buildDepositIndex(everosDeposits.resolveEverosRoot('raven'));
+  } catch {
+    return;
+  }
+  if (!index || !index.size) return;
+  for (const span of storeSpans) {
+    const attrs = span.attributes || {};
+    const sessionId = attrs['memory.session_id'] || span.sessionKey || span.sessionId;
+    const deposit = everosDeposits.resolveDeposit(index, sessionId, parseTime(span.startTime));
+    if (!deposit) {
+      attrs['memory.deposit_status'] = 'pending';
+      span.attributes = attrs;
+      span.displaySubtitle = buildSpanSubtitle(span.name, attrs);
+      continue;
+    }
+    const payload = {
+      parentId: deposit.parentId,
+      timestamp: deposit.timestamp,
+      deltaMs: deposit.deltaMs,
+      counts: deposit.counts,
+      families: {}
+    };
+    for (const [type, entries] of Object.entries(deposit.types)) {
+      payload.families[type] = entries.map((entry) => ({
+        id: entry.id,
+        subject: entry.subject,
+        text: entry.text,
+        startTime: entry.startTime,
+        endTime: entry.endTime
+      }));
+    }
+    attrs['memory.deposit_status'] = 'distilled';
+    attrs['memory.deposit_summary'] = everosDeposits.summarize(deposit);
+    attrs['memory.deposit_json'] = JSON.stringify(payload);
+    span.attributes = attrs;
+    span.displaySubtitle = buildSpanSubtitle(span.name, attrs);
+  }
+}
+
+function buildSessions() {
+  const rawSpans = dedupeSpans(readJsonl('spans')).map(normalizeSpan);
+  const identityIndex = buildSessionIdentityIndex(rawSpans);
+  const projectedSpans = rawSpans.map((span) => projectSpanForDisplay(span, identityIndex)).filter(Boolean);
+  const spans = synthesizeSubagentCallSpans(projectedSpans, identityIndex);
+  enrichStoreDeposits(spans);
+  const events = readJsonl('events');
+  const spansBySessionId = new Map();
+  for (const span of spans) {
+    if (!span.sessionId) continue;
+    if (!spansBySessionId.has(span.sessionId)) spansBySessionId.set(span.sessionId, []);
+    spansBySessionId.get(span.sessionId).push(span);
+  }
+
+  const sessions = [];
+  for (const [sessionId, sessionSpans] of spansBySessionId.entries()) {
+    const traceGroups = buildTraceGroups(sessionSpans);
+    const sessionKey = pickMostFrequent(sessionSpans.map((span) => span.sessionKey));
+    const agentId = pickMostFrequent(sessionSpans.map((span) => span.agentId));
+    const workspaceDir = pickMostFrequent(sessionSpans.map((span) => span.workspaceDir));
+    const trigger = pickMostFrequent(sessionSpans.map((span) => span.trigger));
+    const channelId = pickMostFrequent(sessionSpans.map((span) => span.channelId));
+    const sessionEvents = events.filter((event) => {
+      if (event.sessionId && event.sessionId === sessionId) return true;
+      if (sessionKey && event.sessionKey === sessionKey) return true;
+      return false;
+    });
+    const sessionStartEvent = sessionEvents.find(
+      (event) => event.type === 'session_start' && event.sessionId === sessionId
+    );
+    const resumedFrom = sessionStartEvent?.event?.resumedFrom || null;
+
+    for (const event of sessionEvents.sort((a, b) => parseTime(a.timestamp) - parseTime(b.timestamp))) {
+      const group = chooseTraceRoot(traceGroups, event.traceId, event.timestamp);
+      if (group) group.events.push(event);
+    }
+
+    const hiddenSpanNames = new Set(['skills.scan', 'skills.catalog_read', 'skills.cataloged']);
+    const traces = traceGroups
+      .map((trace) => {
+        const traceKey = `${sessionId}::${trace.root?.spanId || trace.id}`;
+        const normalizedSpans = trace.spans.map((span) => ({ ...span, traceKey }));
+        const meaningfulVisibleSpans = normalizedSpans.filter(
+          (span) => !hiddenSpanNames.has(span.name) && span.name !== 'session.turn'
+        );
+        return {
+          traceKey,
+          traceId: trace.traceId,
+          sessionId,
+          sessionKey,
+          agentId,
+          workspaceDir,
+          trigger,
+          channelId,
+          startTime: trace.startTime,
+          endTime: trace.endTime,
+          durationMs: durationMs(trace.startTime, trace.endTime),
+          spanCount: normalizedSpans.length,
+          visibleSpanCount: meaningfulVisibleSpans.length,
+          spans: normalizedSpans,
+          tree: buildTraceTree(normalizedSpans),
+          events: trace.events.sort((a, b) => parseTime(a.timestamp) - parseTime(b.timestamp))
+        };
+      })
+      .filter((trace) => trace.visibleSpanCount > 0)
+      .sort((a, b) => parseTime(b.startTime) - parseTime(a.startTime));
+
+    sessions.push({
+      sessionId,
+      sessionKey,
+      agentId,
+      workspaceDir,
+      trigger,
+      channelId,
+      resumedFrom,
+      resumedTo: null,
+      startedAt: sessionSpans.map((span) => span.startTime).sort((a, b) => parseTime(a) - parseTime(b))[0] || null,
+      updatedAt: sessionSpans.map((span) => span.endTime).sort((a, b) => parseTime(b) - parseTime(a))[0] || null,
+      traceCount: traces.length,
+      traces
+    });
+  }
+
+  const sessionById = new Map(sessions.map((session) => [session.sessionId, session]));
+  for (const session of sessions) {
+    if (!session.resumedFrom) continue;
+    const parent = sessionById.get(session.resumedFrom);
+    if (parent) parent.resumedTo = session.sessionId;
+  }
+
+  sessions.sort((a, b) => parseTime(b.updatedAt) - parseTime(a.updatedAt));
+
+  return {
+    generatedAt: new Date().toISOString(),
+    sessions
+  };
+}
+
+function isSafeArtifactPath(filePath) {
+  const resolved = path.resolve(filePath);
+  return resolved.startsWith(path.resolve(ARTIFACTS_DIR) + path.sep) || resolved === path.resolve(ARTIFACTS_DIR);
+}
+
+function readArtifact(filePath) {
+  if (!filePath || !isSafeArtifactPath(filePath)) return null;
+  if (!fs.existsSync(filePath)) return null;
+  const content = fs.readFileSync(filePath, 'utf8');
+  let parsed = null;
+  try {
+    parsed = JSON.parse(content);
+  } catch {}
+  return {
+    path: filePath,
+    content,
+    parsed
+  };
+}
+
+function serveStatic(reqPath, res) {
+  if (reqPath === '/' || reqPath === '/index.html') {
+    sendText(res, 200, SHELL_HTML, 'text/html; charset=utf-8');
+    return;
+  }
+  const filePath = path.resolve(path.join(STATIC_DIR, reqPath));
+  if (!filePath.startsWith(path.resolve(STATIC_DIR) + path.sep)) {
+    sendText(res, 403, 'Forbidden');
+    return;
+  }
+  if (!fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
+    sendText(res, 404, 'Not found');
+    return;
+  }
+  const ext = path.extname(filePath).toLowerCase();
+  const typeByExt = {
+    '.html': 'text/html; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+    '.js': 'application/javascript; charset=utf-8',
+    '.json': 'application/json; charset=utf-8'
+  };
+  sendText(res, 200, fs.readFileSync(filePath, 'utf8'), typeByExt[ext] || 'text/plain; charset=utf-8');
+}
+
+// Content search across all spans: title/subtitle/attributes plus the FULL text
+// of every artifact a span references (messages, recalled memories, deposits).
+// Fuzzy = case-insensitive, whitespace-split terms, all must match (AND).
+const MAX_SEARCH_RESULTS = 50;
+const MAX_ARTIFACT_SEARCH_BYTES = 512 * 1024;
+
+function artifactTextForSearch(filePath) {
+  if (!filePath || !isSafeArtifactPath(filePath)) return '';
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile() || stat.size > MAX_ARTIFACT_SEARCH_BYTES) return '';
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function makeSnippet(text, term, radius = 60) {
+  const idx = text.toLowerCase().indexOf(term);
+  if (idx < 0) return '';
+  const start = Math.max(0, idx - radius);
+  const end = Math.min(text.length, idx + term.length + radius);
+  const head = start > 0 ? '…' : '';
+  const tail = end < text.length ? '…' : '';
+  return (head + text.slice(start, end) + tail).replace(/\s+/g, ' ').trim();
+}
+
+function searchSpans(query) {
+  const terms = String(query || '').toLowerCase().split(/\s+/).filter(Boolean);
+  if (!terms.length) return [];
+  const results = [];
+  const data = buildSessions();
+  for (const session of data.sessions) {
+    for (const trace of session.traces || []) {
+      for (const span of trace.spans || []) {
+        const attrs = span.attributes || {};
+        // pieces: [label, text]; artifacts carry the full node input/output.
+        const pieces = [
+          ['title', [span.displayTitle, span.displaySubtitle, span.name].filter(Boolean).join(' ')],
+          ['attributes', JSON.stringify(attrs)]
+        ];
+        for (const [key, value] of Object.entries(attrs)) {
+          if (key.endsWith('artifact_path') && typeof value === 'string') {
+            const text = artifactTextForSearch(value);
+            if (text) pieces.push([key.replace('.artifact_path', ''), text]);
+          }
+        }
+        const combined = pieces.map(([, text]) => text).join('\n').toLowerCase();
+        if (!terms.every((term) => combined.includes(term))) continue;
+        // Snippet from the most specific piece hit by the first term (prefer artifacts).
+        let snippet = '';
+        let field = '';
+        for (const [label, text] of pieces.slice(2).concat([pieces[1], pieces[0]])) {
+          snippet = makeSnippet(text, terms[0]);
+          if (snippet) {
+            field = label;
+            break;
+          }
+        }
+        results.push({
+          sessionId: session.sessionId,
+          traceKey: trace.traceKey,
+          traceId: trace.traceId,
+          spanId: span.spanId,
+          name: span.name,
+          title: span.displayTitle,
+          subtitle: span.displaySubtitle,
+          startTime: span.startTime,
+          field,
+          snippet
+        });
+        if (results.length >= MAX_SEARCH_RESULTS * 4) break;
+      }
+    }
+  }
+  results.sort((a, b) => parseTime(b.startTime) - parseTime(a.startTime));
+  return results.slice(0, MAX_SEARCH_RESULTS);
+}
+
+// Load node-type descriptors, merged by `type` in increasing precedence:
+// bundled → state-dir drop-in → --descriptors CLI. Later sources override.
+// See TRACING_STANDARD.md §7. Never throws — a bad file is skipped.
+function readDescriptorDir(dir) {
+  const out = [];
+  let names;
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(path.join(dir, name), 'utf8'));
+      if (Array.isArray(parsed)) out.push(...parsed);
+      else if (parsed && typeof parsed === 'object') out.push(parsed);
+    } catch {
+      // skip malformed descriptor file
+    }
+  }
+  return out;
+}
+
+function loadDescriptors() {
+  const sources = [
+    ...readDescriptorDir(BUNDLED_DESCRIPTORS_DIR),
+    ...readDescriptorDir(STATE_DESCRIPTORS_DIR),
+    ...(CLI_DESCRIPTORS ? readDescriptorDir(CLI_DESCRIPTORS) : [])
+  ];
+  const byType = new Map();
+  for (const desc of sources) {
+    if (desc && typeof desc.type === 'string') byType.set(desc.type, desc);
+  }
+  return [...byType.values()];
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host || '127.0.0.1'}`);
+
+  if (url.pathname === '/api/health') {
+    sendJson(res, 200, { ok: true, port: PORT, stateDir: STATE_DIR });
+    return;
+  }
+
+  if (url.pathname === '/api/descriptors') {
+    sendJson(res, 200, { descriptors: loadDescriptors() });
+    return;
+  }
+
+  if (url.pathname === '/api/search') {
+    sendJson(res, 200, { results: searchSpans(url.searchParams.get('q') || '') });
+    return;
+  }
+
+  if (url.pathname === '/api/data') {
+    sendJson(res, 200, buildSessions());
+    return;
+  }
+
+  if (url.pathname === '/api/artifact') {
+    const artifactPath = url.searchParams.get('path');
+    const artifact = readArtifact(artifactPath);
+    if (!artifact) {
+      sendJson(res, 404, { error: 'Artifact not found' });
+      return;
+    }
+    sendJson(res, 200, artifact);
+    return;
+  }
+
+  serveStatic(url.pathname, res);
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`Trace UI running at http://127.0.0.1:${PORT}`);
+});

--- a/raven/tracing/viewer/server.js
+++ b/raven/tracing/viewer/server.js
@@ -318,6 +318,7 @@ function buildSpanTitle(name, attrs) {
   if (name === 'skill.rewrite') return 'Query Rewrite';
   if (name === 'skill.gate') return 'Skill Gate';
   if (name === 'context.curate') return 'Context Curation';
+  if (name.startsWith('personalize.')) return 'Personalize ' + name.slice('personalize.'.length);
   if (name === 'memory.recall') return 'Memory Recall';
   if (name === 'memory.store') return 'Memory Store';
   if (name === 'memory.extract') return 'Memory Extract';
@@ -356,6 +357,7 @@ function buildSpanSubtitle(name, attrs) {
     return `${attrs['skill.gate.selected_count'] ?? 0}/${attrs['skill.gate.candidate_count'] ?? 0} selected`;
   }
   if (name === 'context.curate') return attrs['context.curate.produced'] ? 'curated' : '';
+  if (name.startsWith('personalize.')) return attrs['personalize.ok'] === false ? 'failed' : '';
   if (name === 'skill.inject') {
     const names = attrs['skill.inject.names'];
     const label = Array.isArray(names) && names.length ? names.join(', ') : `${attrs['skill.inject.count'] || 0} skills`;

--- a/raven/tracing/viewer/state-dir.js
+++ b/raven/tracing/viewer/state-dir.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+
+// Map a framework name to its trace state dir (where logs/audit-*.log live).
+function frameworkStateDir(name) {
+  const home = os.homedir();
+  switch (String(name || '').toLowerCase()) {
+    case 'openclaw':
+      return process.env.OPENCLAW_STATE_DIR || path.join(home, '.openclaw');
+    case 'hermes':
+      return process.env.HERMES_HOME || path.join(home, '.hermes');
+    case 'raven':
+      return path.join(home, '.raven', 'traces');
+    default:
+      return null;
+  }
+}
+
+// Parse `--state-dir <path>` / `--framework <name>` from argv, set
+// TRACING_STATE_DIR, and splice the consumed flags out of process.argv so
+// downstream positional parsing (e.g. trace-viewer's traceId) still works.
+function applyStateDirArg(argv = process.argv) {
+  const out = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--state-dir' && argv[i + 1]) {
+      process.env.TRACING_STATE_DIR = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--state-dir=')) {
+      process.env.TRACING_STATE_DIR = arg.slice('--state-dir='.length);
+      continue;
+    }
+    if (arg === '--framework' && argv[i + 1]) {
+      const dir = frameworkStateDir(argv[i + 1]);
+      if (dir) process.env.TRACING_STATE_DIR = dir;
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--framework=')) {
+      const dir = frameworkStateDir(arg.slice('--framework='.length));
+      if (dir) process.env.TRACING_STATE_DIR = dir;
+      continue;
+    }
+    out.push(arg);
+  }
+  argv.length = 0;
+  argv.push(...out);
+  return process.env.TRACING_STATE_DIR || null;
+}
+
+module.exports = { applyStateDirArg, frameworkStateDir };

--- a/raven/tracing/viewer/ui/app.css
+++ b/raven/tracing/viewer/ui/app.css
@@ -1,0 +1,2105 @@
+/* ============================================================================
+   Tracing Dashboard — design system
+   Flat, border-driven dark theme for observability. One accent, semantic
+   status colors, a strict spacing / radius / type scale. No gradient chrome.
+   ========================================================================== */
+
+:root {
+  /* surfaces (flat, incrementally lighter) */
+  --bg: #0a0d12;
+  --surface-1: #11151c;
+  --surface-2: #161b23;
+  --surface-3: #1d2430;
+  --surface-inset: #0c0f15;
+
+  /* borders */
+  --border: #232a36;
+  --border-strong: #313a49;
+
+  /* text */
+  --text: #e9edf3;
+  --text-soft: #b0b9c8;
+  --text-muted: #7c8698;
+  --text-faint: #5a6474;
+
+  /* accent + status */
+  --accent: #6ea8fe;
+  --accent-bg: rgba(110, 168, 254, 0.12);
+  --accent-border: rgba(110, 168, 254, 0.4);
+  --success: #46d391;
+  --success-bg: rgba(70, 211, 145, 0.12);
+  --error: #f2748a;
+  --error-bg: rgba(242, 116, 138, 0.13);
+  --warning: #f4b84e;
+  --warning-bg: rgba(244, 184, 78, 0.13);
+  --purple: #c08cf7;
+  --teal: #3fd6c4;
+
+  /* spacing scale */
+  --sp-1: 4px;
+  --sp-2: 6px;
+  --sp-3: 8px;
+  --sp-4: 10px;
+  --sp-5: 12px;
+  --sp-6: 16px;
+  --sp-7: 20px;
+  --sp-8: 24px;
+
+  /* radius scale */
+  --r-sm: 6px;
+  --r-md: 8px;
+  --r-lg: 10px;
+  --r-xl: 12px;
+  --r-pill: 999px;
+
+  /* type scale */
+  --fs-xs: 10px;
+  --fs-sm: 11px;
+  --fs-md: 12px;
+  --fs-lg: 13px;
+  --fs-xl: 15px;
+  --fs-2xl: 18px;
+
+  --shadow: 0 1px 3px rgba(0, 0, 0, 0.32);
+  --focus-ring: 0 0 0 3px rgba(110, 168, 254, 0.18);
+
+  --mono: "IBM Plex Mono", "SFMono-Regular", "Consolas", monospace;
+  --sans: "SF Pro Text", "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+
+  --header-h: 53px;
+  --tabs-h: 44px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+  overflow: hidden;
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: var(--fs-md);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  min-height: 100vh;
+}
+
+/* ── app header ─────────────────────────────────────────────────────────── */
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-6);
+  height: var(--header-h);
+  padding: 0 var(--sp-8);
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-1);
+}
+
+.app-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+}
+
+.app-logo {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--r-md);
+  background: var(--accent-bg);
+  border: 1px solid var(--accent-border);
+  color: var(--accent);
+  font-size: 18px;
+  line-height: 1;
+}
+
+.app-brand h1 {
+  margin: 0;
+  font-size: var(--fs-xl);
+  font-weight: 640;
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+}
+
+.app-status {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-2) var(--sp-4);
+  border-radius: var(--r-pill);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-soft);
+  font-size: var(--fs-sm);
+}
+
+.status-pill::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: var(--r-pill);
+  background: var(--error);
+}
+
+.status-pill.is-connected::before {
+  background: var(--success);
+}
+
+.status-text {
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+}
+
+.status-text strong {
+  color: var(--text-soft);
+  font-family: var(--mono);
+  font-weight: 500;
+}
+
+.app-action {
+  padding-inline: var(--sp-5);
+}
+
+.lang-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-pill);
+  background: var(--surface-2);
+}
+
+.lang-pill {
+  appearance: none;
+  cursor: pointer;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: var(--r-pill);
+  padding: var(--sp-1) var(--sp-3);
+  min-width: 30px;
+  font: inherit;
+  font-size: var(--fs-sm);
+  line-height: 1.4;
+  transition: 140ms ease;
+}
+
+.lang-pill:hover {
+  color: var(--text);
+}
+
+.lang-pill.is-active {
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
+/* ── workspace tabs ─────────────────────────────────────────────────────── */
+.workspace-tabs {
+  display: flex;
+  align-items: stretch;
+  gap: var(--sp-6);
+  height: var(--tabs-h);
+  padding: 0 var(--sp-8);
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-1);
+}
+
+.workspace-tab {
+  appearance: none;
+  cursor: pointer;
+  background: transparent;
+  color: var(--text-muted);
+  border: 0;
+  border-bottom: 2px solid transparent;
+  padding: 0 var(--sp-1);
+  font: inherit;
+  font-size: var(--fs-lg);
+  font-weight: 560;
+  transition: color 140ms ease, border-color 140ms ease;
+}
+
+.workspace-tab:hover {
+  color: var(--text-soft);
+}
+
+.workspace-tab.is-active {
+  border-bottom-color: var(--accent);
+  color: var(--text);
+}
+
+.workspace-tab[disabled] {
+  cursor: default;
+  opacity: 0.5;
+}
+
+/* ── shell layout ───────────────────────────────────────────────────────── */
+.shell {
+  display: grid;
+  grid-template-columns: 236px minmax(280px, 340px) minmax(380px, 1fr);
+  gap: var(--sp-5);
+  height: calc(100vh - var(--header-h) - var(--tabs-h));
+  padding: var(--sp-5) var(--sp-8) var(--sp-8);
+}
+
+.scene {
+  min-height: 0;
+}
+
+.scene-api {
+  display: none;
+  height: calc(100vh - var(--header-h) - var(--tabs-h));
+  padding: var(--sp-5) var(--sp-8) var(--sp-8);
+  overflow: hidden;
+}
+
+body.app-view-api .scene-trace {
+  display: none;
+}
+
+body.app-view-api .scene-api {
+  display: block;
+}
+
+.pane {
+  min-height: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+}
+
+/* ── pane head ──────────────────────────────────────────────────────────── */
+.pane-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-4);
+  min-height: 44px;
+  padding: var(--sp-4) var(--sp-5);
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
+}
+
+.pane-head h1,
+.pane-head h2,
+.pane-head p {
+  margin: 0;
+}
+
+.pane-head h1,
+.pane-head h2 {
+  font-size: var(--fs-lg);
+  font-weight: 620;
+  letter-spacing: -0.01em;
+}
+
+.head-meta,
+.trace-meta,
+.session-meta,
+.trace-tree-note,
+.content-note {
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+}
+
+.muted {
+  color: var(--text-muted);
+}
+
+/* ── shared controls: buttons / tabs ────────────────────────────────────── */
+.ghost-button,
+.tab,
+.session-card,
+.span-node {
+  font: inherit;
+}
+
+.ghost-button {
+  appearance: none;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text-soft);
+  border-radius: var(--r-md);
+  padding: var(--sp-2) var(--sp-5);
+  transition: 140ms ease;
+  font-size: var(--fs-md);
+}
+
+.ghost-button:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-3);
+  color: var(--text);
+}
+
+.tabs {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  border-radius: var(--r-lg);
+  background: var(--surface-inset);
+  border: 1px solid var(--border);
+}
+
+.tab {
+  appearance: none;
+  cursor: pointer;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: var(--r-sm);
+  padding: var(--sp-2) var(--sp-4);
+  font-size: var(--fs-md);
+  transition: 140ms ease;
+}
+
+.tab:hover {
+  color: var(--text-soft);
+}
+
+.tab.is-active {
+  background: var(--surface-3);
+  color: var(--text);
+}
+
+/* ── controls / form fields ─────────────────────────────────────────────── */
+.controls {
+  flex: 0 0 auto;
+  display: grid;
+  gap: var(--sp-4);
+  padding: var(--sp-4) var(--sp-5) var(--sp-5);
+  border-bottom: 1px solid var(--border);
+}
+
+.field {
+  display: grid;
+  gap: var(--sp-2);
+}
+
+.api-only {
+  display: none;
+}
+
+body.app-view-api .api-only {
+  display: grid;
+}
+
+.field span {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.field select,
+.field input {
+  width: 100%;
+  appearance: none;
+  outline: none;
+  border: 1px solid var(--border);
+  background: var(--surface-inset);
+  color: var(--text);
+  border-radius: var(--r-md);
+  padding: var(--sp-3) var(--sp-4);
+  font: inherit;
+  font-size: var(--fs-md);
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.field select:hover,
+.field input:hover {
+  border-color: var(--border-strong);
+}
+
+.field select:focus,
+.field input:focus {
+  border-color: var(--accent-border);
+  box-shadow: var(--focus-ring);
+}
+
+/* ── scroll regions ─────────────────────────────────────────────────────── */
+.session-list,
+.trace-list,
+.details-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+.session-list {
+  padding: var(--sp-3);
+}
+
+.trace-list {
+  padding: var(--sp-3);
+}
+
+.details-body {
+  padding: var(--sp-3);
+}
+
+/* ── session cards ──────────────────────────────────────────────────────── */
+.session-card {
+  appearance: none;
+  width: 100%;
+  text-align: left;
+  position: relative;
+  display: grid;
+  gap: var(--sp-2);
+  padding: var(--sp-4);
+  margin-bottom: var(--sp-2);
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  cursor: pointer;
+  transition: 140ms ease;
+}
+
+.session-card:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-3);
+}
+
+.session-card.is-active {
+  border-color: var(--accent-border);
+  background: var(--surface-3);
+}
+
+.session-card::before {
+  content: "";
+  position: absolute;
+  inset: var(--sp-4) auto var(--sp-4) 0;
+  width: 2px;
+  border-radius: var(--r-pill);
+  background: var(--accent);
+  opacity: 0;
+  transition: opacity 140ms ease;
+}
+
+.session-card.is-active::before {
+  opacity: 1;
+}
+
+.session-card .trace-summary {
+  padding: 0;
+  border-bottom: 0;
+}
+
+.session-card-head,
+.session-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+
+.session-id {
+  font-family: var(--mono);
+  font-size: var(--fs-sm);
+  line-height: 1.35;
+  word-break: break-word;
+}
+
+.session-channel {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.session-chain {
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  line-height: 1.35;
+}
+
+/* ── pills / chips (shared) ─────────────────────────────────────────────── */
+.session-pill,
+.trace-pill,
+.summary-chip,
+.span-chip,
+.session-badge,
+.trace-status,
+.skill-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  width: fit-content;
+  padding: 3px var(--sp-3);
+  border-radius: var(--r-pill);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+  font-family: var(--mono);
+}
+
+.session-pill,
+.trace-pill {
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
+.session-badge,
+.trace-status {
+  background: var(--surface-3);
+  color: var(--text-soft);
+}
+
+.summary-chip {
+  background: var(--surface-3);
+  color: var(--text-soft);
+}
+
+.trace-mini-id {
+  color: var(--text-muted);
+  background: var(--surface-inset);
+}
+
+.summary-chip-success {
+  background: var(--success-bg);
+  color: var(--success);
+}
+
+.summary-chip-error {
+  background: var(--error-bg);
+  color: var(--error);
+}
+
+.summary-chip-neutral,
+.summary-chip-soft {
+  background: var(--surface-3);
+  color: var(--text-soft);
+}
+
+.summary-chip-muted,
+.summary-chip.muted {
+  background: var(--surface-inset);
+  color: var(--text-muted);
+}
+
+.chip-row {
+  display: flex;
+  gap: var(--sp-2);
+  flex-wrap: wrap;
+}
+
+/* ── trace list: groups ─────────────────────────────────────────────────── */
+.trace-group {
+  overflow: hidden;
+  margin-bottom: var(--sp-3);
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+}
+
+.trace-group.is-active {
+  border-color: var(--accent-border);
+}
+
+.trace-header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  padding: var(--sp-4) var(--sp-4) var(--sp-2);
+}
+
+.trace-title {
+  display: grid;
+  gap: var(--sp-1);
+}
+
+.trace-topline {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  flex-wrap: wrap;
+}
+
+.trace-summary {
+  display: flex;
+  gap: var(--sp-1);
+  flex-wrap: wrap;
+  padding: 0 var(--sp-4) var(--sp-3);
+  border-bottom: 1px solid var(--border);
+}
+
+/* ── trace tree ─────────────────────────────────────────────────────────── */
+.trace-tree {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--sp-1);
+  padding: var(--sp-3);
+}
+
+.trace-tree-note {
+  padding: var(--sp-3);
+  border-radius: var(--r-md);
+  background: var(--surface-inset);
+  border: 1px dashed var(--border);
+}
+
+/* ── span node ──────────────────────────────────────────────────────────── */
+.span-node {
+  --node-accent: var(--accent);
+  appearance: none;
+  width: 100%;
+  text-align: left;
+  position: relative;
+  display: block;
+  padding: 0;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface-1);
+  color: var(--text);
+  cursor: pointer;
+  transition: 140ms ease;
+}
+
+.span-node::before {
+  content: "";
+  position: absolute;
+  inset: 6px auto 6px 0;
+  width: 2px;
+  border-radius: var(--r-pill);
+  background: var(--node-accent);
+}
+
+/* Standard span kinds: model (default accent) / tool / subagent / skill /
+   memory / plugin / session. Legacy underscore forms kept as aliases so
+   pre-rename traces still render with their accent. */
+.span-node[data-kind="tool"],
+.span-node[data-kind="tool_call"] {
+  --node-accent: var(--warning);
+}
+
+.span-node[data-kind="subagent"],
+.span-node[data-kind="subagent_call"] {
+  --node-accent: var(--purple);
+}
+
+.span-node[data-kind="skill"],
+.span-node[data-kind="skills"] {
+  --node-accent: var(--success);
+}
+
+.span-node[data-kind="memory"],
+.span-node[data-kind^="memory_"] {
+  --node-accent: var(--teal);
+}
+
+.span-node[data-kind="plugin"],
+.span-node[data-kind="plugin_load"] {
+  --node-accent: var(--text-muted);
+}
+
+.span-node[data-kind="session"] {
+  --node-accent: var(--text-soft);
+}
+
+.span-node:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-2);
+}
+
+.span-node.is-active {
+  border-color: var(--accent-border);
+  background: var(--surface-3);
+}
+
+.span-node.is-failed {
+  --node-accent: var(--error);
+  border-color: var(--error-bg);
+}
+
+.span-node-main {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  align-items: start;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-3) var(--sp-3) var(--sp-4);
+}
+
+.span-node-time {
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.span-node-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--sp-1);
+  min-width: 0;
+}
+
+.span-node-header,
+.span-node-subtitle {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+}
+
+.span-node-title {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.span-node-title strong {
+  font-size: var(--fs-md);
+  font-weight: 620;
+  letter-spacing: -0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.span-chip {
+  background: var(--surface-3);
+  color: var(--text-soft);
+}
+
+.span-node-subtitle {
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+}
+
+.span-state-error {
+  color: var(--error);
+  text-transform: lowercase;
+}
+
+.span-node-subtitle span,
+.trace-meta div {
+  min-width: 0;
+}
+
+/* Subtitle row holds a single text node (e.g. the turn's user query); render it
+   as a block so it fills the grid cell and truncates with an ellipsis instead
+   of wrapping or forcing the node wider than its column. */
+.span-node-subtitle {
+  display: block;
+}
+
+.span-node-subtitle span {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.depth-1 {
+  margin-left: var(--sp-4);
+}
+
+.depth-2 {
+  margin-left: var(--sp-7);
+}
+
+.depth-3,
+.depth-4,
+.depth-5 {
+  margin-left: 30px;
+}
+
+/* ── details: cards & panels ────────────────────────────────────────────── */
+.detail-grid,
+.content-stack {
+  display: grid;
+  gap: var(--sp-3);
+}
+
+.detail-panel,
+.content-card {
+  overflow: hidden;
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+}
+
+.detail-panel-head,
+.content-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--sp-3);
+  min-height: 38px;
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-3);
+}
+
+.detail-panel-head h3,
+.content-card h4 {
+  margin: 0;
+  font-size: var(--fs-md);
+  font-weight: 620;
+}
+
+.meta-tag,
+.card-note {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  font-family: var(--mono);
+}
+
+.wide-card,
+.wide-panel,
+.hero-card {
+  grid-column: 1 / -1;
+}
+
+/* the two model cards use the accent/teal edge as a functional cue */
+.content-card-model-input {
+  border-color: var(--accent-border);
+}
+
+.content-card-model-output {
+  border-color: rgba(63, 214, 196, 0.32);
+}
+
+/* ── metadata grid ──────────────────────────────────────────────────────── */
+.metadata-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.meta-row {
+  padding: var(--sp-3) var(--sp-4);
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.meta-row:nth-child(3n) {
+  border-right: 0;
+}
+
+.meta-row dt {
+  margin: 0 0 var(--sp-1);
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.meta-row dd {
+  margin: 0;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: var(--fs-sm);
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+/* ── events list ────────────────────────────────────────────────────────── */
+.events-list {
+  padding: var(--sp-3);
+}
+
+.events-list ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: var(--sp-2);
+}
+
+.events-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--r-sm);
+  background: var(--surface-inset);
+  color: var(--text-soft);
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+}
+
+.events-list strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* ── hero / metrics rows ────────────────────────────────────────────────── */
+.hero-metrics {
+  display: flex;
+  gap: var(--sp-1);
+  flex-wrap: wrap;
+  padding: var(--sp-3) var(--sp-4);
+}
+
+.content-note {
+  margin: 0;
+  padding: 0 var(--sp-4) var(--sp-3);
+  font-size: var(--fs-xs);
+}
+
+/* ── structured value / pre (shared data renderer) ──────────────────────── */
+.structured-list {
+  display: grid;
+  gap: var(--sp-2);
+}
+
+.structured-row {
+  display: grid;
+  gap: var(--sp-1);
+}
+
+.structured-label {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.structured-value,
+.project-context-path {
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.structured-pre {
+  margin: 0;
+  max-height: 260px;
+  overflow: auto;
+  padding: var(--sp-4);
+  border-radius: var(--r-md);
+  background: var(--surface-inset);
+  border: 1px solid var(--border);
+  color: var(--text-soft);
+  font-family: var(--mono);
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── message list (llm.call / memory.store input+output) ────────────────── */
+.msg-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+  padding: var(--sp-4);
+}
+
+.msg {
+  --msg-accent: var(--border-strong);
+  border-left: 2px solid var(--msg-accent);
+  padding-left: var(--sp-4);
+}
+
+.msg-user {
+  --msg-accent: var(--accent);
+}
+
+.msg-assistant {
+  --msg-accent: var(--teal);
+}
+
+.msg-tool {
+  --msg-accent: var(--warning);
+}
+
+.msg-system {
+  --msg-accent: var(--text-muted);
+}
+
+.msg-role {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--msg-accent);
+  margin-bottom: var(--sp-1);
+}
+
+.msg-body {
+  font-family: var(--mono);
+  font-size: var(--fs-sm);
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+}
+
+.msg-collapse > summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+.msg-collapse > summary::-webkit-details-marker {
+  display: none;
+}
+
+.msg-collapse[open] > summary {
+  margin-bottom: var(--sp-2);
+}
+
+.msg-len {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+}
+
+/* ── model panels ───────────────────────────────────────────────────────── */
+.model-input-layout,
+.evidence-stack,
+.overview-stack {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--sp-3);
+  padding: var(--sp-4);
+}
+
+.model-panel {
+  display: grid;
+  gap: var(--sp-2);
+  padding: var(--sp-4);
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface-inset);
+}
+
+.model-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+
+.model-panel-head strong,
+.detail-panel-head h3 {
+  font-size: var(--fs-md);
+}
+
+/* ── collapsible details (shared marker) ────────────────────────────────── */
+.model-diagnostic-details,
+.project-context-details,
+.skill-summary-details {
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface-inset);
+  overflow: hidden;
+}
+
+.model-diagnostic-details > summary,
+.project-context-details > summary {
+  list-style: none;
+  cursor: pointer;
+  padding: var(--sp-4);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  transition: background-color 140ms ease;
+}
+
+.skill-summary-details {
+  padding: var(--sp-4);
+}
+
+.skill-summary-details summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  cursor: pointer;
+  list-style: none;
+  font-size: var(--fs-md);
+  font-weight: 620;
+}
+
+.model-diagnostic-details > summary::-webkit-details-marker,
+.project-context-details > summary::-webkit-details-marker,
+.skill-summary-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.model-diagnostic-details > summary::before,
+.project-context-details > summary::before,
+.project-context-item > summary::before,
+.skill-summary-details summary::before {
+  content: "›";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--r-pill);
+  background: var(--surface-3);
+  color: var(--text-soft);
+  font-size: var(--fs-lg);
+  line-height: 1;
+  flex: 0 0 auto;
+  transition: transform 140ms ease, background-color 140ms ease, color 140ms ease;
+}
+
+.model-diagnostic-details > summary::after,
+.project-context-details > summary::after,
+.project-context-item > summary::after,
+.skill-summary-details summary::after {
+  content: "Expand";
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+}
+
+html[data-lang="zh"] .model-diagnostic-details > summary::after,
+html[data-lang="zh"] .project-context-details > summary::after,
+html[data-lang="zh"] .project-context-item > summary::after,
+html[data-lang="zh"] .skill-summary-details summary::after {
+  content: "展开";
+}
+
+.model-diagnostic-details[open] > summary::before,
+.project-context-details[open] > summary::before,
+.project-context-item[open] > summary::before,
+.skill-summary-details[open] summary::before {
+  transform: rotate(90deg);
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
+.model-diagnostic-details[open] > summary::after,
+.project-context-details[open] > summary::after,
+.project-context-item[open] > summary::after,
+.skill-summary-details[open] summary::after {
+  content: "Collapse";
+}
+
+html[data-lang="zh"] .model-diagnostic-details[open] > summary::after,
+html[data-lang="zh"] .project-context-details[open] > summary::after,
+html[data-lang="zh"] .project-context-item[open] > summary::after,
+html[data-lang="zh"] .skill-summary-details[open] summary::after {
+  content: "收起";
+}
+
+.model-diagnostic-details > summary:hover,
+.project-context-details > summary:hover,
+.project-context-item > summary:hover,
+.skill-summary-details summary:hover {
+  background: var(--surface-2);
+}
+
+.model-diagnostic-details[open] > summary,
+.project-context-details[open] > summary {
+  border-bottom: 1px solid var(--border);
+}
+
+.model-diagnostic-details .history-list,
+.model-diagnostic-details .system-prompt-grid,
+.project-context-details .project-context-list {
+  padding: var(--sp-4);
+}
+
+/* ── history / project-context items ────────────────────────────────────── */
+.project-context-list,
+.history-list {
+  display: grid;
+  gap: var(--sp-2);
+}
+
+.project-context-item,
+.history-item {
+  --hist-accent: var(--border-strong);
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--hist-accent);
+  background: var(--surface-1);
+}
+
+.history-item {
+  display: grid;
+  gap: var(--sp-2);
+  padding: var(--sp-4);
+}
+
+.history-item-user {
+  --hist-accent: var(--accent);
+}
+
+.history-item-assistant,
+.history-item-assistant_tool {
+  --hist-accent: var(--teal);
+}
+
+.history-item-tool_result {
+  --hist-accent: var(--warning);
+}
+
+.history-item-system {
+  --hist-accent: var(--text-muted);
+}
+
+.project-context-item {
+  padding: 0;
+  overflow: hidden;
+}
+
+.project-context-head,
+.history-item-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+
+.project-context-head {
+  cursor: pointer;
+  list-style: none;
+  padding: var(--sp-4);
+}
+
+.project-context-head::-webkit-details-marker {
+  display: none;
+}
+
+.project-context-preview {
+  margin: 0;
+  padding: 0 var(--sp-4) var(--sp-4);
+  color: var(--text-soft);
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.history-item-meta,
+.history-badges {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  flex-wrap: wrap;
+}
+
+.history-text {
+  color: var(--text-soft);
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── system prompt breakdown ────────────────────────────────────────────── */
+.system-prompt-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--sp-2);
+}
+
+.system-block {
+  display: grid;
+  gap: var(--sp-2);
+  padding: var(--sp-4);
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface-1);
+}
+
+.system-block-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+
+.system-block-head strong {
+  font-size: var(--fs-md);
+}
+
+.chip-grid,
+.system-bullet-list,
+.system-skill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
+}
+
+.system-skill-list {
+  display: grid;
+}
+
+.system-skill-item {
+  display: grid;
+  gap: var(--sp-1);
+}
+
+.system-bullet-item {
+  color: var(--text-soft);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+}
+
+/* ── overview / evidence / skill summary ────────────────────────────────── */
+.overview-row,
+.evidence-card {
+  display: grid;
+  gap: var(--sp-2);
+  padding: var(--sp-4);
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface-inset);
+}
+
+.overview-head,
+.evidence-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+
+.overview-title {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}
+
+.overview-title strong,
+.evidence-head strong {
+  font-size: var(--fs-md);
+}
+
+.overview-tags,
+.evidence-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
+}
+
+.evidence-sub {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  font-family: var(--mono);
+  line-height: 1.4;
+}
+
+.evidence-timeline {
+  display: grid;
+  gap: var(--sp-2);
+}
+
+.evidence-step {
+  display: grid;
+  gap: var(--sp-1);
+  padding-left: var(--sp-4);
+  border-left: 1px solid var(--border-strong);
+}
+
+.evidence-time {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  font-family: var(--mono);
+}
+
+.evidence-chip {
+  width: fit-content;
+}
+
+.skill-summary-list {
+  display: grid;
+  gap: var(--sp-2);
+  margin-top: var(--sp-4);
+}
+
+.skill-summary-item {
+  padding: var(--sp-4);
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface-1);
+}
+
+.skill-summary-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.skill-summary-desc {
+  margin: var(--sp-3) 0 0;
+  color: var(--text-soft);
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+}
+
+.skill-chip {
+  background: var(--surface-3);
+  color: var(--teal);
+}
+
+.skill-chip-read {
+  background: var(--success-bg);
+  color: var(--success);
+}
+
+.skill-chip-catalog {
+  background: var(--surface-3);
+  color: var(--text-soft);
+}
+
+.skill-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
+  padding: var(--sp-3) var(--sp-4);
+}
+
+/* ── raw / code blocks ──────────────────────────────────────────────────── */
+.content-card pre,
+.raw-view pre {
+  margin: 0;
+  padding: var(--sp-4);
+  max-height: 320px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-soft);
+  font-family: var(--mono);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+}
+
+.raw-view {
+  min-height: calc(100vh - 180px);
+  display: flex;
+}
+
+.raw-view pre {
+  flex: 1 1 auto;
+  max-height: none;
+  min-height: calc(100vh - 180px);
+  height: 100%;
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border);
+  background: var(--surface-inset);
+}
+
+/* ── subagent cross-trace jump ──────────────────────────────────────────── */
+.jump-link {
+  margin: var(--sp-4);
+  width: calc(100% - var(--sp-8));
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--surface-inset);
+  color: var(--accent);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  font-family: var(--mono);
+  font-size: var(--fs-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: 140ms ease;
+}
+
+.jump-link:hover {
+  background: var(--surface-2);
+  border-color: var(--accent-border);
+}
+
+/* ========================================================================== */
+/* API dashboard                                                              */
+/* ========================================================================== */
+.api-dashboard {
+  display: grid;
+  gap: var(--sp-5);
+  height: 100%;
+  min-height: 100%;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.api-dashboard-board {
+  min-height: 0;
+}
+
+.api-dashboard-panel,
+.api-dashboard-board {
+  overflow: hidden;
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+}
+
+.api-dashboard-inner {
+  display: grid;
+  gap: var(--sp-5);
+  padding: var(--sp-5);
+}
+
+.api-scope-panel {
+  position: static;
+}
+
+.api-board-scope {
+  border-bottom: 1px solid var(--border);
+}
+
+.api-board-main {
+  display: grid;
+  grid-template-columns: minmax(380px, 0.85fr) minmax(560px, 1.15fr);
+  align-items: start;
+}
+
+.api-board-section {
+  min-width: 0;
+}
+
+.api-board-section + .api-board-section {
+  border-left: 1px solid var(--border);
+}
+
+.api-board-empty {
+  display: grid;
+  gap: var(--sp-2);
+  padding: var(--sp-7) var(--sp-6);
+}
+
+.api-board-empty h3,
+.api-board-empty p {
+  margin: 0;
+}
+
+.api-board-empty h3 {
+  font-size: var(--fs-xl);
+  letter-spacing: -0.02em;
+}
+
+.api-board-empty p {
+  color: var(--text-muted);
+  font-size: var(--fs-md);
+  line-height: 1.5;
+  max-width: 420px;
+}
+
+.api-detail-panel {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.api-detail-panel .api-dashboard-inner {
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.api-overview-panel .api-dashboard-inner {
+  align-content: start;
+}
+
+/* ── toolbar / scope ────────────────────────────────────────────────────── */
+.api-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-4);
+}
+
+.api-toolbar-groups {
+  display: grid;
+  gap: var(--sp-3);
+  min-width: 0;
+}
+
+.api-window-switch,
+.api-filter-summary {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  flex-wrap: wrap;
+}
+
+.api-window-pill,
+.api-status-pill {
+  appearance: none;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text-soft);
+  border-radius: var(--r-md);
+  padding: var(--sp-2) var(--sp-4);
+  font: inherit;
+  font-size: var(--fs-md);
+  transition: 140ms ease;
+}
+
+.api-window-pill:hover,
+.api-status-pill:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.api-window-pill.is-active,
+.api-status-pill.is-active {
+  background: var(--accent-bg);
+  border-color: var(--accent-border);
+  color: var(--accent);
+}
+
+.api-select-group {
+  display: flex;
+  align-items: stretch;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}
+
+.api-inline-field {
+  display: grid;
+  gap: var(--sp-1);
+  min-width: 140px;
+}
+
+.api-inline-field span {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.api-inline-field select {
+  width: 100%;
+  appearance: none;
+  outline: none;
+  border: 1px solid var(--border);
+  background: var(--surface-inset);
+  color: var(--text);
+  border-radius: var(--r-md);
+  padding: var(--sp-3) var(--sp-4);
+  font: inherit;
+  font-size: var(--fs-md);
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.api-inline-field select:hover {
+  border-color: var(--border-strong);
+}
+
+.api-inline-field select:focus {
+  border-color: var(--accent-border);
+  box-shadow: var(--focus-ring);
+}
+
+.api-toolbar-side {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  justify-content: flex-end;
+}
+
+.api-filter-summary {
+  color: var(--text-muted);
+  font-size: var(--fs-md);
+}
+
+/* ── section headings ───────────────────────────────────────────────────── */
+.api-panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--sp-4);
+  padding: var(--sp-4) var(--sp-5) 0;
+  flex: 0 0 auto;
+}
+
+.api-panel-title {
+  display: grid;
+  gap: var(--sp-1);
+}
+
+.api-panel-title h3,
+.api-panel-title p {
+  margin: 0;
+}
+
+.api-panel-title h3 {
+  font-size: var(--fs-lg);
+  font-weight: 620;
+  letter-spacing: -0.01em;
+}
+
+.api-panel-title p {
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  line-height: 1.4;
+}
+
+/* ── stat cards ─────────────────────────────────────────────────────────── */
+.api-overview {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--sp-3);
+}
+
+.api-stat-card {
+  display: grid;
+  gap: var(--sp-2);
+  min-height: 0;
+  padding: var(--sp-4);
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+}
+
+.api-stat-label {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  line-height: 1.25;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.api-stat-value {
+  font-size: var(--fs-2xl);
+  font-weight: 680;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  font-family: var(--mono);
+}
+
+.api-stat-card-success .api-stat-value {
+  color: var(--success);
+}
+
+.api-stat-card-error .api-stat-value {
+  color: var(--error);
+}
+
+.api-stat-card-warning .api-stat-value {
+  color: var(--warning);
+}
+
+/* ── tables ─────────────────────────────────────────────────────────────── */
+.api-table-wrap {
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface-1);
+}
+
+.api-provider-panel .api-table-wrap {
+  min-height: 208px;
+  max-height: 320px;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.api-detail-panel .api-table-wrap {
+  flex: 1 1 auto;
+  min-height: 0;
+  overscroll-behavior: contain;
+}
+
+.api-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--fs-lg);
+}
+
+.api-table thead th,
+.api-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--surface-3);
+  color: var(--text-soft);
+  font-weight: 620;
+  text-align: left;
+  padding: var(--sp-3) var(--sp-5);
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  font-size: var(--fs-md);
+}
+
+.api-table tbody td,
+.api-table td {
+  padding: var(--sp-3) var(--sp-5);
+  border-bottom: 1px solid var(--border);
+  color: var(--text-soft);
+  vertical-align: middle;
+  white-space: nowrap;
+  font-size: var(--fs-md);
+}
+
+.api-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.api-table td:last-child {
+  white-space: normal;
+  min-width: 180px;
+}
+
+.api-table-row {
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.api-table-row:hover {
+  background: var(--surface-2);
+}
+
+.api-table-row.is-active {
+  background: var(--accent-bg);
+}
+
+.api-table-row.is-failed {
+  background: var(--error-bg);
+}
+
+.api-table-empty {
+  text-align: center !important;
+  color: var(--text-muted);
+  padding: var(--sp-8) var(--sp-6) !important;
+}
+
+/* ========================================================================== */
+/* content search                                                             */
+/* ========================================================================== */
+.content-search-results {
+  max-height: 40vh;
+  overflow: auto;
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--border);
+}
+
+.content-hit-head {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  margin-bottom: var(--sp-2);
+}
+
+.content-hit-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: var(--sp-3) var(--sp-4);
+  margin-bottom: var(--sp-2);
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 140ms ease;
+}
+
+.content-hit-item:hover {
+  border-color: var(--accent-border);
+}
+
+.content-hit-title {
+  display: block;
+  font-size: var(--fs-sm);
+  font-weight: 620;
+  margin-bottom: var(--sp-1);
+}
+
+.content-hit-sub {
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+.content-hit-snippet {
+  display: block;
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  line-height: 1.5;
+  color: var(--text-soft);
+  word-break: break-word;
+}
+
+.content-hit-empty {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+}
+
+mark.content-hit-mark {
+  background: var(--warning-bg);
+  color: var(--warning);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+/* ========================================================================== */
+/* empty state                                                                */
+/* ========================================================================== */
+.empty-state {
+  display: grid;
+  place-items: center;
+  min-height: 160px;
+  padding: var(--sp-6);
+  text-align: center;
+}
+
+.empty-title {
+  margin: 0 0 var(--sp-3);
+  font-size: var(--fs-xl);
+  color: var(--text-soft);
+}
+
+.empty-copy {
+  margin: 0;
+  max-width: 30ch;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
+  line-height: 1.6;
+}
+
+/* ========================================================================== */
+/* scrollbars                                                                 */
+/* ========================================================================== */
+.session-list::-webkit-scrollbar,
+.trace-list::-webkit-scrollbar,
+.details-body::-webkit-scrollbar,
+.structured-pre::-webkit-scrollbar,
+.content-card pre::-webkit-scrollbar,
+.raw-view pre::-webkit-scrollbar,
+.api-table-wrap::-webkit-scrollbar,
+.content-search-results::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.session-list::-webkit-scrollbar-track,
+.trace-list::-webkit-scrollbar-track,
+.details-body::-webkit-scrollbar-track,
+.structured-pre::-webkit-scrollbar-track,
+.content-card pre::-webkit-scrollbar-track,
+.raw-view pre::-webkit-scrollbar-track,
+.api-table-wrap::-webkit-scrollbar-track,
+.content-search-results::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.session-list::-webkit-scrollbar-thumb,
+.trace-list::-webkit-scrollbar-thumb,
+.details-body::-webkit-scrollbar-thumb,
+.structured-pre::-webkit-scrollbar-thumb,
+.content-card pre::-webkit-scrollbar-thumb,
+.raw-view pre::-webkit-scrollbar-thumb,
+.api-table-wrap::-webkit-scrollbar-thumb,
+.content-search-results::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border: 2px solid transparent;
+  border-radius: var(--r-pill);
+  background-clip: padding-box;
+}
+
+.session-list::-webkit-scrollbar-thumb:hover,
+.trace-list::-webkit-scrollbar-thumb:hover,
+.details-body::-webkit-scrollbar-thumb:hover,
+.structured-pre::-webkit-scrollbar-thumb:hover,
+.content-card pre::-webkit-scrollbar-thumb:hover,
+.raw-view pre::-webkit-scrollbar-thumb:hover,
+.api-table-wrap::-webkit-scrollbar-thumb:hover,
+.content-search-results::-webkit-scrollbar-thumb:hover {
+  background: var(--text-faint);
+  background-clip: padding-box;
+}
+
+/* ========================================================================== */
+/* responsive                                                                 */
+/* ========================================================================== */
+@media (max-width: 1320px) {
+  .shell {
+    grid-template-columns: 216px minmax(260px, 312px) minmax(340px, 1fr);
+  }
+}
+
+@media (max-width: 1180px) {
+  .api-board-main {
+    grid-template-columns: 1fr;
+  }
+
+  .api-board-section + .api-board-section {
+    border-left: 0;
+    border-top: 1px solid var(--border);
+  }
+}
+
+@media (max-width: 1100px) {
+  html,
+  body {
+    overflow: auto;
+  }
+
+  .shell {
+    grid-template-columns: 1fr;
+    height: auto;
+    min-height: 100vh;
+  }
+
+  .pane {
+    height: auto;
+    min-height: 420px;
+  }
+
+  .session-list,
+  .trace-list,
+  .details-body {
+    max-height: 48vh;
+  }
+
+  .content-stack,
+  .metadata-grid,
+  .model-input-layout,
+  .system-prompt-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .app-header {
+    height: auto;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--sp-3);
+    padding-block: var(--sp-4);
+  }
+
+  .app-status {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .api-overview {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/raven/tracing/viewer/ui/app.js
+++ b/raven/tracing/viewer/ui/app.js
@@ -1,0 +1,2964 @@
+const state = {
+  data: null,
+  descriptors: {},
+  appView: 'trace',
+  selectedSessionId: null,
+  selectedTraceKey: null,
+  selectedSpanId: null,
+  selectedTab: 'content',
+  search: '',
+  contentResults: null,
+  highlightScrollPending: false,
+  agent: 'all',
+  provider: 'all',
+  model: 'all',
+  apiStatus: 'all',
+  apiWindow: '24h',
+  artifactCache: new Map(),
+  isLoading: false,
+  autoRefreshTimer: null,
+  openDetailKeys: new Set(),
+  scrollPositions: new Map(),
+  windowScrollY: 0,
+  pendingScrollRestore: null,
+  detailsRenderSignature: null,
+  lastUpdated: null,
+  connectionStatus: 'idle',
+  lang: (() => {
+    try {
+      const saved = localStorage.getItem('tracing:lang');
+      return saved === 'zh' || saved === 'en' ? saved : 'en';
+    } catch {
+      return 'en';
+    }
+  })()
+};
+
+const AUTO_REFRESH_MS = 5000;
+
+const elements = {
+  connectionStatus: document.getElementById('connectionStatus'),
+  lastUpdated: document.getElementById('lastUpdated'),
+  traceScene: document.getElementById('traceScene'),
+  apiScene: document.getElementById('apiScene'),
+  listTitle: document.getElementById('listTitle'),
+  sessionList: document.getElementById('sessionList'),
+  traceList: document.getElementById('traceList'),
+  detailsBody: document.getElementById('detailsBody'),
+  flowEyebrow: document.getElementById('flowEyebrow'),
+  traceTitle: document.getElementById('traceTitle'),
+  traceMeta: document.getElementById('traceMeta'),
+  detailsTitle: document.getElementById('detailsTitle'),
+  searchInput: document.getElementById('searchInput'),
+  contentSearchResults: document.getElementById('contentSearchResults'),
+  agentFilter: document.getElementById('agentFilter'),
+  providerFilter: document.getElementById('providerFilter'),
+  modelFilter: document.getElementById('modelFilter'),
+  statusFilter: document.getElementById('statusFilter'),
+  refreshButton: document.getElementById('refreshButton'),
+  tabs: [...document.querySelectorAll('.tab[data-tab]')],
+  appViewButtons: [...document.querySelectorAll('.workspace-tab[data-app-view]:not([disabled])')],
+  emptyStateTemplate: document.getElementById('emptyStateTemplate')
+};
+
+const I18N = {
+  en: {
+    'status.connected': 'Connected',
+    'status.disconnected': 'Disconnected',
+    'header.updated': 'Updated',
+    'action.refresh': 'Refresh',
+    'view.api': 'API Calls',
+    'view.trace': 'Traces',
+    'sessions.title': 'Sessions',
+    'field.search': 'Search',
+    'field.status': 'Status',
+    'search.placeholder': 'session / trace / keyword',
+    'status.all': 'All Statuses',
+    'status.okOnly': 'Success Only',
+    'status.errorOnly': 'Failed Only',
+    'status.unreportedOnly': 'Token Unreported Only',
+    'trace.selectSession': 'Select a Session',
+    'details.selectSpan': 'Select a Span',
+    'detailtab.content': 'Input / Output',
+    'detailtab.metadata': 'Metadata',
+    'detailtab.raw': 'Raw',
+    'empty.title': 'Nothing to Show Yet',
+    'empty.copy': 'Refresh, or send another message to try.',
+    'error.loadFailed': 'Failed to Load',
+    'session.resumedFrom': ({ id }) => `Resumed from ${id}`,
+    'session.resumedTo': ({ id }) => `Resumed to ${id}`,
+    'session.startedAt': ({ time }) => `Started ${time}`,
+    'session.updatedAt': ({ time }) => `Updated ${time}`,
+    'round.latest': 'Latest Turn',
+    'round.nth': ({ n }) => `Turn ${n}`,
+    'filter.all': 'All',
+    'filter.allAgent': 'All Agents',
+    'filter.allProvider': 'All Providers',
+    'filter.allModel': 'All Models',
+    'search.contentHits': ({ n, more }) => `${n}${more ? '+' : ''} Content Match${n === 1 && !more ? '' : 'es'}`,
+    'search.noContentHits': 'No Content Matches',
+    'subagent.openFullTrace': 'Open Subagent Full Trace',
+    'subagent.backToMain': 'Back to Main Trace',
+    'subagent.noResult': 'No final result from the subagent yet',
+    'trace.noNodes': 'This trace has no primary execution nodes to show.',
+    'span.noEvents': 'This span has no extra events.',
+    'read.noContent': 'No content captured for this read',
+    'artifact.empty': 'No Artifact',
+    'section.metadata': 'Metadata',
+    'common.success': 'Success',
+    'common.failure': 'Failed',
+    'usage.unreported': 'Token Unreported',
+    'usage.input': 'Input',
+    'usage.output': 'Output',
+    'usage.total': 'Total',
+    'usage.cacheHit': 'Cache Hit',
+    'usage.cacheWrite': 'Cache Write',
+    'usage.cost': 'Cost',
+    'api.stat.totalCalls': 'Total Calls',
+    'api.stat.reportedToken': 'Reported Token',
+    'api.stat.unreportedToken': 'Unreported Token',
+    'api.stat.inputUncached': 'Input Token (Cache Miss)',
+    'api.stat.inputCached': 'Input Token (Cache Hit)',
+    'api.stat.output': 'Output Token',
+    'api.table.empty': 'No Detail',
+    'api.table.noData': 'No Data',
+    'api.keyMetrics': 'Key Metrics',
+    'api.byProviderModel': 'By Provider / Model',
+    'api.noCallsTitle': 'No Model Calls in the Current Range',
+    'api.noCallsCopy': 'Adjust the time range or filters, then check key metrics and provider/model breakdown.',
+    'api.callCount': ({ n }) => `${n} Calls`,
+    'api.detailTitle': ({ n }) => `Call Detail (Latest ${n})`,
+    'api.window.aria': 'Time Range',
+    'status.unreported': 'Unreported',
+    'win.all': 'All',
+    'win.7d': 'Last 7d',
+    'win.24h': 'Last 24h',
+    'win.1h': 'Last 1h',
+    'col.provider': 'Provider',
+    'col.model': 'Model',
+    'col.totalCalls': 'Total Calls',
+    'col.success': 'Success',
+    'col.failure': 'Failed',
+    'col.reportedToken': 'Reported Token',
+    'col.inputUncached': 'Input (Cache Miss)',
+    'col.inputCached': 'Input (Cache Hit)',
+    'col.inputCachedShort': 'Input (Hit)',
+    'col.output': 'Output Token',
+    'col.outputShort': 'Output',
+    'col.time': 'Time',
+    'col.status': 'Status',
+    'col.totalOrError': 'Total Token / Failure Reason'
+  },
+  zh: {
+    'status.connected': '已连接',
+    'status.disconnected': '未连接',
+    'header.updated': '更新',
+    'action.refresh': '刷新',
+    'view.api': 'API 调用',
+    'view.trace': '会话追踪',
+    'sessions.title': '会话列表',
+    'field.search': '搜索',
+    'field.status': '状态',
+    'search.placeholder': 'session / trace / 内容关键词',
+    'status.all': '全部状态',
+    'status.okOnly': '仅成功',
+    'status.errorOnly': '仅失败',
+    'status.unreportedOnly': '仅 Token 未上报',
+    'trace.selectSession': '选择一个会话',
+    'details.selectSpan': '选择一个 Span',
+    'detailtab.content': '输入输出',
+    'detailtab.metadata': '元数据',
+    'detailtab.raw': '原始数据',
+    'empty.title': '还没有可展示的数据',
+    'empty.copy': '刷新一下，或者再发一条消息试试。',
+    'error.loadFailed': '加载失败',
+    'session.resumedFrom': ({ id }) => `续接自 ${id}`,
+    'session.resumedTo': ({ id }) => `已续接到 ${id}`,
+    'session.startedAt': ({ time }) => `开始 ${time}`,
+    'session.updatedAt': ({ time }) => `更新 ${time}`,
+    'round.latest': '最近一轮',
+    'round.nth': ({ n }) => `第 ${n} 轮`,
+    'filter.all': '全部',
+    'filter.allAgent': '全部 agent',
+    'filter.allProvider': '全部 provider',
+    'filter.allModel': '全部 model',
+    'search.contentHits': ({ n, more }) => `内容命中 ${n}${more ? '+' : ''}`,
+    'search.noContentHits': '无内容命中',
+    'subagent.openFullTrace': '打开 subagent 的完整 trace',
+    'subagent.backToMain': '返回主 trace',
+    'subagent.noResult': '还没有拿到子 agent 的最终返回',
+    'trace.noNodes': '这个 trace 当前没有可展示的主要执行节点。',
+    'span.noEvents': '这个 span 没有额外事件。',
+    'read.noContent': '没有拿到这次读取的内容',
+    'artifact.empty': '暂无 artifact',
+    'section.metadata': '元数据',
+    'common.success': '成功',
+    'common.failure': '失败',
+    'usage.unreported': 'Token 未上报',
+    'usage.input': 'input',
+    'usage.output': 'output',
+    'usage.total': 'total',
+    'usage.cacheHit': 'cache hit',
+    'usage.cacheWrite': 'cache write',
+    'usage.cost': 'cost',
+    'api.stat.totalCalls': '总调用',
+    'api.stat.reportedToken': '已上报 Token',
+    'api.stat.unreportedToken': '未上报 Token',
+    'api.stat.inputUncached': '输入 Token（未命中缓存）',
+    'api.stat.inputCached': '输入 Token（命中缓存）',
+    'api.stat.output': '输出 Token',
+    'api.table.empty': '暂无明细',
+    'api.table.noData': '暂无数据',
+    'api.keyMetrics': '关键指标',
+    'api.byProviderModel': '按厂商 / 模型',
+    'api.noCallsTitle': '当前范围没有模型调用',
+    'api.noCallsCopy': '先调整时间范围或筛选条件，再看关键指标和厂商模型分布。',
+    'api.callCount': ({ n }) => `${n} 次调用`,
+    'api.detailTitle': ({ n }) => `调用明细（最近 ${n} 条）`,
+    'api.window.aria': '时间范围',
+    'status.unreported': '未上报',
+    'win.all': '全部',
+    'win.7d': '近一周',
+    'win.24h': '近24h',
+    'win.1h': '近1h',
+    'col.provider': '厂商',
+    'col.model': '模型',
+    'col.totalCalls': '总调用',
+    'col.success': '成功',
+    'col.failure': '失败',
+    'col.reportedToken': '已上报 Token',
+    'col.inputUncached': '输入（未命中缓存）',
+    'col.inputCached': '输入（命中缓存）',
+    'col.inputCachedShort': '输入（命中）',
+    'col.output': '输出 Token',
+    'col.outputShort': '输出',
+    'col.time': '时间',
+    'col.status': '状态',
+    'col.totalOrError': '总 Token / 失败原因'
+  }
+};
+
+function t(key, params) {
+  const table = I18N[state.lang] || I18N.en;
+  const value = key in table ? table[key] : I18N.en[key];
+  if (value == null) return key;
+  return typeof value === 'function' ? value(params || {}) : value;
+}
+
+function translateTree(root) {
+  root.querySelectorAll('[data-i18n]').forEach((node) => {
+    node.textContent = t(node.getAttribute('data-i18n'));
+  });
+  root.querySelectorAll('[data-i18n-ph]').forEach((node) => {
+    node.setAttribute('placeholder', t(node.getAttribute('data-i18n-ph')));
+  });
+  root.querySelectorAll('[data-i18n-aria]').forEach((node) => {
+    node.setAttribute('aria-label', t(node.getAttribute('data-i18n-aria')));
+  });
+}
+
+function applyStaticI18n() {
+  document.documentElement.lang = state.lang === 'zh' ? 'zh-CN' : 'en';
+  document.documentElement.dataset.lang = state.lang;
+  translateTree(document);
+  document.querySelectorAll('.lang-pill[data-lang]').forEach((btn) => {
+    btn.classList.toggle('is-active', btn.dataset.lang === state.lang);
+  });
+}
+
+function setLang(lang) {
+  if (lang !== 'zh' && lang !== 'en') return;
+  if (lang === state.lang) return;
+  state.lang = lang;
+  try {
+    localStorage.setItem('tracing:lang', lang);
+  } catch {
+    /* ignore persistence failures (private mode, etc.) */
+  }
+  state.detailsRenderSignature = null;
+  applyStaticI18n();
+  render();
+}
+
+function escapeHtml(text) {
+  return String(text)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function timeLocale() {
+  return state.lang === 'zh' ? 'zh-CN' : 'en-US';
+}
+
+function formatTime(value) {
+  if (!value) return '-';
+  return new Intl.DateTimeFormat(timeLocale(), {
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  }).format(new Date(value));
+}
+
+function formatTimeOnly(value) {
+  if (!value) return '--:--:--';
+  return new Intl.DateTimeFormat(timeLocale(), {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  }).format(new Date(value));
+}
+
+function formatDuration(ms) {
+  if (ms == null) return '-';
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(ms < 10000 ? 1 : 0)}s`;
+  const mins = Math.floor(ms / 60000);
+  const secs = Math.round((ms % 60000) / 1000);
+  return `${mins}m ${secs}s`;
+}
+
+function shortId(value, len = 12) {
+  if (!value) return '-';
+  const text = String(value);
+  return text.length <= len ? text : `${text.slice(0, len)}...`;
+}
+
+function detailKey(span, key) {
+  return `${span?.spanId || 'span'}::${key}`;
+}
+
+function captureOpenDetails() {
+  const openKeys = new Set();
+  elements.detailsBody
+    ?.querySelectorAll('details[data-detail-key][open]')
+    ?.forEach((node) => {
+      const key = node.getAttribute('data-detail-key');
+      if (key) openKeys.add(key);
+    });
+  state.openDetailKeys = openKeys;
+}
+
+function hydrateOpenDetails() {
+  const details = elements.detailsBody?.querySelectorAll('details[data-detail-key]') || [];
+  details.forEach((node) => {
+    const key = node.getAttribute('data-detail-key');
+    if (!key) return;
+    if (state.openDetailKeys.has(key)) {
+      node.setAttribute('open', '');
+    } else {
+      node.removeAttribute('open');
+    }
+    node.addEventListener('toggle', () => {
+      if (node.open) state.openDetailKeys.add(key);
+      else state.openDetailKeys.delete(key);
+    });
+  });
+}
+
+function scrollNodes() {
+  return [
+    elements.sessionList,
+    elements.traceList,
+    elements.detailsBody,
+    ...Array.from(elements.apiScene?.querySelectorAll('[data-scroll-key]') || [])
+  ].filter(Boolean);
+}
+
+function captureScrollState() {
+  state.windowScrollY = window.scrollY || window.pageYOffset || 0;
+  scrollNodes().forEach((node) => {
+    const key = node.getAttribute('data-scroll-key') || node.id;
+    if (!key) return;
+    state.scrollPositions.set(key, {
+      top: node.scrollTop,
+      left: node.scrollLeft
+    });
+  });
+}
+
+function applyScrollState() {
+  scrollNodes().forEach((node) => {
+    const key = node.getAttribute('data-scroll-key') || node.id;
+    if (!key) return;
+    const pos = state.scrollPositions.get(key);
+    if (!pos) return;
+    if (typeof pos.top === 'number') node.scrollTop = pos.top;
+    if (typeof pos.left === 'number') node.scrollLeft = pos.left;
+  });
+  if (typeof state.windowScrollY === 'number') {
+    window.scrollTo({ top: state.windowScrollY, left: window.scrollX || 0, behavior: 'instant' });
+  }
+}
+
+function restoreScrollState() {
+  if (state.pendingScrollRestore) {
+    cancelAnimationFrame(state.pendingScrollRestore);
+    state.pendingScrollRestore = null;
+  }
+  state.pendingScrollRestore = requestAnimationFrame(() => {
+    applyScrollState();
+    state.pendingScrollRestore = requestAnimationFrame(() => {
+      applyScrollState();
+      state.pendingScrollRestore = null;
+    });
+  });
+}
+
+function sessionChainLabel(session) {
+  if (!session) return '';
+  if (session.resumedFrom) return t('session.resumedFrom', { id: shortId(session.resumedFrom, 12) });
+  if (session.resumedTo) return t('session.resumedTo', { id: shortId(session.resumedTo, 12) });
+  return '';
+}
+
+function traceRoundLabel(session, index) {
+  if (!session) return t('round.nth', { n: index + 1 });
+  const total = sortedTraces(session).length;
+  if (index === 0) return t('round.latest');
+  return t('round.nth', { n: total - index });
+}
+
+function cloneEmptyState() {
+  const node = elements.emptyStateTemplate.content.firstElementChild.cloneNode(true);
+  translateTree(node);
+  return node;
+}
+
+function allSessions() {
+  return state.data?.sessions || [];
+}
+
+function filteredSessions() {
+  const query = state.search.trim().toLowerCase();
+  return allSessions().filter((session) => {
+    if (state.agent !== 'all' && session.agentId !== state.agent) return false;
+    if (!query) return true;
+    const haystack = [
+      session.agentId,
+      session.sessionId,
+      session.sessionKey,
+      session.workspaceDir,
+      ...session.traces.map((trace) => `${trace.traceId} ${trace.traceKey || ''}`)
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(query);
+  });
+}
+
+function allApiCalls() {
+  return allSessions()
+    .flatMap((session) =>
+      (session.traces || []).flatMap((trace) =>
+        (trace.spans || [])
+          .filter((span) => span.name === 'llm.call')
+          .map((span) => ({
+            sessionId: session.sessionId,
+            sessionKey: session.sessionKey,
+            sessionAgentId: session.agentId,
+            traceKey: trace.traceKey,
+            traceId: trace.traceId,
+            traceStartTime: trace.startTime,
+            traceEndTime: trace.endTime,
+            span
+          }))
+      )
+    )
+    .sort(
+      (a, b) =>
+        new Date(b.span.startTime || b.traceStartTime || 0).getTime() -
+        new Date(a.span.startTime || a.traceStartTime || 0).getTime()
+    );
+}
+
+function filteredApiCalls() {
+  const query = state.search.trim().toLowerCase();
+  const now = Date.now();
+  const windowMs =
+    state.apiWindow === '1h'
+      ? 60 * 60 * 1000
+      : state.apiWindow === '24h'
+        ? 24 * 60 * 60 * 1000
+        : state.apiWindow === '7d'
+          ? 7 * 24 * 60 * 60 * 1000
+          : null;
+  return allApiCalls().filter((entry) => {
+    const span = entry.span;
+    const startTime = new Date(span.startTime || entry.traceStartTime || 0).getTime();
+    if (windowMs != null && now - startTime > windowMs) return false;
+    if (state.agent !== 'all' && entry.sessionAgentId !== state.agent) return false;
+    if (state.provider !== 'all' && (span.attributes?.['llm.provider'] || '') !== state.provider) return false;
+    if (state.model !== 'all' && (span.attributes?.['llm.model'] || '') !== state.model) return false;
+    if (!query) return true;
+    const haystack = [
+      entry.sessionAgentId,
+      entry.sessionId,
+      entry.sessionKey,
+      entry.traceId,
+      span.spanId,
+      span.displayTitle,
+      span.attributes?.['llm.provider'],
+      span.attributes?.['llm.model'],
+      span.attributes?.['llm.input_preview'],
+      span.attributes?.['llm.output_preview']
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(query);
+  });
+}
+
+function renderApiFilters() {
+  const calls = allApiCalls();
+  const providers = ['all', ...new Set(calls.map((entry) => entry.span.attributes?.['llm.provider']).filter(Boolean))];
+  const models = ['all', ...new Set(calls.map((entry) => entry.span.attributes?.['llm.model']).filter(Boolean))];
+  elements.providerFilter.innerHTML = providers
+    .map((value) => `<option value="${escapeHtml(value)}">${value === 'all' ? t('filter.allProvider') : escapeHtml(value)}</option>`)
+    .join('');
+  elements.providerFilter.value = state.provider;
+  elements.modelFilter.innerHTML = models
+    .map((value) => `<option value="${escapeHtml(value)}">${value === 'all' ? t('filter.allModel') : escapeHtml(value)}</option>`)
+    .join('');
+  elements.modelFilter.value = state.model;
+  elements.statusFilter.value = state.apiStatus;
+}
+
+function aggregateApiOverview(calls) {
+  const summary = {
+    totalCalls: calls.length,
+    failedCalls: 0,
+    usageReportedCalls: 0,
+    usageUnreportedCalls: 0,
+    input: 0,
+    output: 0,
+    total: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    costTotal: 0,
+    durationTotal: 0,
+    providerModelCounts: new Map()
+  };
+
+  for (const entry of calls) {
+    const span = entry.span;
+    if (span.isFailed) summary.failedCalls += 1;
+    summary.durationTotal += span.durationMs || 0;
+    const usage = usageFromSpan(span);
+    if (usageReported(usage)) {
+      summary.usageReportedCalls += 1;
+      if (usage.input != null) summary.input += usage.input;
+      if (usage.output != null) summary.output += usage.output;
+      if (usage.total != null) summary.total += usage.total;
+      if (usage.cacheRead != null) summary.cacheRead += usage.cacheRead;
+      if (usage.cacheWrite != null) summary.cacheWrite += usage.cacheWrite;
+      if (usage.costTotal != null) summary.costTotal += usage.costTotal;
+    } else {
+      summary.usageUnreportedCalls += 1;
+    }
+    const providerModel = [span.attributes?.['llm.provider'], span.attributes?.['llm.model']]
+      .filter(Boolean)
+      .join(' / ');
+    if (providerModel) {
+      summary.providerModelCounts.set(providerModel, (summary.providerModelCounts.get(providerModel) || 0) + 1);
+    }
+  }
+
+  summary.avgDurationMs = summary.totalCalls ? Math.round(summary.durationTotal / summary.totalCalls) : 0;
+  summary.topModel =
+    [...summary.providerModelCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] || null;
+  return summary;
+}
+
+function groupApiByProviderModel(calls) {
+  const groups = new Map();
+  for (const entry of calls) {
+    const span = entry.span;
+    const provider = span.attributes?.['llm.provider'] || '-';
+    const model = span.attributes?.['llm.model'] || '-';
+    const key = `${provider}::${model}`;
+    if (!groups.has(key)) {
+      groups.set(key, {
+        provider,
+        model,
+        total: 0,
+        success: 0,
+        failed: 0,
+        reported: 0,
+        unreported: 0,
+        input: 0,
+        cacheHit: 0,
+        output: 0
+      });
+    }
+    const bucket = groups.get(key);
+    bucket.total += 1;
+    if (span.isFailed) bucket.failed += 1;
+    else bucket.success += 1;
+    const usage = usageFromSpan(span);
+    if (usageReported(usage)) {
+      bucket.reported += 1;
+      if (usage.input != null) bucket.input += usage.input;
+      if (usage.cacheRead != null) bucket.cacheHit += usage.cacheRead;
+      if (usage.output != null) bucket.output += usage.output;
+    } else {
+      bucket.unreported += 1;
+    }
+  }
+  return [...groups.values()].sort((a, b) => b.total - a.total);
+}
+
+function currentSession() {
+  return allSessions().find((session) => session.sessionId === state.selectedSessionId) || null;
+}
+
+function sortedTraces(session) {
+  return [...(session?.traces || [])].sort(
+    (a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime()
+  );
+}
+
+function currentTrace() {
+  const session = currentSession();
+  if (!session) return null;
+  const traces = sortedTraces(session);
+  return traces.find((trace) => trace.traceKey === state.selectedTraceKey) || traces[0] || null;
+}
+
+function jumpToTraceByTraceId(traceId, spanId) {
+  // Navigate to another trace (subagent run ↔ parent turn) by its traceId.
+  // The subagent trace lives in the same session, so search current session first.
+  if (!traceId) return false;
+  const ordered = currentSession()
+    ? [currentSession(), ...allSessions().filter((s) => s !== currentSession())]
+    : allSessions();
+  for (const session of ordered) {
+    const trace = (session.traces || []).find((t) => t.traceId === traceId);
+    if (!trace) continue;
+    state.selectedSessionId = session.sessionId;
+    state.selectedTraceKey = trace.traceKey;
+    state.selectedSpanId = spanId || trace.tree?.[0]?.spanId || trace.spans?.[0]?.spanId || null;
+    state.detailsRenderSignature = null;
+    render();
+    return true;
+  }
+  return false;
+}
+
+// ── Content search (fuzzy locate across node inputs/outputs) ────────────────
+// Server-side /api/search covers span attributes + full artifact text; here we
+// render the hit list, navigate to the hit span, and highlight matched terms.
+
+function contentSearchTerms() {
+  const query = state.search.trim();
+  if (query.length < 2) return [];
+  return query.toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+function highlightText(text, terms) {
+  if (!text) return '';
+  const lower = text.toLowerCase();
+  const ranges = [];
+  for (const term of terms) {
+    let idx = 0;
+    while (term && (idx = lower.indexOf(term, idx)) !== -1) {
+      ranges.push([idx, idx + term.length]);
+      idx += term.length;
+    }
+  }
+  if (!ranges.length) return escapeHtml(text);
+  ranges.sort((a, b) => a[0] - b[0]);
+  const merged = [];
+  for (const range of ranges) {
+    const last = merged[merged.length - 1];
+    if (last && range[0] <= last[1]) last[1] = Math.max(last[1], range[1]);
+    else merged.push([...range]);
+  }
+  let out = '';
+  let pos = 0;
+  for (const [start, end] of merged) {
+    out += escapeHtml(text.slice(pos, start));
+    out += `<mark class="content-hit-mark">${escapeHtml(text.slice(start, end))}</mark>`;
+    pos = end;
+  }
+  return out + escapeHtml(text.slice(pos));
+}
+
+async function runContentSearch(query) {
+  try {
+    const res = await fetch(`/api/search?q=${encodeURIComponent(query)}`);
+    const payload = await res.json();
+    if (state.search.trim() !== query) return;
+    state.contentResults = payload.results || [];
+  } catch {
+    state.contentResults = [];
+  }
+  renderContentSearchResults();
+}
+
+function renderContentSearchResults() {
+  const box = elements.contentSearchResults;
+  if (!box) return;
+  const terms = contentSearchTerms();
+  if (!terms.length || state.contentResults == null) {
+    box.hidden = true;
+    box.innerHTML = '';
+    return;
+  }
+  box.hidden = false;
+  const results = state.contentResults;
+  const items = results
+    .map(
+      (hit) => `
+      <button class="content-hit-item" type="button"
+        data-session-id="${escapeHtml(hit.sessionId)}"
+        data-trace-key="${escapeHtml(hit.traceKey)}"
+        data-span-id="${escapeHtml(hit.spanId)}">
+        <span class="content-hit-title">${escapeHtml(hit.title || hit.name)}${
+          hit.subtitle ? ` <span class="content-hit-sub">${escapeHtml(hit.subtitle)}</span>` : ''
+        }</span>
+        <span class="content-hit-snippet">${highlightText(hit.snippet || '', terms)}</span>
+      </button>`
+    )
+    .join('');
+  box.innerHTML =
+    `<div class="content-hit-head">${escapeHtml(t('search.contentHits', { n: results.length, more: results.length >= 50 }))}</div>` +
+    (items || `<div class="content-hit-empty">${t('search.noContentHits')}</div>`);
+}
+
+function applyDetailHighlights() {
+  const container = elements.detailsBody;
+  if (!container) return;
+  container.querySelectorAll('mark.content-hit-mark').forEach((mark) => {
+    const parent = mark.parentNode;
+    parent.replaceChild(document.createTextNode(mark.textContent), mark);
+    parent.normalize();
+  });
+  const terms = contentSearchTerms();
+  if (!terms.length) return;
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  const textNodes = [];
+  while (walker.nextNode()) textNodes.push(walker.currentNode);
+  for (const node of textNodes) {
+    const text = node.nodeValue;
+    if (!text) continue;
+    const lower = text.toLowerCase();
+    if (!terms.some((term) => lower.includes(term))) continue;
+    const wrapper = document.createElement('span');
+    wrapper.innerHTML = highlightText(text, terms);
+    node.parentNode.replaceChild(wrapper, node);
+  }
+  if (state.highlightScrollPending) {
+    state.highlightScrollPending = false;
+    const first = container.querySelector('mark.content-hit-mark');
+    if (first) first.scrollIntoView({ block: 'center' });
+  }
+}
+
+function currentApiCall() {
+  return (
+    filteredApiCalls().find(
+      (entry) =>
+        entry.sessionId === state.selectedSessionId &&
+        entry.traceKey === state.selectedTraceKey &&
+        entry.span.spanId === state.selectedSpanId
+    ) || null
+  );
+}
+
+function findSessionByIdentity(sessionId, sessionKey) {
+  return allSessions().find((session) => {
+    if (sessionId && session.sessionId === sessionId) return true;
+    if (sessionKey && session.sessionKey === sessionKey) return true;
+    return false;
+  }) || null;
+}
+
+function currentSpan() {
+  const trace = currentTrace();
+  if (!trace) return null;
+  return trace.spans.find((span) => span.spanId === state.selectedSpanId) || preferredSpan(trace) || null;
+}
+
+function preferredSpan(trace) {
+  if (!trace) return null;
+  return (
+    trace.spans.find((span) => span.name === 'llm.call') ||
+    trace.spans[0] ||
+    null
+  );
+}
+
+function promptSkills(span) {
+  return span?.attributes?.['skills.prompt.names'] || [];
+}
+
+function toNumberOrNull(value) {
+  if (value == null || value === '') return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function usageFromSpan(span) {
+  const attrs = span?.attributes || {};
+  return {
+    input: toNumberOrNull(attrs['llm.usage.input_tokens']),
+    output: toNumberOrNull(attrs['llm.usage.output_tokens']),
+    total: toNumberOrNull(attrs['llm.usage.total_tokens']),
+    cacheRead: toNumberOrNull(attrs['llm.usage.cache_read_tokens']),
+    cacheWrite: toNumberOrNull(attrs['llm.usage.cache_write_tokens']),
+    costTotal: toNumberOrNull(attrs['llm.usage.cost_total'])
+  };
+}
+
+function usageReported(usage) {
+  if (!usage) return false;
+  return ['input', 'output', 'total', 'cacheRead', 'cacheWrite', 'costTotal'].some((key) => usage[key] != null);
+}
+
+function usageChipsFromUsage(usage) {
+  if (!usageReported(usage)) return [{ text: t('usage.unreported'), soft: true }];
+  const chips = [];
+  if (usage.input != null) chips.push({ text: `${usage.input} ${t('usage.input')}` });
+  if (usage.output != null) chips.push({ text: `${usage.output} ${t('usage.output')}` });
+  if (usage.total != null) chips.push({ text: `${usage.total} ${t('usage.total')}` });
+  if (usage.cacheRead != null) chips.push({ text: `${usage.cacheRead} ${t('usage.cacheHit')}` });
+  if (usage.cacheWrite != null) chips.push({ text: `${usage.cacheWrite} ${t('usage.cacheWrite')}` });
+  if (usage.costTotal != null) chips.push({ text: `${t('usage.cost')} ${usage.costTotal}` });
+  return chips;
+}
+
+function aggregateTraceUsage(trace) {
+  const llmSpans = (trace?.spans || []).filter((span) => span.name === 'llm.call');
+  const aggregate = {
+    input: 0,
+    output: 0,
+    total: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    costTotal: 0,
+    reportedCalls: 0,
+    unreportedCalls: 0
+  };
+
+  for (const span of llmSpans) {
+    const usage = usageFromSpan(span);
+    if (!usageReported(usage)) {
+      aggregate.unreportedCalls += 1;
+      continue;
+    }
+    aggregate.reportedCalls += 1;
+    if (usage.input != null) aggregate.input += usage.input;
+    if (usage.output != null) aggregate.output += usage.output;
+    if (usage.total != null) aggregate.total += usage.total;
+    if (usage.cacheRead != null) aggregate.cacheRead += usage.cacheRead;
+    if (usage.cacheWrite != null) aggregate.cacheWrite += usage.cacheWrite;
+    if (usage.costTotal != null) aggregate.costTotal += usage.costTotal;
+  }
+
+  return aggregate;
+}
+
+function traceReadSkills(trace) {
+  return [
+    ...new Set(
+      (trace?.spans || [])
+        .filter((span) => span.name === 'skill.read')
+        .map((span) => span.attributes?.['skill.name'])
+        .filter(Boolean)
+    )
+  ];
+}
+
+function sortedTraceSpans(trace) {
+  return [...(trace?.spans || [])].sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
+}
+
+function buildSkillEvidence(trace) {
+  const spans = sortedTraceSpans(trace);
+  const visibleNames = new Set(['llm.call', 'tool.call', 'subagent.call']);
+  const promptedSet = new Set(tracePromptSkills(trace));
+  return spans
+    .filter((span) => span.name === 'skill.read')
+    .map((readSpan) => {
+      const readTime = new Date(readSpan.endTime || readSpan.startTime).getTime();
+      const readCallId = readSpan.attributes?.['skill.read.tool_call_id'];
+      const followUps = spans
+        .filter((candidate) => {
+          if (candidate.spanId === readSpan.spanId) return false;
+          if (!visibleNames.has(candidate.name)) return false;
+          if (candidate.name === 'tool.call') {
+            const sameReadTool =
+              String(candidate.attributes?.['tool.name'] || '').toLowerCase() === 'read' &&
+              candidate.attributes?.['tool.call_id'] === readCallId;
+            if (sameReadTool) return false;
+          }
+          return new Date(candidate.startTime).getTime() > readTime;
+        })
+        .slice(0, 5);
+      return {
+        skillName: readSpan.attributes?.['skill.name'] || '-',
+        source: readSpan.attributes?.['skill.source'] || '-',
+        path: readSpan.attributes?.['skill.path'] || '',
+        prompted: promptedSet.has(readSpan.attributes?.['skill.name']),
+        readSpan,
+        followUps,
+        status: followUps.length ? 'follow-up seen' : 'read only'
+      };
+    });
+}
+
+function skillStatusTone(status) {
+  if (status === 'follow-up seen') return 'success';
+  if (status === 'read only') return 'neutral';
+  if (status === 'prompted only') return 'soft';
+  if (status === 'catalog only') return 'muted';
+  return 'muted';
+}
+
+function tracePromptSkills(trace) {
+  return [
+    ...new Set(
+      (trace?.spans || [])
+        .filter((span) => span.name === 'llm.call')
+        .flatMap((span) => promptSkills(span))
+        .filter(Boolean)
+    )
+  ];
+}
+
+function traceSummary(trace) {
+  const spans = trace?.spans || [];
+  return {
+    modelCalls: spans.filter((span) => span.name === 'llm.call').length,
+    toolCalls: spans.filter((span) => span.name === 'tool.call').length,
+    subagents: spans.filter((span) => span.name === 'subagent.call').length,
+    readSkills: traceReadSkills(trace),
+    promptSkills: tracePromptSkills(trace),
+    usage: aggregateTraceUsage(trace)
+  };
+}
+
+function buildDepthMap(nodes, depthMap = new Map()) {
+  for (const node of nodes || []) {
+    depthMap.set(node.spanId, node.depth || 0);
+    buildDepthMap(node.children || [], depthMap);
+  }
+  return depthMap;
+}
+
+function orderedVisibleSpans(trace) {
+  const depthMap = buildDepthMap(trace?.tree || []);
+  return (trace?.spans || [])
+    .filter((span) => !['skills.scan', 'skills.catalog_read', 'skills.cataloged'].includes(span.name))
+    .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())
+    .map((span) => ({
+      ...span,
+      depth: depthMap.get(span.spanId) || 0
+    }));
+}
+
+function visibleTraceTree(nodes) {
+  return (nodes || [])
+    .filter((node) => !['skills.scan', 'skills.catalog_read', 'skills.cataloged'].includes(node.name))
+    .map((node) => ({
+      ...node,
+      children: visibleTraceTree(node.children || [])
+    }));
+}
+
+function collectArtifacts(span) {
+  const attrs = span?.attributes || {};
+  const entries = [];
+  const push = (label, filePath) => {
+    if (!filePath) return;
+    entries.push({ label, path: filePath });
+  };
+  push('Model Input', attrs['llm.input.artifact_path']);
+  push('Model Output', attrs['llm.output.artifact_path']);
+  push('Tool Input', attrs['tool.input.artifact_path']);
+  push('Tool Output', attrs['tool.output.artifact_path']);
+  push('Tool Persisted', attrs['tool.persisted.artifact_path']);
+  push('Skill Read', attrs['skill.read.artifact_path']);
+  push('Skill Injected', attrs['skill.inject.artifact_path']);
+  push('Memory Recall', attrs['memory.recall.artifact_path']);
+  push('Memory Store', attrs['memory.store.artifact_path']);
+  push('Subagent Result', attrs['subagent.result.artifact_path']);
+  if (span?.name === 'skill.read' && span?.parentSpanId) {
+    const parentTool = currentTrace()?.spans?.find((candidate) => candidate.spanId === span.parentSpanId) || null;
+    const parentAttrs = parentTool?.attributes || {};
+    push('Read Request', parentAttrs['tool.input.artifact_path']);
+    push('Read Content', parentAttrs['tool.output.artifact_path']);
+  }
+  return entries;
+}
+
+function parsePromptSkillEntries(span, artifacts) {
+  const names = promptSkills(span);
+  const llmInputArtifact = artifacts.find((entry) => entry.label === 'Model Input')?.artifact;
+  const systemPrompt =
+    llmInputArtifact?.parsed?.systemPrompt ||
+    llmInputArtifact?.parsed?.system_prompt ||
+    llmInputArtifact?.parsed?.prompt ||
+    llmInputArtifact?.content ||
+    '';
+
+  const entries = [];
+  const seen = new Set();
+  const xmlPattern = /<skill>\s*<name>([\s\S]*?)<\/name>\s*<description>([\s\S]*?)<\/description>\s*<location>([\s\S]*?)<\/location>\s*<\/skill>/g;
+  let match;
+  while ((match = xmlPattern.exec(systemPrompt)) !== null) {
+    const name = match[1]?.trim();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    entries.push({
+      name,
+      description: match[2]?.trim() || '',
+      location: match[3]?.trim() || ''
+    });
+  }
+
+  if (!entries.length) {
+    return names.map((name) => ({ name, description: '', location: '' }));
+  }
+
+  const byName = new Map(entries.map((entry) => [entry.name, entry]));
+  return names.map((name) => byName.get(name) || { name, description: '', location: '' });
+}
+
+function artifactByLabel(artifacts, label) {
+  return artifacts.find((entry) => entry.label === label)?.artifact || null;
+}
+
+function parseJsonMaybe(value) {
+  if (value == null) return null;
+  if (typeof value === 'object') return value;
+  if (typeof value !== 'string') return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function prettyValue(value, fallback = '(empty)') {
+  if (value == null || value === '') return fallback;
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function parseProjectContextEntries(systemPrompt) {
+  if (!systemPrompt) return [];
+  const entries = [];
+  const pattern = /^## (\/[^\n]+)\n([\s\S]*?)(?=^## \/[^\n]+\n|\Z)/gm;
+  let match;
+  while ((match = pattern.exec(systemPrompt)) !== null) {
+    const filePath = match[1]?.trim();
+    const body = match[2] || '';
+    entries.push({
+      path: filePath,
+      status: body.trim().startsWith('[MISSING]') ? 'missing' : 'loaded',
+      preview: body.trim().split('\n').slice(0, 3).join('\n')
+    });
+  }
+  return entries;
+}
+
+function extractSystemPromptSection(systemPrompt, heading) {
+  if (!systemPrompt) return '';
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`^## ${escaped}\\n([\\s\\S]*?)(?=^## [^\\n]+\\n|\\Z)`, 'm');
+  const match = systemPrompt.match(pattern);
+  return match?.[1]?.trim() || '';
+}
+
+function extractAvailableTools(systemPrompt) {
+  if (!systemPrompt) return [];
+  const toolBlockMatch = systemPrompt.match(/Tool names are case-sensitive\. Call tools exactly as listed\.\n([\s\S]*?)\nTOOLS\.md does not control tool availability;/);
+  if (!toolBlockMatch) return [];
+  return toolBlockMatch[1]
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('- '))
+    .map((line) => {
+      const name = line.slice(2).split(':')[0]?.trim();
+      return name || null;
+    })
+    .filter(Boolean);
+}
+
+function parseSafetyBullets(systemPrompt) {
+  const section = extractSystemPromptSection(systemPrompt, 'Safety');
+  if (!section) return [];
+  return section
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('- '))
+    .map((line) => line.slice(2).trim())
+    .filter(Boolean);
+}
+
+function parseRuntimeSummary(systemPrompt) {
+  const section = extractSystemPromptSection(systemPrompt, 'Runtime');
+  if (!section) return [];
+  return section
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 4);
+}
+
+function classifyHistoryMessage(message) {
+  const role = message?.role || 'unknown';
+  if (role === 'toolResult') return 'tool_result';
+  const items = Array.isArray(message?.content) ? message.content : [message?.content];
+  const hasToolCall = items.some((item) => item && typeof item === 'object' && item.type === 'toolCall');
+  if (role === 'assistant' && hasToolCall) return 'assistant_tool';
+  if (role === 'assistant') return 'assistant';
+  if (role === 'user') return 'user';
+  return 'system';
+}
+
+function summarizeHistoryMessage(message) {
+  const role = message?.role || 'unknown';
+  const content = message?.content;
+  const items = Array.isArray(content) ? content : [content];
+  const parts = [];
+  let toolCalls = 0;
+  let toolResults = 0;
+
+  for (const item of items) {
+    if (typeof item === 'string') {
+      if (item.trim()) parts.push(item.trim());
+      continue;
+    }
+    if (!item || typeof item !== 'object') continue;
+    if (item.type === 'text' && typeof item.text === 'string' && item.text.trim()) {
+      parts.push(item.text.trim());
+      continue;
+    }
+    if (item.type === 'toolCall') {
+      toolCalls += 1;
+      parts.push(`[toolCall] ${item.name || 'tool'}`);
+      continue;
+    }
+  }
+
+  if (role === 'toolResult') {
+    toolResults += 1;
+    if (message.toolName) parts.push(`[toolResult] ${message.toolName}`);
+  }
+
+  return {
+    role,
+    kind: classifyHistoryMessage(message),
+    timestamp: message?.timestamp || null,
+    text: parts.join('\n').trim() || message?.errorMessage || '',
+    toolCalls,
+    toolResults,
+    stopReason: message?.stopReason || null,
+    provider: message?.provider || null,
+    model: message?.model || null,
+    toolName: message?.toolName || null,
+    errorMessage: message?.errorMessage || null
+  };
+}
+
+function renderHistoryMessageItem(item) {
+  const kindLabel = {
+    user: 'user',
+    assistant: 'assistant',
+    assistant_tool: 'assistant + tool',
+    tool_result: 'tool result',
+    system: 'system'
+  }[item.kind] || item.role;
+  const badges = [
+    item.toolCalls ? `${item.toolCalls} tool call` : '',
+    item.toolResults ? `${item.toolResults} tool result` : '',
+    item.toolName || '',
+    item.stopReason || '',
+    item.errorMessage ? 'error' : ''
+  ].filter(Boolean);
+  return `
+    <article class="history-item history-item-${escapeHtml(item.kind)}">
+      <div class="history-item-head">
+        <div class="history-item-meta">
+          <span class="summary-chip">${escapeHtml(kindLabel)}</span>
+          <span class="evidence-time">${escapeHtml(item.timestamp ? formatTime(item.timestamp) : '-')}</span>
+        </div>
+        ${
+          badges.length
+            ? `<div class="history-badges">${badges.map((badge) => `<span class="summary-chip summary-chip-soft">${escapeHtml(badge)}</span>`).join('')}</div>`
+            : ''
+        }
+      </div>
+      <div class="history-text">${escapeHtml(item.text || '(empty)')}</div>
+    </article>
+  `;
+}
+
+function renderModelInputCard(span, artifacts) {
+  if (span.name !== 'llm.call') return '';
+  const inp = artifactByLabel(artifacts, 'Model Input')?.parsed;
+  if (!inp) return '';
+  // Show the ACTUAL request sent to the model — tools + the raw messages list
+  // (inp.messages is the ground truth), not a system/history split. Model /
+  // provider / token usage already live in the top hero block, so not repeated.
+  const messages = Array.isArray(inp.messages) ? inp.messages : [];
+  const tools = Array.isArray(inp.tools) ? inp.tools : [];
+  const note = `${messages.length} Messages${tools.length ? ` · ${tools.length} Tools` : ''}`;
+  const toolsBlock = tools.length
+    ? `
+      <details class="model-diagnostic-details" data-detail-key="${escapeHtml(detailKey(span, 'req-tools'))}">
+        <summary class="model-panel-head"><strong>Tools</strong> <span class="summary-chip">${tools.length}</span></summary>
+        <pre class="structured-pre">${escapeHtml(
+          tools
+            .map((t) => {
+              const fn = (t && t.function) || t || {};
+              return `- ${fn.name || '?'}${fn.description ? `: ${fn.description}` : ''}`;
+            })
+            .join('\n')
+        )}</pre>
+      </details>`
+    : '';
+  return `
+    <article class="content-card wide-card">
+      <header><h4>Model Input</h4><span class="card-note">${escapeHtml(note)}</span></header>
+      ${toolsBlock}
+      ${renderMessages(messages)}
+    </article>`;
+}
+
+// One message exactly as sent to the model: role header + content (string or
+// content blocks) + any tool_calls, mirroring the provider payload.
+function renderRequestMessage(m) {
+  if (!m || typeof m !== 'object') return String(m);
+  const role = m.role || '?';
+  const name = m.name ? ` (${m.name})` : '';
+  let body = '';
+  const c = m.content;
+  if (typeof c === 'string') body = c;
+  else if (Array.isArray(c))
+    body = c
+      .map((b) => (b && typeof b === 'object' ? (b.type === 'text' ? b.text || '' : `[${b.type || 'block'}]`) : String(b)))
+      .join('\n');
+  else if (c != null) body = JSON.stringify(c);
+  let calls = '';
+  if (Array.isArray(m.tool_calls) && m.tool_calls.length) {
+    calls =
+      '\n' +
+      m.tool_calls
+        .map((tc) => {
+          const fn = (tc && tc.function) || {};
+          const args = typeof fn.arguments === 'string' ? fn.arguments : JSON.stringify(fn.arguments || {});
+          return `  → ${fn.name || '?'}(${args})`;
+        })
+        .join('\n');
+  }
+  return `[${role}${name}]\n${body}${calls}`;
+}
+
+function assistantContentText(message) {
+  if (!message) return '';
+  if (typeof message === 'string') return message;
+  const content = Array.isArray(message.content) ? message.content : [];
+  return content
+    .map((part) => {
+      if (!part || typeof part !== 'object') return '';
+      if (part.type === 'text') return part.text || '';
+      if (part.type === 'toolCall') {
+        return `[toolCall] ${part.name || 'unknown'}`;
+      }
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+}
+
+function llmUsageSummary(span) {
+  return usageChipsFromUsage(usageFromSpan(span));
+}
+
+function renderAssistantStep(text, index, total) {
+  return `
+    <article class="history-item history-item-assistant">
+      <div class="history-item-head">
+        <div class="history-item-meta">
+          <span class="summary-chip">Assistant Step</span>
+          <span class="evidence-time">${index + 1} / ${total}</span>
+        </div>
+      </div>
+      <div class="history-text">${escapeHtml(text || '(empty)')}</div>
+    </article>
+  `;
+}
+
+function renderModelOutputCard(span, artifacts) {
+  if (span.name !== 'llm.call') return '';
+  const llmOutput = artifactByLabel(artifacts, 'Model Output')?.parsed;
+  if (!llmOutput) return '';
+
+  // OpenClaw dialect: assistantTexts / lastAssistant. raven dialect: output/content
+  // + a top-level tool_calls array. A tool-calling turn often has empty text and
+  // carries everything in tool_calls, so we must render tool_calls too or the card
+  // collapses to "(no assistant output)" and drops the arguments entirely.
+  const assistantTexts = Array.isArray(llmOutput.assistantTexts) ? llmOutput.assistantTexts : [];
+  const finalMessage =
+    assistantContentText(llmOutput.lastAssistant) ||
+    llmOutput.output ||
+    llmOutput.content ||
+    assistantTexts[assistantTexts.length - 1] ||
+    '';
+
+  // Normalize raven's flat {id,name,arguments} into the {function:{name,arguments}}
+  // shape messageBodyText renders (also tolerate the already-nested OpenAI shape).
+  const toolCalls = (Array.isArray(llmOutput.tool_calls) ? llmOutput.tool_calls : []).map((tc) => ({
+    function: {
+      name: (tc && (tc.name ?? tc.function?.name)) || '?',
+      arguments: (tc && (tc.arguments ?? tc.function?.arguments)) ?? {}
+    }
+  }));
+
+  const steps = assistantTexts.length ? assistantTexts : finalMessage ? [finalMessage] : [];
+  let body;
+  if (steps.length || toolCalls.length) {
+    const msgs = steps.map((t) => ({ role: 'assistant', content: t }));
+    if (toolCalls.length) {
+      if (msgs.length) msgs[msgs.length - 1].tool_calls = toolCalls;
+      else msgs.push({ role: 'assistant', content: '', tool_calls: toolCalls });
+    }
+    body = renderMessages(msgs);
+  } else {
+    body = preBody('(no assistant output)');
+  }
+
+  const reasoning = typeof llmOutput.reasoning_content === 'string' ? llmOutput.reasoning_content : '';
+  const reasoningBlock = reasoning
+    ? `<details class="model-diagnostic-details"><summary class="model-panel-head"><strong>Reasoning</strong></summary><pre class="structured-pre">${escapeHtml(reasoning)}</pre></details>`
+    : '';
+
+  const finish = llmOutput.finish_reason || span.attributes?.['llm.finish_reason'] || '';
+  const note = [
+    steps.length > 1 ? `${steps.length} steps` : '',
+    toolCalls.length ? `${toolCalls.length} tool call${toolCalls.length > 1 ? 's' : ''}` : '',
+    finish
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  return `
+    <article class="content-card wide-card">
+      <header><h4>Model Output</h4>${note ? `<span class="card-note">${escapeHtml(note)}</span>` : ''}</header>
+      ${body}
+      ${reasoningBlock}
+    </article>`;
+}
+
+function renderToolCallCard(span, artifacts) {
+  if (span.name !== 'tool.call') return '';
+  const attrs = span.attributes || {};
+  const toolInput = artifactByLabel(artifacts, 'Tool Input')?.parsed;
+  const toolOutput = artifactByLabel(artifacts, 'Tool Output')?.parsed;
+  const toolPersisted = artifactByLabel(artifacts, 'Tool Persisted')?.parsed;
+  const toolName = attrs['tool.name'] || span.displaySubtitle || '-';
+  const inputParams = toolInput?.params ?? parseJsonMaybe(attrs['tool.args_preview']) ?? null;
+  const outputResult = toolOutput?.result ?? toolOutput?.output ?? toolOutput?.error ?? null;
+  const persistedResult = toolPersisted?.message ?? toolPersisted?.result ?? toolPersisted ?? null;
+
+  return `
+    <article class="content-card wide-card">
+      <header>
+        <h4>Tool Input</h4>
+      </header>
+      <pre class="structured-pre">${escapeHtml(prettyValue(inputParams))}</pre>
+    </article>
+    <article class="content-card wide-card">
+      <header>
+        <h4>Tool Output</h4>
+      </header>
+      <pre class="structured-pre">${escapeHtml(prettyValue(outputResult))}</pre>
+      ${
+        persistedResult != null
+          ? `
+            <details class="model-diagnostic-details" data-detail-key="${escapeHtml(detailKey(span, 'tool-persisted'))}">
+              <summary class="model-panel-head">
+                <strong>Persisted</strong>
+              </summary>
+              <pre class="structured-pre">${escapeHtml(prettyValue(persistedResult))}</pre>
+            </details>
+          `
+          : ''
+      }
+    </article>
+  `;
+}
+
+function latestChildOutput(session) {
+  if (!session) return null;
+  const traces = sortedTraces(session);
+  for (const trace of traces) {
+    const llmSpans = [...(trace.spans || [])]
+      .filter((item) => item.name === 'llm.call')
+      .sort((a, b) => new Date(b.endTime || b.startTime).getTime() - new Date(a.endTime || a.startTime).getTime());
+    const latest = llmSpans[0];
+    if (!latest) continue;
+    const preview = latest.attributes?.['llm.output_preview'] || '';
+    if (preview) {
+      return {
+        text: preview,
+        time: latest.endTime || latest.startTime || null,
+        source: 'child_session'
+      };
+    }
+  }
+  return null;
+}
+
+function renderSubagentCallCard(span, artifacts) {
+  if (span.name !== 'subagent.call') return '';
+  const attrs = span.attributes || {};
+  const toolOutput = artifactByLabel(artifacts, 'Tool Output')?.parsed;
+  const dispatchKind = attrs['subagent.id'] ? `named subagent / ${attrs['subagent.id']}` : 'derived subagent';
+  const task = attrs['subagent.task'] || attrs['subagent.label'] || '';
+  const dispatchInput = task || '';
+  const dispatchOutput = toolOutput?.result ?? toolOutput?.output ?? null;
+  // raven persists the subagent's final return ON the span itself — the
+  // `Subagent Result` artifact ({task, result}) plus the `subagent.result_preview`
+  // attribute — NOT as a separate child session (the openclaw model just below).
+  // Without this, the card only checked the child-session / spawn-tool paths,
+  // found nothing for raven, and fell back to the empty-result placeholder
+  // even though the result was right there.
+  const subagentResult = artifactByLabel(artifacts, 'Subagent Result')?.parsed;
+  const resultText = subagentResult?.result ?? attrs['subagent.result_preview'] ?? null;
+  const childSession = findSessionByIdentity(
+    attrs['subagent.session_id'] || null,
+    attrs['subagent.session_key'] || null
+  );
+  const childOutcome = latestChildOutput(childSession);
+  const outputText = childOutcome?.text || resultText || null;
+  const outputSource = childOutcome
+    ? 'child session final output'
+    : (resultText ? 'subagent result artifact' : 'spawn accepted payload');
+
+  // Forward link: raven runs the subagent as its OWN trace; this dispatch
+  // node only summarizes it. Offer a jump into that trace's full tree.
+  const subTraceId = attrs['subagent.trace_id'] || null;
+  const jumpCard = subTraceId
+    ? `
+    <article class="content-card wide-card">
+      <button type="button" class="jump-link" data-jump-trace-id="${escapeHtml(subTraceId)}">
+        → ${t('subagent.openFullTrace')}
+      </button>
+    </article>`
+    : '';
+
+  return `
+    ${jumpCard}
+    <article class="content-card wide-card">
+      <header>
+        <h4>Subagent Input</h4>
+      </header>
+      <pre class="structured-pre">${escapeHtml(prettyValue(dispatchInput))}</pre>
+    </article>
+    <article class="content-card wide-card">
+      <header>
+        <h4>Subagent Output</h4>
+      </header>
+      <pre class="structured-pre">${escapeHtml(prettyValue(outputText ?? dispatchOutput, outputText || dispatchOutput ? '(empty)' : t('subagent.noResult')))}</pre>
+    </article>
+  `;
+}
+
+function renderSubagentRunCard(span) {
+  if (span.name !== 'subagent.run') return '';
+  const attrs = span.attributes || {};
+  const parentTraceId = attrs['subagent.parent_trace_id'] || null;
+  const parentSpanId = attrs['subagent.parent_span_id'] || null;
+  const task = attrs['subagent.task'] || attrs['subagent.label'] || '';
+  // Back link: this trace is one subagent run; return to the turn that spawned it.
+  const backCard = parentTraceId
+    ? `
+    <article class="content-card wide-card">
+      <button type="button" class="jump-link" data-jump-trace-id="${escapeHtml(parentTraceId)}"${parentSpanId ? ` data-jump-span-id="${escapeHtml(parentSpanId)}"` : ''}>
+        ← ${t('subagent.backToMain')}
+      </button>
+    </article>`
+    : '';
+  return `
+    ${backCard}
+    <article class="content-card wide-card">
+      <header>
+        <h4>Subagent Task</h4>
+      </header>
+      <pre class="structured-pre">${escapeHtml(prettyValue(task))}</pre>
+    </article>
+  `;
+}
+
+async function fetchArtifact(filePath) {
+  if (!filePath) return null;
+  if (state.artifactCache.has(filePath)) return state.artifactCache.get(filePath);
+  const response = await fetch(`/api/artifact?path=${encodeURIComponent(filePath)}`);
+  if (!response.ok) throw new Error(`Artifact request failed: ${response.status}`);
+  const data = await response.json();
+  state.artifactCache.set(filePath, data);
+  return data;
+}
+
+async function loadArtifacts(span) {
+  const entries = collectArtifacts(span);
+  const items = [];
+  for (const entry of entries) {
+    try {
+      const artifact = await fetchArtifact(entry.path);
+      items.push({ ...entry, artifact });
+    } catch (error) {
+      items.push({
+        ...entry,
+        artifact: { path: entry.path, parsed: null, content: '', error: error.message }
+      });
+    }
+  }
+  return items;
+}
+
+function renderAgentFilter() {
+  const source = state.appView === 'api'
+    ? allApiCalls().map((entry) => entry.sessionAgentId)
+    : allSessions().map((session) => session.agentId);
+  const agents = ['all', ...new Set(source.filter(Boolean))];
+  elements.agentFilter.innerHTML = agents
+    .map((agent) => `<option value="${agent}">${agent === 'all' ? t('filter.allAgent') : agent}</option>`)
+    .join('');
+  elements.agentFilter.value = state.agent;
+}
+
+function syncSelection() {
+  if (state.appView === 'api') {
+    const calls = filteredApiCalls();
+    if (!calls.length) {
+      state.selectedSessionId = null;
+      state.selectedTraceKey = null;
+      state.selectedSpanId = null;
+      return;
+    }
+
+    const active =
+      calls.find(
+        (entry) =>
+          entry.sessionId === state.selectedSessionId &&
+          entry.traceKey === state.selectedTraceKey &&
+          entry.span.spanId === state.selectedSpanId
+      ) || calls[0];
+
+    state.selectedSessionId = active.sessionId;
+    state.selectedTraceKey = active.traceKey;
+    state.selectedSpanId = active.span.spanId;
+    return;
+  }
+
+  const sessions = filteredSessions();
+  if (!sessions.length) {
+    state.selectedSessionId = null;
+    state.selectedTraceKey = null;
+    state.selectedSpanId = null;
+    return;
+  }
+
+  const session = sessions.find((item) => item.sessionId === state.selectedSessionId) || sessions[0];
+  state.selectedSessionId = session.sessionId;
+  const traces = sortedTraces(session);
+  const trace = traces.find((item) => item.traceKey === state.selectedTraceKey) || traces[0];
+  state.selectedTraceKey = trace?.traceKey || null;
+  const span = trace?.spans.find((item) => item.spanId === state.selectedSpanId) || preferredSpan(trace);
+  state.selectedSpanId = span?.spanId || null;
+}
+
+function renderSessionList() {
+  if (state.appView === 'api') {
+    elements.sessionList.innerHTML = '';
+    return;
+  }
+  const sessions = filteredSessions();
+  elements.sessionList.innerHTML = '';
+  if (!sessions.length) {
+    elements.sessionList.appendChild(cloneEmptyState());
+    return;
+  }
+
+  for (const session of sessions) {
+    const chainLabel = sessionChainLabel(session);
+    const card = document.createElement('button');
+    card.type = 'button';
+    card.className = `session-card${session.sessionId === state.selectedSessionId ? ' is-active' : ''}`;
+    card.title = `${session.sessionId}\n${session.sessionKey || ''}`.trim();
+    card.innerHTML = `
+      <div class="session-card-head">
+        <span class="session-pill">${escapeHtml(session.agentId || 'agent')}</span>
+        <span class="session-badge">${session.traceCount} traces</span>
+      </div>
+      <div class="session-title-row">
+        <div class="session-id">${escapeHtml(shortId(session.sessionId, 18))}</div>
+        <div class="session-channel">${escapeHtml(session.channelId || 'local')}</div>
+      </div>
+      <div class="session-meta">
+        <div>${escapeHtml(t('session.startedAt', { time: formatTime(session.startedAt) }))}</div>
+        <div>${escapeHtml(t('session.updatedAt', { time: formatTime(session.updatedAt) }))}</div>
+      </div>
+      ${chainLabel ? `<div class="session-chain">${escapeHtml(chainLabel)}</div>` : ''}
+    `;
+    card.addEventListener('click', () => {
+      const traces = sortedTraces(session);
+      state.selectedSessionId = session.sessionId;
+      state.selectedTraceKey = traces[0]?.traceKey || null;
+      state.selectedSpanId = preferredSpan(traces[0])?.spanId || null;
+      render();
+    });
+    elements.sessionList.appendChild(card);
+  }
+}
+
+function renderTraceList() {
+  const session = currentSession();
+  elements.traceList.innerHTML = '';
+  if (!session) {
+    elements.traceTitle.textContent = t('trace.selectSession');
+    elements.traceMeta.textContent = '';
+    elements.traceList.appendChild(cloneEmptyState());
+    return;
+  }
+
+  elements.traceTitle.textContent = `${session.agentId || 'agent'} / ${shortId(session.sessionId, 18)}`;
+  elements.traceMeta.innerHTML = `
+    ${session.workspaceDir ? `<div>${escapeHtml(session.workspaceDir)}</div>` : ''}
+    <div>${session.traceCount} traces</div>
+    ${sessionChainLabel(session) ? `<div>${escapeHtml(sessionChainLabel(session))}</div>` : ''}
+  `;
+
+  sortedTraces(session).forEach((trace, index) => {
+    const summary = traceSummary(trace);
+    const visibleSpans = orderedVisibleSpans(trace);
+    const visibleTree = visibleTraceTree(trace.tree || []);
+    const group = document.createElement('section');
+    group.className = `trace-group${trace.traceKey === state.selectedTraceKey ? ' is-active' : ''}`;
+    group.title = trace.traceKey || trace.traceId;
+    group.innerHTML = `
+      <div class="trace-header">
+        <div class="trace-title">
+          <div class="trace-topline">
+            <span class="trace-pill">${traceRoundLabel(session, index)}</span>
+            <span class="span-chip trace-mini-id">${escapeHtml(shortId(trace.traceId, 10))}</span>
+            <span class="trace-status">${formatDuration(trace.durationMs)}</span>
+          </div>
+          <div class="trace-meta">
+            <div>${formatTime(trace.startTime)} -> ${formatTime(trace.endTime)}</div>
+            <div>${trace.spanCount} spans</div>
+          </div>
+        </div>
+      </div>
+      <div class="trace-summary">
+        <span class="summary-chip">${summary.modelCalls} model</span>
+        <span class="summary-chip">${summary.toolCalls} tool</span>
+        <span class="summary-chip">${summary.subagents} subagent</span>
+      </div>
+      <div class="trace-tree"></div>
+    `;
+
+    const treeHost = group.querySelector('.trace-tree');
+    if (!visibleSpans.length) {
+      const empty = document.createElement('div');
+      empty.className = 'trace-tree-note';
+      empty.textContent = t('trace.noNodes');
+      treeHost.appendChild(empty);
+    } else {
+      visibleTree.forEach((span) => renderSpanNode(span, treeHost));
+    }
+    elements.traceList.appendChild(group);
+  });
+}
+
+function renderApiOverview(summary) {
+  return `
+    <section class="api-overview">
+      <article class="api-stat-card">
+        <div class="api-stat-label">${t('api.stat.totalCalls')}</div>
+        <div class="api-stat-value">${summary.totalCalls}</div>
+      </article>
+      <article class="api-stat-card api-stat-card-success">
+        <div class="api-stat-label">${t('common.success')}</div>
+        <div class="api-stat-value">${summary.totalCalls - summary.failedCalls}</div>
+      </article>
+      <article class="api-stat-card api-stat-card-error">
+        <div class="api-stat-label">${t('common.failure')}</div>
+        <div class="api-stat-value">${summary.failedCalls}</div>
+      </article>
+      <article class="api-stat-card">
+        <div class="api-stat-label">${t('api.stat.reportedToken')}</div>
+        <div class="api-stat-value">${summary.usageReportedCalls}</div>
+      </article>
+      <article class="api-stat-card api-stat-card-warning">
+        <div class="api-stat-label">${t('api.stat.unreportedToken')}</div>
+        <div class="api-stat-value">${summary.usageUnreportedCalls}</div>
+      </article>
+      <article class="api-stat-card">
+        <div class="api-stat-label">${t('api.stat.inputUncached')}</div>
+        <div class="api-stat-value">${summary.input}</div>
+      </article>
+      <article class="api-stat-card">
+        <div class="api-stat-label">${t('api.stat.inputCached')}</div>
+        <div class="api-stat-value">${summary.cacheRead}</div>
+      </article>
+      <article class="api-stat-card">
+        <div class="api-stat-label">${t('api.stat.output')}</div>
+        <div class="api-stat-value">${summary.output}</div>
+      </article>
+    </section>
+  `;
+}
+
+function renderApiCallListRows(calls) {
+  if (!calls.length) {
+    return `
+      <tr>
+        <td class="api-table-empty" colspan="8">${t('api.table.empty')}</td>
+      </tr>
+    `;
+  }
+  return calls.map((entry) => {
+    const span = entry.span;
+    const usage = usageFromSpan(span);
+    const provider = span.attributes?.['llm.provider'] || '-';
+    const model = span.attributes?.['llm.model'] || '-';
+    return `
+      <tr class="api-table-row${span.spanId === state.selectedSpanId ? ' is-active' : ''}${span.isFailed ? ' is-failed' : ''}" data-span-id="${escapeHtml(span.spanId)}">
+        <td>${escapeHtml(formatTime(span.startTime))}</td>
+        <td>${span.isFailed ? `<span class="summary-chip summary-chip-error">${t('common.failure')}</span>` : `<span class="summary-chip summary-chip-success">${t('common.success')}</span>`}</td>
+        <td>${escapeHtml(provider)}</td>
+        <td>${escapeHtml(model)}</td>
+        <td>${escapeHtml(String(usage.input ?? 0))}</td>
+        <td>${escapeHtml(String(usage.cacheRead ?? 0))}</td>
+        <td>${escapeHtml(String(usage.output ?? 0))}</td>
+        <td>${usageReported(usage) ? escapeHtml(String(usage.total ?? 0)) : escapeHtml(span.failureLabel || t('usage.unreported'))}</td>
+      </tr>
+    `;
+  }).join('');
+}
+
+function apiWindowLabel() {
+  return {
+    all: t('win.all'),
+    '7d': t('win.7d'),
+    '24h': t('win.24h'),
+    '1h': t('win.1h')
+  }[state.apiWindow] || t('win.24h');
+}
+
+function renderApiToolbar(calls) {
+  const providers = ['all', ...new Set(allApiCalls().map((entry) => entry.span.attributes?.['llm.provider']).filter(Boolean))];
+  const models = ['all', ...new Set(allApiCalls().map((entry) => entry.span.attributes?.['llm.model']).filter(Boolean))];
+  const agents = ['all', ...new Set(allApiCalls().map((entry) => entry.sessionAgentId).filter(Boolean))];
+
+  return `
+    <div class="api-toolbar">
+      <div class="api-toolbar-groups">
+        <div class="api-window-switch" role="tablist" aria-label="${t('api.window.aria')}">
+          ${[
+            ['all', t('win.all')],
+            ['7d', t('win.7d')],
+            ['24h', t('win.24h')],
+            ['1h', t('win.1h')]
+          ]
+            .map(
+              ([value, label]) => `
+                <button class="api-window-pill${state.apiWindow === value ? ' is-active' : ''}" type="button" data-api-window="${value}">
+                  ${label}
+                </button>
+              `
+            )
+            .join('')}
+        </div>
+        <div class="api-select-group">
+          <label class="api-inline-field">
+            <span>Agent</span>
+            <select id="apiAgentFilterInline">
+              ${agents
+                .map((value) => `<option value="${escapeHtml(value)}"${value === state.agent ? ' selected' : ''}>${value === 'all' ? t('filter.allAgent') : escapeHtml(value)}</option>`)
+                .join('')}
+            </select>
+          </label>
+          <label class="api-inline-field">
+            <span>Provider</span>
+            <select id="apiProviderFilterInline">
+              ${providers
+                .map((value) => `<option value="${escapeHtml(value)}"${value === state.provider ? ' selected' : ''}>${value === 'all' ? t('filter.all') : escapeHtml(value)}</option>`)
+                .join('')}
+            </select>
+          </label>
+          <label class="api-inline-field">
+            <span>Model</span>
+            <select id="apiModelFilterInline">
+              ${models
+                .map((value) => `<option value="${escapeHtml(value)}"${value === state.model ? ' selected' : ''}>${value === 'all' ? t('filter.all') : escapeHtml(value)}</option>`)
+                .join('')}
+            </select>
+          </label>
+        </div>
+      </div>
+      <div class="api-toolbar-side">
+        <div class="api-filter-summary">
+          <span class="summary-chip">${escapeHtml(t('api.callCount', { n: calls.length }))}</span>
+        </div>
+        <button class="ghost-button" type="button" id="apiRefreshButton">${t('action.refresh')}</button>
+      </div>
+    </div>
+  `;
+}
+
+function renderApiDashboard() {
+  const scopedCalls = filteredApiCalls();
+  const detailCalls = scopedCalls.filter((entry) => {
+    const usage = usageFromSpan(entry.span);
+    if (state.apiStatus === 'error') return entry.span.isFailed;
+    if (state.apiStatus === 'ok') return !entry.span.isFailed;
+    if (state.apiStatus === 'unreported') return !usageReported(usage);
+    return true;
+  });
+  const overview = aggregateApiOverview(scopedCalls);
+  const providerRows = groupApiByProviderModel(scopedCalls);
+  const hasScopedCalls = scopedCalls.length > 0;
+  return `
+    <section class="api-dashboard">
+      <section class="api-dashboard-board api-scope-panel">
+        <div class="api-dashboard-inner api-board-scope">
+          ${renderApiToolbar(scopedCalls)}
+        </div>
+        ${
+          hasScopedCalls
+            ? `
+              <div class="api-board-main">
+                <section class="api-board-section api-overview-panel">
+                  <div class="api-panel-head">
+                    <div class="api-panel-title">
+                      <h3>${t('api.keyMetrics')}</h3>
+                    </div>
+                  </div>
+                  <div class="api-dashboard-inner">
+                    ${renderApiOverview(overview)}
+                  </div>
+                </section>
+                <section class="api-board-section api-provider-panel">
+                  <div class="api-panel-head">
+                    <div class="api-panel-title">
+                      <h3>${t('api.byProviderModel')}</h3>
+                    </div>
+                  </div>
+                  <div class="api-dashboard-inner">
+                      <div class="api-table-wrap" data-scroll-key="api-provider-table">
+                      <table class="api-table">
+                        <thead>
+                          <tr>
+                            <th>${t('col.provider')}</th>
+                            <th>${t('col.model')}</th>
+                            <th>${t('col.totalCalls')}</th>
+                            <th>${t('col.success')}</th>
+                            <th>${t('col.failure')}</th>
+                            <th>${t('col.reportedToken')}</th>
+                            <th>${t('col.inputUncached')}</th>
+                            <th>${t('col.inputCached')}</th>
+                            <th>${t('col.output')}</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          ${
+                            providerRows.length
+                              ? providerRows.map((row) => `
+                                <tr>
+                                  <td>${escapeHtml(row.provider)}</td>
+                                  <td>${escapeHtml(row.model)}</td>
+                                  <td>${row.total}</td>
+                                  <td>${row.success}</td>
+                                  <td>${row.failed}</td>
+                                  <td>${row.reported}</td>
+                                  <td>${row.input}</td>
+                                  <td>${row.cacheHit}</td>
+                                  <td>${row.output}</td>
+                                </tr>
+                              `).join('')
+                              : `<tr><td class="api-table-empty" colspan="9">${t('api.table.noData')}</td></tr>`
+                          }
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </section>
+              </div>
+            `
+            : `
+              <div class="api-board-empty">
+                <h3>${t('api.noCallsTitle')}</h3>
+                <p>${t('api.noCallsCopy')}</p>
+              </div>
+            `
+        }
+      </section>
+      <section class="api-dashboard-panel api-detail-panel">
+        <div class="api-panel-head">
+          <div class="api-panel-title">
+            <h3>${escapeHtml(t('api.detailTitle', { n: Math.min(detailCalls.length, 500) }))}</h3>
+          </div>
+          <div class="overview-tags">
+            <button class="api-status-pill${state.apiStatus === 'all' ? ' is-active' : ''}" data-api-status="all" type="button">${t('filter.all')}</button>
+            <button class="api-status-pill${state.apiStatus === 'ok' ? ' is-active' : ''}" data-api-status="ok" type="button">${t('common.success')}</button>
+            <button class="api-status-pill${state.apiStatus === 'error' ? ' is-active' : ''}" data-api-status="error" type="button">${t('common.failure')}</button>
+            <button class="api-status-pill${state.apiStatus === 'unreported' ? ' is-active' : ''}" data-api-status="unreported" type="button">${t('status.unreported')}</button>
+          </div>
+        </div>
+        <div class="api-dashboard-inner">
+          <div class="api-table-wrap" data-scroll-key="api-detail-table">
+            <table class="api-table api-call-detail-table">
+              <thead>
+                <tr>
+                  <th>${t('col.time')}</th>
+                  <th>${t('col.status')}</th>
+                  <th>${t('col.provider')}</th>
+                  <th>${t('col.model')}</th>
+                  <th>${t('col.inputUncached')}</th>
+                  <th>${t('col.inputCachedShort')}</th>
+                  <th>${t('col.outputShort')}</th>
+                  <th>${t('col.totalOrError')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${renderApiCallListRows(detailCalls)}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </section>
+  `;
+}
+
+function renderSpanNode(node, host) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = `span-node depth-${Math.min(node.depth, 5)}${node.spanId === state.selectedSpanId ? ' is-active' : ''}${node.isFailed ? ' is-failed' : ''}`;
+  button.dataset.kind = node.kind;
+  button.title = node.spanId;
+  const primaryMeta = node.displaySubtitle || (node.kind ? node.kind.charAt(0).toUpperCase() + node.kind.slice(1) : '');
+  button.innerHTML = `
+    <div class="span-node-main">
+      <div class="span-node-time">${formatTimeOnly(node.startTime)}</div>
+      <div class="span-node-body">
+        <div class="span-node-header">
+          <div class="span-node-title">
+            <strong>${escapeHtml(node.displayTitle)}</strong>
+            ${node.isFailed ? '<span class="summary-chip summary-chip-error">Error</span>' : ''}
+          </div>
+          <span class="span-chip">${formatDuration(node.durationMs)}</span>
+        </div>
+        <div class="span-node-subtitle">
+          <span>${escapeHtml(primaryMeta)}</span>
+        </div>
+      </div>
+    </div>
+  `;
+  button.addEventListener('click', () => {
+    state.selectedTraceKey = node.traceKey || currentTrace()?.traceKey || null;
+    state.selectedSpanId = node.spanId;
+    state.detailsRenderSignature = null;
+    render();
+  });
+  host.appendChild(button);
+  (node.children || []).forEach((child) => renderSpanNode(child, host));
+}
+
+function renderMetadata(span) {
+  if (span.name === 'session.turn') {
+    const trace = currentTrace();
+    const summary = traceSummary(trace);
+    const attrs = span.attributes || {};
+    const traceStart = trace?.startTime || span.startTime;
+    const traceEnd = trace?.endTime || span.endTime;
+    const traceDuration = trace?.durationMs ?? span.durationMs;
+    const rows = [
+      ['Span ID', span.spanId],
+      ['Trace ID', span.traceId],
+      ['Span Type', span.kind],
+      ['Status', span.isFailed ? (span.failureLabel || span.status?.code || 'FAILED') : (span.status?.code || 'OK')],
+      ['Failed', span.isFailed ? 'yes' : 'no'],
+      ['Duration', formatDuration(traceDuration)],
+      ['Started', formatTime(traceStart)],
+      ['Ended', formatTime(traceEnd)],
+      ['Agent', span.agentId],
+      ['Session ID', span.sessionId],
+      ['Session Key', span.sessionKey],
+      ['Run ID', span.runId],
+      ['Trigger', triggerLabel(span.trigger || attrs['trigger'])],
+      ['Model Calls', summary.modelCalls],
+      ['Tool Calls', summary.toolCalls],
+      ['Subagent Calls', summary.subagents],
+      ['Skill Reads', summary.readSkills.length]
+    ].filter(([, value]) => value || value === 0);
+
+    const events = (span.events || [])
+      .map((event) => `<li><span>${formatTime(event.time)}</span><strong>${escapeHtml(event.name)}</strong></li>`)
+      .join('');
+
+    return `
+      <div class="detail-grid">
+        <section class="detail-panel">
+          <div class="detail-panel-head">
+            <h3>${t('section.metadata')}</h3>
+            <span class="meta-tag">${escapeHtml(span.kind)}</span>
+          </div>
+          <dl class="metadata-grid">
+            ${rows
+              .map(
+                ([label, value]) => `
+                  <div class="meta-row">
+                    <dt>${escapeHtml(label)}</dt>
+                    <dd>${escapeHtml(String(value))}</dd>
+                  </div>
+                `
+              )
+              .join('')}
+          </dl>
+        </section>
+        <section class="detail-panel">
+          <div class="detail-panel-head">
+            <h3>Span Events</h3>
+            <span class="meta-tag">${span.events?.length || 0} events</span>
+          </div>
+          <div class="events-list">
+            ${events ? `<ul>${events}</ul>` : `<div class="trace-tree-note">${t('span.noEvents')}</div>`}
+          </div>
+        </section>
+      </div>
+    `;
+  }
+  const attrs = span.attributes || {};
+  const rows = [
+    ['Span ID', span.spanId],
+    ['Trace ID', span.traceId],
+    ['Parent Span', span.parentSpanId],
+    ['Span Type', span.kind],
+    ['Status', span.isFailed ? (span.failureLabel || span.status?.code || 'FAILED') : (span.status?.code || 'OK')],
+    ['Failed', span.isFailed ? 'yes' : 'no'],
+    ['Duration', formatDuration(span.durationMs)],
+    ['Started', formatTime(span.startTime)],
+    ['Ended', formatTime(span.endTime)],
+    ['Session ID', span.sessionId],
+    ['Session Key', span.sessionKey],
+    ['Run ID', span.runId],
+    ['Agent', span.agentId],
+    ['Workspace', span.workspaceDir],
+    ['Trigger', span.trigger],
+    ['Provider', attrs['llm.provider']],
+    ['Provider Class', attrs['llm.provider_class']],
+    ['Model', attrs['llm.model']],
+    ['Tool', attrs['tool.name']],
+    ['Tool Call ID', attrs['tool.call_id']],
+    ['Subagent Kind', attrs['subagent.id'] ? 'named subagent' : (span.name === 'subagent.call' ? 'derived subagent' : null)],
+    ['Subagent ID', attrs['subagent.id']],
+    ['Subagent Label', attrs['subagent.label']],
+    ['Subagent Session Key', attrs['subagent.session_key']],
+    ['Subagent Run ID', attrs['subagent.run_id']],
+    ['Subagent Status', attrs['subagent.status']],
+    ['Skills In This Prompt', attrs['skills.prompt.count']],
+    ['Read Skill', attrs['skill.name']],
+    ['Read Skill Source', attrs['skill.source']],
+    ['Read Skill Path', attrs['skill.path']]
+  ].filter(([, value]) => value || value === 0);
+
+  const events = (span.events || [])
+    .map((event) => `<li><span>${formatTime(event.time)}</span><strong>${escapeHtml(event.name)}</strong></li>`)
+    .join('');
+
+  return `
+    <div class="detail-grid">
+      <section class="detail-panel">
+        <div class="detail-panel-head">
+          <h3>${t('section.metadata')}</h3>
+          <span class="meta-tag">${escapeHtml(span.kind)}</span>
+        </div>
+        <dl class="metadata-grid">
+          ${rows
+            .map(
+              ([label, value]) => `
+                <div class="meta-row">
+                  <dt>${escapeHtml(label)}</dt>
+                  <dd>${escapeHtml(String(value))}</dd>
+                </div>
+              `
+            )
+            .join('')}
+        </dl>
+      </section>
+      <section class="detail-panel">
+        <div class="detail-panel-head">
+          <h3>Span Events</h3>
+          <span class="meta-tag">${span.events?.length || 0} events</span>
+        </div>
+        <div class="events-list">
+          ${events ? `<ul>${events}</ul>` : `<div class="trace-tree-note">${t('span.noEvents')}</div>`}
+        </div>
+      </section>
+    </div>
+  `;
+}
+
+function prettyArtifactContent(artifact) {
+  if (!artifact) return '';
+  if (artifact.parsed) return JSON.stringify(artifact.parsed, null, 2);
+  return artifact.content || '';
+}
+
+function renderSkillReadCard(trace, span, artifacts) {
+  if (span.name !== 'skill.read') return '';
+  const evidence = buildSkillEvidence(trace).find((item) => item.readSpan.spanId === span.spanId);
+  if (!evidence) return '';
+  const attrs = span.attributes || {};
+  const skillReadArtifact = artifactByLabel(artifacts, 'Skill Read');
+  const readContent = artifactByLabel(artifacts, 'Read Content');
+  const readRequest = artifactByLabel(artifacts, 'Read Request');
+  // raven's read_file→skill.read carries content/params on the re-typed tool
+  // span's own Tool Input/Output artifacts (+ skill.result_preview), not the
+  // openclaw Skill Read / Read Content / Read Request artifacts. Fall back to
+  // raven's so the card isn't empty.
+  const toolInput = artifactByLabel(artifacts, 'Tool Input');
+  const toolOutput = artifactByLabel(artifacts, 'Tool Output');
+  const readInputValue = {
+    skill: attrs['skill.name'] || evidence.skillName || '-',
+    path: attrs['skill.path'] || evidence.path || '-',
+    resolvedPath: attrs['skill.resolved_path'] || skillReadArtifact?.parsed?.resolvedFilePath || '-',
+    source: attrs['skill.source'] || evidence.source || '-',
+    // Content-driven distinction: a materialized scripts bundle => the agent
+    // pulled runnable files; absent => it only loaded the instruction body.
+    scriptsDir: attrs['skill.scripts_dir'] || '(instructions only)',
+    request: readRequest?.parsed?.params ?? toolInput?.parsed?.params ?? null
+  };
+  const readContentValue =
+    readContent?.parsed?.result ??
+    readContent?.parsed?.output ??
+    readContent?.content ??
+    skillReadArtifact?.parsed?.fileInfo?.preview ??
+    toolOutput?.parsed?.result ??
+    attrs['skill.result_preview'] ??
+    '';
+  return `
+    <article class="content-card wide-card">
+      <header>
+        <h4>Skill Input</h4>
+      </header>
+      <pre class="structured-pre">${escapeHtml(prettyValue(readInputValue))}</pre>
+    </article>
+    <article class="content-card wide-card">
+      <header>
+        <h4>Skill Output</h4>
+      </header>
+      <pre class="structured-pre">${escapeHtml(prettyValue(readContentValue, t('read.noContent')))}</pre>
+      ${
+        evidence.followUps.length
+          ? `
+            <details class="model-diagnostic-details" data-detail-key="${escapeHtml(detailKey(span, 'follow-up'))}">
+              <summary class="model-panel-head"><strong>Follow-up</strong> <span class="summary-chip">${evidence.followUps.length} spans</span></summary>
+              <pre class="structured-pre">${escapeHtml(
+                evidence.followUps
+                  .map(
+                    (follow) =>
+                      `${formatTime(follow.startTime)}  ${follow.displayTitle}${
+                        follow.displaySubtitle ? `  ·  ${follow.displaySubtitle}` : ''
+                      }`
+                  )
+                  .join('\n')
+              )}</pre>
+            </details>
+          `
+          : ''
+      }
+    </article>
+  `;
+}
+
+function renderSkillEvidenceCard(trace, span) {
+  return '';
+}
+
+function triggerLabel(value) {
+  if (!value) return 'unknown';
+  if (value === 'user') return 'user';
+  return String(value);
+}
+
+function renderSessionTurnCard(trace, span) {
+  if (span.name !== 'session.turn') return '';
+  const summary = traceSummary(trace);
+  const attrs = span.attributes || {};
+  const session = currentSession();
+  const start = trace?.startTime ? formatTime(trace.startTime) : (span.startTime ? formatTime(span.startTime) : '-');
+  const end = trace?.endTime ? formatTime(trace.endTime) : (span.endTime ? formatTime(span.endTime) : '-');
+  const duration = trace?.durationMs != null ? formatDuration(trace.durationMs) : (span.durationMs != null ? formatDuration(span.durationMs) : '-');
+  const trigger = triggerLabel(span.trigger || attrs['trigger']);
+  const agent = span.agentId || 'agent';
+  // "Loaded this turn": tools / plugin backend+tools / skills, captured on the
+  // turn span by the plugin. Omit the whole block for old traces that predate it.
+  const tools = Array.isArray(attrs['turn.tools']) ? attrs['turn.tools'] : [];
+  const pluginBackend = attrs['turn.plugin.backend'] || null;
+  const pluginTools = Array.isArray(attrs['turn.plugin.tools']) ? attrs['turn.plugin.tools'] : [];
+  const skills = Array.isArray(attrs['turn.skills']) ? attrs['turn.skills'] : [];
+  const skillCount = attrs['turn.skill_count'] != null ? attrs['turn.skill_count'] : skills.length;
+  const hasCaps = attrs['turn.tools'] !== undefined || attrs['turn.skills'] !== undefined || attrs['turn.plugin.backend'] !== undefined;
+  const overview = [
+    `summary   ${agent} · ${trigger} triggered turn`,
+    `session   ${span.sessionId || '-'}`,
+    span.sessionKey && span.sessionKey !== span.sessionId ? `key       ${span.sessionKey}` : null,
+    sessionChainLabel(session) ? `chain     ${sessionChainLabel(session)}` : null,
+    span.runId ? `run       ${span.runId}` : null,
+    `time      ${start}  →  ${end}   (${duration})`
+  ]
+    .filter(Boolean)
+    .join('\n');
+  const callChips = [
+    `${summary.modelCalls} model`,
+    `${summary.toolCalls} tool`,
+    `${summary.subagents} subagent`,
+    `${summary.readSkills.length} skill.read`
+  ]
+    .map((c) => `<span class="summary-chip">${escapeHtml(c)}</span>`)
+    .join('');
+  const capsBlock = hasCaps
+    ? `<details class="model-diagnostic-details" data-detail-key="${escapeHtml(detailKey(span, 'turn-caps'))}">
+        <summary class="model-panel-head"><strong>Loaded This Turn</strong> <span class="summary-chip">${tools.length} Tools · ${skillCount} Skills</span></summary>
+        <pre class="structured-pre">${escapeHtml(
+          `plugin backend: ${pluginBackend || 'none'}\n` +
+            `plugin tools:   ${pluginTools.length ? pluginTools.join(', ') : '(none)'}\n` +
+            `tools (${tools.length}): ${tools.join(', ') || '(none)'}\n` +
+            `skills (${skillCount}): ${skills.join(', ') || '(none)'}`
+        )}</pre>
+      </details>`
+    : '';
+  return `
+    <article class="content-card wide-card">
+      <header><h4>Turn Overview</h4><div class="chip-row">${callChips}</div></header>
+      <pre class="structured-pre">${escapeHtml(overview)}</pre>
+      ${capsBlock}
+    </article>`;
+}
+
+// ── Descriptor-driven node rendering (see TRACING_STANDARD.md) ──────────────
+// The body of a node's detail is rendered from its descriptor: either a
+// `custom:<id>` whole-body renderer, or declarative `panels`. Unknown types fall
+// back to top-level input/output (or an attribute dump). raven's own rich cards
+// are registered here as custom renderers, so dispatch is data-driven with zero
+// regression, and any provider's node type renders without viewer code changes.
+
+const CUSTOM_RENDERERS = {
+  sessionTurn: (span, trace) => renderSessionTurnCard(trace, span),
+  llmCall: (span, trace, artifacts) => renderModelInputCard(span, artifacts) + renderModelOutputCard(span, artifacts),
+  subagentCall: (span, trace, artifacts) => renderSubagentCallCard(span, artifacts) + renderSubagentRunCard(span),
+  skillRead: (span, trace, artifacts) => renderSkillReadCard(trace, span, artifacts) + renderSkillEvidenceCard(trace, span),
+  memoryRecall: (span, trace, artifacts) => renderMemoryRecallCard(span, artifacts),
+  memoryStore: (span, trace, artifacts) => renderMemoryStoreCard(span, artifacts),
+  memoryFeedback: (span) => renderMemoryFeedbackCard(span)
+};
+
+function descriptorFor(name) {
+  return (state.descriptors && state.descriptors[name]) || null;
+}
+
+function resolveCustom(id, span, trace, artifacts) {
+  const fn = CUSTOM_RENDERERS[id];
+  return fn ? fn(span, trace, artifacts) : '';
+}
+
+function applyTemplate(tmpl, obj) {
+  return String(tmpl).replace(/\{([^}]+)\}/g, (_, k) => {
+    const v = obj?.[k.trim()];
+    return v == null ? '' : String(v);
+  });
+}
+
+// resolve top-level input/output payload: artifact if referenced, else preview.
+function topLevelPayload(io, artifacts) {
+  if (!io) return undefined;
+  if (io.artifact_path) {
+    const found = (artifacts || []).find((a) => a.artifact?.path === io.artifact_path);
+    if (found) return found.artifact?.parsed ?? found.artifact?.content;
+  }
+  return io.preview;
+}
+
+// resolve a panel `source` to a value: input | output | attr:x | artifact:prefix.
+function resolveSource(span, source, pick, artifacts) {
+  if (!source) return undefined;
+  let value;
+  if (source === 'input') value = topLevelPayload(span.input, artifacts);
+  else if (source === 'output') value = topLevelPayload(span.output, artifacts);
+  else if (source.startsWith('attr:')) value = span.attributes?.[source.slice(5)];
+  else if (source.startsWith('artifact:')) {
+    const p = span.attributes?.[`${source.slice('artifact:'.length)}.artifact_path`];
+    const found = (artifacts || []).find((a) => a.artifact?.path === p);
+    value = found?.artifact?.parsed ?? found?.artifact?.content;
+  }
+  if (pick && value && typeof value === 'object') value = value[pick];
+  return value;
+}
+
+function renderByKind(value, kind, panel) {
+  if (kind === 'list' && Array.isArray(value)) {
+    const text = value
+      .map((it, i) => {
+        if (panel?.item) return `${i + 1}. ${applyTemplate(panel.item, it)}`;
+        if (it && typeof it === 'object') return `${i + 1}. ${it.text ?? JSON.stringify(it)}`;
+        return `${i + 1}. ${it}`;
+      })
+      .join('\n\n');
+    return preBody(text);
+  }
+  if (kind === 'messages' && Array.isArray(value)) {
+    return preBody(value.map((m) => `[${(m && m.role) || '?'}]\n${(m && m.content) || ''}`).join('\n\n'));
+  }
+  if (kind === 'kv' && value && typeof value === 'object') {
+    const lines = Object.entries(value).map(([k, v]) => `${k}: ${typeof v === 'object' ? JSON.stringify(v) : v}`);
+    return preBody(lines.join('\n'));
+  }
+  if (kind === 'text') return preBody(typeof value === 'string' ? value : prettyValue(value));
+  return `<pre class="structured-pre">${escapeHtml(prettyValue(value))}</pre>`;
+}
+
+function renderPanel(span, panel, artifacts, trace) {
+  if (panel.render && panel.render.startsWith('custom:')) {
+    return resolveCustom(panel.render.slice('custom:'.length), span, trace, artifacts);
+  }
+  const value = resolveSource(span, panel.source, panel.pick, artifacts);
+  return memoryIoCard(panel.title || '', '', renderByKind(value, panel.render || 'json', panel));
+}
+
+function renderFallbackBody(span, artifacts) {
+  const cards = [];
+  if (span.input) {
+    cards.push(memoryIoCard('Input', span.input.kind || '', renderByKind(topLevelPayload(span.input, artifacts), span.input.kind || 'json')));
+  }
+  if (span.output) {
+    cards.push(memoryIoCard('Output', span.output.kind || '', renderByKind(topLevelPayload(span.output, artifacts), span.output.kind || 'json')));
+  }
+  if (cards.length) return cards.join('');
+  const arts = artifacts || [];
+  if (arts.length) {
+    return arts
+      .map(
+        ({ label, artifact }) => `
+          <article class="content-card">
+            <header><h4>${escapeHtml(label)}</h4>
+              <span class="card-note">${escapeHtml(shortId(artifact?.path || '-', 46))}</span></header>
+            <pre>${escapeHtml(prettyArtifactContent(artifact))}</pre>
+          </article>`
+      )
+      .join('');
+  }
+  return `
+    <article class="content-card"><header><h4>Attributes</h4></header>
+      <pre class="structured-pre">${escapeHtml(JSON.stringify(span.attributes || {}, null, 2))}</pre></article>`;
+}
+
+function renderNodeBody(span, trace, artifacts) {
+  const desc = descriptorFor(span.name);
+  if (desc) {
+    if (desc.render && desc.render.startsWith('custom:')) {
+      return resolveCustom(desc.render.slice('custom:'.length), span, trace, artifacts);
+    }
+    if (Array.isArray(desc.panels)) {
+      return desc.panels.map((panel) => renderPanel(span, panel, artifacts, trace)).join('');
+    }
+  }
+  return renderFallbackBody(span, artifacts);
+}
+
+function renderContent(span, trace, artifacts) {
+  const heroSubtitle = span.displaySubtitle || '';
+  const heroModelInfo = span.name === 'llm.call'
+    ? [span.attributes?.['llm.provider'], span.attributes?.['llm.model']].filter(Boolean).join(' / ')
+    : '';
+  const usageChips = span.name === 'llm.call' ? llmUsageSummary(span) : [];
+  const heroStatusText = span.isFailed ? (span.failureLabel || span.status?.code || 'FAILED') : (span.status?.code || 'OK');
+  const heroStatusClass = span.isFailed ? 'summary-chip summary-chip-error' : 'summary-chip';
+  return `
+    <div class="content-stack">
+      <article class="content-card hero-card">
+        <header>
+          <h4>${escapeHtml(span.displayTitle)}</h4>
+          ${heroSubtitle ? `<span class="card-note">${escapeHtml(heroSubtitle)}</span>` : ''}
+        </header>
+        <div class="hero-metrics">
+          <span class="summary-chip">${formatDuration(span.durationMs)}</span>
+          <span class="${heroStatusClass}">${escapeHtml(heroStatusText)}</span>
+          ${heroModelInfo ? `<span class="summary-chip">${escapeHtml(heroModelInfo)}</span>` : ''}
+          ${usageChips.map((chip) => `<span class="summary-chip${chip.soft ? ' summary-chip-soft' : ''}">${escapeHtml(chip.text)}</span>`).join('')}
+        </div>
+      </article>
+      ${renderNodeBody(span, trace, artifacts)}
+    </div>
+  `;
+}
+
+function renderContentLegacy(span, trace, artifacts) {
+  const hiddenArtifactLabels = new Set();
+  if (span.name === 'llm.call') {
+    hiddenArtifactLabels.add('Model Input');
+    hiddenArtifactLabels.add('Model Output');
+  }
+  if (span.name === 'tool.call' || span.name === 'subagent.call') {
+    hiddenArtifactLabels.add('Tool Input');
+    hiddenArtifactLabels.add('Tool Output');
+    hiddenArtifactLabels.add('Tool Persisted');
+  }
+  if (span.name === 'skill.read') {
+    hiddenArtifactLabels.add('Skill Read');
+    hiddenArtifactLabels.add('Read Request');
+    hiddenArtifactLabels.add('Read Content');
+    // raven's read_file→skill.read is a re-typed tool call: its Tool
+    // Input/Output ARE the skill's input/output, now consumed by
+    // renderSkillReadCard. Hide them so they don't double-render as
+    // separate Tool cards alongside the Skill cards.
+    hiddenArtifactLabels.add('Tool Input');
+    hiddenArtifactLabels.add('Tool Output');
+  }
+  if (span.name === 'memory.recall') hiddenArtifactLabels.add('Memory Recall');
+  if (span.name === 'memory.store') hiddenArtifactLabels.add('Memory Store');
+  const artifactEntries = artifacts.filter((entry) => !hiddenArtifactLabels.has(entry.label));
+  const artifactCards = span.name === 'session.turn'
+    ? ''
+    : (span.name === 'llm.call' || span.name === 'tool.call' || span.name === 'subagent.call' || span.name === 'skill.read' || span.name === 'memory.recall' || span.name === 'memory.store' || span.name === 'memory.feedback') && !artifactEntries.length
+    ? ''
+    : artifactEntries.length
+    ? artifactEntries
+        .map(
+          ({ label, artifact }) => `
+          <article class="content-card">
+            <header>
+              <h4>${escapeHtml(label)}</h4>
+                <span class="card-note">${escapeHtml(shortId(artifact?.path || '-', 46))}</span>
+              </header>
+              <pre>${escapeHtml(prettyArtifactContent(artifact))}</pre>
+            </article>
+          `
+        )
+        .join('')
+    : `
+      <article class="content-card">
+        <header>
+          <h4>${t('artifact.empty')}</h4>
+      </header>
+        <pre>${escapeHtml(JSON.stringify(span.attributes || {}, null, 2))}</pre>
+      </article>
+    `;
+
+  const heroSubtitle = span.displaySubtitle || '';
+  const heroModelInfo = span.name === 'llm.call'
+    ? [span.attributes?.['llm.provider'], span.attributes?.['llm.model']].filter(Boolean).join(' / ')
+    : '';
+  const usageChips = span.name === 'llm.call'
+    ? llmUsageSummary(span)
+    : [];
+  const heroStatusText = span.isFailed ? (span.failureLabel || span.status?.code || 'FAILED') : (span.status?.code || 'OK');
+  const heroStatusClass = span.isFailed ? 'summary-chip summary-chip-error' : 'summary-chip';
+
+  return `
+    <div class="content-stack">
+      <article class="content-card hero-card">
+        <header>
+          <h4>${escapeHtml(span.displayTitle)}</h4>
+          ${heroSubtitle ? `<span class="card-note">${escapeHtml(heroSubtitle)}</span>` : ''}
+        </header>
+        <div class="hero-metrics">
+          <span class="summary-chip">${formatDuration(span.durationMs)}</span>
+          <span class="${heroStatusClass}">${escapeHtml(heroStatusText)}</span>
+          ${heroModelInfo ? `<span class="summary-chip">${escapeHtml(heroModelInfo)}</span>` : ''}
+          ${usageChips.map((chip) => `<span class="summary-chip${chip.soft ? ' summary-chip-soft' : ''}">${escapeHtml(chip.text)}</span>`).join('')}
+        </div>
+      </article>
+      ${renderSessionTurnCard(trace, span)}
+      ${renderModelInputCard(span, artifacts)}
+      ${renderModelOutputCard(span, artifacts)}
+      ${renderToolCallCard(span, artifacts)}
+      ${renderSubagentCallCard(span, artifacts)}
+      ${renderSubagentRunCard(span)}
+      ${renderSkillReadCard(trace, span, artifacts)}
+      ${renderSkillEvidenceCard(trace, span)}
+      ${renderMemoryCard(span, artifacts)}
+      ${artifactCards}
+    </div>
+  `;
+}
+
+// Memory nodes as Input → Output, mirroring the llm/tool cards. Under the everos
+// backend only recall/store/feedback fire; each is a request step with a real
+// input and output. store's output is the async-distilled deposit family.
+function renderMemoryCard(span, artifacts) {
+  if (span.name === 'memory.recall') return renderMemoryRecallCard(span, artifacts);
+  if (span.name === 'memory.store') return renderMemoryStoreCard(span, artifacts);
+  if (span.name === 'memory.feedback') return renderMemoryFeedbackCard(span);
+  return '';
+}
+
+function memoryIoCard(title, note, bodyHtml) {
+  return `
+    <article class="content-card wide-card">
+      <header><h4>${escapeHtml(title)}</h4>${note ? `<span class="card-note">${escapeHtml(note)}</span>` : ''}</header>
+      ${bodyHtml}
+    </article>`;
+}
+
+// All memory bodies render as a single structured-pre text block — identical
+// styling/wrapping/alignment to the llm/tool cards (no bespoke list/flex markup).
+function preBody(text) {
+  const t = text == null ? '' : String(text);
+  return `<pre class="structured-pre">${escapeHtml(t.length ? t : '(empty)')}</pre>`;
+}
+
+// Shared role-colored message list — the `messages` body renderer. Used by any
+// node whose input/output is a chat message array (llm.call, memory.store).
+// content: string OR content-block list; assistant tool_calls appended; the
+// system message (reliably huge boilerplate) collapses by default.
+function messageBodyText(m) {
+  let body = '';
+  const c = m && m.content;
+  if (typeof c === 'string') body = c;
+  else if (Array.isArray(c))
+    body = c
+      .map((b) => (b && typeof b === 'object' ? (b.type === 'text' ? b.text || '' : `[${b.type || 'block'}]`) : String(b)))
+      .join('\n');
+  else if (c != null) body = JSON.stringify(c);
+  if (Array.isArray(m && m.tool_calls) && m.tool_calls.length) {
+    body +=
+      (body ? '\n' : '') +
+      m.tool_calls
+        .map((tc) => {
+          const fn = (tc && tc.function) || {};
+          const args = typeof fn.arguments === 'string' ? fn.arguments : JSON.stringify(fn.arguments || {});
+          return `→ ${fn.name || '?'}(${args})`;
+        })
+        .join('\n');
+  }
+  return body;
+}
+
+function renderMessages(messages) {
+  const list = Array.isArray(messages) ? messages : [];
+  if (!list.length) return preBody('(no messages)');
+  return `<div class="msg-list">${list
+    .map((m) => {
+      const role = (m && m.role) || '?';
+      const name = m && m.name ? ` · ${escapeHtml(m.name)}` : '';
+      const body = messageBodyText(m);
+      const bodyHtml = escapeHtml(body || '(empty)');
+      const collapse = role === 'system' || body.length > 800;
+      const inner = collapse
+        ? `<details class="msg-collapse"><summary><span class="msg-role">${escapeHtml(role)}${name}</span><span class="msg-len">${body.length} chars</span></summary><div class="msg-body">${bodyHtml}</div></details>`
+        : `<div class="msg-role">${escapeHtml(role)}${name}</div><div class="msg-body">${bodyHtml}</div>`;
+      return `<div class="msg msg-${escapeHtml(role)}">${inner}</div>`;
+    })
+    .join('')}</div>`;
+}
+
+function renderMemoryRecallCard(span, artifacts) {
+  const attrs = span.attributes || {};
+  const query = attrs['memory.query'] || '';
+  const inNote = [
+    attrs['memory.scope'] ? `scope=${attrs['memory.scope']}` : null,
+    attrs['memory.user_id'] ? `user=${attrs['memory.user_id']}` : null,
+    attrs['memory.top_k'] != null ? `top_k=${attrs['memory.top_k']}` : null
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  const recalled = artifactByLabel(artifacts, 'Memory Recall')?.parsed;
+  const list = Array.isArray(recalled) ? recalled : [];
+  const hits = attrs['memory.hits'];
+  let outText;
+  if (list.length) {
+    outText = list
+      .map((m, i) => {
+        const score = m && m.score != null ? ` (score ${Number(m.score).toFixed(4)})` : '';
+        return `${i + 1}.${score}\n${(m && m.text) || ''}`;
+      })
+      .join('\n\n');
+  } else {
+    outText = hits === 0 ? 'No memories recalled (0 hits).' : 'No recalled-memory artifact captured.';
+  }
+  return (
+    memoryIoCard('Recall · Input', inNote, preBody(query || '(empty query)')) +
+    memoryIoCard('Recall · Output', hits != null ? `${hits} hit${hits === 1 ? '' : 's'}` : '', preBody(outText))
+  );
+}
+
+function renderMemoryStoreCard(span, artifacts) {
+  const attrs = span.attributes || {};
+  const stored = artifactByLabel(artifacts, 'Memory Store')?.parsed;
+  const messages = stored && Array.isArray(stored.messages) ? stored.messages : [];
+  const inBody = messages.length ? renderMessages(messages) : preBody('No stored-messages artifact captured.');
+  const inNote = [
+    attrs['memory.message_count'] != null ? `${attrs['memory.message_count']} msgs` : null,
+    attrs['memory.session_id'] || null
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  const status = attrs['memory.deposit_status'];
+  let outText;
+  let outNote = attrs['memory.deposit_summary'] || '';
+  if (status === 'pending') {
+    outNote = 'async · ~30s';
+    outText =
+      "Not yet distilled — messages ingested as a raw memcell; everos's async cascade (~30s) hasn't produced episode/fact/foresight yet. Refresh later.";
+  } else if (status === 'distilled') {
+    let payload = {};
+    try {
+      payload = JSON.parse(attrs['memory.deposit_json'] || '{}');
+    } catch {
+      payload = {};
+    }
+    const families = payload.families || {};
+    const TYPE_LABEL = {
+      episode: 'episodes',
+      atomic_fact: 'atomic facts',
+      foresight: 'foresights',
+      agent_case: 'agent cases',
+      agent_skill: 'agent skills'
+    };
+    const ORDER = ['episode', 'atomic_fact', 'foresight', 'agent_case', 'agent_skill'];
+    const blocks = ORDER.filter((type) => families[type] && families[type].length)
+      .map((type) => {
+        const lines = families[type]
+          .map((entry, i) => {
+            const win = entry.startTime && entry.endTime ? `  [${entry.startTime} → ${entry.endTime}]` : '';
+            const subj = entry.subject ? `${entry.subject}\n     ` : '';
+            return `  ${i + 1}. ${subj}${entry.text || ''}${win}`;
+          })
+          .join('\n');
+        return `${TYPE_LABEL[type] || type} (${families[type].length})\n${lines}`;
+      })
+      .join('\n\n');
+    const mc = payload.parentId ? ` · memcell ${payload.parentId}` : '';
+    const delta = payload.deltaMs == null ? '?' : payload.deltaMs;
+    const header = `everos distilled this from the turn's memcell${mc}\njoined by (session_id, timestamp), Δ≈${delta}ms. Profile (user.md) is a merged everos doc — async, not per-turn.`;
+    outText = `${header}\n\n${blocks || 'Ingested, but nothing was distilled from this turn.'}`;
+  } else {
+    outText = 'Deposit not resolved (everos data unavailable to the viewer).';
+  }
+  return memoryIoCard('Store · Input', inNote, inBody) + memoryIoCard('Store · Output', outNote, preBody(outText));
+}
+
+function renderMemoryFeedbackCard(span) {
+  const attrs = span.attributes || {};
+  const norm = (v) => {
+    if (typeof v === 'string') {
+      const parsed = parseJsonMaybe(v);
+      if (parsed !== undefined && parsed !== null) v = parsed;
+    }
+    if (v == null) return '(none)';
+    if (Array.isArray(v)) return v.length ? v.join(', ') : '(none)';
+    return String(v);
+  };
+  const inText = `injected skills: ${norm(attrs['memory.injected'])}\nused skills: ${norm(attrs['memory.used'])}`;
+  const outText = 'No output — backend.feedback is a deliberate no-op in everos 1.0: the skill-usage signal is captured but not consumed.';
+  return memoryIoCard('Feedback · Input', '', preBody(inText)) + memoryIoCard('Feedback · Output', 'everos no-op', preBody(outText));
+}
+
+function renderRaw(span, artifacts) {
+  const payload = {
+    span,
+    artifacts: artifacts.map(({ label, artifact }) => ({
+      label,
+      path: artifact?.path,
+      parsed: artifact?.parsed,
+      content: artifact?.parsed ? undefined : artifact?.content,
+      error: artifact?.error
+    }))
+  };
+  return `
+    <div class="raw-view">
+      <pre>${escapeHtml(JSON.stringify(payload, null, 2))}</pre>
+    </div>
+  `;
+}
+
+async function renderDetails() {
+  if (state.appView === 'api') return;
+  state.detailsRenderSignature = currentDetailsSignature();
+  captureOpenDetails();
+  const trace = currentTrace();
+  const span = currentSpan();
+  elements.detailsBody.innerHTML = '';
+  if (!trace || !span) {
+    elements.detailsTitle.textContent = t('details.selectSpan');
+    elements.detailsBody.appendChild(cloneEmptyState());
+    restoreScrollState();
+    return;
+  }
+
+  elements.detailsTitle.textContent = span.name === 'llm.call'
+    ? span.displayTitle
+    : `${span.displayTitle}${span.displaySubtitle ? ` / ${span.displaySubtitle}` : ''}`;
+  const artifacts = await loadArtifacts(span);
+  if (!currentSpan() || currentSpan().spanId !== span.spanId) return;
+
+  if (state.selectedTab === 'metadata') {
+    elements.detailsBody.innerHTML = renderMetadata(span);
+    hydrateOpenDetails();
+    restoreScrollState();
+    applyDetailHighlights();
+    return;
+  }
+
+  if (state.selectedTab === 'raw') {
+    elements.detailsBody.innerHTML = renderRaw(span, artifacts);
+    hydrateOpenDetails();
+    restoreScrollState();
+    applyDetailHighlights();
+    return;
+  }
+
+  elements.detailsBody.innerHTML = renderContent(span, trace, artifacts);
+  elements.detailsBody.querySelectorAll('[data-jump-trace-id]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      jumpToTraceByTraceId(btn.dataset.jumpTraceId, btn.dataset.jumpSpanId || null);
+    });
+  });
+  hydrateOpenDetails();
+  restoreScrollState();
+  applyDetailHighlights();
+}
+
+function currentDetailsSignature() {
+  const trace = currentTrace();
+  const span = currentSpan();
+  if (!trace || !span) return null;
+  return [state.appView, state.selectedTab, state.selectedSessionId, state.selectedTraceKey, state.selectedSpanId].join('::');
+}
+
+function render() {
+  captureScrollState();
+  syncSelection();
+  renderAgentFilter();
+  renderApiFilters();
+  if (elements.connectionStatus) {
+    elements.connectionStatus.textContent = state.connectionStatus === 'connected' ? t('status.connected') : t('status.disconnected');
+    elements.connectionStatus.classList.toggle('is-connected', state.connectionStatus === 'connected');
+    elements.connectionStatus.classList.toggle('is-disconnected', state.connectionStatus !== 'connected');
+  }
+  if (elements.lastUpdated) {
+    elements.lastUpdated.textContent = formatTimeOnly(state.lastUpdated);
+  }
+  document.body.classList.toggle('app-view-api', state.appView === 'api');
+  if (state.appView === 'api') {
+    elements.apiScene.innerHTML = renderApiDashboard();
+    restoreScrollState();
+    const agentInline = document.getElementById('apiAgentFilterInline');
+    const providerInline = document.getElementById('apiProviderFilterInline');
+    const modelInline = document.getElementById('apiModelFilterInline');
+    const apiRefreshButton = document.getElementById('apiRefreshButton');
+    agentInline?.addEventListener('change', (event) => {
+      state.agent = event.target.value;
+      render();
+    });
+    providerInline?.addEventListener('change', (event) => {
+      state.provider = event.target.value;
+      render();
+    });
+    modelInline?.addEventListener('change', (event) => {
+      state.model = event.target.value;
+      render();
+    });
+    apiRefreshButton?.addEventListener('click', () => {
+      state.artifactCache.clear();
+      loadData();
+    });
+    elements.apiScene.querySelectorAll('[data-api-window]').forEach((button) => {
+      button.addEventListener('click', () => {
+        state.apiWindow = button.dataset.apiWindow;
+        render();
+      });
+    });
+    elements.apiScene.querySelectorAll('[data-api-status]').forEach((button) => {
+      button.addEventListener('click', () => {
+        state.apiStatus = button.dataset.apiStatus;
+        render();
+      });
+    });
+    elements.apiScene.querySelectorAll('.api-table-row[data-span-id]').forEach((row) => {
+      row.addEventListener('click', () => {
+        const entry = filteredApiCalls().find((item) => item.span.spanId === row.dataset.spanId);
+        if (!entry) return;
+        state.selectedSessionId = entry.sessionId;
+        state.selectedTraceKey = entry.traceKey;
+        state.selectedSpanId = entry.span.spanId;
+        state.appView = 'trace';
+        state.detailsRenderSignature = null;
+        render();
+      });
+    });
+  } else {
+  elements.listTitle.textContent = t('sessions.title');
+  elements.searchInput.placeholder = t('search.placeholder');
+    renderSessionList();
+    renderTraceList();
+    const nextDetailsSignature = currentDetailsSignature();
+    if (nextDetailsSignature !== state.detailsRenderSignature) {
+      state.detailsRenderSignature = nextDetailsSignature;
+      renderDetails();
+    } else {
+      restoreScrollState();
+    }
+  }
+  elements.tabs.forEach((tab) => {
+    tab.classList.toggle('is-active', tab.dataset.tab === state.selectedTab);
+  });
+  elements.appViewButtons.forEach((button) => {
+    button.classList.toggle('is-active', button.dataset.appView === state.appView);
+  });
+}
+
+async function fetchDescriptors() {
+  try {
+    const res = await fetch('/api/descriptors');
+    const payload = await res.json();
+    const map = {};
+    for (const desc of payload.descriptors || []) {
+      if (desc && desc.type) map[desc.type] = desc;
+    }
+    state.descriptors = map;
+  } catch {
+    state.descriptors = {};
+  }
+}
+
+async function loadData(options = {}) {
+  const { silent = false } = options;
+  if (state.isLoading) return;
+  state.isLoading = true;
+  if (!silent) {
+    elements.refreshButton.disabled = true;
+  }
+  try {
+    const response = await fetch(`/api/data?ts=${Date.now()}`, { cache: 'no-store' });
+    if (!response.ok) throw new Error(`API failed with status ${response.status}`);
+    state.data = await response.json();
+    state.connectionStatus = 'connected';
+    state.lastUpdated = new Date().toISOString();
+    render();
+  } catch (error) {
+    state.connectionStatus = 'disconnected';
+    if (!silent) {
+      elements.sessionList.innerHTML = `
+        <div class="empty-state">
+          <p class="empty-title">${t('error.loadFailed')}</p>
+          <p class="empty-copy">${escapeHtml(error.message)}</p>
+        </div>
+      `;
+    }
+  } finally {
+    state.isLoading = false;
+    if (!silent) {
+      elements.refreshButton.disabled = false;
+    }
+  }
+}
+
+function startAutoRefresh() {
+  if (state.autoRefreshTimer) {
+    clearInterval(state.autoRefreshTimer);
+  }
+  state.autoRefreshTimer = window.setInterval(() => {
+    if (document.hidden) return;
+    loadData({ silent: true });
+  }, AUTO_REFRESH_MS);
+}
+
+let contentSearchTimer = null;
+elements.searchInput.addEventListener('input', (event) => {
+  state.search = event.target.value;
+  state.detailsRenderSignature = null;
+  render();
+  applyDetailHighlights();
+  if (contentSearchTimer) clearTimeout(contentSearchTimer);
+  const query = state.search.trim();
+  if (query.length < 2) {
+    state.contentResults = null;
+    renderContentSearchResults();
+    return;
+  }
+  contentSearchTimer = setTimeout(() => runContentSearch(query), 250);
+});
+
+elements.contentSearchResults.addEventListener('click', (event) => {
+  const item = event.target.closest('[data-span-id]');
+  if (!item) return;
+  state.appView = 'trace';
+  state.selectedSessionId = item.dataset.sessionId;
+  state.selectedTraceKey = item.dataset.traceKey;
+  state.selectedSpanId = item.dataset.spanId;
+  state.highlightScrollPending = true;
+  state.detailsRenderSignature = null;
+  render();
+});
+
+elements.agentFilter.addEventListener('change', (event) => {
+  state.agent = event.target.value;
+  state.detailsRenderSignature = null;
+  render();
+});
+
+elements.providerFilter.addEventListener('change', (event) => {
+  state.provider = event.target.value;
+  render();
+});
+
+elements.modelFilter.addEventListener('change', (event) => {
+  state.model = event.target.value;
+  render();
+});
+
+elements.statusFilter.addEventListener('change', (event) => {
+  state.apiStatus = event.target.value;
+  render();
+});
+
+elements.refreshButton.addEventListener('click', () => {
+  state.artifactCache.clear();
+  loadData();
+});
+
+elements.appViewButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    state.appView = button.dataset.appView;
+    render();
+  });
+});
+
+elements.tabs.forEach((tab) => {
+  tab.addEventListener('click', () => {
+    state.selectedTab = tab.dataset.tab;
+    elements.tabs.forEach((item) => item.classList.toggle('is-active', item === tab));
+    renderDetails();
+  });
+});
+
+document.querySelectorAll('.lang-pill[data-lang]').forEach((button) => {
+  button.addEventListener('click', () => setLang(button.dataset.lang));
+});
+
+applyStaticI18n();
+
+fetchDescriptors().then(() => {
+  loadData();
+  startAutoRefresh();
+});

--- a/raven/tracing/viewer/ui/shell.js
+++ b/raven/tracing/viewer/ui/shell.js
@@ -1,0 +1,107 @@
+// Served by server.js for `/`. The dashboard shell lives here as a JS
+// module (not an .html asset) so the viewer ships as plain JS/CSS only.
+module.exports = String.raw`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Tracing Dashboard</title>
+    <link rel="stylesheet" href="/app.css">
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="app-brand">
+        <div class="app-logo" aria-hidden="true">∿</div>
+        <div>
+          <h1>Tracing Dashboard</h1>
+        </div>
+      </div>
+      <div class="app-status">
+        <span class="status-pill" id="connectionStatus" data-i18n="status.disconnected">Disconnected</span>
+        <span class="status-text"><span data-i18n="header.updated">Updated</span>: <strong id="lastUpdated">--:--:--</strong></span>
+        <div class="lang-switch" role="group" aria-label="Language">
+          <button class="lang-pill" data-lang="en" type="button">EN</button>
+          <button class="lang-pill" data-lang="zh" type="button">中</button>
+        </div>
+        <button class="ghost-button app-action" id="refreshButton" type="button" data-i18n="action.refresh">Refresh</button>
+      </div>
+    </header>
+    <nav class="workspace-tabs">
+      <button class="workspace-tab" data-app-view="api" type="button" data-i18n="view.api">API Calls</button>
+      <button class="workspace-tab is-active" data-app-view="trace" type="button" data-i18n="view.trace">Traces</button>
+    </nav>
+    <div class="scene scene-trace shell" id="traceScene">
+      <aside class="pane pane-sessions">
+        <div class="pane-head">
+          <div>
+            <h1 id="listTitle" data-i18n="sessions.title">Sessions</h1>
+          </div>
+        </div>
+        <div class="controls">
+          <label class="field">
+            <span>Agent</span>
+            <select id="agentFilter"></select>
+          </label>
+          <label class="field field-search">
+            <span data-i18n="field.search">Search</span>
+            <input id="searchInput" type="search" data-i18n-ph="search.placeholder" placeholder="session / trace / keyword">
+          </label>
+          <label class="field api-only">
+            <span>Provider</span>
+            <select id="providerFilter"></select>
+          </label>
+          <label class="field api-only">
+            <span>Model</span>
+            <select id="modelFilter"></select>
+          </label>
+          <label class="field api-only">
+            <span data-i18n="field.status">Status</span>
+            <select id="statusFilter">
+              <option value="all" data-i18n="status.all">All statuses</option>
+              <option value="ok" data-i18n="status.okOnly">Success only</option>
+              <option value="error" data-i18n="status.errorOnly">Failed only</option>
+              <option value="unreported" data-i18n="status.unreportedOnly">Token unreported only</option>
+            </select>
+          </label>
+        </div>
+        <div class="content-search-results" id="contentSearchResults" hidden></div>
+        <div class="session-list" id="sessionList" data-scroll-key="trace-session-list"></div>
+      </aside>
+
+      <main class="pane pane-traces">
+        <div class="pane-head">
+          <div>
+            <h2 id="traceTitle" data-i18n="trace.selectSession">Select a session</h2>
+          </div>
+          <div class="head-meta" id="traceMeta"></div>
+        </div>
+        <div class="trace-list" id="traceList" data-scroll-key="trace-list"></div>
+      </main>
+
+      <section class="pane pane-details">
+        <div class="pane-head">
+          <div>
+            <h2 id="detailsTitle" data-i18n="details.selectSpan">Select a span</h2>
+          </div>
+          <div class="tabs">
+            <button class="tab is-active" data-tab="content" type="button" data-i18n="detailtab.content">Input / Output</button>
+            <button class="tab" data-tab="metadata" type="button" data-i18n="detailtab.metadata">Metadata</button>
+            <button class="tab" data-tab="raw" type="button" data-i18n="detailtab.raw">Raw</button>
+          </div>
+        </div>
+        <div class="details-body" id="detailsBody" data-scroll-key="trace-details"></div>
+      </section>
+    </div>
+    <main class="scene scene-api" id="apiScene"></main>
+
+    <template id="emptyStateTemplate">
+      <div class="empty-state">
+        <p class="empty-title" data-i18n="empty.title">Nothing to show yet</p>
+        <p class="empty-copy" data-i18n="empty.copy">Refresh, or send another message to try.</p>
+      </div>
+    </template>
+
+    <script src="/app.js"></script>
+  </body>
+  </html>
+`;

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -168,6 +168,7 @@ REGISTERED_COMMAND_NAMES = {
     "sessions",
     "skill",
     "status",
+    "tracing",
     "tui",
     "upgrade",
 }

--- a/tests/test_tracing_api.py
+++ b/tests/test_tracing_api.py
@@ -86,6 +86,21 @@ def test_purpose_spans_record_input_and_output(trace_dir):
     assert "skill.rewrite.output.artifact_path" in a
 
 
+def test_personalize_extractor_records_step_io(trace_dir):
+    from raven.tracing import semconv
+
+    with trace.span("personalize.classify", kind="memory") as s:
+        semconv.personalize(
+            s, {"self": object(), "message": "hi", "history": None}, {"needs_clarification": False}, None
+        )
+    a = _spans_written(trace_dir)[0]["attributes"]
+    assert a["span.type"] == "memory"
+    assert a["personalize.step"] == "classify"
+    assert a["personalize.ok"] is True
+    assert "personalize.input.artifact_path" in a
+    assert "personalize.output.artifact_path" in a
+
+
 def test_error_marks_status_and_reraises(trace_dir):
     with pytest.raises(ValueError):
         with trace.span("tool.call", {"tool.name": "read_file"}):

--- a/tests/test_tracing_api.py
+++ b/tests/test_tracing_api.py
@@ -1,0 +1,316 @@
+"""Contract tests for the ``raven.tracing.trace`` facade (standard-api.v1).
+
+Exercises the public ``trace.span`` API and asserts it emits well-formed
+``audit.span.v1`` records: correct nesting, kinds, attributes, artifact refs,
+error status, and no-op when disabled.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from raven.tracing import spans as _spans
+from raven.tracing import trace
+
+
+@pytest.fixture
+def trace_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("RAVEN_TRACING", "1")
+    monkeypatch.setenv("RAVEN_TRACING_DIR", str(tmp_path))
+    _spans._store = None  # force the store to re-init against the temp dir
+    yield tmp_path
+    _spans._store = None
+
+
+def _spans_written(trace_dir):
+    log = trace_dir / "logs" / "audit-spans.log"
+    if not log.exists():
+        return []
+    return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+
+
+def test_nesting_kinds_and_attributes(trace_dir):
+    with trace.span("session.turn", {"turn.input_preview": "hi"}) as root:
+        root_id = root.span_id
+        with trace.span("llm.call", {"llm.provider": "openrouter", "llm.model": "m"}) as s:
+            s.set({"llm.usage.total_tokens": 42})
+
+    spans = _spans_written(trace_dir)
+    by = {sp["name"]: sp for sp in spans}
+    assert len(spans) == 2
+    assert len({sp["traceId"] for sp in spans}) == 1  # one trace
+    assert by["session.turn"]["parentSpanId"] is None  # root
+    assert by["llm.call"]["parentSpanId"] == root_id  # nests under root
+    assert by["session.turn"]["attributes"]["span.type"] == "session"
+    assert by["llm.call"]["attributes"]["span.type"] == "model"
+    assert by["llm.call"]["attributes"]["llm.provider"] == "openrouter"
+    assert by["llm.call"]["attributes"]["llm.usage.total_tokens"] == 42
+    assert all(sp["schemaVersion"] == "audit.span.v1" for sp in spans)
+
+
+def test_invocation_source_derives_from_enclosing_purpose(trace_dir):
+    from raven.tracing import semconv
+
+    # A model call nested under a purpose span self-labels with that purpose;
+    # a model span never becomes its own source (model-under-model inherits).
+    with trace.span("skill.gate", kind="skill"):
+        with trace.span("llm.call") as s:
+            assert s.invocation_source == "skill.gate"
+            semconv.llm_call(s, {"self": None, "messages": [], "tools": None, "model": "openrouter/m"}, None, None)
+    sp = next(x for x in _spans_written(trace_dir) if x["name"] == "llm.call")
+    assert sp["attributes"]["llm.invocation_source"] == "skill.gate"
+
+
+def test_invocation_source_is_none_at_root(trace_dir):
+    with trace.span("session.turn") as root:
+        assert root.invocation_source is None
+
+
+def test_purpose_spans_record_input_and_output(trace_dir):
+    from raven.tracing import semconv
+
+    class _R:
+        need_retrieval = True
+        rewritten_query = "frontend design skills"
+
+    with trace.span("skill.rewrite", kind="skill") as s:
+        semconv.skill_rewrite(s, {"query": "help me install a frontend skill"}, _R(), None)
+    sp = _spans_written(trace_dir)[0]
+    a = sp["attributes"]
+    assert a["skill.rewrite.need_retrieval"] is True
+    # Wrapper node self-reports input/output as artifacts, like llm/tool/memory nodes.
+    assert "skill.rewrite.input.artifact_path" in a
+    assert "skill.rewrite.output.artifact_path" in a
+
+
+def test_error_marks_status_and_reraises(trace_dir):
+    with pytest.raises(ValueError):
+        with trace.span("tool.call", {"tool.name": "read_file"}):
+            raise ValueError("boom")
+
+    spans = _spans_written(trace_dir)
+    assert len(spans) == 1
+    assert spans[0]["status"]["code"] == "ERROR"
+    assert "boom" in spans[0]["status"]["message"]
+
+
+def test_artifact_reference_attached(trace_dir):
+    with trace.span("llm.call", {"llm.provider": "p", "llm.model": "m"}) as s:
+        s.artifact("llm.input", {"messages": [{"role": "user", "content": "hi"}]})
+
+    spans = _spans_written(trace_dir)
+    assert "llm.input.artifact_path" in spans[0]["attributes"]
+
+
+def test_custom_node_uses_explicit_kind(trace_dir):
+    with trace.span("raven.sentinel.tick", {"sentinel.reason": "x"}, kind="plugin"):
+        pass
+
+    spans = _spans_written(trace_dir)
+    assert spans[0]["name"] == "raven.sentinel.tick"
+    assert spans[0]["attributes"]["span.type"] == "plugin"
+
+
+def test_disabled_is_noop(trace_dir, monkeypatch):
+    monkeypatch.setenv("RAVEN_TRACING", "0")
+    with trace.span("should.noop") as n:
+        n.set({"x": 1})
+    assert _spans_written(trace_dir) == []
+
+
+def test_tool_call_extractor(trace_dir):
+    from raven.tracing import semconv
+
+    with trace.span("tool.call") as s:
+        semconv.tool_call(s, {"name": "list_dir", "params": {"path": "."}}, "a\nb", None)
+    sp = _spans_written(trace_dir)[0]
+    assert sp["name"] == "tool.call"
+    assert sp["attributes"]["span.type"] == "tool"
+    assert sp["attributes"]["tool.name"] == "list_dir"
+    assert "tool.input.artifact_path" in sp["attributes"]
+    assert "tool.output.artifact_path" in sp["attributes"]
+
+
+def test_tool_call_retypes_to_skill(trace_dir):
+    from raven.tracing import semconv
+
+    with trace.span("tool.call") as s:
+        semconv.tool_call(s, {"name": "use_skill", "params": {"skill_id": "local/weather"}}, "## weather\nbody", None)
+    sp = _spans_written(trace_dir)[0]
+    assert sp["name"] == "skill.read"  # every skill access retypes to the one skill.read kind
+    assert sp["attributes"]["span.type"] == "skill"
+    assert sp["attributes"]["skill.id"] == "local/weather"
+    assert sp["attributes"]["skill.read.via_tool"] == "use_skill"  # origin preserved
+    assert "skill.scripts_dir" not in sp["attributes"]  # body-only read => no bundle
+
+
+def test_skill_read_reports_materialized_bundle(trace_dir):
+    from raven.tracing import semconv
+
+    body = "## weather\nscripts_dir: /ws/skills/local/weather/scripts\ncached: true\n\nrun it"
+    with trace.span("tool.call") as s:
+        semconv.tool_call(s, {"name": "use_skill", "params": {"skill_id": "local/weather"}}, body, None)
+    sp = _spans_written(trace_dir)[0]
+    assert sp["name"] == "skill.read"
+    # The materialized bundle is the content-driven signal that this access
+    # pulled runnable files, not just the instruction body.
+    assert sp["attributes"]["skill.scripts_dir"] == "/ws/skills/local/weather/scripts"
+
+
+def test_tool_error_result_marks_status(trace_dir):
+    from raven.tracing import semconv
+
+    with trace.span("tool.call") as s:
+        semconv.tool_call(s, {"name": "read_file", "params": {"path": "x"}}, "Error: no such file", None)
+    sp = _spans_written(trace_dir)[0]
+    assert sp["status"]["code"] == "ERROR"
+
+
+def test_memory_extract_extractor(trace_dir):
+    from raven.tracing import semconv
+
+    with trace.span("memory.extract") as s:
+        semconv.memory_extract(
+            s, {"messages": [{"role": "user", "content": "x"}], "model": "m", "enable_foresight": True}, True, None
+        )
+    a = _spans_written(trace_dir)[0]["attributes"]
+    assert a["span.type"] == "memory"
+    assert a["memory.message_count"] == 1
+    assert a["memory.annotated"] is True
+
+
+def test_memory_consolidate_extractor(trace_dir):
+    from raven.tracing import semconv
+
+    class _S:
+        key = "cli:abc"
+        last_consolidated = 3
+        messages = [1, 2, 3]
+
+    with trace.span("memory.consolidate") as s:
+        semconv.memory_consolidate(s, {"session": _S()}, None, None)
+    a = _spans_written(trace_dir)[0]["attributes"]
+    assert a["memory.session_key"] == "cli:abc"
+    assert a["memory.message_count"] == 3
+
+
+def test_subagent_children_nest(trace_dir):
+    from raven.tracing import semconv
+
+    # A subagent span; its inner primitives nest under it via context propagation.
+    with trace.span("subagent.run") as sa:
+        semconv.subagent(
+            sa, {"task_id": "t1", "task": "do x", "label": "worker", "origin": {"session_key": "cli:p"}}, None, None
+        )
+        with trace.span("llm.call", {"llm.provider": "p", "llm.model": "m"}) as inner:
+            inner_parent = inner._parent
+        sa_id = sa.span_id
+    spans = _spans_written(trace_dir)
+    by = {sp["name"]: sp for sp in spans}
+    assert by["subagent.run"]["attributes"]["span.type"] == "subagent"
+    assert by["subagent.run"]["attributes"]["subagent.label"] == "worker"
+    assert inner_parent == sa_id  # inner llm.call nests under the subagent node
+
+
+# ---------------------------------------------------------------------------
+# Contract gates (standard-api.v1). These freeze the adopter/viewer contract
+# and the "tracing can never break the host" invariant. A change that trips
+# them is a deliberate contract change: update the snapshot + bump the schema.
+# ---------------------------------------------------------------------------
+
+
+def test_audit_span_v1_record_shape_is_frozen(trace_dir):
+    with trace.span("llm.call", {"llm.provider": "p", "llm.model": "m"}):
+        pass
+    sp = _spans_written(trace_dir)[0]
+    assert set(sp.keys()) == {
+        "schemaVersion",
+        "traceId",
+        "spanId",
+        "parentSpanId",
+        "name",
+        "kind",
+        "startTime",
+        "endTime",
+        "status",
+        "events",
+        "attributes",
+    }
+    assert sp["schemaVersion"] == "audit.span.v1"
+    assert set(sp["status"].keys()) == {"code", "message"}
+    for key in ("span.type", "framework", "session.id", "channel.id", "audit.schema_version"):
+        assert key in sp["attributes"]
+
+
+def test_span_kind_vocabulary_is_frozen():
+    from raven.tracing import trace as _t
+
+    assert set(_t._KIND_BY_DOMAIN.values()) == {
+        "session",
+        "model",
+        "tool",
+        "subagent",
+        "skill",
+        "memory",
+        "plugin",
+    }
+
+
+def test_standard_span_required_attributes(trace_dir):
+    from raven.tracing import semconv
+
+    class _Resp:
+        content = "hi"
+        tool_calls: list = []
+        usage = None
+        finish_reason = "stop"
+        reasoning_content = None
+
+    with trace.span("llm.call") as s:
+        semconv.llm_call(s, {"self": None, "messages": [], "tools": None, "model": "openrouter/x"}, _Resp(), None)
+    with trace.span("tool.call") as s:
+        semconv.tool_call(s, {"name": "grep", "params": {}}, "ok", None)
+    by = {sp["name"]: sp for sp in _spans_written(trace_dir)}
+    assert by["llm.call"]["attributes"]["llm.provider"]
+    assert by["llm.call"]["attributes"]["llm.model"]
+    assert by["tool.call"]["attributes"]["tool.name"] == "grep"
+
+
+def test_tracing_disabled_is_passthrough(monkeypatch):
+    monkeypatch.setenv("RAVEN_TRACING", "0")
+    calls = {"n": 0}
+
+    @trace.instrument("llm.call")
+    async def f(x):
+        calls["n"] += 1
+        return x * 2
+
+    assert asyncio.run(f(21)) == 42
+    assert calls["n"] == 1
+    assert trace.current() is None
+
+
+def test_tracing_internal_failure_never_breaks_host(trace_dir, monkeypatch):
+    from raven.tracing import spans as _spans
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("tracing store down")
+
+    monkeypatch.setattr(_spans, "emit", _boom)
+
+    @trace.instrument("llm.call")
+    async def ok(x):
+        return x + 1
+
+    @trace.instrument("tool.call")
+    async def app_error():
+        raise ValueError("APP")
+
+    # tracing's own crash must not surface to the host
+    assert asyncio.run(ok(41)) == 42
+    # the host's own exception must propagate unchanged
+    with pytest.raises(ValueError, match="APP"):
+        asyncio.run(app_error())

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -69,6 +69,21 @@ interface SkillsReloadResponse {
 
 export const opsCommands: SlashCommand[] = [
   {
+    help: 'open the tracing dashboard (LLM/tool/memory spans)',
+    name: 'tracing',
+    run: (_arg, ctx) => {
+      ctx.gateway
+        .rpc<SlashExecResponse>('slash.exec', { command: 'tracing', session_id: ctx.sid })
+        .then(
+          ctx.guarded<SlashExecResponse>(r => {
+            const body = r?.output || 'tracing dashboard'
+            ctx.transcript.sys(r?.warning ? `warning: ${r.warning}\n${body}` : body)
+          })
+        )
+        .catch(ctx.guardedErr)
+    }
+  },
+  {
     help: 'stop background processes',
     name: 'stop',
     supported: false,


### PR DESCRIPTION
## Summary

Add an in-tree tracing subsystem and adopt it across raven, giving every run
a structured `audit.span.v1` trace (turn -> model / tool / memory / skill /
subagent) viewable in a bundled dashboard.

The design keeps raven and tracing decoupled so they can iterate independently,
coupled only by a small contract:

- **tracing owns the standard.** `raven/tracing` exposes a thin facade
  (`trace.span` / `@trace.instrument`) over an `audit.span.v1` record format,
  a set of semantic conventions, and a dependency-free Node viewer. Custom
  nodes are supported with no registration (any owned `<domain>.<verb>` name).
- **raven adopts it as a pure consumer.** Instrumentation is one import + one
  `@trace.instrument` decorator per method; **method bodies are untouched**.
  Purposes self-nest via contextvars, so a model call under `skill.gate`,
  `memory.extract`, `subagent.run`, etc. is distinguished by its parent node
  and by a derived `llm.invocation_source` (nearest non-model ancestor).
- **tracing can never break raven.** The facade is no-op when disabled
  (`[tracing]` config or `RAVEN_TRACING=0`) and swallows its own failures while
  re-raising the application's exception unchanged.

Open the dashboard with `raven tracing` (or `/tracing` in the TUI).

Key node behavior: all skill pulls (`use_skill` / `read_skill` / a `read_file`
of a SKILL.md) unify into one `skill.read` node, differentiated by content
(`skill.read.via_tool`, and `skill.scripts_dir` when a runnable bundle was
materialized) rather than by tool name.

## Type

- [x] Feature

## Verification

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

Commands run:

- `uv run pytest tests/test_tracing_api.py -q` -> 20 passed (nesting, kinds,
  attributes, artifacts, retype, invocation_source, and the frozen
  contract + non-interference gates).
- `uv run pytest tests/ -q` -> 4091 passed, 85 failed, 12 errors. The failures
  are pre-existing and unrelated: an identical run with `RAVEN_TRACING=0` (this
  change fully inert) produces the byte-identical failing set, so this change
  adds zero failures. The failures are environment-only (TUI subprocess e2e,
  EverOS real-LLM, sandbox VM, npx MCP) plus a pre-existing async-mock ordering
  issue in the sentinel/attention suite (passes in isolation).
- `uv run ruff check` / `uv run ruff format` -> clean.
- Verified at runtime: raven core diff is annotation-only (each touched file is
  +2 lines: one import, one decorator); disabled pass-through and internal-
  failure isolation confirmed by dedicated tests.

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Backward compatibility: additive only. No existing behavior changes; tracing is
observation-only and defaults can be turned off with `RAVEN_TRACING=0`.
Rollback: revert the branch, or disable via config; raven runs identically
without it. Note: `raven/tracing/instrument.py` monkeypatch path is gone; all
instrumentation is explicit decorators in raven's own source.

Coverage note: the personalizer's four steps (which call `provider.chat`
directly) are instrumented as `personalize.*` purpose spans, so no model
activity is untraced. The only remaining follow-up is the standalone-OSS
extraction (import-optional shim, move raven-specific extractors out, drop raven
branding) -- a planned separate phase that ships tracing as its own package,
out of scope for this PR.

## Related Issues

N/A
