### PR TITLE
chore: bump version to 0.1.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raven"
-version = "0.1.6"
+version = "0.1.7"
 description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3249,7 +3249,7 @@ wheels = [
 
 [[package]]
 name = "raven"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Bump version from 0.1.6 to 0.1.7 for the next release. Touches `pyproject.toml` and `uv.lock` only.

Release-scope changes since v0.1.6:
- feat(agent): offer deep-vs-regular choice for deep_research (#168)
- feat(routing): add opt-in knn task-level model routing backend (#163)
- fix(tracing): show model-call reasoning above the answer, not below (#154)
- fix(tui): announce log path only on abnormal tui exit (#166)
- docs: update readme / chinese readme for recent features (#159, #160)

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

## Verification

- [x] Relevant lint / type checks pass locally

```
uv lock                                                  # resolved, raven 0.1.6 -> 0.1.7
uv run python scripts/check_commit_messages.py origin/main..HEAD   # exit 0
```

## Risk

- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Version-only bump; no code changes.

## Related Issues

N/A