### PR TITLE
perf(tui): cut render delay by deferring provider and memory

### DIFF
--- a/raven/cli/_helpers.py
+++ b/raven/cli/_helpers.py
@@ -61,26 +61,49 @@ def warn_about_pending_cli_reminders(cron_service, config: Config) -> None:
         )
 
 
+def check_provider_credentials(config: Config) -> None:
+    """Fail-fast when the configured provider is missing required credentials.
+
+    Cheap (no litellm import), so it can run at startup even when the real
+    provider is built lazily. Kept in sync with the branches of make_provider.
+    """
+    model = config.agents.defaults.model
+    provider_name = config.get_provider_name(model)
+    p = config.get_provider(model)
+
+    if provider_name == "openai_codex" or model.startswith("openai-codex/"):
+        return
+    if provider_name == "azure_openai":
+        if not p or not p.api_key or not p.api_base:
+            console.print("[red]Error: Azure OpenAI requires api_key and api_base.[/red]")
+            console.print("Set them in ~/.raven/config.json under providers.azure_openai section")
+            console.print("Use the model field to specify the deployment name.")
+            raise typer.Exit(1)
+        return
+    from raven.providers.registry import find_by_name
+
+    spec = find_by_name(provider_name)
+    if not model.startswith("bedrock/") and not (p and p.api_key) and not (spec and (spec.is_oauth or spec.is_local)):
+        console.print("[red]Error: No API key configured.[/red]")
+        console.print("Set one in ~/.raven/config.json under providers section")
+        raise typer.Exit(1)
+
+
 def make_provider(config: Config):
     """Create the appropriate LLM provider from config."""
     from raven.providers.azure_openai_provider import AzureOpenAIProvider
     from raven.providers.base import GenerationSettings
     from raven.providers.openai_codex_provider import OpenAICodexProvider
 
+    check_provider_credentials(config)
+
     model = config.agents.defaults.model
     provider_name = config.get_provider_name(model)
     p = config.get_provider(model)
 
-    # OpenAI Codex (OAuth)
     if provider_name == "openai_codex" or model.startswith("openai-codex/"):
         provider = OpenAICodexProvider(default_model=model)
-    # Azure OpenAI: direct Azure OpenAI endpoint with deployment name
     elif provider_name == "azure_openai":
-        if not p or not p.api_key or not p.api_base:
-            console.print("[red]Error: Azure OpenAI requires api_key and api_base.[/red]")
-            console.print("Set them in ~/.raven/config.json under providers.azure_openai section")
-            console.print("Use the model field to specify the deployment name.")
-            raise typer.Exit(1)
         provider = AzureOpenAIProvider(
             api_key=p.api_key,
             api_base=p.api_base,
@@ -88,17 +111,7 @@ def make_provider(config: Config):
         )
     else:
         from raven.providers.litellm_provider import LiteLLMProvider
-        from raven.providers.registry import find_by_name
 
-        spec = find_by_name(provider_name)
-        if (
-            not model.startswith("bedrock/")
-            and not (p and p.api_key)
-            and not (spec and (spec.is_oauth or spec.is_local))
-        ):
-            console.print("[red]Error: No API key configured.[/red]")
-            console.print("Set one in ~/.raven/config.json under providers section")
-            raise typer.Exit(1)
         # OpenRouter routes qwen3.x-27B through providers that default to
         # reasoning mode (e.g. AtlasCloud): every chat completion emits
         # ~800 chain-of-thought tokens and takes ~30s wall — fatal for
@@ -123,6 +136,28 @@ def make_provider(config: Config):
         max_tokens=defaults.max_tokens,
         reasoning_effort=defaults.reasoning_effort,
     )
+    return provider
+
+
+def make_lazy_provider(config: Config):
+    """Provider that defers the real (litellm-importing) build to the first model
+    call, so AgentLoop construction stays fast. Credentials are checked now
+    (fail-fast preserved) and the real provider is pre-warmed in the background."""
+    from raven.providers.base import GenerationSettings
+    from raven.providers.lazy import LazyProvider
+
+    check_provider_credentials(config)
+    defaults = config.agents.defaults
+    provider = LazyProvider(
+        factory=lambda: make_provider(config),
+        default_model=defaults.model,
+        generation=GenerationSettings(
+            temperature=defaults.temperature,
+            max_tokens=defaults.max_tokens,
+            reasoning_effort=defaults.reasoning_effort,
+        ),
+    )
+    provider.prewarm()
     return provider
 
 

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -338,7 +338,7 @@ def _build_tui_agent_loop():
     try:
         from raven.agent.loop import AgentLoop
         from raven.agent.loop.recovery import limits_from_defaults
-        from raven.cli._helpers import load_runtime_config, make_provider
+        from raven.cli._helpers import load_runtime_config, make_lazy_provider
         from raven.cli._plugin_stack import (
             build_plugin_registry,
             build_plugin_tools,
@@ -354,7 +354,7 @@ def _build_tui_agent_loop():
         ec_config = load_raven_config()
         skill_forge_cfg = ec_config.skill_forge
 
-        provider = make_provider(config)
+        provider = make_lazy_provider(config)
         session_manager = SessionManager(config.workspace_path)
 
         cron = CronService(
@@ -600,23 +600,27 @@ async def _run_rpc_server_until_done(
     # backend.start() (which may trigger lazy warns) through the end of stop().
     # The Node child already inherited the real terminal fds at Popen time (before
     # this function ran), so this dup2 does not affect the child's terminal.
-    with redirect_terminal_fds_to_file(get_logs_dir() / "tui.log"):
-        # Start the embedded backend before serving so the EverOS runtime is up
-        # and its index lock is held for the session. No-op for http/no-op backends.
-        if agent_loop is not None and agent_loop.backend is not None:
-            try:
-                await agent_loop.backend.start()
-            except Exception:
-                from loguru import logger as _logger
+    async def _start_memory_backend() -> None:
+        # Bring up the memory backend off the render path: its everos/lancedb
+        # import (~2-3s) + lifespan must not block the handshake / first render.
+        # recall/store degrade to empty until it is ready.
+        try:
+            await agent_loop.backend.start()
+        except Exception:
+            from loguru import logger as _logger
 
-                _logger.exception(
-                    "tui: memory backend start failed; continuing with degraded memory path",
-                )
-        # everos configure_logging installs a root stdout StreamHandler during start();
-        # strip it so everos records flow to the file sink and never reach the terminal.
+            _logger.exception("tui: memory backend start failed; continuing with degraded memory path")
+        # everos installs a root stdout StreamHandler during start(); strip it now
+        # (after the deferred start) so its records reach the file sink.
+        _strip_tty_stream_handlers()
+
+    with redirect_terminal_fds_to_file(get_logs_dir() / "tui.log"):
+        # Strip any tty handlers installed before serve; the deferred backend
+        # start strips again after it runs.
         _strip_tty_stream_handlers()
 
         serve_task = asyncio.create_task(server.serve_forever())
+        backend_start_task: asyncio.Task | None = None
 
         try:
             # Wait until EITHER handshake completes OR deadline expires OR child exits.
@@ -639,10 +643,21 @@ async def _run_rpc_server_until_done(
 
             if not handshake_done.is_set():
                 return False
-            # Handshake OK — continue serving until child exits.
+            # Handshake OK (UI rendered) — bring up the memory backend now, in the
+            # background, so its heavy import + lifespan happens after render.
+            if agent_loop is not None and agent_loop.backend is not None:
+                backend_start_task = asyncio.create_task(_start_memory_backend())
+            # Continue serving until child exits.
             await proc_done.wait()
             return True
         finally:
+            # Let the background backend start finish before stop() so stop never
+            # races a mid-flight start.
+            if backend_start_task is not None:
+                try:
+                    await backend_start_task
+                except (asyncio.CancelledError, Exception):
+                    pass
             # Fail-safe any pending confirm so a paused dispatch's worker thread
             # is released when the connection drops.
             confirm_broker.cancel_all()

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -4,9 +4,10 @@ The backend is the host's :class:`MemoryBackend` implementation. Three
 operating modes:
 
 - **embedded** (EM-2, this PR): delegate to ``everos.service`` in
-  the same process. If ``everos`` is not installed (or fails to
-  import — version skew, missing native deps, etc.), the backend
-  degrades to a :class:`_NoOpAdapter` and logs once at construction.
+  the same process. The adapter build (the everos/lancedb import) is
+  deferred to ``start()`` to keep construction off the render path; if
+  ``everos`` is not installed (or fails to import — version skew, missing
+  native deps, etc.), the backend degrades to a :class:`_NoOpAdapter`.
 - **http** (EM-3, next PR): HTTP client over EverOS's
   ``POST /api/v1/memory/{search,add,...}``. Currently shadowed by the
   same no-op adapter so wiring code can already select the mode
@@ -35,6 +36,7 @@ Three architectural invariants worth re-stating:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from types import SimpleNamespace
@@ -486,11 +488,14 @@ class EverosBackend:
         # Adapter selection. Tests inject explicit adapters; production
         # wires through one of the per-mode factories below.
         if adapter is not None:
-            self._adapter: _Adapter = adapter
+            self._adapter: _Adapter | None = adapter
         else:
             self._validate_config()
             if self._mode == "embedded":
-                self._adapter = _try_make_real_adapter()
+                # Defer the heavy everos/lancedb import (~2-3s) to start() so it
+                # runs off the render-blocking path. recall/store degrade to
+                # empty until the adapter is built.
+                self._adapter = None
             else:  # "http" — _validate_config rejected anything else
                 self._adapter = self._make_http_adapter()
 
@@ -530,6 +535,11 @@ class EverosBackend:
     # ── Lifecycle ───────────────────────────────────────────────────
 
     async def start(self) -> None:
+        # Build the embedded adapter now (deferred from __init__). The everos /
+        # lancedb import is ~2-3s of sync CPU, so run it in a thread to keep it
+        # off the event loop.
+        if self._mode == "embedded" and self._adapter is None:
+            self._adapter = await asyncio.to_thread(_try_make_real_adapter)
         self._logger.info(
             "EverosBackend.start (mode=%s, adapter=%s)",
             self._mode,
@@ -588,6 +598,8 @@ class EverosBackend:
             )
             return []
         owner_type: _OwnerType = "user" if user_id is not None else "agent"
+        if self._adapter is None:
+            return []  # adapter still building (start() not finished); degrade to no hits
         try:
             data = await self._adapter.search(
                 user_id=user_id,
@@ -632,6 +644,8 @@ class EverosBackend:
         )
         if not payload:
             return
+        if self._adapter is None:
+            return  # adapter still building (start() not finished); drop this turn's store
         n = self._turn_counts.get(session_id, 0) + 1
         self._turn_counts[session_id] = n
         is_final = self._flush_every_turns > 0 and n % self._flush_every_turns == 0

--- a/raven/providers/lazy.py
+++ b/raven/providers/lazy.py
@@ -1,0 +1,67 @@
+"""Lazy LLM provider: defer building the real provider until the first model call.
+
+Building the real provider imports litellm (~2-7s), which — when done eagerly at
+``AgentLoop`` construction — stalls startup even though tools/skills/memory do not
+need it. ``LazyProvider`` answers the two things read before the first call
+(``get_default_model`` and ``generation``) from config, and builds the real
+provider (memoized, thread-safe) only when a chat method is actually invoked.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+from raven.providers.base import GenerationSettings, LLMProvider, LLMResponse, StreamDelta
+
+
+class LazyProvider(LLMProvider):
+    """Proxy that builds the real provider on first chat call (memoized)."""
+
+    def __init__(
+        self,
+        factory: Callable[[], LLMProvider],
+        default_model: str,
+        generation: GenerationSettings,
+    ):
+        super().__init__()
+        self._factory = factory
+        self._default_model = default_model
+        self.generation = generation
+        self._provider: LLMProvider | None = None
+        self._lock = threading.Lock()
+
+    def _built(self) -> LLMProvider:
+        if self._provider is None:
+            with self._lock:
+                if self._provider is None:
+                    self._provider = self._factory()
+        return self._provider
+
+    def prewarm(self) -> None:
+        """Build the real provider in a daemon thread so the ~2-7s litellm import
+        is hidden behind render + user think-time. Safe to race with the first
+        real call (``_built`` is lock-guarded); build errors are left for the
+        first call to surface."""
+
+        def _run() -> None:
+            try:
+                self._built()
+            except Exception:
+                pass
+
+        threading.Thread(target=_run, name="litellm-prewarm", daemon=True).start()
+
+    def get_default_model(self) -> str:
+        return self._default_model
+
+    async def chat(self, *args: Any, **kwargs: Any) -> LLMResponse:
+        return await self._built().chat(*args, **kwargs)
+
+    async def chat_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[StreamDelta]:
+        async for delta in self._built().chat_stream(*args, **kwargs):
+            yield delta
+
+    async def chat_with_retry(self, *args: Any, **kwargs: Any) -> LLMResponse:
+        return await self._built().chat_with_retry(*args, **kwargs)

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -99,3 +99,55 @@ def test_make_provider_custom_routes_through_litellm(tmp_path: Path) -> None:
     )
     provider = _helpers.make_provider(load_config(p))
     assert isinstance(provider, LiteLLMProvider)
+
+
+# ---------------------------------------------------------------------------
+# check_provider_credentials — fail-fast without importing litellm
+# ---------------------------------------------------------------------------
+
+
+def _write_config(tmp_path: Path, *, api_key: str | None) -> Path:
+    provider: dict = {"apiBase": "http://localhost:9000/v1"}
+    if api_key is not None:
+        provider["apiKey"] = api_key
+    p = tmp_path / "config.json"
+    p.write_text(
+        json.dumps(
+            {
+                "agents": {"defaults": {"model": "my-model", "provider": "custom"}},
+                "providers": {"custom": provider},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_check_provider_credentials_exits_when_no_key(tmp_path: Path) -> None:
+    import typer
+
+    from raven.config.loader import load_config
+
+    with pytest.raises(typer.Exit):
+        _helpers.check_provider_credentials(load_config(_write_config(tmp_path, api_key=None)))
+
+
+def test_check_provider_credentials_passes_with_key(tmp_path: Path) -> None:
+    from raven.config.loader import load_config
+
+    _helpers.check_provider_credentials(load_config(_write_config(tmp_path, api_key="sk-x")))  # no raise
+
+
+def test_make_lazy_provider_returns_lazy_without_building(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``make_lazy_provider`` returns a LazyProvider that answers ``get_default_model``
+    from config without building the real (litellm-importing) provider."""
+    from raven.config.loader import load_config
+    from raven.providers.lazy import LazyProvider
+
+    # Stub the real build so prewarm never imports litellm.
+    monkeypatch.setattr(_helpers, "make_provider", lambda _c: SimpleNamespace(name="real"))
+
+    provider = _helpers.make_lazy_provider(load_config(_write_config(tmp_path, api_key="sk-x")))
+
+    assert isinstance(provider, LazyProvider)
+    assert provider.get_default_model() == "my-model"

--- a/tests/test_cli_tui_commands.py
+++ b/tests/test_cli_tui_commands.py
@@ -320,6 +320,7 @@ def rpc_server_deps(monkeypatch: pytest.MonkeyPatch):
 
     ctx["fake_server"] = fake_server
     ctx["fake_confirm_broker"] = fake_confirm_broker
+    ctx["dispatcher"] = fake_dispatcher
     return ctx
 
 
@@ -336,12 +337,35 @@ async def _run_until_done_with_immediate_proc_done(monkeypatch, ctx):
     await _run_rpc_server_until_done(fake_sock, "test-token", 0.01, proc_done)
 
 
-async def test_rpc_runner_calls_backend_start_before_serving(rpc_server_deps, monkeypatch) -> None:
-    """``_run_rpc_server_until_done`` must await ``backend.start()`` once before
-    entering the serve loop when ``agent_loop.backend`` is not None."""
-    await _run_until_done_with_immediate_proc_done(monkeypatch, rpc_server_deps)
+async def _run_until_done_with_handshake(monkeypatch, ctx):
+    """Drive the runner through a successful handshake, then end the session.
 
-    assert rpc_server_deps["start_calls"] == ["start"], "backend.start() must be called exactly once before serving"
+    The memory backend is now started *after* the handshake (off the render
+    path), so tests that assert backend lifecycle must simulate the handshake:
+    we invoke the registered ``system.hello`` handler (which sets
+    ``handshake_done``), let the background start run, then set ``proc_done``.
+    """
+    from raven.cli.tui_commands import _run_rpc_server_until_done
+
+    proc_done = asyncio.Event()
+    fake_sock = MagicMock()
+    runner = asyncio.create_task(_run_rpc_server_until_done(fake_sock, "test-token", 1.0, proc_done))
+    await asyncio.sleep(0.02)  # let the runner register handlers + start serving
+
+    hello = next(c.args[1] for c in ctx["dispatcher"].register.call_args_list if c.args[0] == "system.hello")
+    await hello({"client_version": "0.0.1"})  # sets handshake_done -> triggers background backend start
+    await asyncio.sleep(0.05)  # let the background start run to completion
+
+    proc_done.set()
+    await runner
+
+
+async def test_rpc_runner_starts_backend_after_handshake(rpc_server_deps, monkeypatch) -> None:
+    """``backend.start()`` runs once, in the background after the handshake (off
+    the render path), when ``agent_loop.backend`` is not None."""
+    await _run_until_done_with_handshake(monkeypatch, rpc_server_deps)
+
+    assert rpc_server_deps["start_calls"] == ["start"], "backend.start() must be called exactly once"
 
 
 async def test_rpc_runner_calls_backend_stop_on_exit(rpc_server_deps, monkeypatch) -> None:
@@ -383,7 +407,7 @@ async def test_rpc_runner_stop_called_even_when_serve_raises(rpc_server_deps, mo
 
 async def test_rpc_runner_start_and_stop_each_called_once(rpc_server_deps, monkeypatch) -> None:
     """Exactly one start and one stop — no double-start or double-stop."""
-    await _run_until_done_with_immediate_proc_done(monkeypatch, rpc_server_deps)
+    await _run_until_done_with_handshake(monkeypatch, rpc_server_deps)
 
     assert len(rpc_server_deps["start_calls"]) == 1
     assert len(rpc_server_deps["stop_calls"]) == 1
@@ -423,7 +447,7 @@ async def test_rpc_runner_strips_root_stdout_handler_after_backend_start(rpc_ser
 
     rpc_server_deps["backend"].start = _start_with_root_handler
 
-    await _run_until_done_with_immediate_proc_done(monkeypatch, rpc_server_deps)
+    await _run_until_done_with_handshake(monkeypatch, rpc_server_deps)
 
     assert len(installed_handler) == 1, "spy backend.start() did not run"
     assert installed_handler[0] not in logging.getLogger().handlers, (
@@ -479,7 +503,7 @@ async def test_rpc_runner_activates_fd_redirect_before_backend_start(rpc_server_
         lambda: tmp_path,
     )
 
-    await _run_until_done_with_immediate_proc_done(monkeypatch, rpc_server_deps)
+    await _run_until_done_with_handshake(monkeypatch, rpc_server_deps)
 
     assert "redirect_enter" in call_log, "redirect_terminal_fds_to_file must be entered"
     enter_idx = call_log.index("redirect_enter")

--- a/tests/test_em2_backend.py
+++ b/tests/test_em2_backend.py
@@ -92,13 +92,12 @@ class TestConstruction:
         with pytest.raises(ValueError, match="invalid mode"):
             EverosBackend(_ctx(tmp_path, mode="embeded"))
 
-    def test_embedded_mode_selects_real_or_no_op(self, tmp_path: Path) -> None:
-        """Embedded mode picks the real adapter when everos imports
-        cleanly, else falls back to no-op. Both are valid; we only
-        assert the type is one of the two so the test stays hermetic
-        whether or not everos is installed in the active venv."""
+    def test_embedded_mode_defers_adapter_to_start(self, tmp_path: Path) -> None:
+        """Embedded mode defers the (heavy everos/lancedb) adapter build to
+        start(): at construction the adapter is None, so the ~2-3s import stays
+        off the render-blocking build path. start() then selects real/no-op."""
         b = EverosBackend(_ctx(tmp_path, mode="embedded"))
-        assert isinstance(b._adapter, (_NoOpAdapter, _RealEverosAdapter))
+        assert b._adapter is None
 
     def test_make_backend_factory(self, tmp_path: Path) -> None:
         b = make_backend(_ctx(tmp_path))
@@ -117,6 +116,24 @@ class TestLifecycle:
         await b.stop()
         await b.start()
         await b.stop()
+
+    async def test_start_builds_deferred_embedded_adapter(self, tmp_path: Path) -> None:
+        """start() builds the embedded adapter that __init__ deferred."""
+        b = EverosBackend(_ctx(tmp_path, mode="embedded"))
+        assert b._adapter is None
+        try:
+            await b.start()
+            assert isinstance(b._adapter, (_NoOpAdapter, _RealEverosAdapter))
+        finally:
+            await b.stop()
+
+    async def test_recall_and_store_degrade_before_adapter_built(self, tmp_path: Path) -> None:
+        """Before start() builds the deferred adapter, recall returns empty and
+        store is a no-op (the render-window degrade), not a crash."""
+        b = EverosBackend(_ctx(tmp_path, mode="embedded"))
+        assert b._adapter is None
+        assert await b.recall("hi", user_id="alice", top_k=5) == []
+        await b.store("sess", [{"role": "user", "content": "hi"}])  # must not raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lazy_provider.py
+++ b/tests/test_lazy_provider.py
@@ -1,0 +1,110 @@
+"""Unit tests for ``LazyProvider`` -- defers the real (litellm-importing) build."""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from raven.providers.base import GenerationSettings
+from raven.providers.lazy import LazyProvider
+
+
+class _FakeProvider:
+    def __init__(self) -> None:
+        self.generation = GenerationSettings()
+
+    def get_default_model(self) -> str:
+        return "built-model"
+
+    async def chat(self, *args, **kwargs) -> str:
+        return "chat"
+
+    async def chat_stream(self, *args, **kwargs):
+        yield "delta"
+
+    async def chat_with_retry(self, *args, **kwargs) -> str:
+        return "retry"
+
+
+def _lazy(calls: list) -> LazyProvider:
+    def factory() -> _FakeProvider:
+        calls.append(1)
+        return _FakeProvider()
+
+    return LazyProvider(factory, default_model="cfg-model", generation=GenerationSettings(temperature=0.5))
+
+
+def test_construction_and_config_reads_do_not_build() -> None:
+    calls: list = []
+    lp = _lazy(calls)
+
+    assert calls == []  # constructing did not call the factory
+    assert lp.get_default_model() == "cfg-model"  # from config, not the built provider
+    assert lp.generation.temperature == 0.5  # from config
+    assert calls == []  # neither read triggered a build
+
+
+def test_first_chat_builds_and_memoizes() -> None:
+    calls: list = []
+    lp = _lazy(calls)
+
+    assert asyncio.run(lp.chat([])) == "chat"
+    assert calls == [1]
+    assert asyncio.run(lp.chat([])) == "chat"
+    assert calls == [1]  # not rebuilt
+
+
+def test_chat_stream_and_retry_delegate() -> None:
+    calls: list = []
+    lp = _lazy(calls)
+
+    async def _drain():
+        return [d async for d in lp.chat_stream([])]
+
+    assert asyncio.run(_drain()) == ["delta"]
+    assert asyncio.run(lp.chat_with_retry([])) == "retry"
+    assert calls == [1]  # one build shared across both
+
+
+def test_built_is_thread_safe() -> None:
+    calls: list = []
+
+    def factory() -> _FakeProvider:
+        time.sleep(0.05)  # widen the race window
+        calls.append(1)
+        return _FakeProvider()
+
+    lp = LazyProvider(factory, "cfg-model", GenerationSettings())
+    threads = [threading.Thread(target=lp._built) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert calls == [1]  # built exactly once despite concurrent access
+
+
+def test_prewarm_builds_in_background() -> None:
+    built = threading.Event()
+
+    def factory() -> _FakeProvider:
+        built.set()
+        return _FakeProvider()
+
+    lp = LazyProvider(factory, "cfg-model", GenerationSettings())
+    lp.prewarm()
+
+    assert built.wait(timeout=2.0), "prewarm did not build the provider in the background"
+
+
+def test_prewarm_swallows_build_error() -> None:
+    def factory():
+        raise RuntimeError("boom")
+
+    lp = LazyProvider(factory, "cfg-model", GenerationSettings())
+    lp.prewarm()  # must not raise
+    time.sleep(0.05)
+    # the error surfaces on a real call instead
+    with pytest.raises(RuntimeError, match="boom"):
+        asyncio.run(lp.chat([]))

--- a/ui-tui/src/__tests__/branding.test.tsx
+++ b/ui-tui/src/__tests__/branding.test.tsx
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest'
 import type { SessionInfo } from '../types.js'
 
 import { ravenLogo, ravenLogoWord, RAVEN_WORD_WIDTH } from '../banner.js'
-import { Branding, formatProvider, SessionPanel } from '../components/branding.js'
+import { Branding, formatProvider, SessionPanel, StartupLoader } from '../components/branding.js'
 import { DEFAULT_THEME } from '../theme.js'
 
 describe('Branding', () => {
@@ -36,6 +36,14 @@ describe('SessionPanel', () => {
     const { lastFrame } = render(<SessionPanel info={info} maxCols={80} sid="test" t={DEFAULT_THEME} />)
     expect(lastFrame()).toContain('raven upgrade')
     expect(lastFrame()).not.toContain('raven update')
+  })
+})
+
+describe('StartupLoader', () => {
+  it('renders a spinner frame and the first startup message', () => {
+    const { lastFrame } = render(<StartupLoader t={DEFAULT_THEME} />)
+    expect(lastFrame()).toContain('summoning raven')
+    expect(lastFrame()).toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/)
   })
 })
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -360,10 +360,7 @@ export function useMainApp(gw: GatewayClient, rpcClient?: ChatStreamRpcClient) {
   }, [])
 
   const rpc: GatewayRpc = useCallback(
-    async <T extends object = Record<string, unknown>>(
-      method: string,
-      params: Record<string, unknown> = {}
-    ) => {
+    async <T extends object = Record<string, unknown>>(method: string, params: Record<string, unknown> = {}) => {
       try {
         const result = asRpcResult<T>(await gw.request<T>(method, params))
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -25,7 +25,7 @@ import { PerfPane } from '../lib/perfPane.js'
 import { AgentsOverlay } from './agentsOverlay.js'
 import { GoodVibesHeart, StatusRule, StickyPromptTracker, TranscriptScrollbar } from './appChrome.js'
 import { FloatingOverlays, PromptZone } from './appOverlays.js'
-import { Banner, Panel, SessionPanel } from './branding.js'
+import { Banner, Panel, SessionPanel, StartupLoader } from './branding.js'
 import { FpsOverlay } from './fpsOverlay.js'
 import { HelpHint } from './helpHint.js'
 import { MessageLine } from './messageLine.js'
@@ -119,7 +119,11 @@ const TranscriptPane = memo(function TranscriptPane({
                 <Box flexDirection="column" paddingTop={1}>
                   <Banner t={ui.theme} />
 
-                  {row.msg.info && <SessionPanel info={row.msg.info} sid={ui.sid} t={ui.theme} />}
+                  {row.msg.info ? (
+                    <SessionPanel info={row.msg.info} sid={ui.sid} t={ui.theme} />
+                  ) : (
+                    <StartupLoader t={ui.theme} />
+                  )}
                 </Box>
               ) : row.msg.kind === 'panel' && row.msg.panelData ? (
                 <Panel sections={row.msg.panelData.sections} t={ui.theme} title={row.msg.panelData.title} />

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -41,6 +41,31 @@ function InlineLoader({ label, t }: { label: string; t: Theme }) {
   )
 }
 
+const STARTUP_MESSAGES = ['summoning raven…', 'building agent loop…', 'loading tools & skills…']
+const STARTUP_LABEL_MS = 900
+
+// Placeholder shown in the intro row while the backend builds the agent loop,
+// before the session.info handshake populates SessionPanel. Wrapped in the same
+// rounded box as SessionPanel so the handoff reads as one region's content
+// changing rather than a block appearing from nowhere.
+export function StartupLoader({ t }: { t: Theme }) {
+  const [step, setStep] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => setStep(n => n + 1), STARTUP_LABEL_MS)
+
+    return () => clearInterval(id)
+  }, [])
+
+  const label = STARTUP_MESSAGES[Math.min(step, STARTUP_MESSAGES.length - 1)] ?? STARTUP_MESSAGES[0]
+
+  return (
+    <Box borderColor={t.color.border} borderStyle="round" marginBottom={1} paddingX={2} paddingY={1}>
+      <InlineLoader label={label} t={t} />
+    </Box>
+  )
+}
+
 export function ArtLines({ lines }: { lines: [string, string][] }) {
   return (
     <>


### PR DESCRIPTION
## Summary

Profiling `raven tui` bring-up put the agent-loop build
(`_build_tui_agent_loop`) at ~7s, so the TUI showed an empty shell
for several seconds before real content (issue #128 reports it as a
4-5s delay). Two eager imports on that path dominated: litellm when
the loop built its provider, and the everos/lancedb memory backend
(its `start()` measured ~2.5s). Deferring both off the render path
drops the build to ~1.8s -- the diffuse-import residual -- and a
startup loader fills what remains.

- `perf`: `LazyProvider` defers litellm to the first chat (with a
  background prewarm); `EverosBackend` defers its adapter import into
  `start()`, which the TUI runs in the background after the render
  handshake. recall/store degrade to empty until the backend is ready.
  A cheap credential check keeps startup fail-fast without importing
  litellm.
- `feat(tui)`: a `StartupLoader` (braille spinner in the SessionPanel
  box) fills the pre-handshake gap and is replaced by the real panel
  the moment `session.info` arrives.

The empty-shell window drops from ~7s to ~1-2s, with real tool/skill
counts and no `-32008` on the first send.

Non-blocking trade-offs (documented, not bugs): the residual ~1.8s is
diffuse imports with no single lever; quitting within the first ~2.5s
waits briefly on the background backend task; a first message sent
within ~2.5s runs one turn without memory recall (silent degrade).
Phase-timing startup logs (one of the issue's acceptance items) were
not added -- the delay was root-fixed rather than instrumented.

Also reformats `useMainApp.ts` (a pre-existing drift from #80) so the
whole-tree prettier hook passes on this first ui-tui change since.

## Type

- [x] Fix
- [x] Feature

## Verification

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally

Commands: `make lint-python`, `make test-python`, and
`cd ui-tui && npm run lint && npm run type-check && npm test && npm run build`.

## Risk

- [x] Backward compatibility considered

Provider swap on model change still works (the loop holds a plain
assignable provider attribute). agent/gateway paths keep `make_provider`;
only the TUI uses the lazy path.

## Related Issues

Fixes #128
