### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raven"
-version = "0.1.4"
+version = "0.1.5"
 description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3249,7 +3249,7 @@ wheels = [
 
 [[package]]
 name = "raven"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Bump version from 0.1.4 to 0.1.5 for release. Two feature PRs landed on main since v0.1.4:

- #136 feat(agent): integrate mirothinker deep_research tool
- #135 feat(tracing): in-tree tracing subsystem with decoupled adopter contract

Only pyproject.toml and uv.lock change (version field synced via `uv lock`).

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

## Verification

- [x] Relevant lint / type checks pass locally

Ran `uv lock` to sync the lockfile; commit-message lint passes (`check_commit_messages.py`).

## Risk

- [x] Backward compatibility considered

Version-only bump; no source changes.

## Related Issues

N/A