### PR TITLE
fix(tui): announce log path only on abnormal tui exit

### DIFF
--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -894,6 +894,18 @@ def _print_node_help(out=None) -> None:
     typer.echo(msg, file=out)
 
 
+def _is_abnormal_child_exit(exit_code: int) -> bool:
+    """A child exit worth surfacing to the user: not a clean exit, not one of
+    the signals the parent forwards for a graceful shutdown, and not the
+    RPC-handshake failure path (which reports itself).
+
+    The graceful signal codes mirror ui-tui gracefulExit.ts, which maps SIGHUP
+    to 129 (terminal closed), SIGINT to 130 (Ctrl+C) and SIGTERM to 143
+    (kill / process manager) through one clean-exit path. A hard SIGKILL (137)
+    is left abnormal. ``_RPC_HANDSHAKE_EXIT_CODE`` is 3."""
+    return exit_code not in (0, 129, 130, 143, _RPC_HANDSHAKE_EXIT_CODE)
+
+
 def _diagnose_crash(node_path: str, dist_entry: Path, cwd: Path) -> None:
     """When `tui` child exits non-zero, re-run capturing stderr for diagnosis."""
     try:
@@ -1006,7 +1018,9 @@ def tui(
 
     # Redirect parent loguru to a file so RpcServer / cli.dispatch / etc.
     # logs don't corrupt the Ink reconciler. (Skipped for the no-RPC paths
-    # which exit before Ink renders.)
+    # which exit before Ink renders.) The file is created here at startup and
+    # a normal run/exit only writes INFO lifecycle records, so the path is
+    # surfaced to the user only on an abnormal child exit (see below).
     if not no_rpc:
         _suppress_noisy_watchers()
         log_path = redirect_loguru_to_file(
@@ -1014,7 +1028,6 @@ def tui(
             retention=3,
             record_filter=_drop_watcher_spam,
         )
-        typer.echo(f"📝 TUI logs → {log_path}", err=True)
 
     if dev:
         # tsx watch via local node_modules.
@@ -1073,8 +1086,13 @@ def tui(
             exit_code = run_subprocess(node_path, [str(dist_entry)], cwd=dist_cwd)
         else:
             exit_code = run_subprocess_with_rpc(node_path, [str(dist_entry)], cwd=dist_cwd)
-        if exit_code != 0 and exit_code != 130 and exit_code != _RPC_HANDSHAKE_EXIT_CODE:
+        if _is_abnormal_child_exit(exit_code):
             _diagnose_crash(node_path, dist_entry, dist_cwd)
+
+    # tui.log stays silent on a clean run; surface it only when the child
+    # exited abnormally (see _is_abnormal_child_exit).
+    if not no_rpc and _is_abnormal_child_exit(exit_code):
+        typer.echo(f"📝 TUI logs → {log_path} (exit {exit_code})", err=True)
 
     if check:
         # --check passes when Node was found and child process spawned,

--- a/tests/test_cli_tui_commands.py
+++ b/tests/test_cli_tui_commands.py
@@ -514,3 +514,60 @@ async def test_rpc_runner_activates_fd_redirect_before_backend_start(rpc_server_
     exit_idx = call_log.index("redirect_exit")
     stop_idx = call_log.index("stop")
     assert stop_idx < exit_idx, "redirect must be held THROUGH backend.stop()"
+
+
+# ---------------------------------------------------------------------------
+# log-path notice: surfaced only on abnormal child exit (#131)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "abnormal"),
+    [
+        (0, False),
+        (129, False),
+        (130, False),
+        (143, False),
+        (3, False),
+        (1, True),
+        (137, True),
+        (255, True),
+    ],
+)
+def test_is_abnormal_child_exit(exit_code: int, abnormal: bool) -> None:
+    """Clean (0), the graceful signal codes SIGHUP/SIGINT/SIGTERM (129/130/143)
+    and the handshake path (3) are not abnormal; a hard SIGKILL (137) is."""
+    from raven.cli.tui_commands import _is_abnormal_child_exit
+
+    assert _is_abnormal_child_exit(exit_code) is abnormal
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "should_announce"),
+    [(0, False), (129, False), (130, False), (143, False), (1, True), (137, True)],
+)
+def test_tui_announces_log_path_only_on_abnormal_exit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, exit_code: int, should_announce: bool
+) -> None:
+    """The log-path notice reaches stderr only on an abnormal child exit; a
+    clean exit (0) or Ctrl+C (130) leaves stderr silent."""
+    from typer.testing import CliRunner
+
+    from raven.cli import tui_commands
+
+    monkeypatch.setattr(tui_commands, "_stdout_isatty", lambda: False)
+    monkeypatch.setattr(tui_commands, "find_node", lambda: ("/fake/node", (22, 0, 0)))
+    monkeypatch.setattr(tui_commands, "resolve_dist_entry", lambda: tmp_path / "entry.js")
+    monkeypatch.setattr(tui_commands, "_suppress_noisy_watchers", lambda: None)
+    monkeypatch.setattr(tui_commands, "redirect_loguru_to_file", lambda *a, **k: tmp_path / "tui.log")
+    monkeypatch.setattr(tui_commands, "_diagnose_crash", lambda *a, **k: None)
+    monkeypatch.setattr(tui_commands, "run_subprocess_with_rpc", lambda *a, **k: exit_code)
+
+    result = CliRunner(mix_stderr=False).invoke(tui_commands.tui_app, [])
+
+    assert result.exit_code == exit_code
+    if should_announce:
+        assert "TUI logs" in result.stderr
+        assert f"(exit {exit_code})" in result.stderr
+    else:
+        assert "TUI logs" not in result.stderr


### PR DESCRIPTION
## Summary

`raven tui` echoed the log-path notice on every launch, leaving noise
in the terminal scrollback after a clean exit. It is only actionable
when something went wrong, so it now surfaces (with the exit code)
only when the child exits abnormally.

A normal exit is a clean 0, one of the signal codes the parent
forwards for a graceful shutdown -- SIGHUP (129), SIGINT (130),
SIGTERM (143) -- or the RPC-handshake path (3); a hard SIGKILL (137)
stays abnormal. A shared `_is_abnormal_child_exit` predicate gates
both the notice and the existing crash re-diagnosis, which previously
also fired on a SIGHUP/SIGTERM exit. The tui.log redirect and rotation
are unchanged; a normal run only writes INFO lifecycle records.

Investigation for #131: on a normal exit tui.log holds only INFO
lifecycle records (no error-looking lines) and the file is created at
startup, not by Ctrl+C. Verified by code reading -- an interactive TTY
exit cannot be reproduced headless.

## Type

- [x] Fix

## Verification

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally

Commands: `uv run pytest tests/test_cli_tui_commands.py` (25 passed),
`make lint-python`.

## Risk

- [x] Backward compatibility considered

Behavior-preserving for abnormal exits (crash diagnosis still runs);
only removes the every-launch notice and stops treating graceful
signal exits as crashes.

## Related Issues

Fixes #131