### PR TITLE
docs: update readme for recent features

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Raven again.
 - Start the Raven harness in a terminal-native TUI with `raven` or `raven tui`.
 - Run a one-shot shell task with `raven agent -m "..."`.
 - Configure providers, sandboxing, channels, and memory with `raven onboard`.
+- Enable the MiroThinker deep_research tool with `raven deep-research enable`.
+- Open captured LLM/tool/memory spans with `raven tracing`.
 - Browse built-in and local SkillForge skills with `raven skill list`.
 - Resume, fork, export, or delete previous work with `raven sessions list`.
 - Check proactive memory and scheduled nudges with `raven sentinel status`.
@@ -245,6 +247,14 @@ an honest generalisation number. One command
 (`python -m raven.evolver run --config <yaml>`), fully resumable. Start at
 [raven/evolver/README.md](raven/evolver/README.md).
 
+### 7. Research and Observability in the Harness
+
+Raven now includes two opt-in surfaces for deeper work. `raven deep-research`
+configures the MiroThinker-backed `deep_research` tool so an agent can run a
+multi-source research pass when the task calls for it. `raven tracing` opens a
+local dashboard for captured LLM, tool, and memory spans, making it easier to
+inspect what happened inside a run without changing the agent workflow.
+
 <br>
 <div align="right">
 
@@ -280,6 +290,9 @@ official endorsement unless explicitly approved by EverMind.
 | Configure Raven | `raven onboard` |
 | Run a one-shot shell task | `raven agent -m "..."` |
 | Review providers | `raven provider list` |
+| Configure Deep Research | `raven deep-research enable` |
+| Inspect Deep Research config | `raven deep-research get` |
+| Open tracing dashboard | `raven tracing` |
 | List messaging channels | `raven channels list` |
 | Start the messaging gateway | `raven gateway` |
 | Manage sessions | `raven sessions list` |
@@ -300,6 +313,8 @@ official endorsement unless explicitly approved by EverMind.
 | First-time install and setup | [Quick Install](#quick-install) |
 | Source-based development | [Developer Workflow](#developer-workflow) and [docs/dev.md](docs/dev.md) |
 | Memory and plugin architecture | [docs/memory-plugin-architecture.md](docs/memory-plugin-architecture.md) |
+| Configure Deep Research | `raven deep-research --help` |
+| Inspect tracing and observability | `raven tracing` and [docs/TRACING_STANDARD_API.md](docs/TRACING_STANDARD_API.md) |
 | Sandbox usage and debugging | [docs/sandbox/usage.md](docs/sandbox/usage.md) |
 | Proactivity design | [docs/Proactivity-Plan.md](docs/Proactivity-Plan.md) |
 | Benchmark self-evolution | [raven/evolver/README.md](raven/evolver/README.md) |
@@ -333,7 +348,9 @@ Channels / TUI / Gateway
         +--> Memory Engine    EverOS / local skills / SkillForge
         +--> Proactive Engine Sentinel / scheduler / nudge policy
         +--> TokenWise        usage tracking / cache placement / routing
+        +--> Tracing          captured LLM / tool / memory spans
         +--> Eval Engine      task judgement and coordination
+        +--> Evolver          benchmark-driven harness self-evolution
 ```
 
 ### Repo Layout
@@ -349,6 +366,8 @@ raven/
 ├── proactive_engine/   # Sentinel, scheduler, nudges, feedback
 ├── memory_engine/      # EverOS memory, local skills, SkillForge
 ├── token_wise/         # Usage tracking, cache placement, routing
+├── tracing/            # Span capture and local tracing dashboard
+├── evolver/            # Benchmark-driven harness self-evolution
 ├── sandbox/            # Isolated command execution
 ├── security/           # Trust boundaries and network checks
 ├── cli/                # `raven` command line entry point
@@ -356,6 +375,7 @@ raven/
 
 ui-tui/                 # React/Ink native terminal UI
 bridge/                 # WhatsApp TypeScript bridge
+benchmarks/             # Benchmark adapters, including AppWorld evolver wiring
 ```
 
 <br>
@@ -393,6 +413,9 @@ core product surfaces are already in the repository.
 | Sentinel proactivity | Implemented, still evolving |
 | TokenWise strategies | Implemented |
 | SkillForge | Implemented |
+| Deep Research tool | Implemented, opt-in configuration |
+| Tracing dashboard | Implemented |
+| Evolver pipeline | Implemented, benchmark adapters still evolving |
 | Eval engine | Partial |
 
 <br>

--- a/README.md
+++ b/README.md
@@ -159,10 +159,13 @@ breaks down when the agent becomes part of your daily environment:
 Raven treats the harness around the agent as the product, not a thin wrapper or
 an edge case.
 
-Raven's self-improving harness is built around three product bets:
+Raven's self-improving harness is built around four product bets:
 
 - **Memory-first harness:** user memory, agent memory, and world knowledge stay
   separate, durable, and reusable across sessions.
+- **Deep Research as a tool:** long-form, multi-source research can be enabled
+  with `raven deep-research enable` and then used by the agent when the task
+  calls for deeper investigation.
 - **Self-improving skills:** repeated workflows can become skills, collect
   feedback, and evolve instead of staying buried in chat history.
 - **Agent Templates:** builders can start from Raven, define an agent for a
@@ -193,6 +196,11 @@ Raven's self-improving harness is built around three product bets:
 <td><strong>Proactivity</strong></td>
 <td>Sentinel, scheduler, nudge policy, and deferred decision flow</td>
 <td>Usually waits until the user types again</td>
+</tr>
+<tr>
+<td><strong>Deep Research</strong></td>
+<td>Opt-in MiroThinker-backed deep_research tool enabled with <code>raven deep-research enable</code></td>
+<td>Usually external search tabs, ad hoc browser prompts, or one-off research scripts</td>
 </tr>
 <tr>
 <td><strong>Skill evolution</strong></td>

--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@
 
 # Raven
 
-Raven is **The Self-Improving Agent Harness**, built on [EverOS](https://github.com/EverMind-AI/EverOS).
+Raven is **The Self-Improving Agent Harness**, built on [EverOS](https://github.com/EverMind-AI/EverOS), with opt-in Deep Research for multi-source investigation.
 
 Raven helps agents improve across runs by continuously refining the systems around them: tools, skills, memory, code execution, policies, and working environment. EverOS provides durable user memory, agent memory, and world knowledge across sessions, so successful workflows can evolve into reusable Agent Templates and digital workers.
+
+**Update:** Raven added Deep Research. Enable it with `raven deep-research enable`
+to give the agent access to MiroThinker-backed, multi-source research when a
+task needs deeper investigation.
 
 <p align="center">
   <img src="https://github.com/user-attachments/assets/a4dc5b21-c8e7-4397-95e1-50afeeb826e4" alt="Starting Raven from the command line" width="100%">


### PR DESCRIPTION
## Summary

Update the root README so the latest public surfaces are visible without changing the existing structure.

The README now mentions:

- Deep Research setup through `raven deep-research enable`.
- The tracing dashboard through `raven tracing`.
- The existing evolver pipeline in the architecture and status sections.
- The related command and documentation entry points.

## Type

- [ ] Fix
- [ ] Feature
- [x] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- [ ] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

Commands run:

- `raven --help`
- `raven deep-research --help`
- `raven tracing --help`
- `make check-large-files`
- `make check-commits COMMIT_RANGE=origin/main..HEAD`
- `git diff --check origin/main..HEAD -- README.md`

No Python test suite was run because this is a README-only documentation change.

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

This is a documentation-only change and does not alter runtime behavior.

## Related Issues

N/A
