### PR TITLE
perf(cli): defer litellm import to cut cold start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ lint-bridge:
 test: test-python test-tui
 
 test-python:
-	uv run --extra dev pytest tests/test_commit_lint.py tests/test_large_file_check.py -q
+	uv run --extra dev pytest tests/test_commit_lint.py tests/test_large_file_check.py tests/test_cli_smoke.py tests/test_litellm_setup.py -q
 
 test-tui:
 	npm test --prefix ui-tui

--- a/raven/agent/__init__.py
+++ b/raven/agent/__init__.py
@@ -1,7 +1,31 @@
 """Agent core module."""
 
-from raven.agent.context import ContextBuilder
-from raven.agent.loop import AgentLoop
-from raven.memory_engine.consolidate.consolidator import MemoryStore
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from raven.agent.context import ContextBuilder
+    from raven.agent.loop import AgentLoop
+    from raven.memory_engine.consolidate.consolidator import MemoryStore
 
 __all__ = ["AgentLoop", "ContextBuilder", "MemoryStore"]
+
+# Lazy re-exports (PEP 562): importing a ``raven.agent`` submodule must not
+# eagerly construct ``AgentLoop`` -> litellm, which dominates CLI cold start.
+_LAZY_EXPORTS = {
+    "ContextBuilder": "raven.agent.context",
+    "AgentLoop": "raven.agent.loop",
+    "MemoryStore": "raven.memory_engine.consolidate.consolidator",
+}
+
+
+def __getattr__(name: str) -> object:
+    module_path = _LAZY_EXPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    return getattr(importlib.import_module(module_path), name)
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/raven/cli/commands.py
+++ b/raven/cli/commands.py
@@ -42,17 +42,6 @@ from rich.console import Console
 
 from raven import __logo__, __version__
 
-# LiteLLM prints a red-bold "Provider List: ..." banner to stdout when it
-# can't match a model prefix. For our custom-provider setup this fires on
-# every call, clashes with prompt_toolkit's rendered prompt, and shows up
-# as ?[1;31m... garbage when patch_stdout is active. Silence it.
-try:
-    import litellm
-
-    litellm.suppress_debug_info = True
-except Exception:
-    pass
-
 app = typer.Typer(
     name="raven",
     help=f"{__logo__} Raven - Agent Framework",

--- a/raven/cli/provider_commands.py
+++ b/raven/cli/provider_commands.py
@@ -106,9 +106,10 @@ def _login_github_copilot() -> None:
     console.print("[cyan]Starting GitHub Copilot device flow...[/cyan]\n")
 
     async def _trigger():
-        from litellm import acompletion
+        from raven.providers.litellm_setup import import_litellm
 
-        await acompletion(
+        litellm = import_litellm()
+        await litellm.acompletion(
             model="github_copilot/gpt-4o",
             messages=[{"role": "user", "content": "hi"}],
             max_tokens=1,

--- a/raven/providers/__init__.py
+++ b/raven/providers/__init__.py
@@ -1,8 +1,34 @@
 """LLM provider abstraction module."""
 
-from raven.providers.azure_openai_provider import AzureOpenAIProvider
-from raven.providers.base import LLMProvider, LLMResponse
-from raven.providers.litellm_provider import LiteLLMProvider
-from raven.providers.openai_codex_provider import OpenAICodexProvider
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from raven.providers.azure_openai_provider import AzureOpenAIProvider
+    from raven.providers.base import LLMProvider, LLMResponse
+    from raven.providers.litellm_provider import LiteLLMProvider
+    from raven.providers.openai_codex_provider import OpenAICodexProvider
 
 __all__ = ["LLMProvider", "LLMResponse", "LiteLLMProvider", "OpenAICodexProvider", "AzureOpenAIProvider"]
+
+# Lazy re-exports (PEP 562): importing a provider submodule must not eagerly pull
+# ``litellm_provider`` -> litellm, which dominates CLI cold start.
+_LAZY_EXPORTS = {
+    "LLMProvider": "raven.providers.base",
+    "LLMResponse": "raven.providers.base",
+    "LiteLLMProvider": "raven.providers.litellm_provider",
+    "OpenAICodexProvider": "raven.providers.openai_codex_provider",
+    "AzureOpenAIProvider": "raven.providers.azure_openai_provider",
+}
+
+
+def __getattr__(name: str) -> object:
+    module_path = _LAZY_EXPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    return getattr(importlib.import_module(module_path), name)
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/raven/providers/litellm_provider.py
+++ b/raven/providers/litellm_provider.py
@@ -9,12 +9,14 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 import json_repair
-import litellm
-from litellm import acompletion
 from loguru import logger
 
 from raven.providers.base import LLMProvider, LLMResponse, StreamDelta, ToolCallRequest
+from raven.providers.litellm_setup import import_litellm
 from raven.providers.registry import find_by_model, find_gateway
+
+litellm = import_litellm()
+acompletion = litellm.acompletion
 
 # LiteLLM's async logging worker (LoggingWorker) binds its queue to a single
 # event loop. Raven runs each turn under a fresh loop (asyncio.run per call), so
@@ -97,8 +99,6 @@ class LiteLLMProvider(LLMProvider):
         if api_base:
             litellm.api_base = api_base
 
-        # Disable LiteLLM logging noise
-        litellm.suppress_debug_info = True
         # Drop unsupported parameters for providers (e.g., gpt-5 rejects some params)
         litellm.drop_params = True
 

--- a/raven/providers/litellm_setup.py
+++ b/raven/providers/litellm_setup.py
@@ -1,0 +1,34 @@
+"""Import litellm with its import-time terminal noise silenced.
+
+litellm prints a "Provider List" banner (gated by ``suppress_debug_info``) and,
+because it installs its own stderr ``StreamHandler`` on its ``LiteLLM*`` loggers,
+emits DEBUG to the terminal *while importing*. Raise those loggers' levels across
+the import so that DEBUG never reaches the terminal, then restore them.
+
+Stripping the handlers for the rest of the session stays with raven's
+``_strip_tty_stream_handlers`` (it runs after this deferred import in the TUI
+path); doing it here too would mutate global logging state as a side effect of
+merely importing a provider module.
+"""
+
+import logging
+
+# litellm attaches its stderr handler to all three (litellm/_logging.py).
+_LITELLM_LOGGERS = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
+
+
+def import_litellm():
+    """Import litellm with its banner disabled and import-time DEBUG suppressed."""
+    loggers = [logging.getLogger(name) for name in _LITELLM_LOGGERS]
+    prev_levels = [lg.level for lg in loggers]
+    for lg in loggers:
+        lg.setLevel(logging.WARNING)
+    try:
+        import litellm
+
+        litellm.suppress_debug_info = True
+    finally:
+        for lg, prev in zip(loggers, prev_levels):
+            lg.setLevel(prev)
+
+    return litellm

--- a/raven/token_wise/pricing.py
+++ b/raven/token_wise/pricing.py
@@ -53,7 +53,9 @@ _OPENROUTER_CACHE_TIME: float = 0.0
 def _try_litellm_rates(model: str, input_tokens: int, output_tokens: int) -> tuple[float, float] | None:
     """Ask LiteLLM for per-token rates. Returns (prompt_rate, completion_rate) or None."""
     try:
-        import litellm
+        from raven.providers.litellm_setup import import_litellm
+
+        litellm = import_litellm()
     except Exception:
         return None
 
@@ -166,7 +168,9 @@ def _try_openrouter_rates(model: str) -> tuple[float, float] | None:
 def _try_litellm_context_window(model: str) -> int | None:
     """LiteLLM's static model metadata — offline, covers most mapped providers."""
     try:
-        import litellm
+        from raven.providers.litellm_setup import import_litellm
+
+        litellm = import_litellm()
     except Exception:
         return None
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -186,6 +186,23 @@ def test_version_flag_matches_installed_metadata() -> None:
     assert f"Raven v{pkg_version('raven')}" in r.stdout
 
 
+def test_cli_import_does_not_pull_litellm() -> None:
+    """The CLI entry module must not eagerly import litellm (it dominates cold
+    start). Checked in a subprocess: ``sys.modules`` is process-global, so a full
+    ``pytest tests/`` run pollutes it via sibling tests that import litellm and an
+    in-process assertion would false-fail.
+    """
+    import subprocess
+    import sys
+
+    r = subprocess.run(
+        [sys.executable, "-c", "import raven.cli.commands, sys; assert 'litellm' not in sys.modules"],
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, r.stderr
+
+
 def test_no_logs_subcommand_registered() -> None:
     """There is no ``raven logs`` command; adding one must break this test."""
     assert "logs" not in _registered_command_names()

--- a/tests/test_litellm_setup.py
+++ b/tests/test_litellm_setup.py
@@ -1,0 +1,32 @@
+"""Unit tests for ``import_litellm`` -- banner + import-time DEBUG silencing."""
+
+import logging
+
+from raven.providers.litellm_setup import import_litellm
+
+_LITELLM_LOGGERS = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
+
+
+def test_import_litellm_disables_banner() -> None:
+    module = import_litellm()
+
+    assert module.suppress_debug_info is True
+
+
+def test_import_litellm_restores_logger_levels() -> None:
+    """The import-time level bump must not persist, or runtime DEBUG would stop
+    propagating to the file sink."""
+    for name in _LITELLM_LOGGERS:
+        logging.getLogger(name).setLevel(logging.DEBUG)
+
+    import_litellm()
+
+    for name in _LITELLM_LOGGERS:
+        assert logging.getLogger(name).level == logging.DEBUG
+
+
+def test_import_litellm_is_idempotent() -> None:
+    first = import_litellm()
+    second = import_litellm()
+
+    assert first is second


### PR DESCRIPTION
## Summary

Every `raven` command imported litellm eagerly, and litellm was ~85% of the
~2.35s cold start -- so even `raven --version` paid the full tax. This defers
litellm to the code paths that actually need a model:

- Drop the top-level `import litellm` in the CLI entry module.
- Make `raven.agent` and `raven.providers` PEP 562 lazy re-exports, so importing
  a submodule no longer eagerly constructs `AgentLoop` -> litellm (0 in-repo
  callers of the re-exports, so no behavior change).
- Route every litellm import through a single `import_litellm()` helper that
  silences litellm's "Provider List" banner and suppresses its import-time DEBUG
  from the terminal (litellm installs its own stderr handler and logs while
  importing; the deferred import happens after raven's CLI logging setup, so the
  helper keeps that noise off the terminal / Ink TUI).

Result: `raven --version` starts in ~0.4s (from ~2.35s). Verified the everos
memory substrate was never on the startup path; it was not the bottleneck.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

## Verification

- `raven --version`: ~2.35s -> ~0.4s (direct `.venv/bin/raven`).
- `python -X importtime -c "import raven.cli.commands"`: 0 litellm.
- Real logging path (`redirect_loguru_to_file` + provider import) and an
  interactive `raven tui`: 0 `LiteLLM:DEBUG` lines leaked to the terminal.
- `make test-python` (now includes `test_cli_smoke.py` + `test_litellm_setup.py`).
- Affected suites (agent loop / providers / token_wise / tui logging isolation): pass.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [ ] Rollback path is clear for risky changes

## Related Issues

Fixes #142