### PR TITLE
fix(tracing): show model-call reasoning above the answer, not below

### DIFF
--- a/raven/tracing/viewer/ui/app.js
+++ b/raven/tracing/viewer/ui/app.js
@@ -1354,11 +1354,14 @@ function renderModelOutputCard(span, artifacts) {
   ]
     .filter(Boolean)
     .join(' · ');
+  // Reasoning precedes the answer chronologically (the model thinks, then
+  // responds), so render it above the body — collapsed, since it is long and
+  // diagnostic.
   return `
     <article class="content-card wide-card">
       <header><h4>Model Output</h4>${note ? `<span class="card-note">${escapeHtml(note)}</span>` : ''}</header>
-      ${body}
       ${reasoningBlock}
+      ${body}
     </article>`;
 }
 


### PR DESCRIPTION
## Summary

Fix the reading order of a model-call detail in the tracing viewer: reasoning
now renders **above** the assistant answer instead of below it.

The Model Output card appended the (collapsed) `Reasoning` block after the
answer body, so the card read bottom-up. Reasoning precedes the answer
chronologically -- the model thinks, then responds -- so it belongs at the top
of the card. It stays collapsed by default since it is long and diagnostic.

Reasoning is part of the model's *output* (it comes from `llm.output`'s
`reasoning_content`), so it stays inside the Model Output card rather than
moving to the Model Input area (system prompt / tools / history).

Card order is now: `Model Output` header -> `Reasoning` (folded) -> answer.

## Type

- [x] Fix

## Verification

- [x] Application changes have been tested thoroughly

- `node --check raven/tracing/viewer/ui/app.js` -> OK.
- Booted the viewer against real traces and opened a `minimax/minimax-m3`
  model call that carries reasoning. Confirmed the Model Output card children
  are now `header -> Reasoning(details) -> answer` (DOM check
  `reasoningBeforeAnswer: true`) and verified it visually.

## Risk

- [x] Backward compatibility considered

Viewer-only, presentation-only change: no data model, schema, or API change;
purely reorders two blocks within one detail card.

## Related Issues

N/A -- follow-up polish on the tracing viewer merged in #135.
