### PR TITLE
fix: derive __version__ from installed package metadata

### DIFF
--- a/raven/__init__.py
+++ b/raven/__init__.py
@@ -15,6 +15,8 @@ See LICENSE for attribution.
 """
 
 import logging as _logging
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 
 class _LiteLLMBotocorePreloadFilter(_logging.Filter):
@@ -42,5 +44,8 @@ class _LiteLLMBotocorePreloadFilter(_logging.Filter):
 
 _logging.getLogger("LiteLLM").addFilter(_LiteLLMBotocorePreloadFilter())
 
-__version__ = "0.1.3"
+try:
+    __version__ = _pkg_version("raven")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
 __logo__ = "🐦‍⬛"

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -175,6 +175,17 @@ REGISTERED_COMMAND_NAMES = {
 }
 
 
+def test_version_flag_matches_installed_metadata() -> None:
+    """``raven --version`` reports the installed package version, not a
+    hand-written literal, so it can never drift from ``pyproject.toml``."""
+    from importlib.metadata import version as pkg_version
+
+    r = runner.invoke(app, ["--version"])
+    assert r.exception is None
+    assert r.exit_code == 0
+    assert f"Raven v{pkg_version('raven')}" in r.stdout
+
+
 def test_no_logs_subcommand_registered() -> None:
     """There is no ``raven logs`` command; adding one must break this test."""
     assert "logs" not in _registered_command_names()


### PR DESCRIPTION
## Change description

`raven --version` printed a stale `0.1.3` even after the release bump to `0.1.5`. The root cause: `raven/__init__.py` carried a hand-written `__version__` literal that the release flow (which edits only `pyproject.toml`, per `RELEASING.md`) never updated -- a hidden second source of truth.

This derives `__version__` from installed package metadata (`importlib.metadata.version("raven")`, with a `PackageNotFoundError` fallback), matching the existing in-repo pattern in `cli/upgrade_commands._current_version` and `tui_rpc/methods/system._raven_version`. Now `raven --version`, the TUI intro banner, and `pyproject.toml` all resolve to a single source of truth through the installed dist-info.

Added `test_version_flag_matches_installed_metadata` to `tests/test_cli_smoke.py`, asserting the flag output equals the installed metadata version (not a pinned literal, so it can never re-introduce drift).

Out of scope: the slow `raven --version` startup (litellm eager import) is a separate, pre-existing perf concern tracked alongside #128, not addressed here.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Document
- [ ] Others

## Related issues (if there is)

Fixes #138

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [ ] Code follows security best practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary