### PR TITLE
feat(agent): offer deep-vs-regular choice for deep_research

### DIFF
--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -23,7 +23,12 @@ from raven.agent.loop.recovery import (
 )
 from raven.agent.subagent import SubagentManager
 from raven.agent.tools.ask_user import AskUserTool
-from raven.agent.tools.deep_research import DeepResearchManager, DeepResearchTool
+from raven.agent.tools.deep_research import (
+    DeepResearchManager,
+    DeepResearchOfferTool,
+    DeepResearchTool,
+    deep_research_mode,
+)
 from raven.agent.tools.file_search import FindTool, GrepTool
 from raven.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from raven.agent.tools.media_gen import (
@@ -63,7 +68,7 @@ if TYPE_CHECKING:
         RuntimeConfig,
         SkillForgeRouterConfig,
     )
-    from raven.config.schema import ChannelsConfig, ExecToolConfig
+    from raven.config.schema import ChannelsConfig, DeepResearchToolConfig, ExecToolConfig
     from raven.context_engine import ContextEngine
     from raven.memory_engine.backend import MemoryBackend
     from raven.proactive_engine.schedulers.cron.service import CronService
@@ -74,6 +79,7 @@ if TYPE_CHECKING:
     from raven.spine.turn import TurnRequest
     from raven.token_wise.base import UsageSnapshot
     from raven.token_wise.registry import StrategyRegistry
+    from raven.tui_rpc.question_broker import QuestionBroker
 
 
 @dataclass
@@ -598,22 +604,23 @@ class AgentLoop:
                         output_subdir=media.output_subdir,
                     )
                 )
-        # Deep research (MiroThinker) is opt-in: a paid, minute-scale HTTP engine
-        # registered only when a key is configured, so an unconfigured deploy
-        # never exposes a tool that errors on first call.
+        # Deep research (MiroThinker) is a paid, minute-scale HTTP engine, so it is
+        # never a plain default tool. Two modes: ``real`` (key configured) is the
+        # working tool + async manager; ``offer`` (no key) is a same-named stand-in
+        # that, on a research query, asks the user deep-vs-regular and guides setup.
         self.deep_research_manager: DeepResearchManager | None = None
-        if DeepResearchTool.is_configured(self.deep_research_config):
-            self.deep_research_manager = DeepResearchManager(
-                self.deep_research_config, workspace=self.workspace, proxy=self.web_proxy
-            )
-            self.tools.register(
-                DeepResearchTool(
-                    self.deep_research_config,
-                    workspace=self.workspace,
-                    proxy=self.web_proxy,
-                    manager=self.deep_research_manager,
-                )
-            )
+        # The async-delivery submit handle (gateway-wired, post-construction). Kept
+        # on the loop so a manager built later by promotion inherits it too, rather
+        # than only the startup manager -- see ``set_deep_research_submit``.
+        self._deep_research_submit: Callable[[Any], Any] | None = None
+        # The deep-vs-regular ask broker (transport-wired, post-construction). Kept
+        # on the loop for the same reason: a tool built later by promotion must
+        # inherit it, else it silently skips the ask -- see ``set_deep_research_broker``.
+        self._deep_research_broker: QuestionBroker | None = None
+        if deep_research_mode(self.deep_research_config) == "real":
+            self._register_real_deep_research(self.deep_research_config)
+        else:
+            self.tools.register(DeepResearchOfferTool())
         self.tools.register(MessageTool())
         self.tools.register(SpawnTool(manager=self.subagents))
         # The QuestionBroker is a per-transport singleton, late-bound via
@@ -1125,6 +1132,64 @@ class AgentLoop:
                     pass
                 self._mcp_stack = None
             raise
+
+    def _register_real_deep_research(self, cfg: DeepResearchToolConfig) -> None:
+        """Build the working deep_research tool (+ async manager) and register it.
+        Shared by initial registration and mid-session promotion."""
+        self.deep_research_manager = DeepResearchManager(cfg, workspace=self.workspace, proxy=self.web_proxy)
+        # Inherit the gateway's async-delivery handle if it was wired before this
+        # manager existed (i.e. a promotion after startup), so a channel keeps the
+        # async path instead of falling back to a blocking synchronous run.
+        if self._deep_research_submit is not None:
+            self.deep_research_manager.set_submit(self._deep_research_submit)
+        tool = DeepResearchTool(cfg, workspace=self.workspace, proxy=self.web_proxy, manager=self.deep_research_manager)
+        # Inherit the deep-vs-regular ask broker too, else the promoted tool would
+        # silently skip the ask and run the paid engine unprompted.
+        if self._deep_research_broker is not None:
+            tool.set_broker(self._deep_research_broker)
+        self.tools.register(tool)
+
+    def set_deep_research_submit(self, submit: Callable[[Any], Any]) -> None:
+        """Wire the async-delivery submit handle (gateway only). Stored on the loop
+        and applied to the current manager, so a later promotion inherits it too."""
+        self._deep_research_submit = submit
+        if self.deep_research_manager is not None:
+            self.deep_research_manager.set_submit(submit)
+
+    def set_deep_research_broker(self, broker: QuestionBroker) -> None:
+        """Wire the deep-vs-regular ask broker (TUI/gateway). Stored on the loop and
+        applied to the currently-registered deep_research tool, so a tool built
+        later by promotion inherits it too (mirrors ``set_deep_research_submit``)."""
+        self._deep_research_broker = broker
+        if (tool := self.tools.get("deep_research")) is not None and hasattr(tool, "set_broker"):
+            tool.set_broker(broker)
+
+    def _maybe_promote_deep_research(self) -> None:
+        """Swap the offer stand-in for the working tool once a key appears on disk,
+        so a mid-session ``raven deep-research enable`` is picked up on the next
+        turn without a restart. Called from ``run_turn`` before the per-turn tool
+        wiring, so the promoted tool gets this turn's stream callback and routing.
+
+        Re-reads config (the in-memory copy is fixed at startup); a corrupt config
+        must not fail the turn, so a read error just skips promotion. The promoted
+        manager inherits the gateway's async-delivery handle via
+        ``set_deep_research_submit``, so a channel keeps the async path."""
+        if not isinstance(self.tools.get("deep_research"), DeepResearchOfferTool):
+            return
+        from raven.config.loader import ConfigReadError
+        from raven.config.schema import DeepResearchToolConfig
+        from raven.config.update_tools import get_deep_research
+
+        try:
+            cfg = DeepResearchToolConfig(**get_deep_research(redact=False))
+        except ConfigReadError as exc:
+            logger.warning("deep_research: skipping promotion, config unreadable: {}", exc)
+            return
+        if not DeepResearchTool.is_configured(cfg):
+            return
+        self.deep_research_config = cfg
+        self._register_real_deep_research(cfg)
+        logger.info("deep_research: promoted offer stand-in to the working tool (key configured mid-session)")
 
     def _set_tool_context(
         self, channel: str, chat_id: str, message_id: str | None = None, session_key: str | None = None
@@ -2316,6 +2381,11 @@ class AgentLoop:
                     await emit(Text(content=content))
 
             message_tool.set_send_callback(_route_to_stream)
+
+        # Pick up a mid-session `deep-research enable` before the wiring below, so
+        # a promoted working tool gets THIS turn's stream callback and (in
+        # _process_message) routing context -- not just the next turn's.
+        self._maybe_promote_deep_research()
 
         # deep_research (streaming surfaces only): stream its progress live and
         # deliver its finished answer inline, so the tool returns a compact

--- a/raven/agent/tools/deep_research.py
+++ b/raven/agent/tools/deep_research.py
@@ -23,6 +23,7 @@ from loguru import logger
 
 from raven.agent.tools.base import Tool
 from raven.config.schema import DeepResearchToolConfig
+from raven.tui_rpc.question_broker import QuestionBroker
 
 DEFAULT_BASE_URL = "https://api.miromind.ai/v1"
 DEFAULT_MODEL = "mirothinker-1-7-deepresearch-mini"
@@ -87,9 +88,11 @@ class DeepResearchTool(Tool):
         "required": ["query"],
     }
 
-    # Registry ceiling: raise well above the default so a legitimate minute-scale
-    # run isn't timer-killed. The inner httpx read timeout (below) stays under
-    # this so the tool, not the ceiling, owns the timeout path.
+    # The tool asks the user deep-vs-regular up front, a human wait that must not
+    # be timer-killed, so it is a blocking_interaction (the registry applies no
+    # timeout). execute() therefore caps the engine run itself with
+    # ``timeout_seconds`` via asyncio.wait_for around _run_engine.
+    blocking_interaction = True
     timeout_seconds = 900.0
     # Idle read timeout between SSE chunks: research streams chunks continuously,
     # so a gap this long means the stream is dead. Well under timeout_seconds.
@@ -113,11 +116,18 @@ class DeepResearchTool(Tool):
         # each other's routing (same reason MessageTool keeps its callback here).
         self._stream_cb: ContextVar[StreamCallback | None] = ContextVar("deep_research_stream_cb", default=None)
         self._routing: ContextVar[_Routing | None] = ContextVar("deep_research_routing", default=None)
+        # Late-bound (transport singleton) so the tool can ask the user
+        # deep-vs-regular before a paid run; None where unavailable (e.g. raven
+        # agent), in which case the run proceeds without asking.
+        self._broker: QuestionBroker | None = None
 
     @staticmethod
     def is_configured(config: DeepResearchToolConfig) -> bool:
         """Whether a key is reachable, so the loop can register the tool opt-in."""
         return bool(config.api_key or os.environ.get("MIROTHINKER_API_KEY"))
+
+    def set_broker(self, broker: QuestionBroker | None) -> None:
+        self._broker = broker
 
     def set_stream_callback(self, cb: StreamCallback | None) -> None:
         """Wire the per-turn stream callback (turn-local). Set only on surfaces
@@ -133,6 +143,19 @@ class DeepResearchTool(Tool):
         return self._config.api_key or os.environ.get("MIROTHINKER_API_KEY", "")
 
     async def execute(self, query: str, **kwargs: Any) -> str:
+        # Deep search is slow + paid: confirm deep-vs-regular before running. No
+        # broker (e.g. raven agent) -> honour the model's choice and run.
+        routing = self._routing.get()
+        if await _ask_search_mode(self._broker, routing.conversation if routing else "") == "regular":
+            return _USE_REGULAR
+        # The ask above is a human wait (blocking_interaction, so the registry does
+        # not time it out); the engine run carries its own total cap here instead.
+        try:
+            return await asyncio.wait_for(self._run_engine(query), timeout=self.timeout_seconds)
+        except asyncio.TimeoutError:
+            return self._result("timeout", content=f"deep_research exceeded {self.timeout_seconds:.0f}s")
+
+    async def _run_engine(self, query: str) -> str:
         key = self._api_key()
         if not key:
             return self._result(
@@ -261,6 +284,124 @@ class DeepResearchTool(Tool):
             },
             ensure_ascii=False,
         )
+
+
+# The deep-vs-regular routing choice, offered whenever the model reaches for
+# deep_research (deep search is slow + paid, so the user decides per query).
+# Deep first (it is the thorough option). The display text is the match key the
+# frontend echoes back verbatim.
+_MODE_DEEP = "Deep search (thorough, a few minutes)"
+_MODE_REGULAR = "Regular web search (quick)"
+_ASK_PROMPT = (
+    "This looks like a research question. Use deep search -- an external engine "
+    "(MiroThinker) that runs broad, multi-source research over a few minutes and "
+    "uses your deep-research quota -- or a regular quick web search?"
+)
+
+# Honest description for the unconfigured stand-in: unlike DeepResearchTool's
+# ("returns a finished answer"), it tells the model the engine is not set up, so
+# the model still reaches for it on research-shaped queries without being misled.
+_OFFER_DESCRIPTION = (
+    "Deep, multi-source web research via an external engine (MiroThinker), NOT "
+    "set up on this deployment. Call this for an open-ended research question; "
+    "the user is then asked to pick deep search (which they can set up) or a "
+    "regular quick search."
+)
+# These offer-path results are phrased as factual status, not imperatives: a
+# well-aligned model treats tool output as data and refuses embedded commands (a
+# strong "do NOT answer / reply with only this" was rejected as a prompt injection
+# in testing). (The older receipt/ack strings below keep mild imperatives.)
+_USE_REGULAR = "deep_research did not run: the user chose a regular web search instead."
+# Shown to the USER directly via the broker prompt below. Command FIRST so it
+# survives the scrollback's truncated tool-call line (cut at ~60 chars); the live
+# picker wraps and shows it all anyway.
+_SETUP_PROMPT = (
+    "Run `raven deep-research enable` to set up deep research (paste a MiroMind API "
+    "key -- it works from your next message, no restart). Do a regular web search "
+    "in the meantime?"
+)
+_MEANWHILE_REGULAR = "Yes, do a regular web search now"
+_MEANWHILE_WAIT = "No, I'll set it up first"
+_SETUP_STOP = (
+    "deep_research did not run: it is not configured and the user chose to set it up "
+    "first (they were shown the `raven deep-research enable` command). They will "
+    "re-ask once it is enabled; no answer is expected now."
+)
+
+
+async def _ask_search_mode(broker: QuestionBroker | None, cid: str) -> str | None:
+    """Ask the user deep-vs-regular for a research query. Returns ``"deep"`` /
+    ``"regular"``, or ``None`` only when there is no broker at all (e.g. raven
+    agent) -- then the caller honours the model's choice. Shared by the working
+    tool and the offer stand-in so both prompt identically; a timeout / unknown
+    answer fail-safes to the cheaper ``regular``.
+
+    A broker but an empty cid means the tool has no conversation context -- e.g. a
+    concurrent turn was handed a just-promoted tool before its per-turn context
+    was wired. We cannot ask there, so we ``regular`` rather than run the paid
+    engine unasked (the promoting turn itself is wired and asks normally)."""
+    if not broker:
+        return None
+    if not cid:
+        return "regular"
+    answer = await broker.await_question(
+        cid, prompt=_ASK_PROMPT, choices=[_MODE_DEEP, _MODE_REGULAR], default=_MODE_REGULAR
+    )
+    return "deep" if answer == _MODE_DEEP else "regular"
+
+
+class DeepResearchOfferTool(Tool):
+    """Stand-in for deep_research on an unconfigured deploy.
+
+    Registered under the same name/parameters as DeepResearchTool so the model
+    reaches for it identically on research-shaped queries, but with an honest
+    description and no key. On call it asks the user deep-vs-regular (same prompt
+    as the working tool); picking deep shows the setup steps -- via a second broker
+    prompt the user sees directly, never relayed by the model -- and asks about a
+    regular search meanwhile. It never runs research itself: once a key is
+    configured the loop swaps in the real tool on the next turn (see
+    ``AgentLoop._maybe_promote_deep_research``). Without a broker (e.g. ``raven
+    agent``) it degrades to the regular tools.
+    """
+
+    name = "deep_research"
+    description = _OFFER_DESCRIPTION
+    parameters = DeepResearchTool.parameters
+    # Broker manages its own fail-safe timeout, so the registry must not wrap it
+    # (same contract as ask_user).
+    blocking_interaction = True
+
+    def __init__(self) -> None:
+        self._broker: QuestionBroker | None = None
+        self._cid: ContextVar[str] = ContextVar("deep_research_offer_cid", default="")
+
+    def set_broker(self, broker: QuestionBroker | None) -> None:
+        self._broker = broker
+
+    def set_context(self, channel: str, chat_id: str, session_key: str) -> None:
+        """Match DeepResearchTool's signature so the loop's ``_set_tool_context``
+        wires it uniformly; the broker keys by the conversation (session_key)."""
+        self._cid.set(session_key)
+
+    async def execute(self, query: str, **kwargs: Any) -> str:
+        cid = self._cid.get()
+        if await _ask_search_mode(self._broker, cid) != "deep":
+            return _USE_REGULAR
+        # Deep chosen, but this stand-in only exists unconfigured. Show the setup
+        # steps via a broker prompt the user sees directly (the model would drop
+        # them) and ask whether to run a regular search meanwhile.
+        answer = await self._broker.await_question(
+            cid, prompt=_SETUP_PROMPT, choices=[_MEANWHILE_REGULAR, _MEANWHILE_WAIT], default=_MEANWHILE_REGULAR
+        )
+        # Only an explicit "I'll set it up" waits; anything else (regular, free-form,
+        # timeout default) falls to a regular search -- symmetric with the first ask.
+        return _SETUP_STOP if answer == _MEANWHILE_WAIT else _USE_REGULAR
+
+
+def deep_research_mode(config: DeepResearchToolConfig) -> str:
+    """Which deep_research variant to register: the working ``real`` tool when a
+    key is set, else the unconfigured ``offer`` stand-in."""
+    return "real" if DeepResearchTool.is_configured(config) else "offer"
 
 
 def _error_message(response: httpx.Response) -> str:

--- a/raven/cli/deep_research_commands.py
+++ b/raven/cli/deep_research_commands.py
@@ -226,7 +226,7 @@ def get_cmd() -> None:
 
 @deep_research_app.command("reset")
 def reset_cmd() -> None:
-    """Clear deep_research config (disables the tool: no key -> not registered)."""
+    """Clear the deep_research key (new sessions start with the setup offer)."""
     from rich.console import Console
 
     console = Console()
@@ -235,4 +235,4 @@ def reset_cmd() -> None:
     except ConfigReadError as exc:
         console.print(f"[red]✗[/red] {exc}")
         raise typer.Exit(1) from exc
-    console.print("[green]✓[/green] deep_research reset (key cleared; tool will not register)")
+    console.print("[green]✓[/green] deep_research reset (key cleared; new sessions start with the setup offer)")

--- a/raven/cli/gateway_commands.py
+++ b/raven/cli/gateway_commands.py
@@ -449,8 +449,9 @@ def register(app: typer.Typer) -> None:
                 # Deep research (channel/async) delivers its finished answer back
                 # via a deliver_text turn; wiring submit here (gateway only) is
                 # what flips the tool from its synchronous path to the async one.
-                if agent.deep_research_manager is not None:
-                    agent.deep_research_manager.set_submit(gw_scheduler.submit)
+                # Goes through the loop so a manager built later by promotion (a
+                # mid-session enable) inherits the handle too, not just this one.
+                agent.set_deep_research_submit(gw_scheduler.submit)
 
                 # ask_user round-trip on the channel side: the QuestionBroker
                 # renders the agent's clarify.request as an outbound Text to the
@@ -479,8 +480,12 @@ def register(app: typer.Typer) -> None:
                     await gw_hub.dispatch(_Text(content=body, source=source))
 
                 question_broker = QuestionBroker(send_frame=_question_to_channel)
+                # Wire the broker into the mid-turn askers. deep_research goes
+                # through the loop so a tool built later by promotion (a mid-session
+                # enable) inherits the broker too, not just the startup one.
                 if (ask_tool := agent.tools.get("ask_user")) is not None and hasattr(ask_tool, "set_broker"):
                     ask_tool.set_broker(question_broker)
+                agent.set_deep_research_broker(question_broker)
 
                 # Channel inbound runs through the spine: a permitted
                 # message is submitted as a USER turn. /stop and /restart are

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -518,11 +518,14 @@ async def _run_rpc_server_until_done(
     except RpcError as e:
         build_error = e
 
-    # Late-bind the QuestionBroker into the ask_user tool now that the loop
-    # (and its tool registry) exists; the broker itself was built up-front.
-    if agent_loop is not None and (ask_tool := agent_loop.tools.get("ask_user")) is not None:
-        if hasattr(ask_tool, "set_broker"):
+    # Late-bind the QuestionBroker into the tools that ask the user mid-turn, now
+    # that the loop (and its tool registry) exists; the broker was built up-front.
+    # deep_research goes through the loop so a tool built later by promotion (a
+    # mid-session enable) inherits the broker too, not just the startup one.
+    if agent_loop is not None:
+        if (ask_tool := agent_loop.tools.get("ask_user")) is not None and hasattr(ask_tool, "set_broker"):
             ask_tool.set_broker(question_broker)
+        agent_loop.set_deep_research_broker(question_broker)
 
     def _agent_loop_factory():
         if agent_loop is not None:

--- a/tests/test_agent_loop_run_emit.py
+++ b/tests/test_agent_loop_run_emit.py
@@ -15,6 +15,8 @@ import pytest
 
 from raven.agent.loop import AgentLoop
 from raven.agent.tools.base import Tool
+from raven.agent.tools.deep_research import DeepResearchOfferTool
+from raven.config.schema import DeepResearchToolConfig
 from raven.providers.base import LLMResponse, StreamDelta, ToolCallRequest
 from raven.sandbox import SandboxInitError
 from raven.spine.events import MediaOut as EvMediaOut
@@ -367,6 +369,32 @@ async def test_no_inline_tool_stream_leaves_deep_research_callback_unset(tmp_pat
 
     assert not any(isinstance(e, EvReasoning) and e.content == "searching the web..." for e in sink.events)
     assert not any(isinstance(e, EvText) and e.content == "ANSWER-BODY" for e in sink.events)
+
+
+async def test_mid_session_promotion_streams_on_the_promoting_turn(tmp_path, monkeypatch):
+    # Regression guard: promotion must run BEFORE run_turn wires the stream
+    # callback, so a tool promoted on this very turn still streams (progress +
+    # receipt), not just next turn. If promotion moved after the wiring, the
+    # promoted tool would miss the callback and this progress event would vanish.
+    monkeypatch.delenv("MIROTHINKER_API_KEY", raising=False)
+    loop = AgentLoop(provider=_dr_stream_provider(), workspace=tmp_path, deep_research_config=DeepResearchToolConfig())
+    _stub_edges(loop)
+    assert isinstance(loop.tools.get("deep_research"), DeepResearchOfferTool)  # starts unconfigured
+
+    import raven.config.update_tools as ut
+
+    monkeypatch.setattr(
+        ut,
+        "get_deep_research",
+        lambda **_kw: {"api_key": "sk", "api_base": "", "model": ""},
+    )
+    # Promote to a streaming fake (not the real HTTP tool) so we observe wiring only.
+    monkeypatch.setattr(loop, "_register_real_deep_research", lambda cfg: loop.tools.register(_FakeDeepResearch()))
+    sink = _EmitCollector()
+
+    await loop.run_turn(_req("q"), sink, _drain, stream=True, inline_tool_stream=True)
+
+    assert any(isinstance(e, EvReasoning) and e.content == "searching the web..." for e in sink.events)
 
 
 async def test_inject_message_merged_before_next_iteration(tmp_path):

--- a/tests/test_deep_research_tool.py
+++ b/tests/test_deep_research_tool.py
@@ -15,8 +15,15 @@ from pathlib import Path
 import httpx
 import pytest
 
+from raven.agent.loop import AgentLoop
 from raven.agent.tools import deep_research as dr_mod
-from raven.agent.tools.deep_research import DeepResearchManager, DeepResearchTool, _extract_output_text
+from raven.agent.tools.deep_research import (
+    DeepResearchManager,
+    DeepResearchOfferTool,
+    DeepResearchTool,
+    _extract_output_text,
+    deep_research_mode,
+)
 from raven.config.schema import DeepResearchToolConfig
 
 ANSWER = (
@@ -297,6 +304,265 @@ async def test_async_report_write_failure_still_delivers_answer(tmp_path: Path, 
 
     assert len(captured) == 1
     assert captured[0].deliver_text == ANSWER  # answer delivered, not a "failed" message
+
+
+# ── offer stand-in on an unconfigured deploy + registration mode ──
+
+
+class _ScriptBroker:
+    """Fake QuestionBroker: returns scripted answers in order, recording the
+    prompts/choices it was shown (so tests can assert what the user saw)."""
+
+    def __init__(self, script: list) -> None:
+        self._script = list(script)
+        self.choices_seen: list[list[str]] = []
+        self.prompts_seen: list[str] = []
+
+    async def await_question(self, cid, *, prompt, choices, default="", timeout_s=600.0):
+        self.prompts_seen.append(prompt)
+        self.choices_seen.append(choices)
+        return self._script.pop(0)
+
+
+def _offer(broker=None, *, cid: str = "cli:direct") -> DeepResearchOfferTool:
+    tool = DeepResearchOfferTool()
+    if broker is not None:
+        tool.set_broker(broker)
+        tool.set_context("cli", "direct", cid)
+    return tool
+
+
+async def test_offer_no_broker_falls_back_to_regular():
+    tool = DeepResearchOfferTool()
+    tool.set_context("cli", "direct", "cli:direct")  # cid set, but no broker
+    assert await tool.execute(query="q") == dr_mod._USE_REGULAR
+
+
+async def test_offer_no_cid_falls_back_to_regular():
+    tool = DeepResearchOfferTool()
+    tool.set_broker(_ScriptBroker([dr_mod._MODE_DEEP]))  # broker set, but no context
+    assert await tool.execute(query="q") == dr_mod._USE_REGULAR
+
+
+async def test_offer_regular_choice_uses_regular():
+    broker = _ScriptBroker([dr_mod._MODE_REGULAR])
+    assert await _offer(broker).execute(query="q") == dr_mod._USE_REGULAR
+    assert len(broker.choices_seen) == 1
+
+
+async def test_offer_freeform_answer_is_regular():
+    broker = _ScriptBroker(["something the user typed"])
+    assert await _offer(broker).execute(query="q") == dr_mod._USE_REGULAR
+
+
+async def test_offer_deep_then_regular_meanwhile():
+    # Deep on an unconfigured deploy never runs the engine. It shows setup steps
+    # via a 2nd broker prompt (seen by the user directly, not model-relayed) and
+    # asks about a regular search meanwhile; "yes" -> regular.
+    broker = _ScriptBroker([dr_mod._MODE_DEEP, dr_mod._MEANWHILE_REGULAR])
+    assert await _offer(broker).execute(query="q") == dr_mod._USE_REGULAR
+    assert len(broker.choices_seen) == 2  # deep/regular, then meanwhile yes/no
+    assert "raven deep-research enable" in broker.prompts_seen[1]  # command shown to the user
+
+
+async def test_offer_deep_then_wait_stops():
+    # "No, I'll set it up" -> tell the model to stop, not answer with regular.
+    broker = _ScriptBroker([dr_mod._MODE_DEEP, dr_mod._MEANWHILE_WAIT])
+    assert await _offer(broker).execute(query="q") == dr_mod._SETUP_STOP
+
+
+async def test_offer_deep_then_freeform_meanwhile_is_regular():
+    # Only an explicit "set it up" waits; a free-form answer to the meanwhile
+    # question falls to regular (symmetric with the first ask), never stuck waiting.
+    broker = _ScriptBroker([dr_mod._MODE_DEEP, "uh, whatever"])
+    assert await _offer(broker).execute(query="q") == dr_mod._USE_REGULAR
+
+
+# ── working tool also asks deep-vs-regular (product: deep is slow + paid) ──
+
+
+async def test_real_tool_regular_choice_skips_engine(tmp_path: Path, monkeypatch):
+    # Even configured, picking regular must NOT hit the engine.
+    def _boom(*_a, **_k):
+        raise AssertionError("engine must not run when the user picks regular")
+
+    monkeypatch.setattr(dr_mod.httpx, "AsyncClient", _boom)
+    tool = DeepResearchTool(DeepResearchToolConfig(api_key="sk-test"), workspace=tmp_path)
+    tool.set_broker(_ScriptBroker([dr_mod._MODE_REGULAR]))
+    tool.set_context("cli", "direct", "cli:direct")
+    assert await tool.execute(query="q") == dr_mod._USE_REGULAR
+
+
+async def test_real_tool_deep_choice_runs_engine(tmp_path: Path, monkeypatch):
+    _patch(monkeypatch, lambda req: httpx.Response(200, content=_sse(ANSWER)))
+    tool = DeepResearchTool(DeepResearchToolConfig(api_key="sk-test"), workspace=tmp_path)
+    tool.set_broker(_ScriptBroker([dr_mod._MODE_DEEP]))
+    tool.set_context("cli", "direct", "cli:direct")
+    result = json.loads(await tool.execute(query="q"))
+    assert result["status"] == "ok" and result["content"] == ANSWER
+
+
+async def test_real_tool_no_broker_runs_engine(tmp_path: Path, monkeypatch):
+    # raven agent (no broker): can't ask -> honour the model's choice and run.
+    _patch(monkeypatch, lambda req: httpx.Response(200, content=_sse(ANSWER)))
+    tool = DeepResearchTool(DeepResearchToolConfig(api_key="sk-test"), workspace=tmp_path)
+    result = json.loads(await tool.execute(query="q"))
+    assert result["status"] == "ok" and result["content"] == ANSWER
+
+
+async def test_real_tool_broker_but_no_context_uses_regular(tmp_path: Path, monkeypatch):
+    # A concurrent turn can be handed a just-promoted real tool before its per-turn
+    # context is wired (broker set, cid empty). It must NOT run the paid engine
+    # unasked -- fall back to regular.
+    def _boom(*_a, **_k):
+        raise AssertionError("engine must not run without the deep/regular ask")
+
+    monkeypatch.setattr(dr_mod.httpx, "AsyncClient", _boom)
+    tool = DeepResearchTool(DeepResearchToolConfig(api_key="sk-test"), workspace=tmp_path)
+    tool.set_broker(_ScriptBroker([]))  # broker present, but set_context never called -> no cid
+    assert await tool.execute(query="q") == dr_mod._USE_REGULAR
+
+
+async def test_real_tool_run_capped_by_timeout(tmp_path: Path, monkeypatch):
+    # blocking_interaction removes the registry timeout, so execute() must cap the
+    # engine run itself: a hung run resolves to a timeout result, not forever.
+    tool = DeepResearchTool(DeepResearchToolConfig(api_key="sk-test"), workspace=tmp_path)
+    tool.timeout_seconds = 0.05  # instance override; no broker -> ask is skipped
+
+    async def _hang(_query):
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(tool, "_run_engine", _hang)
+    result = json.loads(await tool.execute(query="q"))
+    assert result["status"] == "timeout"
+
+
+class _StubProvider:
+    """Minimal provider: AgentLoop construction reads the default model but the
+    turn path is never exercised in these tests."""
+
+    def get_default_model(self) -> str:
+        return "stub-model"
+
+    async def chat_with_retry(self, **kwargs):  # pragma: no cover - never invoked
+        raise NotImplementedError
+
+
+def _offer_loop(tmp_path: Path) -> AgentLoop:
+    """A loop that starts unconfigured, so the offer stand-in is registered."""
+    return AgentLoop(provider=_StubProvider(), workspace=tmp_path, deep_research_config=DeepResearchToolConfig())
+
+
+def test_promote_swaps_offer_for_real_when_key_appears(tmp_path: Path, monkeypatch):
+    import raven.config.update_tools as ut
+
+    monkeypatch.delenv("MIROTHINKER_API_KEY", raising=False)
+    loop = _offer_loop(tmp_path)
+    assert isinstance(loop.tools.get("deep_research"), DeepResearchOfferTool)
+    # A key now on disk (as if `raven deep-research enable` ran in another process).
+    monkeypatch.setattr(
+        ut,
+        "get_deep_research",
+        lambda **_kw: {"api_key": "sk", "api_base": "", "model": ""},
+    )
+    loop._maybe_promote_deep_research()
+    assert isinstance(loop.tools.get("deep_research"), DeepResearchTool)
+    assert loop.deep_research_manager is not None
+
+
+def test_promote_noop_when_still_unconfigured(tmp_path: Path, monkeypatch):
+    import raven.config.update_tools as ut
+
+    monkeypatch.delenv("MIROTHINKER_API_KEY", raising=False)
+    loop = _offer_loop(tmp_path)
+    monkeypatch.setattr(
+        ut,
+        "get_deep_research",
+        lambda **_kw: {"api_key": "", "api_base": "", "model": ""},
+    )
+    loop._maybe_promote_deep_research()
+    assert isinstance(loop.tools.get("deep_research"), DeepResearchOfferTool)  # unchanged
+    assert loop.deep_research_manager is None
+
+
+def test_promote_inherits_gateway_submit_handle(tmp_path: Path, monkeypatch):
+    # A gateway wires the async-delivery handle at startup, before any key exists
+    # (manager is None then). A later promotion must inherit it so a channel keeps
+    # the async path instead of a blocking synchronous run.
+    import raven.config.update_tools as ut
+
+    monkeypatch.delenv("MIROTHINKER_API_KEY", raising=False)
+    loop = _offer_loop(tmp_path)
+    loop.set_deep_research_submit(lambda _req: None)
+    monkeypatch.setattr(
+        ut,
+        "get_deep_research",
+        lambda **_kw: {"api_key": "sk", "api_base": "", "model": ""},
+    )
+    loop._maybe_promote_deep_research()
+    assert loop.deep_research_manager is not None
+    assert loop.deep_research_manager.can_deliver()  # async delivery wired, not sync fallback
+
+
+def test_promoted_tool_inherits_broker(tmp_path: Path, monkeypatch):
+    # The broker is wired once at startup onto the offer stand-in; a tool built
+    # later by promotion must inherit it, else it skips the ask and runs the paid
+    # engine unprompted -- defeating the whole deep-vs-regular gate.
+    import raven.config.update_tools as ut
+
+    monkeypatch.delenv("MIROTHINKER_API_KEY", raising=False)
+    loop = _offer_loop(tmp_path)
+    broker = _ScriptBroker([dr_mod._MODE_REGULAR])
+    loop.set_deep_research_broker(broker)  # startup wiring (onto the offer stand-in)
+    monkeypatch.setattr(ut, "get_deep_research", lambda **_kw: {"api_key": "sk", "api_base": "", "model": ""})
+    loop._maybe_promote_deep_research()
+    tool = loop.tools.get("deep_research")
+    assert isinstance(tool, DeepResearchTool)
+    assert tool._broker is broker  # inherited -> will ask, not silently run
+
+
+def test_set_deep_research_broker_applies_to_current_tool(tmp_path: Path, monkeypatch):
+    # The immediate-apply path (onto the tool registered right now), independent of
+    # promotion: startup wiring must reach the offer stand-in too.
+    monkeypatch.delenv("MIROTHINKER_API_KEY", raising=False)
+    loop = _offer_loop(tmp_path)
+    broker = _ScriptBroker([])
+    loop.set_deep_research_broker(broker)
+    assert loop.tools.get("deep_research")._broker is broker
+
+
+def test_promote_survives_unreadable_config(tmp_path: Path, monkeypatch):
+    # A corrupt config.json must not fail the turn: promotion runs every turn in
+    # offer mode, so an unreadable config just skips promotion (the tool stays the
+    # offer stand-in) instead of raising up through _process_message.
+    import raven.config.update_tools as ut
+    from raven.config.loader import ConfigReadError
+
+    monkeypatch.delenv("MIROTHINKER_API_KEY", raising=False)
+    loop = _offer_loop(tmp_path)
+
+    def _boom(**_kw):
+        raise ConfigReadError("bad json")
+
+    monkeypatch.setattr(ut, "get_deep_research", _boom)
+    loop._maybe_promote_deep_research()  # must not raise
+    assert isinstance(loop.tools.get("deep_research"), DeepResearchOfferTool)  # unchanged
+
+
+def test_both_deep_research_variants_accept_broker():
+    # The CLI double-bind loop over ("ask_user", "deep_research") wires whichever
+    # variant is registered; both ask the user deep-vs-regular, so both take a broker.
+    assert hasattr(DeepResearchOfferTool, "set_broker")
+    assert hasattr(DeepResearchTool, "set_broker")
+
+
+def test_deep_research_mode_two_states(monkeypatch):
+    monkeypatch.delenv("MIROTHINKER_API_KEY", raising=False)
+    assert deep_research_mode(DeepResearchToolConfig(api_key="sk")) == "real"
+    assert deep_research_mode(DeepResearchToolConfig()) == "offer"  # unconfigured -> offer
+    # An env key counts as configured: register the working tool.
+    monkeypatch.setenv("MIROTHINKER_API_KEY", "sk-env")
+    assert deep_research_mode(DeepResearchToolConfig()) == "real"
 
 
 def test_extract_output_text_concatenates_message_output_only():


### PR DESCRIPTION
## Summary

Deep research (MiroThinker) is a paid, minute-scale engine. It used to be a silent opt-in: unconfigured deploys never exposed it (users could not discover it), and configured deploys ran it without confirmation.

Now, when the model reaches for `deep_research` on a research-shaped query, the tool first asks the user **deep vs regular** (deep is slow and paid, so the choice is theirs each time):

- configured + deep -> runs the engine; regular -> falls back to `web_search` / `web_fetch`.
- not configured -> a same-named offer stand-in shows the exact `raven deep-research enable` command via the broker prompt (shown to the user directly, not relayed by the model, so it is never dropped) and asks whether to search normally meanwhile. A mid-session `raven deep-research enable` is picked up on the next turn via per-turn promotion -- no restart.

Simple questions are designed not to trigger the prompt: the model uses `web_search` / `web_fetch` directly and does not reach for `deep_research`. Wired on TUI + gateway (where the `ask_user` broker exists); `raven agent` has no broker and degrades to the model's choice.

## Type

- [x] Feature

## Verification

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally

Commands run:

- `uv run pytest tests/test_deep_research_tool.py tests/test_config_update_tools.py tests/test_cli_deep_research_commands.py tests/test_agent_loop_run_emit.py tests/test_tool_registry_timeout.py tests/test_cli_gateway_commands.py -q` -> 122 passed
- `bash .claude/scripts/preflight_ci.sh` -> all preflight checks passed (commitlint, commit-message check, large-files, pre-commit, ruff lint/format, focused tests)
- Real-machine acceptance in `raven tui`: simple question does not prompt; a research question prompts deep-vs-regular; picking deep while unconfigured shows the enable command and offers a regular search meanwhile.

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

- Paid engine: the deep-vs-regular confirm keeps a slow, billed run from starting without the user's say-so.
- Configured deploys: unchanged except for the one-time confirm before each deep run; no config migration.
- Unconfigured deploys: now expose a same-named offer stand-in (previously nothing registered).
- Rollback: revert the single commit.

## Related Issues

Closes #167
