### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raven"
-version = "0.1.5"
+version = "0.1.6"
 description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3249,7 +3249,7 @@ wheels = [
 
 [[package]]
 name = "raven"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Bump Raven package metadata from 0.1.5 to 0.1.6 so the release tag can build a wheel from the current main branch.

This release carries the changes merged after v0.1.5:

- Version display now derives from installed package metadata (#139).
- Tracing dashboard port reuse avoids taking over non-Raven viewers (#141).
- CLI startup defers LiteLLM imports for faster cold start (#147).
- Self-evolution stack and AppWorld benchmark entry points are included (#140).
- TUI render delay is reduced by deferring provider and memory loading (#157).

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

## Verification

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

Commands run:

- `PYTHONPATH=. uv run pytest tests/test_cli_smoke.py::test_version_flag_matches_installed_metadata -q`
- `make check-commits COMMIT_RANGE=origin/main..HEAD`
- `PYTHONPATH=. uv run python scripts/check_commit_file.py /tmp/raven-commit-msg.txt`

No user-facing docs or screenshots were needed for this version metadata bump; release notes will be published with the GitHub Release.

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

This changes package metadata only. Rollback is to delete the v0.1.6 tag/release if publication fails before users upgrade, or publish a follow-up patch release if a released package issue is found.

## Related Issues

N/A
