### PR TITLE
feat(agent): integrate mirothinker deep_research tool

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -68,6 +68,12 @@ _Avoid_: "function" — a Tool is the agent-facing capability, not a Python func
 The name→`Tool` table the Agent Loop dispatches into: resolves a tool by name and runs
 its `execute` under a timeout, returning the string result or a structured error.
 
+**Deep Research** (`agent/tools/deep_research.py`):
+Opt-in tool delegating an open-ended research question to the MiroThinker API; returns a
+finished, cited answer. Streamed inline on CLI/TUI, async on channels (background run +
+verbatim `deliver_text` push). Configured via `raven deep-research` or onboarding Step 5.
+_Avoid_: "Subagent" — it is a single long-running tool, not a spawned agent.
+
 **Checkpoint** (`agent/loop/checkpoint.py`):
 A once-per-turn commit of the workspace into a shadow git repo (separate from the
 user's `.git`), so an interrupted or failed turn can be rolled back.
@@ -403,7 +409,7 @@ under `agent_memory/profile/` (soul.md, agent.md) and `user_memory/profile/` (us
 `HEARTBEAT.md` / `TOOLS.md` stay at the Workspace root.
 
 **Onboarding** (`raven onboard` → `run_wizard`):
-The first-run wizard (LLM provider → sandbox → channel → EverOS memory) that also seeds the
+The first-run wizard (LLM provider → sandbox → channel → EverOS memory → deep_research) that also seeds the
 Workspace via `sync_workspace_templates()`; gated at startup by `ensure_configured_or_onboard()`.
 
 **Bootstrap Files**:

--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -30,7 +30,7 @@ from raven.agent.tools.media_gen import (
     SpeechGenerateTool,
     VideoGenerateTool,
 )
-from raven.agent.tools.deep_research import DeepResearchTool
+from raven.agent.tools.deep_research import DeepResearchManager, DeepResearchTool
 from raven.agent.tools.message import MessageTool
 from raven.agent.tools.registry import ToolRegistry
 from raven.agent.tools.shell import ExecTool
@@ -601,9 +601,18 @@ class AgentLoop:
         # Deep research (MiroThinker) is opt-in: a paid, minute-scale HTTP engine
         # registered only when a key is configured, so an unconfigured deploy
         # never exposes a tool that errors on first call.
+        self.deep_research_manager: DeepResearchManager | None = None
         if DeepResearchTool.is_configured(self.deep_research_config):
+            self.deep_research_manager = DeepResearchManager(
+                self.deep_research_config, workspace=self.workspace, proxy=self.web_proxy
+            )
             self.tools.register(
-                DeepResearchTool(self.deep_research_config, workspace=self.workspace, proxy=self.web_proxy)
+                DeepResearchTool(
+                    self.deep_research_config,
+                    workspace=self.workspace,
+                    proxy=self.web_proxy,
+                    manager=self.deep_research_manager,
+                )
             )
         self.tools.register(MessageTool())
         self.tools.register(SpawnTool(manager=self.subagents))
@@ -1121,13 +1130,13 @@ class AgentLoop:
         self, channel: str, chat_id: str, message_id: str | None = None, session_key: str | None = None
     ) -> None:
         """Update context for all tools that need routing info."""
-        for name in ("message", "spawn", "cron"):
+        for name in ("message", "spawn", "cron", "deep_research"):
             if tool := self.tools.get(name):
                 if not hasattr(tool, "set_context"):
                     continue
                 if name == "message":
                     tool.set_context(channel, chat_id, message_id)
-                elif name == "spawn":
+                elif name in ("spawn", "deep_research"):
                     tool.set_context(channel, chat_id, session_key or f"{channel}:{chat_id}")
                 else:
                     tool.set_context(channel, chat_id)
@@ -2212,6 +2221,25 @@ class AgentLoop:
         from raven.spine.runner import TurnOutcome
 
         cid = req.conversation or f"{req.source.channel}:{req.source.chat_id}"
+
+        # Verbatim delivery (deliver_text — see TurnRequest). Persist before
+        # emit, mirroring the normal turn's save-then-reply order, so a save
+        # failure never leaves the user a delivered message no turn recorded.
+        # The after-turn work a normal turn does in _process_message is reduced
+        # to what a no-model delivery needs: backend.store indexes the report;
+        # after_turn is a no-op without a turn_id; consolidation is the curator's
+        # job on its next assemble.
+        if req.deliver_text is not None:
+            session = self.sessions.get_or_create(cid)
+            msg = {"role": "assistant", "content": req.deliver_text}
+            self._save_turn(session, [msg], 0)
+            self.sessions.save(session)
+            await self._dispatch_backend_store(cid, [msg])
+            await emit(Text(content=req.deliver_text))
+            return TurnOutcome(
+                usage=Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+                explicit_reply=True,
+            )
 
         streamed = False
 

--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -23,6 +23,7 @@ from raven.agent.loop.recovery import (
 )
 from raven.agent.subagent import SubagentManager
 from raven.agent.tools.ask_user import AskUserTool
+from raven.agent.tools.deep_research import DeepResearchManager, DeepResearchTool
 from raven.agent.tools.file_search import FindTool, GrepTool
 from raven.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from raven.agent.tools.media_gen import (
@@ -30,7 +31,6 @@ from raven.agent.tools.media_gen import (
     SpeechGenerateTool,
     VideoGenerateTool,
 )
-from raven.agent.tools.deep_research import DeepResearchManager, DeepResearchTool
 from raven.agent.tools.message import MessageTool
 from raven.agent.tools.registry import ToolRegistry
 from raven.agent.tools.shell import ExecTool

--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -30,6 +30,7 @@ from raven.agent.tools.media_gen import (
     SpeechGenerateTool,
     VideoGenerateTool,
 )
+from raven.agent.tools.deep_research import DeepResearchTool
 from raven.agent.tools.message import MessageTool
 from raven.agent.tools.registry import ToolRegistry
 from raven.agent.tools.shell import ExecTool
@@ -260,6 +261,7 @@ class AgentLoop:
         max_concurrent_subagents: int = 4,
         max_subagent_spawns_per_hour: int = 30,
         media_config: Any = None,
+        deep_research_config: Any = None,
         disabled_tools: list[str] | None = None,
         tool_search_config: Any = None,
         # AG-1: optional plugin-provided MemoryBackend. When supplied,
@@ -319,9 +321,10 @@ class AgentLoop:
         self.brave_api_key = brave_api_key
         self.jina_api_key = jina_api_key
         self.web_proxy = web_proxy
-        from raven.config.schema import MediaGenConfig
+        from raven.config.schema import DeepResearchToolConfig, MediaGenConfig
 
         self.media_config = media_config or MediaGenConfig()
+        self.deep_research_config = deep_research_config or DeepResearchToolConfig()
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
@@ -595,6 +598,13 @@ class AgentLoop:
                         output_subdir=media.output_subdir,
                     )
                 )
+        # Deep research (MiroThinker) is opt-in: a paid, minute-scale HTTP engine
+        # registered only when a key is configured, so an unconfigured deploy
+        # never exposes a tool that errors on first call.
+        if DeepResearchTool.is_configured(self.deep_research_config):
+            self.tools.register(
+                DeepResearchTool(self.deep_research_config, workspace=self.workspace, proxy=self.web_proxy)
+            )
         self.tools.register(MessageTool())
         self.tools.register(SpawnTool(manager=self.subagents))
         # The QuestionBroker is a per-transport singleton, late-bound via
@@ -2149,6 +2159,7 @@ class AgentLoop:
         drain: Drain,
         *,
         stream: bool = True,
+        inline_tool_stream: bool = False,
         usage_sink: dict[str, Any] | None = None,
         text_sink: dict[str, Any] | None = None,
     ) -> TurnOutcome:
@@ -2277,6 +2288,27 @@ class AgentLoop:
                     await emit(Text(content=content))
 
             message_tool.set_send_callback(_route_to_stream)
+
+        # deep_research (streaming surfaces only): stream its progress live and
+        # deliver its finished answer inline, so the tool returns a compact
+        # receipt and the model relays instead of re-emitting/rewriting. Progress
+        # rides Reasoning (TUI thinking.delta / CLI progress line); the answer
+        # follows the same stream switch as the main reply.
+        if inline_tool_stream:
+            dr_tool = self.tools.get("deep_research")
+            if dr_tool is not None and hasattr(dr_tool, "set_stream_callback"):
+
+                async def _route_deep_research(kind: str, text: str) -> None:
+                    if not text:
+                        return
+                    if kind == "progress":
+                        await emit(Reasoning(content=text))
+                    elif stream:
+                        await on_token(text)
+                    else:
+                        await emit(Text(content=text))
+
+                dr_tool.set_stream_callback(_route_deep_research)
 
         # A CRON turn must not let the agent schedule new cron jobs mid-run. The
         # CronTool guards via a ContextVar; set it here, in the lane task that runs

--- a/raven/agent/spine_runner.py
+++ b/raven/agent/spine_runner.py
@@ -5,6 +5,10 @@ spine never imports the agent.
 ``stream`` is the canon Q2-D assembly switch: a streaming outlet (TUI) passes
 True so the reply streams as StreamDelta and dissolves; a non-streaming outlet
 (REPL) passes False so the reply is one Text.
+
+``inline_tool_stream`` lets a long tool (deep_research) stream its output inline
+and return a compact receipt; on for local interactive surfaces (CLI/TUI), off
+for channels/gateway (they wait for async delivery).
 """
 
 from __future__ import annotations
@@ -18,9 +22,12 @@ if TYPE_CHECKING:
 
 
 class AgentTurnRunner:
-    def __init__(self, agent_loop: AgentLoop, *, stream: bool) -> None:
+    def __init__(self, agent_loop: AgentLoop, *, stream: bool, inline_tool_stream: bool = False) -> None:
         self._loop = agent_loop
         self._stream = stream
+        self._inline_tool_stream = inline_tool_stream
 
     async def run(self, req: TurnRequest, emit: Emit, drain: Drain) -> TurnOutcome:
-        return await self._loop.run_turn(req, emit, drain, stream=self._stream)
+        return await self._loop.run_turn(
+            req, emit, drain, stream=self._stream, inline_tool_stream=self._inline_tool_stream
+        )

--- a/raven/agent/tools/deep_research.py
+++ b/raven/agent/tools/deep_research.py
@@ -39,6 +39,7 @@ class _Routing:
     chat_id: str
     conversation: str
 
+
 # Coarse progress shown while the engine works, keyed by the reasoning-step type
 # the stream reports. One line per step-type change (not per token) keeps it
 # readable on both a terminal and the TUI.
@@ -167,9 +168,7 @@ class DeepResearchTool(Tool):
                 ) as r:
                     if r.status_code != 200:
                         await r.aread()
-                        return self._result(
-                            "error", content=f"deep_research HTTP {r.status_code}: {_error_message(r)}"
-                        )
+                        return self._result("error", content=f"deep_research HTTP {r.status_code}: {_error_message(r)}")
                     content, finish, usage = await self._consume(r, cb)
         except httpx.TimeoutException as e:
             detail = str(e) or "the research engine went quiet"
@@ -388,7 +387,9 @@ class DeepResearchManager:
                 # must not lose the answer we already have, so log, don't raise.
                 try:
                     logger.info(
-                        "deep_research [{}] report saved: {}", resp_id, _write_report_file(self._workspace, answer, query)
+                        "deep_research [{}] report saved: {}",
+                        resp_id,
+                        _write_report_file(self._workspace, answer, query),
                     )
                 except Exception as e:
                     logger.error("deep_research [{}] report save failed: {}", resp_id, e)

--- a/raven/agent/tools/deep_research.py
+++ b/raven/agent/tools/deep_research.py
@@ -1,11 +1,20 @@
-"""Deep research tool: delegate a question to the MiroThinker API over SSE."""
+"""Deep research tool: delegate a question to the MiroThinker API.
 
+Two transports share one tool. Local interactive surfaces (CLI/TUI) stream the
+answer inline over ``/chat/completions`` SSE. Channels (weixin, ...) run it
+async: the tool hands the query to :class:`DeepResearchManager`, which
+submits it to the ``/v1/responses`` background endpoint, polls, and delivers the
+finished answer back to the conversation verbatim via a ``deliver_text`` turn.
+"""
+
+import asyncio
 import datetime
 import json
 import os
 import uuid
 from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +28,16 @@ DEFAULT_BASE_URL = "https://api.miromind.ai/v1"
 DEFAULT_MODEL = "mirothinker-1-7-deepresearch-mini"
 # Hardcoded (not a config field), like the skill-hub cache / checkpoint subdirs.
 _OUTPUT_SUBDIR = "deep_research"
+
+
+@dataclass(frozen=True)
+class _Routing:
+    """Per-turn delivery target. Frozen and stored in a ContextVar so a
+    concurrent turn cannot clobber this turn's routing (the tool is shared)."""
+
+    channel: str
+    chat_id: str
+    conversation: str
 
 # Coarse progress shown while the engine works, keyed by the reasoning-step type
 # the stream reports. One line per step-type change (not per token) keeps it
@@ -75,13 +94,24 @@ class DeepResearchTool(Tool):
     # so a gap this long means the stream is dead. Well under timeout_seconds.
     _READ_TIMEOUT_S = 180.0
 
-    def __init__(self, config: DeepResearchToolConfig, workspace: Path, proxy: str | None = None):
+    def __init__(
+        self,
+        config: DeepResearchToolConfig,
+        workspace: Path,
+        proxy: str | None = None,
+        manager: "DeepResearchManager | None" = None,
+    ):
         self._config = config
         self._workspace = Path(workspace)
         self._proxy = proxy
+        # Background manager for the async (channel) transport; None on local
+        # surfaces. Even when present it only routes async once its submit handle
+        # is wired (gateway-only) — see ``DeepResearchManager.can_deliver``.
+        self._manager = manager
         # Turn-local so a user turn and a concurrent proactive turn cannot clobber
         # each other's routing (same reason MessageTool keeps its callback here).
         self._stream_cb: ContextVar[StreamCallback | None] = ContextVar("deep_research_stream_cb", default=None)
+        self._routing: ContextVar[_Routing | None] = ContextVar("deep_research_routing", default=None)
 
     @staticmethod
     def is_configured(config: DeepResearchToolConfig) -> bool:
@@ -92,6 +122,11 @@ class DeepResearchTool(Tool):
         """Wire the per-turn stream callback (turn-local). Set only on surfaces
         that render the answer inline (CLI/TUI); left unset elsewhere."""
         self._stream_cb.set(cb)
+
+    def set_context(self, channel: str, chat_id: str, session_key: str) -> None:
+        """Set the per-turn delivery routing (turn-local), so the async transport
+        knows which conversation to push the finished answer back to."""
+        self._routing.set(_Routing(channel=channel, chat_id=chat_id, conversation=session_key))
 
     def _api_key(self) -> str:
         return self._config.api_key or os.environ.get("MIROTHINKER_API_KEY", "")
@@ -108,6 +143,13 @@ class DeepResearchTool(Tool):
             )
 
         cb = self._stream_cb.get()
+        # Async (channel) transport: no inline stream callback but a wired
+        # manager (gateway-only). Hand off to the background poller, which later
+        # delivers the finished answer verbatim via a deliver_text turn.
+        if cb is None and self._manager is not None and self._manager.can_deliver():
+            if (routing := self._routing.get()) is not None:
+                return await self._manager.start(query, routing)
+
         base = (self._config.api_base or DEFAULT_BASE_URL).rstrip("/")
         model = self._config.model or DEFAULT_MODEL
         payload = {"model": model, "messages": [{"role": "user", "content": query}], "stream": True}
@@ -189,12 +231,7 @@ class DeepResearchTool(Tool):
         return "".join(parts), finish, usage
 
     def _write_report(self, content: str, query: str) -> str:
-        out_dir = self._workspace / _OUTPUT_SUBDIR
-        out_dir.mkdir(parents=True, exist_ok=True)
-        stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-        path = out_dir / f"deep_research-{stamp}-{uuid.uuid4().hex[:8]}.md"
-        path.write_text(f"# {query}\n\n{content}\n", encoding="utf-8")
-        return str(path)
+        return _write_report_file(self._workspace, content, query)
 
     @staticmethod
     def _result(
@@ -232,3 +269,188 @@ def _error_message(response: httpx.Response) -> str:
         return (response.json().get("error") or {}).get("message") or response.text[:200]
     except Exception:
         return response.text[:200]
+
+
+def _write_report_file(workspace: Path, content: str, query: str) -> str:
+    out_dir = Path(workspace) / _OUTPUT_SUBDIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    path = out_dir / f"deep_research-{stamp}-{uuid.uuid4().hex[:8]}.md"
+    path.write_text(f"# {query}\n\n{content}\n", encoding="utf-8")
+    return str(path)
+
+
+def _extract_output_text(body: dict[str, Any]) -> str:
+    """Pull the answer from a completed Responses payload: concatenate the
+    ``output_text`` parts of the ``message`` items. Research runs carry tool
+    calls too, so ``output`` can hold several items — never assume index 0."""
+    parts: list[str] = []
+    for item in body.get("output") or []:
+        if item.get("type") != "message":
+            continue
+        for c in item.get("content") or []:
+            if c.get("type") == "output_text" and c.get("text"):
+                parts.append(c["text"])
+    return "".join(parts)
+
+
+class DeepResearchManager:
+    """Runs a deep-research query in the background and delivers the finished
+    answer back to its conversation verbatim.
+
+    Mirrors :class:`SubagentManager`'s shape — a fire-and-forget asyncio task per
+    query, an in-flight guard (one research per conversation), and a late-bound
+    submit handle (wired gateway-only) used to re-enter the spine. Unlike
+    SubagentManager it does NOT re-inject a model turn: the answer is delivered
+    as-is through a ``deliver_text`` turn, so the model cannot rewrite it.
+    """
+
+    _POLL_INTERVAL_S = 5.0
+    # Overall ceiling for one background research, matching the flagship's
+    # observed worst case with headroom; the poll loop gives up past this.
+    _MAX_POLL_S = 3600.0
+
+    def __init__(self, config: DeepResearchToolConfig, workspace: Path, proxy: str | None = None):
+        self._config = config
+        self._workspace = Path(workspace)
+        self._proxy = proxy
+        # Late-bound (gateway wires it after building the scheduler). Until then
+        # can_deliver() is False and the tool falls back to a synchronous path.
+        self._submit: Callable[[Any], Any] | None = None
+        # In-flight guard: conversation -> poll task. One research per
+        # conversation; released by the task's done-callback (fires on success,
+        # error, OR cancellation), so a crash can never wedge the guard.
+        self._active: dict[str, asyncio.Task[None]] = {}
+
+    def set_submit(self, submit: Callable[[Any], Any]) -> None:
+        self._submit = submit
+
+    def can_deliver(self) -> bool:
+        """Whether async delivery is wired (gateway only). The tool checks this
+        to decide between the async transport and the synchronous fallback."""
+        return self._submit is not None
+
+    async def start(self, query: str, routing: _Routing) -> str:
+        """Submit the research, spawn the background poller, return an ack the
+        model relays. Refuses if the conversation already has one running; on a
+        submit failure returns an error receipt and starts nothing."""
+        if (existing := self._active.get(routing.conversation)) is not None and not existing.done():
+            return json.dumps(
+                {
+                    "status": "busy",
+                    "note": (
+                        "A deep research is already running for this conversation. Tell the user to "
+                        "wait for it to finish before starting another; do not start a second one."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+        try:
+            resp_id = await self._submit_research(query)
+        except Exception as e:
+            logger.error("deep_research async submit failed: {}", e)
+            return json.dumps(
+                {"status": "error", "note": f"deep_research could not start: {e}. Tell the user it failed to start."},
+                ensure_ascii=False,
+            )
+
+        task = asyncio.create_task(self._run(resp_id, query, routing))
+        self._active[routing.conversation] = task
+        task.add_done_callback(lambda _: self._active.pop(routing.conversation, None))
+        logger.info("deep_research async started [{}] for {}", resp_id, routing.conversation)
+        return json.dumps(
+            {
+                "status": "started",
+                "note": (
+                    "Deep research has started in the background. Tell the user it is underway and the "
+                    "result will arrive on its own when ready. Do NOT attempt the research yourself and "
+                    "do NOT call deep_research again for this."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    async def _run(self, resp_id: str, query: str, routing: _Routing) -> None:
+        """Poll to completion, then deliver the answer verbatim. Any failure
+        becomes an error delivery; the guard is released by the done-callback
+        regardless, and submit errors here are logged, never propagated."""
+        try:
+            answer = await self._poll(resp_id)
+        except asyncio.CancelledError:
+            raise  # teardown (e.g. session cancel) — no delivery; guard freed by callback
+        except Exception as e:
+            logger.error("deep_research [{}] failed: {}", resp_id, e)
+            text = f"Deep research failed: {e}"
+        else:
+            text = answer or "Deep research finished but returned no content."
+            if answer:
+                # Saving the report is best-effort: a write failure (disk/perms)
+                # must not lose the answer we already have, so log, don't raise.
+                try:
+                    logger.info(
+                        "deep_research [{}] report saved: {}", resp_id, _write_report_file(self._workspace, answer, query)
+                    )
+                except Exception as e:
+                    logger.error("deep_research [{}] report save failed: {}", resp_id, e)
+        try:
+            self._deliver(routing, text)
+        except Exception as e:
+            logger.error("deep_research [{}] delivery failed: {}", resp_id, e)
+
+    def _deliver(self, routing: _Routing, text: str) -> None:
+        from raven.spine import ChatType, Origin, Source, TurnRequest
+
+        # _submit is guaranteed set: _deliver is only reached from a task that
+        # start() spawned, and start() runs only when can_deliver() was true.
+        self._submit(
+            TurnRequest(
+                origin=Origin.SUBAGENT,
+                source=Source(
+                    channel=routing.channel,
+                    chat_id=routing.chat_id,
+                    sender_id="deep_research",
+                    chat_type=ChatType.DM,
+                ),
+                text="",
+                conversation=routing.conversation,
+                deliver_text=text,
+            )
+        )
+
+    def _headers(self) -> dict[str, str]:
+        key = self._config.api_key or os.environ.get("MIROTHINKER_API_KEY", "")
+        return {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
+
+    def _base(self) -> str:
+        return (self._config.api_base or DEFAULT_BASE_URL).rstrip("/")
+
+    async def _submit_research(self, query: str) -> str:
+        model = self._config.model or DEFAULT_MODEL
+        async with httpx.AsyncClient(timeout=httpx.Timeout(60.0, connect=10.0), proxy=self._proxy) as client:
+            r = await client.post(
+                f"{self._base()}/responses",
+                headers=self._headers(),
+                json={"model": model, "input": query, "background": True, "stream": False},
+            )
+            if r.status_code not in (200, 202):
+                raise RuntimeError(f"HTTP {r.status_code}: {_error_message(r)}")
+            resp_id = r.json().get("id")
+            if not resp_id:
+                raise RuntimeError("no response id returned")
+            return resp_id
+
+    async def _poll(self, resp_id: str) -> str:
+        waited = 0.0
+        async with httpx.AsyncClient(timeout=httpx.Timeout(60.0, connect=10.0), proxy=self._proxy) as client:
+            while waited < self._MAX_POLL_S:
+                r = await client.get(f"{self._base()}/responses/{resp_id}", headers=self._headers())
+                r.raise_for_status()
+                body = r.json()
+                status = body.get("status")
+                if status == "completed":
+                    return _extract_output_text(body)
+                if status in ("failed", "cancelled"):
+                    raise RuntimeError(f"research {status}")
+                await asyncio.sleep(self._POLL_INTERVAL_S)
+                waited += self._POLL_INTERVAL_S
+        raise RuntimeError("research timed out")

--- a/raven/agent/tools/deep_research.py
+++ b/raven/agent/tools/deep_research.py
@@ -1,0 +1,234 @@
+"""Deep research tool: delegate a question to the MiroThinker API over SSE."""
+
+import datetime
+import json
+import os
+import uuid
+from collections.abc import Awaitable, Callable
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from raven.agent.tools.base import Tool
+from raven.config.schema import DeepResearchToolConfig
+
+DEFAULT_BASE_URL = "https://api.miromind.ai/v1"
+DEFAULT_MODEL = "mirothinker-1-7-deepresearch-mini"
+# Hardcoded (not a config field), like the skill-hub cache / checkpoint subdirs.
+_OUTPUT_SUBDIR = "deep_research"
+
+# Coarse progress shown while the engine works, keyed by the reasoning-step type
+# the stream reports. One line per step-type change (not per token) keeps it
+# readable on both a terminal and the TUI.
+_PROGRESS_LABELS = {
+    "thinking": "thinking...",
+    "web_search": "searching the web...",
+    "fetch_url_content": "reading a page...",
+    "execute_python": "running analysis...",
+    "execute_command": "running a command...",
+}
+
+# The callback signature the loop wires per-turn on streaming surfaces:
+# ``cb("progress", line)`` while researching, ``cb("answer", content)`` once done.
+StreamCallback = Callable[[str, str], Awaitable[None]]
+
+
+class DeepResearchTool(Tool):
+    """Delegate a research question to MiroThinker and return its finished answer.
+
+    The API is OpenAI-compatible but the answer is minute-scale; it is consumed
+    over SSE (``stream: true``) so the connection keeps flowing and is not
+    dropped as idle. On a streaming surface (CLI/TUI) the loop wires a callback
+    via ``set_stream_callback``: progress streams live and the finished answer is
+    delivered to the user directly, so the tool returns only a compact receipt
+    and the main model does not re-emit (and thus cannot rewrite) the answer.
+    Without a callback (e.g. a channel) it returns the full structured result.
+    """
+
+    name = "deep_research"
+    description = (
+        "Delegate a question that needs broad web search and multi-source "
+        "cross-checking to an external deep-research engine (MiroThinker). "
+        "Blocks for minutes. Returns a FINISHED, self-contained answer with its "
+        "own inline citations and a References section. Relay it to the user "
+        "as-is; do NOT rewrite, re-summarize, or run extra web_search after it "
+        "(that wastes tokens and can corrupt its citations). If it reports a "
+        "non-ok status, re-run with a sharper query or report the failure. Use "
+        "for open-ended research; for a single quick lookup use web_search."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "The research question"},
+        },
+        "required": ["query"],
+    }
+
+    # Registry ceiling: raise well above the default so a legitimate minute-scale
+    # run isn't timer-killed. The inner httpx read timeout (below) stays under
+    # this so the tool, not the ceiling, owns the timeout path.
+    timeout_seconds = 900.0
+    # Idle read timeout between SSE chunks: research streams chunks continuously,
+    # so a gap this long means the stream is dead. Well under timeout_seconds.
+    _READ_TIMEOUT_S = 180.0
+
+    def __init__(self, config: DeepResearchToolConfig, workspace: Path, proxy: str | None = None):
+        self._config = config
+        self._workspace = Path(workspace)
+        self._proxy = proxy
+        # Turn-local so a user turn and a concurrent proactive turn cannot clobber
+        # each other's routing (same reason MessageTool keeps its callback here).
+        self._stream_cb: ContextVar[StreamCallback | None] = ContextVar("deep_research_stream_cb", default=None)
+
+    @staticmethod
+    def is_configured(config: DeepResearchToolConfig) -> bool:
+        """Whether a key is reachable, so the loop can register the tool opt-in."""
+        return bool(config.api_key or os.environ.get("MIROTHINKER_API_KEY"))
+
+    def set_stream_callback(self, cb: StreamCallback | None) -> None:
+        """Wire the per-turn stream callback (turn-local). Set only on surfaces
+        that render the answer inline (CLI/TUI); left unset elsewhere."""
+        self._stream_cb.set(cb)
+
+    def _api_key(self) -> str:
+        return self._config.api_key or os.environ.get("MIROTHINKER_API_KEY", "")
+
+    async def execute(self, query: str, **kwargs: Any) -> str:
+        key = self._api_key()
+        if not key:
+            return self._result(
+                "error",
+                content=(
+                    "deep_research: no API key configured. Set it under "
+                    "tools.deep_research.apiKey or export MIROTHINKER_API_KEY."
+                ),
+            )
+
+        cb = self._stream_cb.get()
+        base = (self._config.api_base or DEFAULT_BASE_URL).rstrip("/")
+        model = self._config.model or DEFAULT_MODEL
+        payload = {"model": model, "messages": [{"role": "user", "content": query}], "stream": True}
+
+        try:
+            logger.debug("deep_research: {} via {}", model, "proxy" if self._proxy else "direct")
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(self._READ_TIMEOUT_S, connect=10.0), proxy=self._proxy
+            ) as client:
+                async with client.stream(
+                    "POST",
+                    f"{base}/chat/completions",
+                    headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+                    json=payload,
+                ) as r:
+                    if r.status_code != 200:
+                        await r.aread()
+                        return self._result(
+                            "error", content=f"deep_research HTTP {r.status_code}: {_error_message(r)}"
+                        )
+                    content, finish, usage = await self._consume(r, cb)
+        except httpx.TimeoutException as e:
+            detail = str(e) or "the research engine went quiet"
+            return self._result("timeout", content=f"deep_research timed out: {detail}")
+        except Exception as e:
+            logger.error("deep_research error: {}", e)
+            return self._result("error", content=f"deep_research error: {e}")
+
+        status = {"stop": "ok", "cancelled": "timeout"}.get(finish, "error")
+        report_ref = self._write_report(content, query) if content else None
+        # Streaming surface: deliver the finished answer to the user directly and
+        # hand the model a compact receipt, so it relays (a short ack) instead of
+        # re-emitting the whole answer. Errors stay on the plain path (they are
+        # short, and letting the model relay them is fine).
+        if cb is not None and status == "ok" and content:
+            await cb("answer", content)
+            return self._receipt(status, report_ref)
+        return self._result(status, content=content or "(empty response)", report_ref=report_ref, usage=usage)
+
+    @staticmethod
+    async def _consume(
+        response: httpx.Response, cb: StreamCallback | None
+    ) -> tuple[str, str | None, dict[str, Any] | None]:
+        """Accumulate delta.content; grab finish_reason/usage from the tail; emit a
+        coarse progress line whenever the reasoning-step type changes (if wired)."""
+        parts: list[str] = []
+        finish: str | None = None
+        usage: dict[str, Any] | None = None
+        last_step: str | None = None
+        async for line in response.aiter_lines():
+            if not line.startswith("data:"):
+                continue
+            data = line[len("data:") :].strip()
+            if not data or data == "[DONE]":
+                continue
+            try:
+                chunk = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            choice = (chunk.get("choices") or [{}])[0]
+            delta = choice.get("delta") or {}
+            if delta.get("content"):
+                parts.append(delta["content"])
+            if cb is not None:
+                for step in delta.get("reasoning_steps") or []:
+                    kind = step.get("type")
+                    # Skip "thinking" (the between-action default) and de-dup
+                    # consecutive same-action steps, so progress shows a few
+                    # meaningful milestones (search/fetch/exec) instead of the
+                    # thinking<->action churn flooding the terminal.
+                    if not kind or kind == "thinking" or kind == last_step:
+                        continue
+                    last_step = kind
+                    await cb("progress", _PROGRESS_LABELS.get(kind, kind))
+            if choice.get("finish_reason"):
+                finish = choice["finish_reason"]
+            if chunk.get("usage"):
+                usage = chunk["usage"]
+        return "".join(parts), finish, usage
+
+    def _write_report(self, content: str, query: str) -> str:
+        out_dir = self._workspace / _OUTPUT_SUBDIR
+        out_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        path = out_dir / f"deep_research-{stamp}-{uuid.uuid4().hex[:8]}.md"
+        path.write_text(f"# {query}\n\n{content}\n", encoding="utf-8")
+        return str(path)
+
+    @staticmethod
+    def _result(
+        status: str,
+        *,
+        content: str,
+        report_ref: str | None = None,
+        usage: dict[str, Any] | None = None,
+    ) -> str:
+        return json.dumps(
+            {"status": status, "content": content, "report_ref": report_ref, "usage": usage},
+            ensure_ascii=False,
+        )
+
+    @staticmethod
+    def _receipt(status: str, report_ref: str | None) -> str:
+        return json.dumps(
+            {
+                "status": status,
+                "report_ref": report_ref,
+                "delivered": True,
+                "note": (
+                    "The full answer, with its citations, is ALREADY shown to the user. "
+                    "Reply with at most a one-line acknowledgement. Do NOT restate it, and do "
+                    "NOT add any facts, figures, or your own summary -- your numbers may "
+                    "contradict the researched answer. If it looks off-target, say so and offer to re-run."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+
+def _error_message(response: httpx.Response) -> str:
+    try:
+        return (response.json().get("error") or {}).get("message") or response.text[:200]
+    except Exception:
+        return response.text[:200]

--- a/raven/cli/_repl_spine.py
+++ b/raven/cli/_repl_spine.py
@@ -24,17 +24,20 @@ from raven.spine import (
     TurnRequest,
 )
 from raven.spine.delivery import Capabilities, DeliveryHub, make_hub_sink
+from raven.spine.events import Reasoning
 
 
 class CliOutlet:
     """Renders a turn's deliverables to the terminal. Runs non-streaming (run_turn
     stream=False), so the reply arrives as one Text; ToolEvent/MediaOut are eaten.
 
-    ``render_notice`` is opt-in progress rendering for the one-shot ``-m`` path:
-    when set, a Notice renders as a progress line, gated by the same two config
-    flags the bus path honored — PROGRESS by ``send_progress``, TOOL_HINT by
-    ``send_tool_hints``. The interactive REPL leaves it None (it never showed
-    progress, so eating Notice is status quo, not a regression).
+    ``render_notice`` is opt-in progress rendering: when set, a Notice (and the
+    Reasoning a long tool like deep_research streams, see ``deliver``) renders as
+    a progress line, gated by ``send_progress`` (PROGRESS) and ``send_tool_hints``
+    (TOOL_HINT). Both the one-shot ``-m`` path and the interactive REPL wire it so
+    deep_research progress is visible; note this also surfaces the model's
+    per-tool progress hint on every tool call, gated by the same flags. A surface
+    that omits it eats Notice / Reasoning as before.
 
     ``render_marker`` is opt-in: a Text whose ``source.extras._sentinel_origin``
     is set renders this proactive marker before its content (the interactive
@@ -69,6 +72,11 @@ class CliOutlet:
                 self._render_notice(out.detail or "")
             elif out.kind is NoticeKind.TOOL_HINT and self._send_tool_hints:
                 self._render_notice(out.detail or "")
+        elif isinstance(out, Reasoning):
+            # A long tool (deep_research) streams coarse progress as Reasoning; the
+            # model itself never emits Reasoning here (REPL runs non-streaming).
+            if self._render_notice is not None and self._send_progress and out.content:
+                self._render_notice(out.content)
         # Other Notice kinds / ToolEvent / MediaOut are eaten (render-can't path).
 
 
@@ -104,7 +112,7 @@ def build_repl(
         )
     )
     scheduler = Scheduler(
-        AgentTurnRunner(agent_loop, stream=False),
+        AgentTurnRunner(agent_loop, stream=False, inline_tool_stream=True),
         OriginPools(user=user_pool, system=system_pool),
         make_hub_sink(hub),
     )

--- a/raven/cli/agent_commands.py
+++ b/raven/cli/agent_commands.py
@@ -337,6 +337,7 @@ def register(app: typer.Typer) -> None:
             jina_api_key=config.tools.web.jina_api_key or None,
             web_proxy=config.tools.web.proxy or None,
             media_config=config.effective_media_config(),
+            deep_research_config=config.tools.deep_research,
             exec_config=config.tools.exec,
             cron_service=cron,
             restrict_to_workspace=config.tools.restrict_to_workspace,
@@ -520,11 +521,15 @@ def register(app: typer.Typer) -> None:
                     console.print()
                     console.print("[bold magenta]🐦‍⬛ [主动][/bold magenta]")
 
+                _ch = agent_loop.channels_config
                 scheduler, hub, teardown = build_repl(
                     agent_loop,
                     cli_channel,
                     lambda t: _print_agent_response(t, render_markdown=markdown),
+                    render_notice=lambda c: console.print(f"  [dim]↳ {c}[/dim]"),
                     render_marker=_render_nudge_marker,
+                    send_progress=bool(_ch.send_progress) if _ch else False,
+                    send_tool_hints=bool(_ch.send_tool_hints) if _ch else False,
                 )
                 # Subagent result re-injection submits a SUBAGENT-origin turn.
                 agent_loop.subagents.set_submit(scheduler.submit)

--- a/raven/cli/commands.py
+++ b/raven/cli/commands.py
@@ -129,6 +129,7 @@ upgrade_commands.register(app)
 
 from raven.cli.channel_commands import channels_app
 from raven.cli.cron_commands import cron_app
+from raven.cli.deep_research_commands import deep_research_app
 from raven.cli.provider_commands import provider_app
 from raven.cli.sandbox_commands import sandbox_app
 from raven.cli.sentinel_commands import sentinel_app
@@ -136,6 +137,7 @@ from raven.cli.skill_commands import skill_app
 
 app.add_typer(channels_app, name="channels")
 app.add_typer(cron_app, name="cron")
+app.add_typer(deep_research_app, name="deep-research")
 app.add_typer(provider_app, name="provider")
 app.add_typer(sandbox_app, name="sandbox")
 app.add_typer(sentinel_app, name="sentinel")

--- a/raven/cli/commands.py
+++ b/raven/cli/commands.py
@@ -164,9 +164,18 @@ def run() -> None:
     so in-process test hosts keep normal exit semantics.
     """
     from raven.cli._exit import flush_and_hard_exit, lancedb_finalization_hazard
+    from raven.config.loader import ConfigReadError
 
     try:
         app()
+    except ConfigReadError as exc:
+        # A config-write command (channels/provider/deep-research/onboard) hit an
+        # unparseable config. The write layer already refused (file untouched);
+        # surface it cleanly here, once, for every command instead of a traceback.
+        from rich.console import Console
+
+        Console(stderr=True).print(f"[red]✗[/red] {exc}")
+        raise SystemExit(1) from exc
     except SystemExit as exc:
         code = exc.code
         if not isinstance(code, int):

--- a/raven/cli/deep_research_commands.py
+++ b/raven/cli/deep_research_commands.py
@@ -77,9 +77,7 @@ def _pick_model(questionary: Any, style: Any, qmark: str, t: Any) -> str:
             value=_FLAGSHIP_MODEL,
         ),
     ]
-    picked = questionary.select(
-        t("Select a model:", "选择 model:"), choices=choices, style=style, qmark=qmark
-    ).ask()
+    picked = questionary.select(t("Select a model:", "选择 model:"), choices=choices, style=style, qmark=qmark).ask()
     if picked is None:
         raise typer.Exit(1)  # Ctrl+C
     return picked

--- a/raven/cli/deep_research_commands.py
+++ b/raven/cli/deep_research_commands.py
@@ -1,0 +1,240 @@
+"""``raven deep-research`` — configure the MiroThinker deep_research tool.
+
+Subcommands: ``enable`` / ``get`` / ``reset``. ``enable`` with flags writes
+directly (non-interactive); with no flags it runs the interactive wizard flow,
+which is shared verbatim with onboard's deep_research step.
+
+Config writes go through ``raven.config.update_tools`` only. Key validation is a
+free ``GET /v1/models`` (NOT a chat completion — MiroThinker's chat endpoint
+always runs a real, minute-scale, billed research, so a chat "ping" would both
+time out and cost money).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import typer
+
+from raven.agent.tools.deep_research import DEFAULT_MODEL
+from raven.config.update_tools import ConfigReadError, get_deep_research, reset_deep_research, set_deep_research
+
+SIGNUP_URL = "https://platform.miromind.ai/console/api-keys"
+
+_FLAGSHIP_MODEL = "mirothinker-1-7-deepresearch"
+
+deep_research_app = typer.Typer(help="Configure the deep_research tool (MiroThinker).", no_args_is_help=True)
+
+
+def _validate_key(api_key: str, api_base: str, *, transport: Any = None) -> dict[str, Any]:
+    """Free ``GET /v1/models`` key check. 200 = key valid; returns model ids.
+
+    Mirrors update_providers' models-test, including its ``/v1`` de-dup: the
+    MiroThinker default base already ends in ``/v1``, so appending ``/v1/models``
+    blindly would 404. ``transport`` is injectable for tests.
+    """
+    import httpx
+
+    from raven.agent.tools.deep_research import DEFAULT_BASE_URL
+
+    base = (api_base or DEFAULT_BASE_URL).rstrip("/")
+    url = base + "/models"
+    if "/v1" not in base:
+        url = base + "/v1/models"
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    kwargs: dict[str, Any] = {"timeout": 10}
+    if transport is not None:
+        kwargs["transport"] = transport
+    try:
+        with httpx.Client(**kwargs) as client:
+            resp = client.get(url, headers=headers)
+    except httpx.HTTPError as exc:
+        return {"ok": False, "status": "network_error", "model_ids": None, "error": str(exc)}
+    if resp.status_code != 200:
+        return {"ok": False, "status": f"http_{resp.status_code}", "model_ids": None, "error": resp.text[:200]}
+    ids: list[str] = []
+    try:
+        for item in resp.json().get("data") or []:
+            if isinstance(item, dict) and item.get("id"):
+                ids.append(item["id"])
+    except Exception:
+        pass
+    return {"ok": True, "status": "ok", "model_ids": ids, "error": None}
+
+
+def _pick_model(questionary: Any, style: Any, qmark: str, t: Any) -> str:
+    # A short description aligned after each id. The shared 256k/16k window is
+    # left out -- it is identical for both, so it is noise here and only bloats
+    # the label (which questionary truncates rather than wraps).
+    width = max(len(DEFAULT_MODEL), len(_FLAGSHIP_MODEL))
+    choices = [
+        questionary.Choice(
+            f"{DEFAULT_MODEL.ljust(width)}   {t('faster, lower cost', '更快、更省')} ({t('recommended', '推荐')})",
+            value=DEFAULT_MODEL,
+        ),
+        questionary.Choice(
+            f"{_FLAGSHIP_MODEL.ljust(width)}   {t('deeper reasoning, broader tools', '更强推理、更广工具')}",
+            value=_FLAGSHIP_MODEL,
+        ),
+    ]
+    picked = questionary.select(
+        t("Select a model:", "选择 model:"), choices=choices, style=style, qmark=qmark
+    ).ask()
+    if picked is None:
+        raise typer.Exit(1)  # Ctrl+C
+    return picked
+
+
+def configure_deep_research(*, non_interactive: bool = False, warnings: Optional[list[str]] = None) -> bool:
+    """Interactive configure flow, shared by ``enable`` (no flags) and onboard.
+
+    Returns True when a key was configured this run (or kept), False when
+    skipped/cancelled. Non-interactive with no key to work from just records a
+    warning and skips (the caller handles flag-driven writes directly).
+    """
+    warnings = warnings if warnings is not None else []
+    from raven.cli._styles import RAVEN_STYLE
+    from raven.cli.onboard_commands import _QMARK, _prompt_api_key, _require_questionary, _t, console
+
+    if non_interactive:
+        warnings.append("deep_research: skipped (non-interactive; pass --key to configure)")
+        return False
+
+    try:
+        current = get_deep_research(redact=False)
+    except ConfigReadError as exc:
+        console.print(f"[red]✗[/red] {exc}")
+        raise typer.Exit(1) from exc
+    q = _require_questionary()
+
+    if current["api_key"]:
+        choice = q.select(
+            _t("deep_research is already configured.", "deep_research 已配置。"),
+            choices=[
+                q.Choice(_t("Keep current", "保持现有"), value="keep"),
+                q.Choice(_t("Reconfigure", "重新配置"), value="reconfigure"),
+            ],
+            style=RAVEN_STYLE,
+            qmark=_QMARK,
+        ).ask()
+        if choice is None:
+            raise typer.Exit(1)  # Ctrl+C
+        if choice == "keep":
+            return True
+    else:
+        choice = q.select(
+            _t("Enable deep_research (MiroThinker)?", "启用 deep_research(MiroThinker)?"),
+            choices=[
+                q.Choice(_t("Yes, configure it", "是,配置"), value="configure"),
+                q.Choice(_t("Skip for now", "暂时跳过"), value="skip"),
+            ],
+            style=RAVEN_STYLE,
+            qmark=_QMARK,
+        ).ask()
+        if choice is None:
+            raise typer.Exit(1)  # Ctrl+C
+        if choice == "skip":
+            return False
+
+    console.print(
+        _t(
+            f"Create an API key at [link={SIGNUP_URL}]{SIGNUP_URL}[/link], then paste it below.",
+            f"到 [link={SIGNUP_URL}]{SIGNUP_URL}[/link] 创建 API key,然后粘贴到下面。",
+        )
+    )
+
+    while True:
+        key = _prompt_api_key("deep_research")
+        res = _validate_key(key, current["api_base"])
+        if res["ok"]:
+            break
+        console.print(f"[yellow]⚠[/yellow] {_t('Key validation failed', 'Key 验证失败')}: {res['status']}")
+        action = q.select(
+            _t("What now?", "怎么办?"),
+            choices=[
+                q.Choice(_t("Re-enter key", "重新输入 key"), value="retry"),
+                q.Choice(_t("Save anyway", "仍然保存"), value="save"),
+                q.Choice(_t("Cancel", "取消"), value="cancel"),
+            ],
+            style=RAVEN_STYLE,
+            qmark=_QMARK,
+        ).ask()
+        if action is None:
+            raise typer.Exit(1)  # Ctrl+C
+        if action == "retry":
+            continue
+        if action == "save":
+            break
+        return False  # explicit cancel
+
+    model = _pick_model(q, RAVEN_STYLE, _QMARK, _t)
+    set_deep_research({"api_key": key, "model": model})
+    console.print(f"[green]✓[/green] {_t('deep_research configured', 'deep_research 已配置')}")
+    return True
+
+
+@deep_research_app.command("enable")
+def enable_cmd(
+    key: Optional[str] = typer.Option(None, "--key", help="MiroThinker API key."),
+    model: Optional[str] = typer.Option(None, "--model", help="Model id (defaults to the mini engine)."),
+    api_base: Optional[str] = typer.Option(None, "--api-base", help="Override the API base URL."),
+) -> None:
+    """Configure deep_research. No flags -> interactive wizard."""
+    from rich.console import Console
+
+    console = Console()
+
+    if key is None and model is None and api_base is None:
+        configure_deep_research(non_interactive=False)
+        return
+
+    fields: dict[str, Any] = {}
+    if key is not None:
+        fields["api_key"] = key
+    if api_base is not None:
+        fields["api_base"] = api_base
+    if model is not None:
+        fields["model"] = model
+    elif key is not None:
+        fields["model"] = DEFAULT_MODEL  # --key without --model: default to the mini engine
+
+    try:
+        set_deep_research(fields)
+    except ConfigReadError as exc:
+        console.print(f"[red]✗[/red] {exc}")
+        raise typer.Exit(1) from exc
+    console.print("[green]✓[/green] deep_research configured")
+    if fields.get("api_key"):
+        res = _validate_key(fields["api_key"], fields.get("api_base") or "")
+        if not res["ok"]:
+            console.print(f"[yellow]⚠[/yellow] key validation: {res['status']} (config saved anyway)")
+
+
+@deep_research_app.command("get")
+def get_cmd() -> None:
+    """Print the current deep_research config (key redacted)."""
+    from rich.console import Console
+
+    console = Console()
+    try:
+        cfg = get_deep_research(redact=True)
+    except ConfigReadError as exc:
+        console.print(f"[red]✗[/red] {exc}")
+        raise typer.Exit(1) from exc
+    console.print(f"api_key : {cfg['api_key']}")
+    console.print(f"api_base: {cfg['api_base'] or '(default)'}")
+    console.print(f"model   : {cfg['model'] or '(default: ' + DEFAULT_MODEL + ')'}")
+
+
+@deep_research_app.command("reset")
+def reset_cmd() -> None:
+    """Clear deep_research config (disables the tool: no key -> not registered)."""
+    from rich.console import Console
+
+    console = Console()
+    try:
+        reset_deep_research()
+    except ConfigReadError as exc:
+        console.print(f"[red]✗[/red] {exc}")
+        raise typer.Exit(1) from exc
+    console.print("[green]✓[/green] deep_research reset (key cleared; tool will not register)")

--- a/raven/cli/gateway_commands.py
+++ b/raven/cli/gateway_commands.py
@@ -217,6 +217,7 @@ def register(app: typer.Typer) -> None:
             jina_api_key=config.tools.web.jina_api_key or None,
             web_proxy=config.tools.web.proxy or None,
             media_config=config.effective_media_config(),
+            deep_research_config=config.tools.deep_research,
             exec_config=config.tools.exec,
             cron_service=cron,
             restrict_to_workspace=config.tools.restrict_to_workspace,

--- a/raven/cli/gateway_commands.py
+++ b/raven/cli/gateway_commands.py
@@ -428,6 +428,11 @@ def register(app: typer.Typer) -> None:
                     agent.decision_consumer.executor.set_submit(gw_scheduler.submit)
                 # Subagent result re-injection submits a SUBAGENT-origin turn.
                 agent.subagents.set_submit(gw_scheduler.submit)
+                # Deep research (channel/async) delivers its finished answer back
+                # via a deliver_text turn; wiring submit here (gateway only) is
+                # what flips the tool from its synchronous path to the async one.
+                if agent.deep_research_manager is not None:
+                    agent.deep_research_manager.set_submit(gw_scheduler.submit)
 
                 # ask_user round-trip on the channel side: the QuestionBroker
                 # renders the agent's clarify.request as an outbound Text to the

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -3623,9 +3623,7 @@ def register(app: typer.Typer) -> None:
         skip_sandbox: bool = typer.Option(False, "--skip-sandbox", help="Skip Step 2 (run location)"),
         skip_channel: bool = typer.Option(False, "--skip-channel", help="Skip Step 3 (channel setup)"),
         skip_memory: bool = typer.Option(False, "--skip-memory", help="Skip Step 4 (long-term memory)"),
-        skip_deep_research: bool = typer.Option(
-            False, "--skip-deep-research", help="Skip Step 5 (deep_research tool)"
-        ),
+        skip_deep_research: bool = typer.Option(False, "--skip-deep-research", help="Skip Step 5 (deep_research tool)"),
         non_interactive: bool = typer.Option(
             False,
             "--non-interactive",

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -1,4 +1,4 @@
-"""Four-step onboarding wizard: LLM provider → sandbox → channel → memory.
+"""Five-step onboarding wizard: LLM provider → sandbox → channel → memory → deep research.
 
 Goal: get a new user from ``pip install`` to a working agent in a few
 minutes, without ever opening ``~/.raven/config.json`` or
@@ -11,7 +11,8 @@ Steps (mirrors ``my_docs/temp/onboard-flow.mermaid``):
   3. Chat channel (optional, stackable)
   4. EverOS long-term memory (optional; llm/embedding required once enabled,
      rerank/multimodal optional)
-  5. Done
+  5. deep_research tool (optional; MiroThinker key + model)
+  6. Done
 
 All writes go through the ``update_providers`` / ``update_channels`` /
 ``update`` / ``update_everos`` ops libraries — this module owns the UX layer,
@@ -20,7 +21,7 @@ not config-schema knowledge.
 Navigation: questionary 2.1.1 has no first-class cross-screen "back", so the
 wizard is a screen state machine and back is expressed as a ``0) back``
 sentinel choice on the screens that support it (Step 1 <-> language pick,
-Step 2 -> Step 1); Steps 3 and 4 are optional and forward-only (re-run
+Step 2 -> Step 1); Steps 3, 4 and 5 are optional and forward-only (re-run
 ``onboard`` to change them). Ctrl+C exits at any point, keeping whatever was
 already written.
 """
@@ -43,7 +44,7 @@ from raven.cli._helpers import (
 
 console = Console()
 
-_TOTAL_STEPS = 4
+_TOTAL_STEPS = 5
 
 # Sentinel returned by a screen function to ask the runner to go back one
 # screen; ``None`` from a picker means Ctrl+C (exit).
@@ -3417,12 +3418,13 @@ def run_wizard(
     skip_sandbox: bool = False,
     skip_channel: bool = False,
     skip_memory: bool = False,
+    skip_deep_research: bool = False,
     non_interactive: bool = False,
     yes: bool = False,
     reset: bool = False,
     skip_test: bool = False,
 ) -> None:
-    """Run the 4-step onboarding wizard end-to-end.
+    """Run the 5-step onboarding wizard end-to-end.
 
     The reusable entry point: the ``onboard`` CLI command and the startup gate
     both call this. Screens form a state machine so a ``0) Back`` choice can
@@ -3445,6 +3447,7 @@ def run_wizard(
             skip_sandbox=skip_sandbox,
             skip_channel=skip_channel,
             skip_memory=skip_memory,
+            skip_deep_research=skip_deep_research,
             non_interactive=non_interactive,
             yes=yes,
             reset=reset,
@@ -3452,6 +3455,29 @@ def run_wizard(
         )
     finally:
         _logger.enable("raven")
+
+
+def _step5_deep_research(*, skip: bool, non_interactive: bool, warnings: list[str]) -> object:
+    """Step 5 — deep_research (MiroThinker) tool, optional, forward-only.
+
+    Delegates to the shared configure flow (also reachable via
+    ``raven deep-research enable``). Skipped on --skip-deep-research or
+    non-interactive; leaving it unconfigured just means the opt-in tool stays
+    unregistered.
+    """
+    _step_header(5, _t("Deep research tool", "深度研究工具"))
+    if skip or non_interactive:
+        console.print(
+            _t(
+                "  [dim]Skipping deep_research (configure later: raven deep-research enable).[/dim]",
+                "  [dim]跳过 deep_research(以后可用 raven deep-research enable 配置)。[/dim]",
+            )
+        )
+        return None
+    from raven.cli.deep_research_commands import configure_deep_research
+
+    configure_deep_research(non_interactive=non_interactive, warnings=warnings)
+    return None
 
 
 def _run_wizard_body(
@@ -3464,6 +3490,7 @@ def _run_wizard_body(
     skip_sandbox: bool = False,
     skip_channel: bool = False,
     skip_memory: bool = False,
+    skip_deep_research: bool = False,
     non_interactive: bool = False,
     yes: bool = False,
     reset: bool = False,
@@ -3488,12 +3515,14 @@ def _run_wizard_body(
                 "[bold #fbe23f]✨ Welcome to the Raven setup wizard[/bold #fbe23f]\n\n"
                 "[dim]We'll configure, in order:[/dim]\n"
                 "  [#fbe23f]①[/#fbe23f] LLM      [#fbe23f]②[/#fbe23f] Run location      "
-                "[#fbe23f]③[/#fbe23f] Chat channel      [#fbe23f]④[/#fbe23f] Long-term memory\n\n"
+                "[#fbe23f]③[/#fbe23f] Chat channel      [#fbe23f]④[/#fbe23f] Long-term memory      "
+                "[#fbe23f]⑤[/#fbe23f] Deep research\n\n"
                 "[dim]↑↓ select · Enter confirm · Ctrl+C quit anytime — anything already written is kept.[/dim]",
                 "[bold #fbe23f]✨ 欢迎使用 Raven 配置向导[/bold #fbe23f]\n\n"
                 "[dim]我们将依次配置:[/dim]\n"
                 "  [#fbe23f]①[/#fbe23f] LLM      [#fbe23f]②[/#fbe23f] 运行位置      "
-                "[#fbe23f]③[/#fbe23f] 聊天渠道      [#fbe23f]④[/#fbe23f] 长期记忆\n\n"
+                "[#fbe23f]③[/#fbe23f] 聊天渠道      [#fbe23f]④[/#fbe23f] 长期记忆      "
+                "[#fbe23f]⑤[/#fbe23f] 深度研究\n\n"
                 "[dim]↑↓ 选择 · Enter 确认 · 随时 Ctrl+C 退出 — 已写入的配置会保留。[/dim]",
             ),
             border_style="#c8a900",
@@ -3524,6 +3553,11 @@ def _run_wizard_body(
             main_model=_load_current_default_model(),
             warnings=warnings,
             skip_test=skip_test,
+        ),
+        lambda: _step5_deep_research(
+            skip=skip_deep_research,
+            non_interactive=non_interactive,
+            warnings=warnings,
         ),
     ]
 
@@ -3588,6 +3622,9 @@ def register(app: typer.Typer) -> None:
         skip_sandbox: bool = typer.Option(False, "--skip-sandbox", help="Skip Step 2 (run location)"),
         skip_channel: bool = typer.Option(False, "--skip-channel", help="Skip Step 3 (channel setup)"),
         skip_memory: bool = typer.Option(False, "--skip-memory", help="Skip Step 4 (long-term memory)"),
+        skip_deep_research: bool = typer.Option(
+            False, "--skip-deep-research", help="Skip Step 5 (deep_research tool)"
+        ),
         non_interactive: bool = typer.Option(
             False,
             "--non-interactive",
@@ -3605,7 +3642,7 @@ def register(app: typer.Typer) -> None:
             help="Skip the one-shot test message (avoids a billed call; connectivity is still checked)",
         ),
     ) -> None:
-        """Four-step setup wizard: LLM provider → sandbox → channel → memory."""
+        """Five-step setup wizard: LLM provider → sandbox → channel → memory → deep research."""
         run_wizard(
             provider=provider,
             api_key=api_key,
@@ -3615,6 +3652,7 @@ def register(app: typer.Typer) -> None:
             skip_sandbox=skip_sandbox,
             skip_channel=skip_channel,
             skip_memory=skip_memory,
+            skip_deep_research=skip_deep_research,
             non_interactive=non_interactive,
             yes=yes,
             reset=reset,

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -28,7 +28,6 @@ already written.
 
 from __future__ import annotations
 
-import json
 import sys
 from typing import Any, Callable, Optional
 
@@ -162,7 +161,9 @@ def _require_questionary() -> Any:
 def _config_language() -> str:
     """Read the saved UI language from the on-disk config ('en' / 'zh').
 
-    Tolerant of a missing / unreadable config (fresh install) → defaults to 'en'.
+    A missing / empty config (fresh install) defaults to 'en'; a malformed one
+    raises ConfigReadError (surfaced by the CLI entrypoint) rather than being
+    silently read as empty.
     """
     data = _load_raw_config()
     lang = data.get("language")
@@ -247,16 +248,16 @@ def _check_tty_or_die(non_interactive: bool) -> None:
 
 
 def _load_raw_config() -> dict[str, Any]:
-    """Return the parsed on-disk config, or ``{}`` if absent/unreadable."""
-    from raven.config.loader import get_config_path
+    """Return the parsed on-disk config, or ``{}`` if absent/empty.
 
-    path = get_config_path()
-    if not path.exists():
-        return {}
-    try:
-        return json.loads(path.read_text(encoding="utf-8")) or {}
-    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
-        return {}
+    A present-but-unparseable config raises ConfigReadError (surfaced cleanly by
+    the CLI entrypoint) instead of being silently treated as empty -- which
+    would let onboard misread state and write over a config whose only fault is
+    a syntax typo.
+    """
+    from raven.config.loader import get_config_path, read_raw_or_raise
+
+    return read_raw_or_raise(get_config_path()) or {}
 
 
 def _configured_providers() -> list[str]:

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -386,6 +386,7 @@ def _build_tui_agent_loop():
             brave_api_key=config.tools.web.search.api_key or None,
             web_proxy=config.tools.web.proxy or None,
             media_config=config.effective_media_config(),
+            deep_research_config=config.tools.deep_research,
             exec_config=config.tools.exec,
             cron_service=cron,
             restrict_to_workspace=config.tools.restrict_to_workspace,

--- a/raven/config/loader.py
+++ b/raven/config/loader.py
@@ -1,8 +1,11 @@
 """Configuration loading utilities."""
 
 import json
+import sys
 from pathlib import Path
+from typing import Any
 
+from loguru import logger
 from pydantic import ValidationError
 
 from raven.config.schema import Config
@@ -45,6 +48,44 @@ def get_config_path() -> Path:
     return Path.home() / ".raven" / "config.json"
 
 
+class ConfigReadError(Exception):
+    """An existing config file could not be parsed. Callers doing a
+    read-modify-write MUST NOT proceed: overwriting would replace the user's
+    whole config with just their section (data loss). Only a genuinely-absent
+    file is safe to create fresh.
+
+    Deliberately NOT a RuntimeError: the CLI write commands wrap their ops in a
+    broad ``except RuntimeError`` (for provider OAuth-refusal etc.), and we want
+    a parse error to bypass those and reach the single ``run()`` handler (or a
+    caller's explicit ``except ConfigReadError``), not be swept up implicitly."""
+
+
+def read_raw_or_raise(path: Path) -> dict[str, Any]:
+    """Read a config file as raw JSON for a read-modify-write cycle.
+
+    Returns ``{}`` ONLY when the file is absent. A present-but-unreadable file
+    raises :class:`ConfigReadError` rather than returning ``{}`` -- returning
+    ``{}`` and then writing was the bug that wiped a real config over a lone
+    JSON syntax error (e.g. a // comment). The single read path for every
+    ``update_*`` write module.
+    """
+    if not path.exists():
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+        if not text.strip():
+            return {}  # empty file: no data to lose, safe to create fresh (like absent)
+        data = json.loads(text)
+        # A valid-JSON non-object (null / list / scalar) is not a usable config;
+        # return {} so callers get a mapping (not None) without an AttributeError.
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
+        raise ConfigReadError(
+            f"{path} is not valid JSON ({exc}). Fix it first (JSON allows no comments or "
+            "trailing commas); your config was left unchanged."
+        ) from exc
+
+
 def load_config(config_path: Path | None = None) -> Config:
     """
     Load configuration from file or create default.
@@ -64,11 +105,16 @@ def load_config(config_path: Path | None = None) -> Config:
                 data = json.load(f)
             data = _migrate_config(data)
         except json.JSONDecodeError as e:
-            # Corrupted JSON (e.g. mid-write race): tolerate and fall
-            # back to defaults so a transient bad-read doesn't brick
-            # callers. Schema mismatches below are NOT tolerated.
-            print(f"Warning: corrupted JSON in {path}: {e}")
-            print("Using default configuration.")
+            # Boot on defaults for a malformed file (a transient mid-write race
+            # shouldn't brick callers) but warn LOUDLY -- a persistent syntax
+            # error would else revert every setting with no visible cause.
+            # Raising instead needs atomic save_config first (separate change).
+            msg = (
+                f"config at {path} is not valid JSON ({e}) -- IGNORING it and running on "
+                "DEFAULTS. Fix the file (JSON allows no comments or trailing commas) and restart."
+            )
+            print(f"WARNING: {msg}", file=sys.stderr)
+            logger.warning(msg)
         else:
             try:
                 config = Config.model_validate(data)

--- a/raven/config/schema.py
+++ b/raven/config/schema.py
@@ -487,6 +487,21 @@ class MediaGenConfig(Base):
     output_subdir: str = "generated"  # where generated files are written under workspace
 
 
+class DeepResearchToolConfig(Base):
+    """MiroThinker deep-research tool configuration.
+
+    A blocking HTTP tool that delegates a research question to the MiroThinker
+    API and returns a structured result. Registered only when ``api_key`` (or
+    ``MIROTHINKER_API_KEY``) is set — it is a paid, minute-scale engine, not a
+    default tool. Empty ``api_base`` / ``model`` fall back at call time to the
+    MiroMind endpoint and the mini engine.
+    """
+
+    api_key: str = ""
+    api_base: str = ""  # defaults to https://api.miromind.ai/v1
+    model: str = ""  # defaults to mirothinker-1-7-deepresearch-mini
+
+
 class MCPServerConfig(Base):
     """MCP server connection configuration (stdio or HTTP)."""
 
@@ -526,6 +541,7 @@ class ToolsConfig(Base):
     web: WebToolsConfig = Field(default_factory=WebToolsConfig)
     exec: ExecToolConfig = Field(default_factory=ExecToolConfig)
     media: MediaGenConfig = Field(default_factory=MediaGenConfig)
+    deep_research: DeepResearchToolConfig = Field(default_factory=DeepResearchToolConfig)
     restrict_to_workspace: bool = False  # If true, restrict all tool access to workspace directory
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
     sandbox: SandboxConfig = Field(default_factory=SandboxConfig)

--- a/raven/config/update.py
+++ b/raven/config/update.py
@@ -18,7 +18,7 @@ from typing import Any
 from loguru import logger
 from pydantic.alias_generators import to_camel
 
-from raven.config.loader import get_config_path
+from raven.config.loader import get_config_path, read_raw_or_raise
 from raven.config.schema import CronConfig
 
 # Shared Skill Hub endpoint seeded into a fresh config's skillForge.router.hub.
@@ -27,16 +27,6 @@ from raven.config.schema import CronConfig
 # onboarded config shows the live endpoint. apiKey is NOT seeded — the user
 # supplies their own Bearer token.
 _DEFAULT_SKILL_HUB_ENDPOINT = "https://skillhub.evermind.ai"
-
-
-def _load_raw(path: Path) -> dict[str, Any]:
-    if not path.exists():
-        return {}
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        logger.warning("config/update: failed to read {}: {}", path, exc)
-        return {}
 
 
 def _write_atomic(path: Path, data: dict[str, Any]) -> None:
@@ -62,7 +52,7 @@ def update_cron_config(
     if key not in CronConfig.model_fields:
         raise KeyError(f"Unknown cron config key: {key!r}. Supported: {sorted(CronConfig.model_fields)}")
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     cron_section = data.setdefault("cron", {})
     camel_key = to_camel(key)
     prev = cron_section.get(camel_key)
@@ -80,7 +70,7 @@ def reset_cron_config(*, config_path: Path | None = None) -> None:
     defaults to disk" principle.
     """
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     removed = data.pop("cron", None)
     _write_atomic(path, data)
     logger.info("config/update: cron section reset (was {!r})", removed)
@@ -100,7 +90,7 @@ def set_sentinel_enabled(
     on a running process.
     """
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     section = data.setdefault("sentinel", {})
     prev = section.get("enabled")
     # No-op when already in the desired state (absent defaults to False) —
@@ -133,7 +123,7 @@ def set_sentinel_nudge_quota(
             raise ValueError(f"{label} must be >= 1 (got {val})")
 
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     sentinel = data.setdefault("sentinel", {})
     np_key = "nudge_policy" if "nudge_policy" in sentinel else "nudgePolicy"
     np = sentinel.setdefault(np_key, {})
@@ -179,7 +169,7 @@ def set_language(
     chosen language.
     """
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     prev = data.get("language")
     data["language"] = language
     _write_atomic(path, data)
@@ -200,7 +190,7 @@ def set_default_model(
     created ``Config()`` baked in, which is typically a different vendor).
     """
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     defaults = data.setdefault("agents", {}).setdefault("defaults", {})
     prev = defaults.get("model")
     defaults["model"] = model
@@ -221,7 +211,7 @@ def set_sandbox_backend(
     the loader validates on next read.
     """
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     # sandbox lives under tools (Config.tools.sandbox), not at the root — the
     # root Config forbids extras, so a top-level "sandbox" key fails schema
     # validation on the next load.
@@ -274,7 +264,7 @@ def init_extension_block_defaults(*, config_path: Path | None = None) -> None:
     )
 
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
 
     mem = MemoryConfig()
     memory = data.setdefault("memory", {})
@@ -334,7 +324,7 @@ def set_memory_backend(
     and flips this flag here.
     """
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     section = data.setdefault("memory", {})
     prev = section.get("backend")
     section["backend"] = backend

--- a/raven/config/update_channels.py
+++ b/raven/config/update_channels.py
@@ -18,23 +18,12 @@ from loguru import logger
 from pydantic import BaseModel, ValidationError
 from pydantic_core import PydanticUndefined
 
-from raven.config.loader import get_config_path
+from raven.config.loader import get_config_path, read_raw_or_raise
 from raven.config.schema import ChannelsConfig
 
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
-
-
-def _load_raw(path: Path) -> dict[str, Any]:
-    """Read raw JSON. Returns empty dict if file is missing or malformed."""
-    if not path.exists():
-        return {}
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        logger.warning("update_channels: failed to read {}: {}", path, exc)
-        return {}
 
 
 def _write_atomic(path: Path, data: dict[str, Any]) -> None:
@@ -364,7 +353,7 @@ def get_channel_config(
     """
     cls = _channel_schema_cls(name)
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     raw_section = (data.get("channels") or {}).get(name) or {}
 
     try:
@@ -400,7 +389,7 @@ def reset_channel(
     """
     cls = _channel_schema_cls(name)
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     data.setdefault("channels", {})
     instance = cls()
     data["channels"][name] = instance.model_dump(by_alias=True)
@@ -427,7 +416,7 @@ def _patch_channel(
         raise KeyError(f"Unknown field(s) {unknown} for channel '{name}'. Available fields: {sorted(specs.keys())}")
 
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     raw_section = (data.get("channels") or {}).get(name) or {}
 
     try:

--- a/raven/config/update_providers.py
+++ b/raven/config/update_providers.py
@@ -27,24 +27,13 @@ from loguru import logger
 from pydantic import BaseModel, ValidationError
 from pydantic_core import PydanticUndefined
 
-from raven.config.loader import get_config_path
+from raven.config.loader import get_config_path, read_raw_or_raise
 from raven.config.schema import ProvidersConfig
 from raven.providers.registry import ProviderSpec, find_by_name
 
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
-
-
-def _load_raw(path: Path) -> dict[str, Any]:
-    """Read raw JSON. Returns empty dict if file is missing or malformed."""
-    if not path.exists():
-        return {}
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        logger.warning("update_providers: failed to read {}: {}", path, exc)
-        return {}
 
 
 def _write_atomic(path: Path, data: dict[str, Any]) -> None:
@@ -345,7 +334,7 @@ def list_providers(*, config_path: Path | None = None) -> list[dict[str, Any]]:
     - ``api_base``           current value (or ``None`` if untouched)
     """
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     raw_providers = data.get("providers") or {}
 
     out: list[dict[str, Any]] = []
@@ -406,7 +395,7 @@ def get_provider_config(
     """
     cls = _provider_schema_cls(name)
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     raw_section = (data.get("providers") or {}).get(name) or {}
 
     try:
@@ -468,7 +457,7 @@ def set_provider_fields(
             )
 
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     raw_section = (data.get("providers") or {}).get(name) or {}
 
     try:
@@ -520,7 +509,7 @@ def reset_provider(
     spec = _provider_spec(name)
 
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     data.setdefault("providers", {})
     data["providers"][name] = cls().model_dump(by_alias=True)
     _write_atomic(path, data)
@@ -560,7 +549,7 @@ def add_provider_model(
     Returns the new model list. Raises KeyError for an unknown provider.
     """
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     cls, models = _load_provider_models(name, data)
     if model not in models:
         models.append(model)
@@ -584,7 +573,7 @@ def remove_provider_model(
     Returns the new model list. Raises KeyError for an unknown provider.
     """
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     cls, models = _load_provider_models(name, data)
     if model in models:
         models = [m for m in models if m != model]

--- a/raven/config/update_tools.py
+++ b/raven/config/update_tools.py
@@ -20,34 +20,10 @@ from typing import Any
 from loguru import logger
 from pydantic import ValidationError
 
-from raven.config.loader import get_config_path
+from raven.config.loader import ConfigReadError, get_config_path, read_raw_or_raise
 from raven.config.schema import DeepResearchToolConfig
 
 _SECTION = "deepResearch"  # camelCase alias of ToolsConfig.deep_research
-
-
-class ConfigReadError(RuntimeError):
-    """An existing config file could not be parsed. Callers MUST NOT proceed to
-    write: overwriting would replace the user's whole config with just the new
-    section (data loss). Only a genuinely-absent file is safe to create fresh."""
-
-
-def _load_raw(path: Path) -> dict[str, Any]:
-    """Read raw JSON. Empty dict ONLY when the file is absent.
-
-    A present-but-unreadable file raises ConfigReadError rather than returning
-    {} -- returning {} here and then writing was exactly the bug that wiped a
-    real config whose only fault was a JSON syntax error (e.g. // comments).
-    """
-    if not path.exists():
-        return {}
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        raise ConfigReadError(
-            f"{path} is not valid JSON ({exc}). Fix it first (JSON allows no comments or "
-            "trailing commas); your config was left unchanged."
-        ) from exc
 
 
 def _write_atomic(path: Path, data: dict[str, Any]) -> None:
@@ -59,7 +35,7 @@ def _write_atomic(path: Path, data: dict[str, Any]) -> None:
 
 
 def _current(path: Path) -> DeepResearchToolConfig:
-    raw = (_load_raw(path).get("tools") or {}).get(_SECTION) or {}
+    raw = (read_raw_or_raise(path).get("tools") or {}).get(_SECTION) or {}
     try:
         return DeepResearchToolConfig.model_validate(raw)
     except ValidationError:
@@ -79,7 +55,7 @@ def set_deep_research(fields: dict[str, Any], *, config_path: Path | None = None
         raise KeyError(f"Unknown deep_research field(s) {unknown}. Available: {sorted(valid)}")
 
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     working = _current(path).model_dump()
     prev = {k: working.get(k) for k in fields}
     working.update(fields)
@@ -104,7 +80,7 @@ def get_deep_research(*, redact: bool = True, config_path: Path | None = None) -
 def reset_deep_research(*, config_path: Path | None = None) -> None:
     """Reset ``tools.deepResearch`` to schema defaults (clears the key)."""
     path = config_path or get_config_path()
-    data = _load_raw(path)
+    data = read_raw_or_raise(path)
     data.setdefault("tools", {})[_SECTION] = DeepResearchToolConfig().model_dump(by_alias=True)
     _write_atomic(path, data)
     logger.info("update_tools: deep_research reset to defaults")

--- a/raven/config/update_tools.py
+++ b/raven/config/update_tools.py
@@ -1,0 +1,113 @@
+"""Atomic operations for tool config sections under ``tools.*``.
+
+This module is the ONLY write path for tool configuration (today just
+``tools.deepResearch``). Entry points -- CLI commands, the onboard wizard --
+must call functions here; direct load_config / save_config on the tools
+section is forbidden, matching update_channels / update_providers.
+
+Values land camelCase on disk (``tools.deepResearch.apiKey``) via a Pydantic
+validate + ``model_dump(by_alias=True)`` round-trip, so the file never grows a
+parallel snake_case key.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+from pydantic import ValidationError
+
+from raven.config.loader import get_config_path
+from raven.config.schema import DeepResearchToolConfig
+
+_SECTION = "deepResearch"  # camelCase alias of ToolsConfig.deep_research
+
+
+class ConfigReadError(RuntimeError):
+    """An existing config file could not be parsed. Callers MUST NOT proceed to
+    write: overwriting would replace the user's whole config with just the new
+    section (data loss). Only a genuinely-absent file is safe to create fresh."""
+
+
+def _load_raw(path: Path) -> dict[str, Any]:
+    """Read raw JSON. Empty dict ONLY when the file is absent.
+
+    A present-but-unreadable file raises ConfigReadError rather than returning
+    {} -- returning {} here and then writing was exactly the bug that wiped a
+    real config whose only fault was a JSON syntax error (e.g. // comments).
+    """
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ConfigReadError(
+            f"{path} is not valid JSON ({exc}). Fix it first (JSON allows no comments or "
+            "trailing commas); your config was left unchanged."
+        ) from exc
+
+
+def _write_atomic(path: Path, data: dict[str, Any]) -> None:
+    """Atomic write: temp-file then os.replace. Preserves indent=2, UTF-8."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _current(path: Path) -> DeepResearchToolConfig:
+    raw = (_load_raw(path).get("tools") or {}).get(_SECTION) or {}
+    try:
+        return DeepResearchToolConfig.model_validate(raw)
+    except ValidationError:
+        return DeepResearchToolConfig()
+
+
+def set_deep_research(fields: dict[str, Any], *, config_path: Path | None = None) -> dict[str, Any]:
+    """Patch ``tools.deepResearch`` fields (``api_key`` / ``api_base`` / ``model``).
+
+    Validate-then-write: the merged section is validated before anything lands,
+    so a bad value raises rather than corrupting the file. Returns
+    ``{field: previous_value}`` for caller logging.
+    """
+    valid = set(DeepResearchToolConfig.model_fields)
+    unknown = [k for k in fields if k not in valid]
+    if unknown:
+        raise KeyError(f"Unknown deep_research field(s) {unknown}. Available: {sorted(valid)}")
+
+    path = config_path or get_config_path()
+    data = _load_raw(path)
+    working = _current(path).model_dump()
+    prev = {k: working.get(k) for k in fields}
+    working.update(fields)
+    validated = DeepResearchToolConfig.model_validate(working)
+
+    data.setdefault("tools", {})[_SECTION] = validated.model_dump(by_alias=True)
+    _write_atomic(path, data)
+    return prev
+
+
+def get_deep_research(*, redact: bool = True, config_path: Path | None = None) -> dict[str, Any]:
+    """Return ``tools.deepResearch`` as ``{api_key, api_base, model}``.
+
+    ``api_key`` is redacted by default: ``'****set****'`` when set, ``'(empty)'``
+    otherwise.
+    """
+    inst = _current(config_path or get_config_path())
+    key = ("****set****" if inst.api_key else "(empty)") if redact else inst.api_key
+    return {"api_key": key, "api_base": inst.api_base, "model": inst.model}
+
+
+def reset_deep_research(*, config_path: Path | None = None) -> None:
+    """Reset ``tools.deepResearch`` to schema defaults (clears the key)."""
+    path = config_path or get_config_path()
+    data = _load_raw(path)
+    data.setdefault("tools", {})[_SECTION] = DeepResearchToolConfig().model_dump(by_alias=True)
+    _write_atomic(path, data)
+    logger.info("update_tools: deep_research reset to defaults")
+
+
+__all__ = ["ConfigReadError", "set_deep_research", "get_deep_research", "reset_deep_research"]

--- a/raven/context_engine/assembler.py
+++ b/raven/context_engine/assembler.py
@@ -123,7 +123,7 @@ class ContextAssembler(ContextEngine):
         for _, text in seg6_parts:
             system = system + "\n\n---\n\n" + text
 
-        messages = [{"role": "system", "content": system}, *history, user_msg]
+        messages = [{"role": "system", "content": system}, *_coalesce_assistant(history), user_msg]
         return AssembledContext(
             messages=messages,
             metadata=meta | {"engine": self.name},
@@ -150,6 +150,42 @@ class ContextAssembler(ContextEngine):
         else:
             merged = [{"type": "text", "text": runtime_ctx}] + user_content
         return {"role": "user", "content": merged}
+
+
+def _coalesce_assistant(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Merge adjacent plain-assistant messages into one.
+
+    A verbatim ``deliver_text`` turn records the bot's answer as an assistant
+    message; it can land right after a prior assistant reply (the "on it" ack),
+    leaving two adjacent assistant turns. Some providers reject consecutive
+    same-role messages and nothing else in the pipeline merges them. Only plain
+    assistants (no ``tool_calls``, str content) merge — an assistant carrying
+    tool_calls is always followed by its tool result, never another assistant,
+    and merging it would break tool-call adjacency. The merged-in message must
+    also carry no reasoning fields, so the merge never silently drops the
+    reasoning_content / thinking_blocks history projection preserves (deliver_text
+    answers have none; this only guards a hypothetical future adjacency source).
+    """
+    out: list[dict[str, Any]] = []
+    for msg in history:
+        prev = out[-1] if out else None
+        if (
+            prev is not None
+            and msg.get("role") == "assistant"
+            and prev.get("role") == "assistant"
+            and not msg.get("tool_calls")
+            and not prev.get("tool_calls")
+            and not msg.get("reasoning_content")
+            and not msg.get("thinking_blocks")
+            and isinstance(msg.get("content"), str)
+            and isinstance(prev.get("content"), str)
+        ):
+            merged = dict(prev)
+            merged["content"] = f"{prev['content']}\n\n{msg['content']}"
+            out[-1] = merged
+            continue
+        out.append(msg)
+    return out
 
 
 __all__ = ["ContextAssembler"]

--- a/raven/spine/turn.py
+++ b/raven/spine/turn.py
@@ -57,3 +57,8 @@ class TurnRequest:
     conversation: str | None = None
     busy: BusyPolicy = BusyPolicy.APPEND
     sentinel: SentinelExtras | None = None
+    # Verbatim delivery: when set, the turn skips the model entirely and emits
+    # this text as-is (a background task pushing a finished result back to its
+    # conversation). Runs through the lane so the session write stays serialized;
+    # the model never sees it, so it cannot be rewritten. See AgentLoop.run_turn.
+    deliver_text: str | None = None

--- a/raven/tui_rpc/methods/config.py
+++ b/raven/tui_rpc/methods/config.py
@@ -144,17 +144,20 @@ def _config_path() -> Path:
 
 
 def _load_config() -> dict[str, Any]:
-    """Load ``config.json`` or return an empty dict on any failure.
+    """Load ``config.json`` for a read-modify-write (get/set/_set_model).
 
-    Symmetric with setup.status's v0.1 fallback policy — we never want a stray
-    write or unreadable file to crash a get/set call. The on-disk file is the
+    Absent / empty -> ``{}`` (safe to create fresh). A present-but-unparseable
+    file raises ConfigValidationError rather than the old empty-dict fallback:
+    returning ``{}`` here and then ``_save_config`` would overwrite the user's
+    whole config with just the changed key (data loss). The on-disk file is the
     source of truth; downstream loaders read the same file independently.
     """
-    path = _config_path()
+    from raven.config.loader import ConfigReadError, read_raw_or_raise
+
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (FileNotFoundError, OSError, json.JSONDecodeError):
-        return {}
+        return read_raw_or_raise(_config_path())
+    except ConfigReadError as exc:
+        raise ConfigValidationError(str(exc)) from exc
 
 
 def _save_config(payload: dict[str, Any]) -> None:

--- a/raven/tui_rpc/spine.py
+++ b/raven/tui_rpc/spine.py
@@ -90,7 +90,9 @@ class TuiTurnRunner(AgentTurnRunner):
                 self._readback_texts[req.conversation] = text
             return outcome
         usage_sink: dict[str, Any] = {}
-        outcome = await self._loop.run_turn(req, emit, drain, stream=True, usage_sink=usage_sink)
+        outcome = await self._loop.run_turn(
+            req, emit, drain, stream=True, inline_tool_stream=True, usage_sink=usage_sink
+        )
 
         # A synthetic tool.complete when the message tool fired (the loop
         # skips it on the general tool path), so the UI records the agent acted —

--- a/tests/test_agent_loop_run_emit.py
+++ b/tests/test_agent_loop_run_emit.py
@@ -55,6 +55,36 @@ class _FakeTool(Tool):
         return "tool-ran"
 
 
+class _FakeDeepResearch(Tool):
+    """Fake deep_research: on execute it drives its stream callback with a progress
+    line then the finished answer, so run_turn's inline routing can be pinned
+    without real HTTP."""
+
+    def __init__(self) -> None:
+        self._cb = None
+
+    @property
+    def name(self) -> str:
+        return "deep_research"
+
+    @property
+    def description(self) -> str:
+        return "fake deep research"
+
+    @property
+    def parameters(self) -> dict:
+        return {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]}
+
+    def set_stream_callback(self, cb) -> None:
+        self._cb = cb
+
+    async def execute(self, query, **kwargs) -> str:
+        if self._cb is not None:
+            await self._cb("progress", "searching the web...")
+            await self._cb("answer", "ANSWER-BODY")
+        return '{"status": "ok", "delivered": true}'
+
+
 class _FakeChatProvider:
     """Non-streaming path: ``chat_with_retry`` returns scripted LLMResponses."""
 
@@ -254,6 +284,85 @@ async def test_run_tool_call_emits_tool_events_and_notice(tmp_path):
     assert any(isinstance(e, EvNotice) and e.kind is NoticeKind.TOOL_HINT for e in sink.events)
     assert any(isinstance(e, EvStreamDelta) and e.delta == "done" for e in sink.events)
     assert not any(isinstance(e, EvText) for e in sink.events)  # streamed final dissolves
+
+
+# ── deep_research inline streaming: run_turn's _route_deep_research (2a) ──
+
+
+def _dr_stream_provider():
+    return _FakeStreamToolProvider(
+        [
+            [
+                StreamDelta(
+                    content=None,
+                    tool_call_delta={
+                        "tool_calls": [
+                            {"index": 0, "id": "d1", "function": {"name": "deep_research", "arguments": '{"query": "q"}'}}
+                        ]
+                    },
+                )
+            ],
+            [StreamDelta(content="ok done")],
+        ]
+    )
+
+
+def _dr_chat_provider():
+    return _FakeChatProvider(
+        [
+            LLMResponse(
+                content=None,
+                tool_calls=[ToolCallRequest(id="d1", name="deep_research", arguments={"query": "q"})],
+                finish_reason="tool_calls",
+            ),
+            LLMResponse(content="", finish_reason="stop"),
+        ]
+    )
+
+
+async def test_inline_tool_stream_routes_progress_to_reasoning_and_answer_to_stream(tmp_path):
+    # TUI path (stream=True): deep_research progress -> Reasoning (thinking.delta),
+    # the finished answer -> StreamDelta (token.delta). Pins _route_deep_research.
+    loop = AgentLoop(provider=_dr_stream_provider(), workspace=tmp_path)
+    _stub_edges(loop)
+    loop.tools.register(_FakeDeepResearch())
+    sink = _EmitCollector()
+
+    await loop.run_turn(_req("q"), sink, _drain, stream=True, inline_tool_stream=True)
+
+    deltas = [e.delta for e in sink.events if isinstance(e, EvStreamDelta)]
+    assert any(isinstance(e, EvReasoning) and e.content == "searching the web..." for e in sink.events)
+    # Answer streams as a delta AND the model's coda still flows after it (the
+    # `if not streamed` boundary must not swallow the coda once the answer set it).
+    assert "ANSWER-BODY" in deltas
+    assert "ok done" in deltas
+
+
+async def test_inline_tool_stream_answer_as_text_when_not_streaming(tmp_path):
+    # CLI/REPL path (stream=False): answer -> Text so a non-streaming outlet renders it.
+    loop = AgentLoop(provider=_dr_chat_provider(), workspace=tmp_path)
+    _stub_edges(loop)
+    loop.tools.register(_FakeDeepResearch())
+    sink = _EmitCollector()
+
+    await loop.run_turn(_req("q"), sink, _drain, stream=False, inline_tool_stream=True)
+
+    assert any(isinstance(e, EvReasoning) and e.content == "searching the web..." for e in sink.events)
+    assert any(isinstance(e, EvText) and e.content == "ANSWER-BODY" for e in sink.events)
+
+
+async def test_no_inline_tool_stream_leaves_deep_research_callback_unset(tmp_path):
+    # Without inline_tool_stream (gateway/channels), the callback is never wired, so
+    # the tool emits nothing inline -> no progress/answer routing.
+    loop = AgentLoop(provider=_dr_chat_provider(), workspace=tmp_path)
+    _stub_edges(loop)
+    loop.tools.register(_FakeDeepResearch())
+    sink = _EmitCollector()
+
+    await loop.run_turn(_req("q"), sink, _drain, stream=False, inline_tool_stream=False)
+
+    assert not any(isinstance(e, EvReasoning) and e.content == "searching the web..." for e in sink.events)
+    assert not any(isinstance(e, EvText) and e.content == "ANSWER-BODY" for e in sink.events)
 
 
 async def test_inject_message_merged_before_next_iteration(tmp_path):

--- a/tests/test_agent_loop_run_emit.py
+++ b/tests/test_agent_loop_run_emit.py
@@ -710,6 +710,122 @@ async def test_run_turn_reconstructs_metadata_from_source_extras(tmp_path):
     assert seen.get("message_id") == "m1"  # extras -> metadata -> _set_tool_context
 
 
+# ── deliver_text: verbatim background delivery, skips the model (2b) ──
+
+
+async def test_run_turn_deliver_text_emits_verbatim_skips_model_and_indexes(tmp_path):
+    # A background task pushes a finished result back via deliver_text: run_turn
+    # emits it as one Text verbatim, records it to the session, and hands it to
+    # the backend index — and never touches the model.
+    class _NoCallProvider:
+        async def chat_stream(self, **kwargs):
+            raise AssertionError("model must not be called for a deliver_text turn")
+            yield  # unreachable; keeps this an async generator
+
+        async def chat_with_retry(self, **kwargs):
+            raise AssertionError("model must not be called for a deliver_text turn")
+
+        def get_default_model(self) -> str:
+            return "fake/model"
+
+    stored: list = []
+
+    class _FakeBackend:
+        async def store(self, key, messages) -> None:
+            stored.append((key, messages))
+
+    loop = AgentLoop(provider=_NoCallProvider(), workspace=tmp_path)
+    _stub_edges(loop)
+    loop.backend = _FakeBackend()
+    sink = _EmitCollector()
+
+    req = TurnRequest(
+        origin=Origin.SUBAGENT,
+        source=Source(channel="weixin", chat_id="c", sender_id="deep_research", chat_type=ChatType.DM),
+        text="",
+        conversation="weixin:c",
+        deliver_text="FULL REPORT [1]",
+    )
+    outcome = await loop.run_turn(req, sink, _drain, stream=False)
+
+    texts = [e for e in sink.events if isinstance(e, EvText)]
+    assert len(texts) == 1 and texts[0].content == "FULL REPORT [1]"
+    assert not any(isinstance(e, EvStreamDelta) for e in sink.events)  # not streamed through the model
+    assert outcome.explicit_reply is True
+
+    session = loop.sessions.get_or_create("weixin:c")
+    assert any(m.get("role") == "assistant" and m.get("content") == "FULL REPORT [1]" for m in session.messages)
+    assert stored and stored[0][0] == "weixin:c"
+    assert stored[0][1][0]["content"] == "FULL REPORT [1]"
+
+
+async def test_run_turn_deliver_text_persists_before_emit(tmp_path):
+    # save-then-send order: if the session save fails, nothing was emitted, so
+    # the user is never left with a delivered message that no turn recorded.
+    loop = AgentLoop(provider=_FakeChatProvider([]), workspace=tmp_path)
+    _stub_edges(loop)
+
+    def _boom(_session) -> None:
+        raise RuntimeError("save failed")
+
+    loop.sessions.save = _boom
+    sink = _EmitCollector()
+
+    req = TurnRequest(
+        origin=Origin.SUBAGENT,
+        source=Source(channel="weixin", chat_id="c", sender_id="deep_research", chat_type=ChatType.DM),
+        text="",
+        conversation="weixin:c",
+        deliver_text="REPORT",
+    )
+    with pytest.raises(RuntimeError):
+        await loop.run_turn(req, sink, _drain, stream=False)
+    assert not any(isinstance(e, EvText) for e in sink.events)  # save failed -> nothing delivered
+
+
+async def test_run_turn_wires_deep_research_delivery_routing(tmp_path):
+    # _set_tool_context routes the deep_research tool's delivery context so the
+    # async transport knows which conversation to push the finished answer to.
+    class _FakeDRRouting(Tool):
+        def __init__(self) -> None:
+            self.ctx: tuple | None = None
+
+        @property
+        def name(self) -> str:
+            return "deep_research"
+
+        @property
+        def description(self) -> str:
+            return "fake deep research (routing)"
+
+        @property
+        def parameters(self) -> dict:
+            return {"type": "object", "properties": {}, "required": []}
+
+        def set_context(self, channel: str, chat_id: str, session_key: str) -> None:
+            self.ctx = (channel, chat_id, session_key)
+
+        async def execute(self, **kwargs) -> str:
+            return "{}"
+
+    loop = AgentLoop(
+        provider=_FakeChatProvider([LLMResponse(content="ok", finish_reason="stop")]),
+        workspace=tmp_path,
+    )
+    _stub_edges(loop)
+    dr = _FakeDRRouting()
+    loop.tools.register(dr)
+
+    req = TurnRequest(
+        origin=Origin.USER,
+        source=Source(channel="weixin", chat_id="c", sender_id="u", chat_type=ChatType.DM),
+        text="hi",
+        conversation="weixin:c",
+    )
+    await loop.run_turn(req, _EmitCollector(), _drain, stream=False)
+    assert dr.ctx == ("weixin", "c", "weixin:c")
+
+
 async def test_run_turn_empty_extras_reconstructs_empty_metadata(tmp_path):
     # No-regression: a host source carries no extras -> metadata={} ->
     # _set_tool_context sees message_id=None.

--- a/tests/test_agent_loop_run_emit.py
+++ b/tests/test_agent_loop_run_emit.py
@@ -297,7 +297,11 @@ def _dr_stream_provider():
                     content=None,
                     tool_call_delta={
                         "tool_calls": [
-                            {"index": 0, "id": "d1", "function": {"name": "deep_research", "arguments": '{"query": "q"}'}}
+                            {
+                                "index": 0,
+                                "id": "d1",
+                                "function": {"name": "deep_research", "arguments": '{"query": "q"}'},
+                            }
                         ]
                     },
                 )

--- a/tests/test_cli_deep_research_commands.py
+++ b/tests/test_cli_deep_research_commands.py
@@ -28,7 +28,9 @@ def cfg(tmp_path: Path, monkeypatch) -> Path:
     monkeypatch.setattr(ut, "get_config_path", lambda: p)
     # CLI enable does a best-effort validation after writing; stub it so tests
     # never touch the network.
-    monkeypatch.setattr(drc, "_validate_key", lambda *a, **k: {"ok": True, "status": "ok", "model_ids": [], "error": None})
+    monkeypatch.setattr(
+        drc, "_validate_key", lambda *a, **k: {"ok": True, "status": "ok", "model_ids": [], "error": None}
+    )
     return p
 
 
@@ -115,11 +117,15 @@ class _FakeQuestionary:
 def test_configure_interactive_happy_path(tmp_path: Path, monkeypatch):
     p = tmp_path / "config.json"
     monkeypatch.setattr(ut, "get_config_path", lambda: p)
-    monkeypatch.setattr(drc, "_validate_key", lambda *a, **k: {"ok": True, "status": "ok", "model_ids": [], "error": None})
+    monkeypatch.setattr(
+        drc, "_validate_key", lambda *a, **k: {"ok": True, "status": "ok", "model_ids": [], "error": None}
+    )
     # onboard helpers the flow lazy-imports:
     import raven.cli.onboard_commands as ob
 
-    monkeypatch.setattr(ob, "_require_questionary", lambda: _FakeQuestionary(["configure", "mirothinker-1-7-deepresearch"]))
+    monkeypatch.setattr(
+        ob, "_require_questionary", lambda: _FakeQuestionary(["configure", "mirothinker-1-7-deepresearch"])
+    )
     monkeypatch.setattr(ob, "_prompt_api_key", lambda *a, **k: "sk-interactive")
 
     assert configure_deep_research(non_interactive=False, warnings=[]) is True
@@ -132,7 +138,9 @@ def _setup_interactive(monkeypatch, tmp_path: Path, answers: list, *, validate=N
     """Isolate config + stub the onboard helpers the flow lazy-imports."""
     p = tmp_path / "config.json"
     monkeypatch.setattr(ut, "get_config_path", lambda: p)
-    monkeypatch.setattr(drc, "_validate_key", validate or (lambda *a, **k: {"ok": True, "status": "ok", "model_ids": [], "error": None}))
+    monkeypatch.setattr(
+        drc, "_validate_key", validate or (lambda *a, **k: {"ok": True, "status": "ok", "model_ids": [], "error": None})
+    )
     import raven.cli.onboard_commands as ob
 
     monkeypatch.setattr(ob, "_require_questionary", lambda: _FakeQuestionary(answers))
@@ -162,7 +170,9 @@ def test_configure_skip_when_unconfigured_returns_false(tmp_path: Path, monkeypa
 
 def test_configure_validation_fail_then_save(tmp_path: Path, monkeypatch):
     fail = {"ok": False, "status": "http_401", "model_ids": None, "error": "bad"}
-    p = _setup_interactive(monkeypatch, tmp_path, ["configure", "save", "mirothinker-1-7-deepresearch"], validate=lambda *a, **k: fail)
+    p = _setup_interactive(
+        monkeypatch, tmp_path, ["configure", "save", "mirothinker-1-7-deepresearch"], validate=lambda *a, **k: fail
+    )
     assert configure_deep_research(non_interactive=False, warnings=[]) is True  # saved despite bad key
     assert json.loads(p.read_text())["tools"]["deepResearch"]["apiKey"] == "sk-typed"
 
@@ -190,7 +200,9 @@ def test_configure_validation_retry_then_ok(tmp_path: Path, monkeypatch):
 def test_enable_flag_bad_key_warns_but_writes(tmp_path: Path, monkeypatch):
     p = tmp_path / "config.json"
     monkeypatch.setattr(ut, "get_config_path", lambda: p)
-    monkeypatch.setattr(drc, "_validate_key", lambda *a, **k: {"ok": False, "status": "http_401", "model_ids": None, "error": "x"})
+    monkeypatch.setattr(
+        drc, "_validate_key", lambda *a, **k: {"ok": False, "status": "http_401", "model_ids": None, "error": "x"}
+    )
     result = runner.invoke(deep_research_app, ["enable", "--key", "sk-bad"])
     assert result.exit_code == 0 and "key validation" in result.stdout
     assert json.loads(p.read_text())["tools"]["deepResearch"]["apiKey"] == "sk-bad"  # saved anyway
@@ -199,7 +211,9 @@ def test_enable_flag_bad_key_warns_but_writes(tmp_path: Path, monkeypatch):
 def test_enable_with_api_base_flag_writes_it(tmp_path: Path, monkeypatch):
     p = tmp_path / "config.json"
     monkeypatch.setattr(ut, "get_config_path", lambda: p)
-    monkeypatch.setattr(drc, "_validate_key", lambda *a, **k: {"ok": True, "status": "ok", "model_ids": [], "error": None})
+    monkeypatch.setattr(
+        drc, "_validate_key", lambda *a, **k: {"ok": True, "status": "ok", "model_ids": [], "error": None}
+    )
     runner.invoke(deep_research_app, ["enable", "--key", "sk-x", "--api-base", "https://mirror.example.com/v1"])
     assert json.loads(p.read_text())["tools"]["deepResearch"]["apiBase"] == "https://mirror.example.com/v1"
 
@@ -252,7 +266,9 @@ def test_enable_refuses_malformed_config_and_preserves_file(tmp_path: Path, monk
     monkeypatch.setattr(ut, "get_config_path", lambda: p)
     original = '{\n  "providers": {"openai": {"apiKey": "sk-o"}},\n  // comment => invalid JSON\n}\n'
     p.write_text(original, encoding="utf-8")
-    result = runner.invoke(deep_research_app, ["enable", "--key", "sk-x", "--model", "mirothinker-1-7-deepresearch-mini"])
+    result = runner.invoke(
+        deep_research_app, ["enable", "--key", "sk-x", "--model", "mirothinker-1-7-deepresearch-mini"]
+    )
     assert result.exit_code != 0
     assert p.read_text(encoding="utf-8") == original  # NOT clobbered
 

--- a/tests/test_cli_deep_research_commands.py
+++ b/tests/test_cli_deep_research_commands.py
@@ -1,0 +1,289 @@
+"""Unit tests for `raven deep-research` (enable / get / reset) + shared flow.
+
+Key validation is asserted to hit ``GET /v1/models`` (not a chat completion)
+and to NOT double the ``/v1`` segment (the MiroThinker default base already
+ends in ``/v1``) -- guarding the F1/round-2 fixes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from raven.cli import deep_research_commands as drc
+from raven.cli.deep_research_commands import DEFAULT_MODEL, _validate_key, configure_deep_research, deep_research_app
+from raven.config import update_tools as ut
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def cfg(tmp_path: Path, monkeypatch) -> Path:
+    p = tmp_path / "config.json"
+    monkeypatch.setattr(ut, "get_config_path", lambda: p)
+    # CLI enable does a best-effort validation after writing; stub it so tests
+    # never touch the network.
+    monkeypatch.setattr(drc, "_validate_key", lambda *a, **k: {"ok": True, "status": "ok", "model_ids": [], "error": None})
+    return p
+
+
+# ── _validate_key: GET /v1/models, no /v1 doubling ──
+
+
+def test_validate_key_ok_hits_v1_models_once():
+    seen: dict = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["path"] = req.url.path
+        seen["auth"] = req.headers.get("authorization")
+        return httpx.Response(200, json={"data": [{"id": "mirothinker-1-7-deepresearch-mini"}]})
+
+    res = _validate_key("sk-x", "", transport=httpx.MockTransport(handler))
+    assert res["ok"] and "mirothinker-1-7-deepresearch-mini" in res["model_ids"]
+    assert seen["path"] == "/v1/models"  # default base already has /v1 -> not /v1/v1/models
+    assert seen["auth"] == "Bearer sk-x"
+
+
+def test_validate_key_401_is_not_ok():
+    res = _validate_key("bad", "", transport=httpx.MockTransport(lambda r: httpx.Response(401, json={"e": "x"})))
+    assert not res["ok"] and res["status"] == "http_401"
+
+
+def test_validate_key_network_error():
+    def boom(r):
+        raise httpx.ConnectError("down")
+
+    res = _validate_key("x", "", transport=httpx.MockTransport(boom))
+    assert not res["ok"] and res["status"] == "network_error"
+
+
+# ── enable / get / reset ──
+
+
+def test_enable_flags_write_camelcase(cfg: Path):
+    result = runner.invoke(deep_research_app, ["enable", "--key", "sk-abc", "--model", "mirothinker-1-7-deepresearch"])
+    assert result.exit_code == 0
+    section = json.loads(cfg.read_text())["tools"]["deepResearch"]
+    assert section["apiKey"] == "sk-abc" and section["model"] == "mirothinker-1-7-deepresearch"
+
+
+def test_enable_key_only_defaults_to_mini(cfg: Path):
+    assert runner.invoke(deep_research_app, ["enable", "--key", "sk-x"]).exit_code == 0
+    assert json.loads(cfg.read_text())["tools"]["deepResearch"]["model"] == DEFAULT_MODEL
+
+
+def test_get_redacts_key(cfg: Path):
+    runner.invoke(deep_research_app, ["enable", "--key", "sk-x"])
+    result = runner.invoke(deep_research_app, ["get"])
+    assert result.exit_code == 0 and "****set****" in result.stdout
+
+
+def test_reset_clears_key(cfg: Path):
+    runner.invoke(deep_research_app, ["enable", "--key", "sk-x"])
+    assert runner.invoke(deep_research_app, ["reset"]).exit_code == 0
+    assert json.loads(cfg.read_text())["tools"]["deepResearch"]["apiKey"] == ""
+
+
+# ── shared configure flow ──
+
+
+def test_configure_non_interactive_skips_with_warning():
+    warnings: list[str] = []
+    assert configure_deep_research(non_interactive=True, warnings=warnings) is False
+    assert any("deep_research" in w for w in warnings)
+
+
+class _FakeQuestionary:
+    """Minimal questionary stand-in: select().ask() pops scripted answers."""
+
+    def __init__(self, answers: list) -> None:
+        self._answers = list(answers)
+
+    def Choice(self, label, value=None):  # noqa: N802 (mirror questionary API)
+        return value
+
+    def select(self, *args, **kwargs):
+        val = self._answers.pop(0)
+        return type("_Ask", (), {"ask": staticmethod(lambda: val)})()
+
+
+def test_configure_interactive_happy_path(tmp_path: Path, monkeypatch):
+    p = tmp_path / "config.json"
+    monkeypatch.setattr(ut, "get_config_path", lambda: p)
+    monkeypatch.setattr(drc, "_validate_key", lambda *a, **k: {"ok": True, "status": "ok", "model_ids": [], "error": None})
+    # onboard helpers the flow lazy-imports:
+    import raven.cli.onboard_commands as ob
+
+    monkeypatch.setattr(ob, "_require_questionary", lambda: _FakeQuestionary(["configure", "mirothinker-1-7-deepresearch"]))
+    monkeypatch.setattr(ob, "_prompt_api_key", lambda *a, **k: "sk-interactive")
+
+    assert configure_deep_research(non_interactive=False, warnings=[]) is True
+    section = json.loads(p.read_text())["tools"]["deepResearch"]
+    assert section["apiKey"] == "sk-interactive"
+    assert section["model"] == "mirothinker-1-7-deepresearch"
+
+
+def _setup_interactive(monkeypatch, tmp_path: Path, answers: list, *, validate=None) -> Path:
+    """Isolate config + stub the onboard helpers the flow lazy-imports."""
+    p = tmp_path / "config.json"
+    monkeypatch.setattr(ut, "get_config_path", lambda: p)
+    monkeypatch.setattr(drc, "_validate_key", validate or (lambda *a, **k: {"ok": True, "status": "ok", "model_ids": [], "error": None}))
+    import raven.cli.onboard_commands as ob
+
+    monkeypatch.setattr(ob, "_require_questionary", lambda: _FakeQuestionary(answers))
+    monkeypatch.setattr(ob, "_prompt_api_key", lambda *a, **k: "sk-typed")
+    return p
+
+
+def test_configure_keep_existing_skips_reprompt(tmp_path: Path, monkeypatch):
+    p = _setup_interactive(monkeypatch, tmp_path, ["keep"])
+    ut.set_deep_research({"api_key": "sk-old", "model": "m"}, config_path=p)
+    assert configure_deep_research(non_interactive=False, warnings=[]) is True
+    assert json.loads(p.read_text())["tools"]["deepResearch"]["apiKey"] == "sk-old"  # unchanged
+
+
+def test_configure_reconfigure_existing_writes_new(tmp_path: Path, monkeypatch):
+    p = _setup_interactive(monkeypatch, tmp_path, ["reconfigure", "mirothinker-1-7-deepresearch"])
+    ut.set_deep_research({"api_key": "sk-old", "model": "m"}, config_path=p)
+    assert configure_deep_research(non_interactive=False, warnings=[]) is True
+    assert json.loads(p.read_text())["tools"]["deepResearch"]["apiKey"] == "sk-typed"
+
+
+def test_configure_skip_when_unconfigured_returns_false(tmp_path: Path, monkeypatch):
+    p = _setup_interactive(monkeypatch, tmp_path, ["skip"])
+    assert configure_deep_research(non_interactive=False, warnings=[]) is False
+    assert not p.exists() or "deepResearch" not in json.loads(p.read_text()).get("tools", {})
+
+
+def test_configure_validation_fail_then_save(tmp_path: Path, monkeypatch):
+    fail = {"ok": False, "status": "http_401", "model_ids": None, "error": "bad"}
+    p = _setup_interactive(monkeypatch, tmp_path, ["configure", "save", "mirothinker-1-7-deepresearch"], validate=lambda *a, **k: fail)
+    assert configure_deep_research(non_interactive=False, warnings=[]) is True  # saved despite bad key
+    assert json.loads(p.read_text())["tools"]["deepResearch"]["apiKey"] == "sk-typed"
+
+
+def test_configure_validation_fail_then_cancel(tmp_path: Path, monkeypatch):
+    fail = {"ok": False, "status": "http_401", "model_ids": None, "error": "bad"}
+    p = _setup_interactive(monkeypatch, tmp_path, ["configure", "cancel"], validate=lambda *a, **k: fail)
+    assert configure_deep_research(non_interactive=False, warnings=[]) is False  # cancelled, nothing written
+
+
+def test_configure_validation_retry_then_ok(tmp_path: Path, monkeypatch):
+    calls = {"n": 0}
+
+    def _flaky(*a, **k):
+        calls["n"] += 1
+        return {"ok": calls["n"] > 1, "status": "http_401" if calls["n"] == 1 else "ok", "model_ids": [], "error": None}
+
+    p = _setup_interactive(
+        monkeypatch, tmp_path, ["configure", "retry", "mirothinker-1-7-deepresearch"], validate=_flaky
+    )
+    assert configure_deep_research(non_interactive=False, warnings=[]) is True
+    assert calls["n"] == 2  # first validate failed, retry validated ok
+
+
+def test_enable_flag_bad_key_warns_but_writes(tmp_path: Path, monkeypatch):
+    p = tmp_path / "config.json"
+    monkeypatch.setattr(ut, "get_config_path", lambda: p)
+    monkeypatch.setattr(drc, "_validate_key", lambda *a, **k: {"ok": False, "status": "http_401", "model_ids": None, "error": "x"})
+    result = runner.invoke(deep_research_app, ["enable", "--key", "sk-bad"])
+    assert result.exit_code == 0 and "key validation" in result.stdout
+    assert json.loads(p.read_text())["tools"]["deepResearch"]["apiKey"] == "sk-bad"  # saved anyway
+
+
+def test_enable_with_api_base_flag_writes_it(tmp_path: Path, monkeypatch):
+    p = tmp_path / "config.json"
+    monkeypatch.setattr(ut, "get_config_path", lambda: p)
+    monkeypatch.setattr(drc, "_validate_key", lambda *a, **k: {"ok": True, "status": "ok", "model_ids": [], "error": None})
+    runner.invoke(deep_research_app, ["enable", "--key", "sk-x", "--api-base", "https://mirror.example.com/v1"])
+    assert json.loads(p.read_text())["tools"]["deepResearch"]["apiBase"] == "https://mirror.example.com/v1"
+
+
+def test_enable_no_flags_enters_interactive(monkeypatch):
+    called: list = []
+    monkeypatch.setattr(drc, "configure_deep_research", lambda **k: called.append(k))
+    assert runner.invoke(deep_research_app, ["enable"]).exit_code == 0
+    assert called and called[0].get("non_interactive") is False
+
+
+def test_validate_key_custom_base_without_v1_appends_v1_models():
+    seen: dict = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["path"] = req.url.path
+        return httpx.Response(200, json={"data": []})
+
+    # base has no /v1 -> the appender adds /v1/models (the other half of the F1 dedup)
+    _validate_key("sk-x", "https://custom.example.com", transport=httpx.MockTransport(handler))
+    assert seen["path"] == "/v1/models"
+
+
+def test_configure_ctrl_c_at_menu_exits(tmp_path: Path, monkeypatch):
+    # questionary .ask() returns None on Ctrl+C; the flow must raise typer.Exit,
+    # matching onboard's convention (not silently treat it as skip/keep).
+    _setup_interactive(monkeypatch, tmp_path, [None])
+    with pytest.raises(typer.Exit):
+        configure_deep_research(non_interactive=False, warnings=[])
+
+
+def test_configure_ctrl_c_at_keep_menu_exits(tmp_path: Path, monkeypatch):
+    p = _setup_interactive(monkeypatch, tmp_path, [None])
+    ut.set_deep_research({"api_key": "sk-old", "model": "m"}, config_path=p)  # configured -> keep/reconfigure menu
+    with pytest.raises(typer.Exit):
+        configure_deep_research(non_interactive=False, warnings=[])
+
+
+def test_configure_ctrl_c_at_model_pick_exits(tmp_path: Path, monkeypatch):
+    # configure -> key -> validate ok -> Ctrl+C at model select
+    _setup_interactive(monkeypatch, tmp_path, ["configure", None])
+    with pytest.raises(typer.Exit):
+        configure_deep_research(non_interactive=False, warnings=[])
+
+
+def test_enable_refuses_malformed_config_and_preserves_file(tmp_path: Path, monkeypatch):
+    # REGRESSION (real-machine data-loss bug): a malformed real config must not
+    # be wiped -- enable exits non-zero and leaves the file untouched.
+    p = tmp_path / "config.json"
+    monkeypatch.setattr(ut, "get_config_path", lambda: p)
+    original = '{\n  "providers": {"openai": {"apiKey": "sk-o"}},\n  // comment => invalid JSON\n}\n'
+    p.write_text(original, encoding="utf-8")
+    result = runner.invoke(deep_research_app, ["enable", "--key", "sk-x", "--model", "mirothinker-1-7-deepresearch-mini"])
+    assert result.exit_code != 0
+    assert p.read_text(encoding="utf-8") == original  # NOT clobbered
+
+
+def test_get_refuses_malformed_config(tmp_path: Path, monkeypatch):
+    p = tmp_path / "config.json"
+    monkeypatch.setattr(ut, "get_config_path", lambda: p)
+    p.write_text("{  // bad\n}", encoding="utf-8")
+    assert runner.invoke(deep_research_app, ["get"]).exit_code != 0
+
+
+def test_reset_refuses_malformed_config_preserves_file(tmp_path: Path, monkeypatch):
+    p = tmp_path / "config.json"
+    monkeypatch.setattr(ut, "get_config_path", lambda: p)
+    original = "{  // bad\n}"
+    p.write_text(original, encoding="utf-8")
+    assert runner.invoke(deep_research_app, ["reset"]).exit_code != 0
+    assert p.read_text(encoding="utf-8") == original  # not clobbered
+
+
+def test_configure_refuses_malformed_config(tmp_path: Path, monkeypatch):
+    p = tmp_path / "config.json"
+    monkeypatch.setattr(ut, "get_config_path", lambda: p)
+    p.write_text("{  // bad\n}", encoding="utf-8")
+    with pytest.raises(typer.Exit):  # reads config first -> ConfigReadError -> Exit, no questionary
+        configure_deep_research(non_interactive=False, warnings=[])
+
+
+def test_configure_ctrl_c_at_validation_action_menu_exits(tmp_path: Path, monkeypatch):
+    fail = {"ok": False, "status": "http_401", "model_ids": None, "error": "bad"}
+    # configure -> key -> validate fails -> Ctrl+C at the retry/save/cancel menu
+    _setup_interactive(monkeypatch, tmp_path, ["configure", None], validate=lambda *a, **k: fail)
+    with pytest.raises(typer.Exit):
+        configure_deep_research(non_interactive=False, warnings=[])

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -155,6 +155,7 @@ def test_onboard_help_lists_all_flags() -> None:
         "--skip-sandbox",
         "--skip-channel",
         "--skip-memory",
+        "--skip-deep-research",
         "--non-interactive",
         "--yes",
         "--reset",
@@ -467,6 +468,7 @@ def test_onboard_interactive_uses_stubbed_pickers(
     monkeypatch.setattr(onboard_commands, "_step2_sandbox", lambda **_: None)
     monkeypatch.setattr(onboard_commands, "_step3_channel", lambda **_: None)
     monkeypatch.setattr(onboard_commands, "_step4_memory", lambda **_: None)
+    monkeypatch.setattr(onboard_commands, "_step5_deep_research", lambda **_: None)
 
     r = runner.invoke(app, ["onboard"])
     assert r.exit_code == 0, r.stdout
@@ -601,6 +603,7 @@ def test_step1_picker_uses_catalog_when_available(tmp_env: Path, monkeypatch: py
     monkeypatch.setattr(onboard_commands, "_step2_sandbox", lambda **_: None)
     monkeypatch.setattr(onboard_commands, "_step3_channel", lambda **_: None)
     monkeypatch.setattr(onboard_commands, "_step4_memory", lambda **_: None)
+    monkeypatch.setattr(onboard_commands, "_step5_deep_research", lambda **_: None)
 
     r = runner.invoke(app, ["onboard"])
     assert r.exit_code == 0, r.stdout
@@ -1342,6 +1345,7 @@ def test_back_navigation_rewinds_one_screen(tmp_env: Path, monkeypatch: pytest.M
     monkeypatch.setattr(onboard_commands, "_step2_sandbox", _s2)
     monkeypatch.setattr(onboard_commands, "_step3_channel", _s3)
     monkeypatch.setattr(onboard_commands, "_step4_memory", lambda **_: None)
+    monkeypatch.setattr(onboard_commands, "_step5_deep_research", lambda **_: None)
 
     onboard_commands.run_wizard(non_interactive=False)
     # s2 returns BACK once → s1 replays → s2 again → forward.
@@ -1369,6 +1373,7 @@ def test_first_screen_back_does_not_skip_step1(
     monkeypatch.setattr(onboard_commands, "_step2_sandbox", lambda **_: None)
     monkeypatch.setattr(onboard_commands, "_step3_channel", lambda **_: None)
     monkeypatch.setattr(onboard_commands, "_step4_memory", lambda **_: None)
+    monkeypatch.setattr(onboard_commands, "_step5_deep_research", lambda **_: None)
 
     onboard_commands.run_wizard(non_interactive=False)
 
@@ -1414,6 +1419,7 @@ def test_switch_provider_returns_to_picker_keeps_steps(
     monkeypatch.setattr(onboard_commands, "_step2_sandbox", lambda **_: None)
     monkeypatch.setattr(onboard_commands, "_step3_channel", lambda **_: None)
     monkeypatch.setattr(onboard_commands, "_step4_memory", lambda **_: None)
+    monkeypatch.setattr(onboard_commands, "_step5_deep_research", lambda **_: None)
 
     # Should complete (not raise typer.Exit) — steps 2/3/4 ran.
     onboard_commands.run_wizard(non_interactive=False)
@@ -1578,3 +1584,33 @@ def test_prompt_channel_fields_gates_skip_on_required(monkeypatch: pytest.Monkey
     assert "back" in _ph_text(app_id_ph)  # first field: rewind affordance
     assert app_secret_ph is None  # required later field: no skip hint
     assert "skip" in _ph_text(encrypt_ph)  # optional field: skip hint
+
+
+# --------------------------------------------------------------------------- step 5 (deep_research)
+
+
+def test_total_steps_is_five() -> None:
+    # Adding the deep_research step bumped the wizard from 4 to 5; the progress
+    # dots + "Step n/N" header derive from this constant.
+    assert onboard_commands._TOTAL_STEPS == 5
+
+
+def test_step5_skip_or_non_interactive_never_configures(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Both the --skip-deep-research and non-interactive paths must return without
+    # entering the interactive configure flow (which would hit questionary/network).
+    import raven.cli.deep_research_commands as drc
+
+    calls: list = []
+    monkeypatch.setattr(drc, "configure_deep_research", lambda **k: calls.append(k))
+    assert onboard_commands._step5_deep_research(skip=True, non_interactive=False, warnings=[]) is None
+    assert onboard_commands._step5_deep_research(skip=False, non_interactive=True, warnings=[]) is None
+    assert calls == []
+
+
+def test_step5_interactive_delegates_to_shared_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    import raven.cli.deep_research_commands as drc
+
+    seen: dict = {}
+    monkeypatch.setattr(drc, "configure_deep_research", lambda **k: seen.update(k) or True)
+    onboard_commands._step5_deep_research(skip=False, non_interactive=False, warnings=["w"])
+    assert seen.get("non_interactive") is False and seen.get("warnings") == ["w"]

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1614,3 +1614,13 @@ def test_step5_interactive_delegates_to_shared_flow(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(drc, "configure_deep_research", lambda **k: seen.update(k) or True)
     onboard_commands._step5_deep_research(skip=False, non_interactive=False, warnings=["w"])
     assert seen.get("non_interactive") is False and seen.get("warnings") == ["w"]
+
+
+def test_load_raw_config_raises_on_malformed(tmp_env: Path) -> None:
+    # onboard's read gate must not silently treat a malformed config as empty
+    # (which would let it misread state / write over a config with a typo).
+    from raven.config.loader import ConfigReadError
+
+    tmp_env.write_text("{  // comment => invalid JSON\n}", encoding="utf-8")
+    with pytest.raises(ConfigReadError):
+        onboard_commands._load_raw_config()

--- a/tests/test_cli_provider_commands.py
+++ b/tests/test_cli_provider_commands.py
@@ -357,3 +357,14 @@ def test_test_command_unknown_provider_exits_1(tmp_config: Path) -> None:
     r = runner.invoke(app, ["provider", "test", "no-such-provider"])
     assert r.exit_code == 1
     assert "No registry entry" in r.output or "Unknown provider" in r.output
+
+
+def test_provider_set_refuses_malformed_config_and_preserves_file(tmp_config: Path) -> None:
+    # REGRESSION: provider set must not clobber a malformed config. ConfigReadError
+    # is not a RuntimeError, so it bypasses the command's `except RuntimeError`
+    # (which is for OAuth-refusal) and is handled uniformly at the CLI entrypoint.
+    original = '{\n  "providers": {"openai": {"apiKey": "sk-o"}},\n  // comment => invalid JSON\n}\n'
+    tmp_config.write_text(original, encoding="utf-8")
+    result = runner.invoke(app, ["provider", "set", "openrouter", "--api-key", "sk-x"])
+    assert result.exit_code != 0
+    assert tmp_config.read_text(encoding="utf-8") == original  # NOT clobbered

--- a/tests/test_cli_repl_spine.py
+++ b/tests/test_cli_repl_spine.py
@@ -23,8 +23,8 @@ from raven.spine import (
     TurnStarted,
     Usage,
 )
-from raven.spine.events import Reasoning
 from raven.spine.delivery import Outlet
+from raven.spine.events import Reasoning
 
 
 def _src(channel="cli", chat_id="c1") -> Source:
@@ -75,9 +75,7 @@ async def test_runner_delegates_to_run_turn_with_stream_false():
     events, emit = _collect()
     outcome = await runner.run(req, emit, lambda: [])
     # The REPL runner passes stream=False so run_turn emits a Text, not StreamDelta.
-    assert loop.calls == [
-        {"text": "hi", "stream": False, "inline_tool_stream": False, "conversation": "cli:c1"}
-    ]
+    assert loop.calls == [{"text": "hi", "stream": False, "inline_tool_stream": False, "conversation": "cli:c1"}]
     assert len(events) == 1 and isinstance(events[0], Text)
     assert events[0].content == "hi there" and events[0].source is src
     assert outcome.explicit_reply is True

--- a/tests/test_cli_repl_spine.py
+++ b/tests/test_cli_repl_spine.py
@@ -23,6 +23,7 @@ from raven.spine import (
     TurnStarted,
     Usage,
 )
+from raven.spine.events import Reasoning
 from raven.spine.delivery import Outlet
 
 
@@ -35,8 +36,15 @@ class FakeAgentLoop:
         self.reply = reply
         self.calls: list[dict] = []
 
-    async def run_turn(self, req, emit, drain, *, stream) -> TurnOutcome:
-        self.calls.append({"text": req.text, "stream": stream, "conversation": req.conversation})
+    async def run_turn(self, req, emit, drain, *, stream, inline_tool_stream=False) -> TurnOutcome:
+        self.calls.append(
+            {
+                "text": req.text,
+                "stream": stream,
+                "inline_tool_stream": inline_tool_stream,
+                "conversation": req.conversation,
+            }
+        )
         # The REPL wires stream=False, so run_turn emits the reply as one Text.
         await emit(Text(content=self.reply, source=req.source))
         return TurnOutcome(usage=Usage(0, 0, 0), explicit_reply=True)
@@ -67,7 +75,9 @@ async def test_runner_delegates_to_run_turn_with_stream_false():
     events, emit = _collect()
     outcome = await runner.run(req, emit, lambda: [])
     # The REPL runner passes stream=False so run_turn emits a Text, not StreamDelta.
-    assert loop.calls == [{"text": "hi", "stream": False, "conversation": "cli:c1"}]
+    assert loop.calls == [
+        {"text": "hi", "stream": False, "inline_tool_stream": False, "conversation": "cli:c1"}
+    ]
     assert len(events) == 1 and isinstance(events[0], Text)
     assert events[0].content == "hi there" and events[0].source is src
     assert outcome.explicit_reply is True
@@ -79,6 +89,16 @@ async def test_runner_stream_flag_is_forwarded():
     events, emit = _collect()
     await runner.run(TurnRequest(origin=Origin.USER, source=_src(), text="hi", conversation="cli:c1"), emit, lambda: [])
     assert loop.calls[0]["stream"] is True  # build_tui would pass True; build_repl False
+
+
+async def test_runner_forwards_inline_tool_stream():
+    # build_repl / build_tui wire inline_tool_stream=True so deep_research streams
+    # its answer inline; the gateway leaves it False.
+    loop = FakeAgentLoop()
+    runner = AgentTurnRunner(loop, stream=False, inline_tool_stream=True)
+    events, emit = _collect()
+    await runner.run(TurnRequest(origin=Origin.USER, source=_src(), text="hi", conversation="cli:c1"), emit, lambda: [])
+    assert loop.calls[0]["inline_tool_stream"] is True
 
 
 # --- CliOutlet ---
@@ -138,6 +158,25 @@ async def test_cli_outlet_renders_tool_hint_when_send_tool_hints_on():
     assert notices == ['read_file("x")']  # progress suppressed, tool-hint shown
 
 
+async def test_cli_outlet_renders_reasoning_as_progress():
+    # deep_research streams coarse progress as Reasoning; CliOutlet renders it as a
+    # progress line (gated by render_notice + send_progress, like Notice PROGRESS).
+    notices, outlet = _notice_outlet(send_progress=True, send_tool_hints=False)
+    await outlet.deliver(Reasoning(content="searching the web..."))
+    assert notices == ["searching the web..."]
+
+
+async def test_cli_outlet_eats_reasoning_without_progress():
+    # No render_notice (interactive REPL before wiring) -> eaten, status quo.
+    rendered: list[str] = []
+    await CliOutlet("cli", rendered.append).deliver(Reasoning(content="searching..."))
+    assert rendered == []
+    # render_notice set but send_progress off -> also eaten.
+    notices, outlet = _notice_outlet(send_progress=False, send_tool_hints=False)
+    await outlet.deliver(Reasoning(content="searching..."))
+    assert notices == []
+
+
 # --- make_hub_sink ---
 
 
@@ -166,7 +205,7 @@ async def test_sink_routes_deliverables_and_drops_lifecycle():
 
 
 class _EchoLoop:
-    async def run_turn(self, req, emit, drain, *, stream) -> TurnOutcome:
+    async def run_turn(self, req, emit, drain, *, stream, inline_tool_stream=False) -> TurnOutcome:
         # REPL wires stream=False; run_turn emits the reply as one Text.
         await emit(Text(content=f"reply<{req.text}>", source=req.source))
         return TurnOutcome(usage=Usage(0, 0, 0), explicit_reply=True)
@@ -228,7 +267,7 @@ async def test_repl_loop_handles_empty_reply_without_hanging():
     events: list[str] = []
 
     class EmptyLoop:
-        async def run_turn(self, req, emit, drain, *, stream) -> TurnOutcome:
+        async def run_turn(self, req, emit, drain, *, stream, inline_tool_stream=False) -> TurnOutcome:
             # An empty reply emits no Text (run_turn skips empty content); the loop
             # must still not hang — wait_idle returns since no queue was built.
             return TurnOutcome(usage=Usage(0, 0, 0), explicit_reply=False)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -158,6 +158,7 @@ REGISTERED_COMMAND_NAMES = {
     "agent",
     "channels",
     "cron",
+    "deep-research",
     "doctor",
     "gateway",
     "onboard",

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -141,3 +141,64 @@ def test_schema_validation_error_raises(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="schema validation"):
         load_config(p)
+
+
+def test_read_raw_or_raise_absent_returns_empty(tmp_path: Path) -> None:
+    from raven.config.loader import read_raw_or_raise
+
+    assert read_raw_or_raise(tmp_path / "nope.json") == {}
+
+
+def test_read_raw_or_raise_valid(tmp_path: Path) -> None:
+    from raven.config.loader import read_raw_or_raise
+
+    p = tmp_path / "c.json"
+    p.write_text('{"a": 1}', encoding="utf-8")
+    assert read_raw_or_raise(p) == {"a": 1}
+
+
+def test_read_raw_or_raise_malformed_raises(tmp_path: Path) -> None:
+    from raven.config.loader import ConfigReadError, read_raw_or_raise
+
+    p = tmp_path / "bad.json"
+    p.write_text("{  // comment\n}", encoding="utf-8")
+    with pytest.raises(ConfigReadError):
+        read_raw_or_raise(p)
+
+
+def test_load_config_malformed_warns_loudly_and_uses_defaults(tmp_path: Path, capsys) -> None:
+    from raven.config.loader import load_config
+    from raven.config.schema import Config
+
+    p = tmp_path / "bad.json"
+    p.write_text("{  // comment\n}", encoding="utf-8")
+    cfg = load_config(p)  # must NOT raise (boot resilience)
+    assert isinstance(cfg, Config)
+    assert "IGNORING" in capsys.readouterr().err  # loud stderr warning, not silent
+
+
+def test_read_raw_or_raise_empty_file_is_empty_dict(tmp_path: Path) -> None:
+    from raven.config.loader import read_raw_or_raise
+
+    p = tmp_path / "empty.json"
+    p.write_text("   \n", encoding="utf-8")
+    assert read_raw_or_raise(p) == {}  # empty = no data to lose, not malformed
+
+
+def test_read_raw_or_raise_json_null_is_empty_dict(tmp_path: Path) -> None:
+    from raven.config.loader import read_raw_or_raise
+
+    p = tmp_path / "null.json"
+    p.write_text("null", encoding="utf-8")
+    assert read_raw_or_raise(p) == {}  # valid JSON but not an object -> {} (no AttributeError)
+
+
+def test_config_read_error_is_not_runtimeerror() -> None:
+    # Intentional: the CLI write commands wrap ops in `except RuntimeError`
+    # (OAuth-refusal etc.); ConfigReadError must NOT be a RuntimeError so a parse
+    # error bypasses those and reaches the single run() handler. Do not "fix"
+    # this to RuntimeError.
+    from raven.config.loader import ConfigReadError
+
+    assert not issubclass(ConfigReadError, RuntimeError)
+    assert issubclass(ConfigReadError, Exception)

--- a/tests/test_config_update.py
+++ b/tests/test_config_update.py
@@ -346,3 +346,20 @@ def test_init_extension_defaults_round_trips_through_loader(cfg_path: Path) -> N
     assert rc.skill_forge.embedding_url == "http://localhost:1357"
     assert rc.skill_forge.embedding_api_key is None
     assert rc.skill_forge.mass_library_db is None
+
+
+def test_malformed_config_refuses_write_and_preserves_file(cfg_path: Path) -> None:
+    # REGRESSION: update.py is the write path for cron/sentinel/onboard; a
+    # present-but-unparseable config must NOT be clobbered (the real-machine bug
+    # reproduced via set_sandbox_backend wiping providers).
+    from raven.config.loader import ConfigReadError
+    from raven.config.update import set_default_model, set_language
+
+    original = '{\n  "providers": {"openai": {"apiKey": "sk-o"}},\n  // comment => invalid JSON\n}\n'
+    cfg_path.write_text(original, encoding="utf-8")
+    with pytest.raises(ConfigReadError):
+        set_language("zh", config_path=cfg_path)
+    assert cfg_path.read_text(encoding="utf-8") == original  # untouched
+    with pytest.raises(ConfigReadError):
+        set_default_model("openrouter/x", config_path=cfg_path)
+    assert cfg_path.read_text(encoding="utf-8") == original

--- a/tests/test_config_update_channels.py
+++ b/tests/test_config_update_channels.py
@@ -389,3 +389,18 @@ def test_email_two_secrets_both_redacted(cfg_path: Path) -> None:
     assert cfg["imap_password"] == "****set****"
     assert cfg["smtp_password"] == "****set****"
     assert cfg["imap_host"] == "imap.x"  # non-secret stays plain
+
+
+def test_malformed_config_refuses_write_and_preserves_file(cfg_path: Path) -> None:
+    # REGRESSION: a present-but-unparseable config must NOT be clobbered by a
+    # write command (the bug that wiped a real config down to one section).
+    from raven.config.loader import ConfigReadError
+
+    original = '{\n  "channels": {"telegram": {"enabled": true}},\n  // comment => invalid JSON\n}\n'
+    cfg_path.write_text(original, encoding="utf-8")
+    with pytest.raises(ConfigReadError):
+        enable_channel("telegram", {"token": "x"}, config_path=cfg_path)
+    assert cfg_path.read_text(encoding="utf-8") == original  # untouched
+    with pytest.raises(ConfigReadError):
+        set_channel_fields("telegram", {"token": "y"}, config_path=cfg_path)
+    assert cfg_path.read_text(encoding="utf-8") == original

--- a/tests/test_config_update_providers.py
+++ b/tests/test_config_update_providers.py
@@ -486,3 +486,14 @@ def test_remove_absent_model_is_noop(cfg_path: Path) -> None:
 def test_add_provider_model_unknown_provider_raises(cfg_path: Path) -> None:
     with pytest.raises(KeyError):
         add_provider_model("nonexistent_provider", "x", config_path=cfg_path)
+
+
+def test_malformed_config_refuses_write_and_preserves_file(cfg_path: Path) -> None:
+    # REGRESSION: a present-but-unparseable config must NOT be clobbered.
+    from raven.config.loader import ConfigReadError
+
+    original = '{\n  "providers": {"openai": {"apiKey": "sk-o"}},\n  // comment => invalid JSON\n}\n'
+    cfg_path.write_text(original, encoding="utf-8")
+    with pytest.raises(ConfigReadError):
+        set_provider_fields("openai", {"api_key": "sk-x"}, config_path=cfg_path)
+    assert cfg_path.read_text(encoding="utf-8") == original  # untouched

--- a/tests/test_config_update_tools.py
+++ b/tests/test_config_update_tools.py
@@ -1,0 +1,105 @@
+"""Unit tests for raven.config.update_tools (tools.deepResearch write path).
+
+Pins the camelCase-on-disk contract: writes land as ``tools.deepResearch.apiKey``
+(not snake_case), matching the rest of config.json.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from raven.config import update_tools as ut
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Path:
+    return tmp_path / "config.json"
+
+
+def _raw(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_set_writes_camelcase_no_snake_leak(cfg: Path):
+    ut.set_deep_research({"api_key": "sk-abc", "model": "mirothinker-1-7-deepresearch-mini"}, config_path=cfg)
+    section = _raw(cfg)["tools"]["deepResearch"]
+    assert section == {"apiKey": "sk-abc", "apiBase": "", "model": "mirothinker-1-7-deepresearch-mini"}
+    assert "api_key" not in section  # no parallel snake_case key
+
+
+def test_set_merges_and_returns_prev(cfg: Path):
+    ut.set_deep_research({"api_key": "sk-1"}, config_path=cfg)
+    prev = ut.set_deep_research({"model": "mirothinker-1-7-deepresearch"}, config_path=cfg)
+    section = _raw(cfg)["tools"]["deepResearch"]
+    assert section["apiKey"] == "sk-1"  # earlier field preserved across a later patch
+    assert section["model"] == "mirothinker-1-7-deepresearch"
+    assert prev == {"model": ""}
+
+
+def test_set_rejects_unknown_field(cfg: Path):
+    with pytest.raises(KeyError):
+        ut.set_deep_research({"bogus": "x"}, config_path=cfg)
+
+
+def test_set_preserves_sibling_tool_sections(cfg: Path):
+    cfg.write_text(json.dumps({"tools": {"web": {"searchProvider": "brave"}}}), encoding="utf-8")
+    ut.set_deep_research({"api_key": "sk-abc"}, config_path=cfg)
+    tools = _raw(cfg)["tools"]
+    assert tools["web"] == {"searchProvider": "brave"}  # untouched
+    assert tools["deepResearch"]["apiKey"] == "sk-abc"
+
+
+def test_set_initializes_on_upgraded_config_without_tools_key(cfg: Path):
+    # Upgraded user whose config predates deep_research: no `tools` key at all.
+    # `enable` must create tools.deepResearch (not raise KeyError) and leave the
+    # rest of the config intact -- so users can opt in without re-running onboard.
+    cfg.write_text(json.dumps({"providers": {"openai": {"apiKey": "sk-o"}}}), encoding="utf-8")
+    ut.set_deep_research({"api_key": "sk-new"}, config_path=cfg)
+    data = _raw(cfg)
+    assert data["tools"]["deepResearch"]["apiKey"] == "sk-new"
+    assert data["providers"]["openai"]["apiKey"] == "sk-o"  # untouched
+
+
+def test_get_redacts_key(cfg: Path):
+    ut.set_deep_research({"api_key": "sk-secret", "model": "m"}, config_path=cfg)
+    got = ut.get_deep_research(redact=True, config_path=cfg)
+    assert got["api_key"] == "****set****"
+    assert got["model"] == "m"
+    assert ut.get_deep_research(redact=False, config_path=cfg)["api_key"] == "sk-secret"
+
+
+def test_get_empty_when_unset(cfg: Path):
+    assert ut.get_deep_research(redact=True, config_path=cfg)["api_key"] == "(empty)"
+
+
+def test_malformed_config_refuses_write_and_preserves_file(cfg: Path):
+    # REGRESSION: a present-but-unparseable config (e.g. // comments, trailing
+    # comma) must NEVER be clobbered. set/get/reset raise ConfigReadError and
+    # leave the file byte-for-byte intact -- returning {} then writing here once
+    # wiped a real config down to just the deepResearch section.
+    original = '{\n  "providers": {"openai": {"apiKey": "sk-o"}},\n  // a comment => invalid JSON\n}\n'
+    cfg.write_text(original, encoding="utf-8")
+    for op in (
+        lambda: ut.set_deep_research({"api_key": "sk-x"}, config_path=cfg),
+        lambda: ut.get_deep_research(config_path=cfg),
+        lambda: ut.reset_deep_research(config_path=cfg),
+    ):
+        with pytest.raises(ut.ConfigReadError):
+            op()
+    assert cfg.read_text(encoding="utf-8") == original  # untouched after all three
+
+
+def test_tolerates_invalid_section(cfg: Path):
+    cfg.write_text(json.dumps({"tools": {"deepResearch": {"apiKey": ["not", "a", "string"]}}}), encoding="utf-8")
+    # section fails validation -> falls back to defaults instead of crashing
+    assert ut.get_deep_research(config_path=cfg)["api_key"] == "(empty)"
+
+
+def test_reset_clears_key(cfg: Path):
+    ut.set_deep_research({"api_key": "sk-abc", "model": "m"}, config_path=cfg)
+    ut.reset_deep_research(config_path=cfg)
+    section = _raw(cfg)["tools"]["deepResearch"]
+    assert section == {"apiKey": "", "apiBase": "", "model": ""}

--- a/tests/test_deep_research_tool.py
+++ b/tests/test_deep_research_tool.py
@@ -19,7 +19,9 @@ from raven.agent.tools import deep_research as dr_mod
 from raven.agent.tools.deep_research import DeepResearchManager, DeepResearchTool, _extract_output_text
 from raven.config.schema import DeepResearchToolConfig
 
-ANSWER = "## Answer\n\nLangChain leads [1].\n\n### References\n[1] LangChain. <https://github.com/langchain-ai/langchain>\n"
+ANSWER = (
+    "## Answer\n\nLangChain leads [1].\n\n### References\n[1] LangChain. <https://github.com/langchain-ai/langchain>\n"
+)
 USAGE = {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150}
 
 
@@ -107,10 +109,7 @@ async def test_timeout_reported_not_raised(tool: DeepResearchTool, monkeypatch):
 
 async def test_finish_none_is_error(tool: DeepResearchTool, monkeypatch):
     # Stream ends (via [DONE]) without ever sending a finish_reason chunk — abnormal.
-    body = (
-        b'data: {"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}\n\n'
-        b"data: [DONE]\n\n"
-    )
+    body = b'data: {"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}\n\ndata: [DONE]\n\n'
     _patch(monkeypatch, lambda req: httpx.Response(200, content=body))
     result = json.loads(await tool.execute(query="q"))
     assert result["status"] == "error"
@@ -141,6 +140,7 @@ async def test_stream_callback_delivers_answer_and_returns_receipt(tool: DeepRes
         events.append((kind, text))
 
     tool.set_stream_callback(cb)
+
     # Step churn: thinking is skipped; consecutive same-action collapses; only a
     # change to a new action type emits. Here -> search, fetch, search = 3 lines.
     def step(kind: str) -> bytes:

--- a/tests/test_deep_research_tool.py
+++ b/tests/test_deep_research_tool.py
@@ -8,6 +8,7 @@ content is a self-contained answer with a References section).
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 
@@ -15,7 +16,7 @@ import httpx
 import pytest
 
 from raven.agent.tools import deep_research as dr_mod
-from raven.agent.tools.deep_research import DeepResearchTool
+from raven.agent.tools.deep_research import DeepResearchManager, DeepResearchTool, _extract_output_text
 from raven.config.schema import DeepResearchToolConfig
 
 ANSWER = "## Answer\n\nLangChain leads [1].\n\n### References\n[1] LangChain. <https://github.com/langchain-ai/langchain>\n"
@@ -182,3 +183,128 @@ def test_is_configured_gate(monkeypatch):
     assert DeepResearchTool.is_configured(DeepResearchToolConfig(api_key="sk")) is True
     monkeypatch.setenv("MIROTHINKER_API_KEY", "sk-env")
     assert DeepResearchTool.is_configured(DeepResearchToolConfig()) is True
+
+
+# ── async (channel) transport: Responses API + background delivery (2b) ──
+
+
+def _responses_handler(answer: str = ANSWER, poll_status: str = "completed"):
+    """MockTransport handler for the Responses API: POST submit -> 202 with id;
+    GET poll -> the given status (completed carries a multi-item output)."""
+
+    def handler(req):
+        if req.method == "POST":
+            return httpx.Response(202, json={"id": "resp_x", "status": "in_progress", "output": []})
+        if poll_status == "completed":
+            return httpx.Response(
+                200,
+                json={
+                    "status": "completed",
+                    "output": [
+                        {"type": "reasoning", "content": []},
+                        {"type": "message", "content": [{"type": "output_text", "text": answer}]},
+                    ],
+                },
+            )
+        return httpx.Response(200, json={"status": poll_status, "output": []})
+
+    return handler
+
+
+def _async_tool(tmp_path: Path, submit) -> DeepResearchTool:
+    cfg = DeepResearchToolConfig(api_key="sk-test")
+    mgr = DeepResearchManager(cfg, workspace=tmp_path)
+    if submit is not None:
+        mgr.set_submit(submit)
+    tool = DeepResearchTool(cfg, workspace=tmp_path, manager=mgr)
+    tool.set_context("weixin", "chat1", "weixin:chat1")
+    tool._mgr = mgr  # test handle
+    return tool
+
+
+async def test_async_mode_returns_ack_then_delivers_verbatim(tmp_path: Path, monkeypatch):
+    captured: list = []
+    tool = _async_tool(tmp_path, submit=lambda req: captured.append(req))
+    _patch(monkeypatch, _responses_handler())
+
+    ack = json.loads(await tool.execute(query="q"))
+    assert ack["status"] == "started"  # immediate ack, does not block for the research
+    assert "content" not in ack  # no answer inline — it is delivered later
+
+    await tool._mgr._active["weixin:chat1"]  # let the background poller finish
+
+    assert len(captured) == 1
+    req = captured[0]
+    assert req.deliver_text == ANSWER  # delivered verbatim, not rewritten
+    assert req.conversation == "weixin:chat1"
+    assert req.source.channel == "weixin" and req.source.chat_id == "chat1"
+    assert (tmp_path / "deep_research").is_dir()  # report also saved to disk
+
+
+async def test_async_guard_one_research_per_conversation(tmp_path: Path):
+    tool = _async_tool(tmp_path, submit=lambda req: None)
+
+    async def _never() -> None:
+        await asyncio.Event().wait()
+
+    t = asyncio.create_task(_never())
+    tool._mgr._active["weixin:chat1"] = t  # simulate an in-flight research
+    try:
+        ack = json.loads(await tool.execute(query="q"))
+        assert ack["status"] == "busy"  # refused, no second task
+    finally:
+        t.cancel()
+
+
+async def test_async_failure_releases_guard_and_delivers_error(tmp_path: Path, monkeypatch):
+    captured: list = []
+    tool = _async_tool(tmp_path, submit=lambda req: captured.append(req))
+    _patch(monkeypatch, _responses_handler(poll_status="failed"))
+
+    ack = json.loads(await tool.execute(query="q"))
+    assert ack["status"] == "started"
+    await tool._mgr._active["weixin:chat1"]
+    await asyncio.sleep(0)  # let the done-callback run
+
+    assert len(captured) == 1 and "failed" in captured[0].deliver_text.lower()
+    assert "weixin:chat1" not in tool._mgr._active  # guard released despite the failure
+
+
+async def test_async_not_wired_falls_back_to_sse(tmp_path: Path, monkeypatch):
+    # Manager present but submit not wired (non-gateway) -> can_deliver False ->
+    # the tool takes the synchronous SSE path, never the async ack.
+    tool = _async_tool(tmp_path, submit=None)
+    tool.set_context("cli", "direct", "cli:direct")
+    _patch(monkeypatch, lambda req: httpx.Response(200, content=_sse(ANSWER)))
+    result = json.loads(await tool.execute(query="q"))
+    assert result["status"] == "ok" and result["content"] == ANSWER
+
+
+async def test_async_report_write_failure_still_delivers_answer(tmp_path: Path, monkeypatch):
+    # A disk/permission failure saving the local report must NOT discard the real
+    # answer we already have — deliver it anyway, don't report a false failure.
+    captured: list = []
+    tool = _async_tool(tmp_path, submit=lambda req: captured.append(req))
+    _patch(monkeypatch, _responses_handler())
+
+    def _boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(dr_mod, "_write_report_file", _boom)
+
+    await tool.execute(query="q")
+    await tool._mgr._active["weixin:chat1"]
+
+    assert len(captured) == 1
+    assert captured[0].deliver_text == ANSWER  # answer delivered, not a "failed" message
+
+
+def test_extract_output_text_concatenates_message_output_only():
+    body = {
+        "output": [
+            {"type": "reasoning", "content": [{"type": "reasoning_text", "text": "ignore"}]},
+            {"type": "message", "content": [{"type": "output_text", "text": "A"}, {"type": "refusal", "text": "X"}]},
+            {"type": "message", "content": [{"type": "output_text", "text": "B"}]},
+        ]
+    }
+    assert _extract_output_text(body) == "AB"

--- a/tests/test_deep_research_tool.py
+++ b/tests/test_deep_research_tool.py
@@ -1,0 +1,184 @@
+"""Unit tests for the deep_research tool (MiroThinker, SSE).
+
+Hermetic: an httpx.MockTransport feeds a canned SSE chunk stream, so no real
+network or key is touched. The chunk shape mirrors a real MiroThinker stream
+(delta.content pieces, a final chunk carrying finish_reason + usage; the
+content is a self-contained answer with a References section).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from raven.agent.tools import deep_research as dr_mod
+from raven.agent.tools.deep_research import DeepResearchTool
+from raven.config.schema import DeepResearchToolConfig
+
+ANSWER = "## Answer\n\nLangChain leads [1].\n\n### References\n[1] LangChain. <https://github.com/langchain-ai/langchain>\n"
+USAGE = {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150}
+
+
+def _sse(content: str, finish_reason: str = "stop", usage: dict | None = USAGE) -> bytes:
+    """Build an SSE body: content split into delta chunks + a final finish chunk."""
+    lines = []
+
+    def emit(obj: dict) -> None:
+        lines.append(f"data: {json.dumps(obj)}\n\n")
+
+    emit({"choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}]})
+    lines.append(": heartbeat\n\n")  # keep-alive comment the server sends on idle; must be skipped
+    for piece in (content[i : i + 20] for i in range(0, len(content), 20)):
+        emit({"choices": [{"index": 0, "delta": {"content": piece}, "finish_reason": None}]})
+    final: dict = {"choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}]}
+    if usage is not None:
+        final["usage"] = usage
+    emit(final)
+    lines.append("data: [DONE]\n\n")
+    return "".join(lines).encode()
+
+
+def _patch(monkeypatch, handler) -> None:
+    real_client = httpx.AsyncClient
+
+    def factory(*_args, **_kwargs):
+        return real_client(transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(dr_mod.httpx, "AsyncClient", factory)
+
+
+@pytest.fixture
+def tool(tmp_path: Path) -> DeepResearchTool:
+    return DeepResearchTool(DeepResearchToolConfig(api_key="sk-test"), workspace=tmp_path)
+
+
+async def test_ok_accumulates_full_content(tool: DeepResearchTool, tmp_path: Path, monkeypatch):
+    _patch(monkeypatch, lambda req: httpx.Response(200, content=_sse(ANSWER)))
+    result = json.loads(await tool.execute(query="who leads"))
+
+    assert result["status"] == "ok"
+    # Content is the full answer, reconstructed verbatim from the chunk stream.
+    assert result["content"] == ANSWER
+    assert result["usage"]["total_tokens"] == 150
+    # No summary / no sources fields in the contract.
+    assert set(result) == {"status", "content", "report_ref", "usage"}
+
+    # Report persisted to disk; ref points at it; full content preserved there.
+    ref = Path(result["report_ref"])
+    assert ref.is_file() and ref.parent == tmp_path / "deep_research"
+    assert ANSWER in ref.read_text()
+
+
+async def test_cancelled_finish_is_timeout(tool: DeepResearchTool, monkeypatch):
+    _patch(monkeypatch, lambda req: httpx.Response(200, content=_sse("partial", finish_reason="cancelled")))
+    result = json.loads(await tool.execute(query="q"))
+    assert result["status"] == "timeout"
+
+
+async def test_empty_stream_no_report(tool: DeepResearchTool, monkeypatch):
+    _patch(monkeypatch, lambda req: httpx.Response(200, content=_sse("", usage=None)))
+    result = json.loads(await tool.execute(query="q"))
+    assert result["status"] == "ok"
+    assert result["report_ref"] is None
+    assert result["content"] == "(empty response)"
+
+
+async def test_http_error_reported_not_raised(tool: DeepResearchTool, monkeypatch):
+    body = {"error": {"code": "insufficient_balance", "message": "out of credits", "type": "billing"}}
+    _patch(monkeypatch, lambda req: httpx.Response(402, json=body))
+    result = json.loads(await tool.execute(query="q"))
+    assert result["status"] == "error"
+    assert "out of credits" in result["content"]
+    assert result["report_ref"] is None
+
+
+async def test_timeout_reported_not_raised(tool: DeepResearchTool, monkeypatch):
+    def handler(req):
+        raise httpx.ReadTimeout("slow", request=req)
+
+    _patch(monkeypatch, handler)
+    result = json.loads(await tool.execute(query="q"))
+    assert result["status"] == "timeout"
+
+
+async def test_finish_none_is_error(tool: DeepResearchTool, monkeypatch):
+    # Stream ends (via [DONE]) without ever sending a finish_reason chunk — abnormal.
+    body = (
+        b'data: {"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}\n\n'
+        b"data: [DONE]\n\n"
+    )
+    _patch(monkeypatch, lambda req: httpx.Response(200, content=body))
+    result = json.loads(await tool.execute(query="q"))
+    assert result["status"] == "error"
+
+
+async def test_http_error_non_json_body(tool: DeepResearchTool, monkeypatch):
+    _patch(monkeypatch, lambda req: httpx.Response(503, text="upstream boom"))
+    result = json.loads(await tool.execute(query="q"))
+    assert result["status"] == "error"
+    assert "boom" in result["content"] or "503" in result["content"]
+
+
+async def test_no_key_is_error(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("MIROTHINKER_API_KEY", raising=False)
+    tool = DeepResearchTool(DeepResearchToolConfig(), workspace=tmp_path)
+    result = json.loads(await tool.execute(query="q"))
+    assert result["status"] == "error"
+    assert "no API key" in result["content"]
+
+
+async def test_stream_callback_delivers_answer_and_returns_receipt(tool: DeepResearchTool, monkeypatch):
+    # A streaming surface wires a callback: progress streams, the answer is
+    # delivered via the callback, and execute() returns a compact receipt (no
+    # full content) so the model cannot re-emit/rewrite it.
+    events: list[tuple[str, str]] = []
+
+    async def cb(kind: str, text: str) -> None:
+        events.append((kind, text))
+
+    tool.set_stream_callback(cb)
+    # Step churn: thinking is skipped; consecutive same-action collapses; only a
+    # change to a new action type emits. Here -> search, fetch, search = 3 lines.
+    def step(kind: str) -> bytes:
+        return f'data: {{"choices":[{{"index":0,"delta":{{"reasoning_steps":[{{"type":"{kind}"}}]}},"finish_reason":null}}]}}\n\n'.encode()
+
+    body = b"".join(
+        step(k) for k in ("thinking", "web_search", "web_search", "thinking", "fetch_url_content", "web_search")
+    )
+    body += _sse(ANSWER)  # role + heartbeat + content deltas + finish + [DONE]
+    _patch(monkeypatch, lambda req: httpx.Response(200, content=body))
+
+    result = json.loads(await tool.execute(query="q"))
+
+    # Compact receipt: no full content, but flags delivery + points at the report.
+    assert result["status"] == "ok"
+    assert "content" not in result
+    assert result["delivered"] is True
+    assert result["report_ref"]
+
+    progress = [t for k, t in events if k == "progress"]
+    assert progress == ["searching the web...", "reading a page...", "searching the web..."]
+    assert "thinking..." not in progress  # thinking is not surfaced
+    # The finished answer was delivered verbatim via the callback.
+    answer = next(t for k, t in events if k == "answer")
+    assert answer == ANSWER
+
+
+async def test_no_callback_returns_full_content(tool: DeepResearchTool, monkeypatch):
+    # Without a wired callback (e.g. a channel), execute() falls back to the full
+    # structured result so the answer is not lost.
+    _patch(monkeypatch, lambda req: httpx.Response(200, content=_sse(ANSWER)))
+    result = json.loads(await tool.execute(query="q"))
+    assert result["content"] == ANSWER
+    assert "delivered" not in result
+
+
+def test_is_configured_gate(monkeypatch):
+    monkeypatch.delenv("MIROTHINKER_API_KEY", raising=False)
+    assert DeepResearchTool.is_configured(DeepResearchToolConfig()) is False
+    assert DeepResearchTool.is_configured(DeepResearchToolConfig(api_key="sk")) is True
+    monkeypatch.setenv("MIROTHINKER_API_KEY", "sk-env")
+    assert DeepResearchTool.is_configured(DeepResearchToolConfig()) is True

--- a/tests/test_default_context_engine.py
+++ b/tests/test_default_context_engine.py
@@ -449,3 +449,58 @@ class TestTurnPassthrough:
         joined = "\n".join(str(m.get("content")) for m in ac.messages)
         assert "slack" in joined
         assert "C123" in joined
+
+
+# ── consecutive-assistant coalescing (2b deliver_text support) ──
+
+
+def test_coalesce_assistant_merges_adjacent_plain_only():
+    from raven.context_engine.assembler import _coalesce_assistant
+
+    # The ack ("on it") + a verbatim deliver_text answer land as two adjacent
+    # assistant messages; they merge into one so providers that reject
+    # consecutive same-role messages do not choke on the next turn.
+    history = [
+        {"role": "user", "content": "research X"},
+        {"role": "assistant", "content": "on it"},
+        {"role": "assistant", "content": "FULL REPORT"},
+    ]
+    out = _coalesce_assistant(history)
+    assert [m["role"] for m in out] == ["user", "assistant"]
+    assert out[-1]["content"] == "on it\n\nFULL REPORT"
+
+
+def test_coalesce_assistant_preserves_tool_call_adjacency():
+    from raven.context_engine.assembler import _coalesce_assistant
+
+    # An assistant carrying tool_calls is never merged — its tool result follows
+    # it, so merging would break tool-call adjacency.
+    history = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "res"},
+        {"role": "assistant", "content": "done"},
+    ]
+    assert _coalesce_assistant(history) == history
+
+
+def test_coalesce_assistant_ignores_non_adjacent():
+    from raven.context_engine.assembler import _coalesce_assistant
+
+    history = [
+        {"role": "assistant", "content": "a"},
+        {"role": "user", "content": "u"},
+        {"role": "assistant", "content": "b"},
+    ]
+    assert _coalesce_assistant(history) == history
+
+
+def test_coalesce_assistant_skips_when_merged_in_carries_reasoning():
+    from raven.context_engine.assembler import _coalesce_assistant
+
+    # The merged-in message carries reasoning_content — merging would silently
+    # drop it (contra the reasoning-field history projection), so skip the merge.
+    history = [
+        {"role": "assistant", "content": "a"},
+        {"role": "assistant", "content": "b", "reasoning_content": "why"},
+    ]
+    assert _coalesce_assistant(history) == history

--- a/tests/test_spine_turn.py
+++ b/tests/test_spine_turn.py
@@ -76,3 +76,10 @@ def test_turn_request_has_no_conversation_id_derivation():
     fields = {f.name for f in dataclasses.fields(TurnRequest)}
     assert "conversation" in fields
     assert "conversation_id" not in fields
+
+
+def test_turn_request_deliver_text_defaults_none():
+    # New optional field must default None so existing keyword constructors
+    # (~15 call sites) are unaffected.
+    req = TurnRequest(origin=Origin.USER, source=_src(), text="hi")
+    assert req.deliver_text is None

--- a/tests/test_tui_rpc_config.py
+++ b/tests/test_tui_rpc_config.py
@@ -272,3 +272,24 @@ async def test_config_methods_registered_via_helper(fake_home: Path) -> None:
         }
     )
     assert resp["error"]["code"] == -32010
+
+
+async def test_config_set_refuses_malformed_config_and_preserves_file(fake_home: Path) -> None:
+    # REGRESSION: TUI config.set must not clobber a malformed config down to one
+    # key (same data-loss failure mode as the CLI write path).
+    cfg = fake_home / ".raven" / "config.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    original = '{\n  "tui": {"theme": "dark"},\n  // comment => invalid JSON\n}\n'
+    cfg.write_text(original, encoding="utf-8")
+    with pytest.raises(ConfigValidationError):
+        await config_set({"key": "tui.theme", "value": "dracula"})
+    assert cfg.read_text(encoding="utf-8") == original  # NOT clobbered
+
+
+async def test_config_get_refuses_malformed_config(fake_home: Path) -> None:
+    # The read path also surfaces a broken config (not a silent empty dict).
+    cfg = fake_home / ".raven" / "config.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text('{\n  "tui": {"theme": "dark"},\n  // bad\n}\n', encoding="utf-8")
+    with pytest.raises(ConfigValidationError):
+        await config_get({"keys": ["tui.theme"]})

--- a/tests/test_tui_rpc_spine.py
+++ b/tests/test_tui_rpc_spine.py
@@ -57,7 +57,9 @@ class _RunTurnLoop:
         self.tools = tools if tools is not None else {}
         self.last_stream = None
 
-    async def run_turn(self, req, emit, drain, *, stream, inline_tool_stream=False, usage_sink=None, text_sink=None) -> TurnOutcome:
+    async def run_turn(
+        self, req, emit, drain, *, stream, inline_tool_stream=False, usage_sink=None, text_sink=None
+    ) -> TurnOutcome:
         self.last_stream = stream
         for ev in self._events:
             await emit(ev)

--- a/tests/test_tui_rpc_spine.py
+++ b/tests/test_tui_rpc_spine.py
@@ -57,7 +57,7 @@ class _RunTurnLoop:
         self.tools = tools if tools is not None else {}
         self.last_stream = None
 
-    async def run_turn(self, req, emit, drain, *, stream, usage_sink=None, text_sink=None) -> TurnOutcome:
+    async def run_turn(self, req, emit, drain, *, stream, inline_tool_stream=False, usage_sink=None, text_sink=None) -> TurnOutcome:
         self.last_stream = stream
         for ev in self._events:
             await emit(ev)
@@ -113,7 +113,7 @@ async def test_runner_emits_eve22_synthetic_tool_complete_when_message_tool_fire
     message_tool = MessageTool()
     loop = _RunTurnLoop(tools={"message": message_tool})
 
-    async def _run_turn(req, emit, drain, *, stream, usage_sink=None):
+    async def _run_turn(req, emit, drain, *, stream, inline_tool_stream=False, usage_sink=None):
         # the message tool replied this turn (turn-local sent flag)
         message_tool._turn.set(replace(message_tool._cur(), sent=True))
         return TurnOutcome(usage=Usage(0, 0, 0), explicit_reply=True)
@@ -378,7 +378,7 @@ async def test_cron_turn_deliverables_key_to_dead_conversation_not_user_session(
 
 async def test_failed_turn_emits_error():
     class _BoomLoop:
-        async def run_turn(self, req, emit, drain, *, stream, usage_sink=None) -> TurnOutcome:
+        async def run_turn(self, req, emit, drain, *, stream, inline_tool_stream=False, usage_sink=None) -> TurnOutcome:
             raise RuntimeError("boom")
 
     emitter = FakeEmitter()
@@ -401,7 +401,7 @@ async def test_cancelled_turn_does_not_emit_error():
     started = asyncio.Event()
 
     class _HangLoop:
-        async def run_turn(self, req, emit, drain, *, stream, usage_sink=None) -> TurnOutcome:
+        async def run_turn(self, req, emit, drain, *, stream, inline_tool_stream=False, usage_sink=None) -> TurnOutcome:
             started.set()
             await asyncio.sleep(3600)
             return TurnOutcome(usage=Usage(0, 0, 0), explicit_reply=True)


### PR DESCRIPTION
## Summary

Integrate MiroThinker as an async `deep_research` tool, end to end.

- **Tool + streaming** (`feat(agent)`): add the `deep_research` tool with CLI/TUI streaming.
- **Async channel delivery** (`feat(agent)`): a `deliver_text` turn primitive delivers the research result to channels verbatim (out-of-band), since a MiroThinker run is minute-scale and must not block the turn.
- **CLI config + onboard** (`feat(cli)`): `raven deep-research enable/get/reset` plus an onboard step so users configure the tool without hand-editing `config.json`. Key validation uses the free `GET /v1/models` probe (a `/chat/completions` ping would trigger a full billed research run).
- **Config write-safety fix** (`fix(config)`): every config-write command shared a raw reader that swallowed a JSON parse error and returned `{}`, so writing over a present-but-unparseable `config.json` (e.g. one with `//` comments) wiped the whole file down to just the command's own section. Found while testing `deep-research enable` on a real config. A single shared `read_raw_or_raise` now raises `ConfigReadError` for a present-but-unparseable file; all six raw read-modify-write points converge on it, and the CLI surfaces it once, cleanly, leaving the file untouched.

## Type

- [x] Feature

## Verification

- `uv run pytest` (config layer + deep-research/onboard/provider CLI + tui_rpc config + cli smoke): **340 passed**.
- `uv run ruff check` on all touched files: clean.
- Real-machine (isolated): async `deep_research` result delivered to a WeChat channel verbatim; onboard step walked; `deep-research enable` against a malformed `config.json` refuses with a friendly message and leaves the file byte-identical (verified with `cmp`).

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A

---

Reviewer notes:
- Mixed-topic PR on purpose: it is a `feat` (deep_research) that also carries the `fix(config)` bug it exposed; the squash commit takes the `feat(agent)` title and GitHub collects both `Co-authored-by` trailers.
- Full `uv run pytest` still shows env-dependent failures (sandbox VM, TUI Ink/Node E2E, missing channel SDKs) that predate this branch; the tests covering the code changed here (340) pass. A base comparison to confirm none are new is still pending.
- The MiroThinker test key used for real-machine checks is isolated and is not committed anywhere in this branch.