### PR TITLE
fix: use redirect-free install.ps1 url on windows powershell 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ Run this in PowerShell:
 irm https://raven.evermind.ai/install.ps1 | iex
 ```
 
+On **Windows PowerShell 5.1** (the version built into Windows) that command
+fails with `Permanent Redirect`. Use the direct URL instead:
+
+```powershell
+irm https://raw.githubusercontent.com/EverMind-AI/Raven/refs/heads/main/install.ps1 | iex
+```
+
 ### After installation
 
 The installer handles everything: uv, Python 3.12, Node.js 22, and Raven.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,6 +76,13 @@ curl -fsSL https://raven.evermind.ai/install.sh | bash
 irm https://raven.evermind.ai/install.ps1 | iex
 ```
 
+在 **Windows PowerShell 5.1**（Windows 自带的默认版本）下，上面的命令会报
+`Permanent Redirect`，请改用直连地址：
+
+```powershell
+irm https://raw.githubusercontent.com/EverMind-AI/Raven/refs/heads/main/install.ps1 | iex
+```
+
 ### 安装完成后
 
 安装器会处理全部依赖：uv、Python 3.12、Node.js 22 和 Raven。

--- a/raven/channels/manager.py
+++ b/raven/channels/manager.py
@@ -40,7 +40,7 @@ def _missing_dep_hint(modname: str) -> str:
     if editable:
         return f"Run: uv sync --extra channel-{modname}"
     if sys.platform == "win32":
-        return "Re-run the installer to add channels: irm https://raven.evermind.ai/install.ps1 | iex"
+        return "Re-run the installer to add channels: irm https://raw.githubusercontent.com/EverMind-AI/Raven/refs/heads/main/install.ps1 | iex"
     return "Re-run the installer to add channels: curl -fsSL https://raven.evermind.ai/install.sh | bash"
 
 

--- a/tests/test_channels_manager.py
+++ b/tests/test_channels_manager.py
@@ -154,7 +154,7 @@ def test_hint_package_not_found_points_to_installer(monkeypatch):
 
 @pytest.mark.parametrize(
     "platform, marker",
-    [("win32", "install.ps1"), ("darwin", "install.sh"), ("linux", "install.sh")],
+    [("win32", "raw.githubusercontent.com"), ("darwin", "install.sh"), ("linux", "install.sh")],
 )
 def test_hint_installer_matches_os(monkeypatch, platform, marker):
     """Wheel install picks the installer for the running OS (irm vs curl)."""
@@ -168,7 +168,7 @@ def test_hint_installer_matches_os(monkeypatch, platform, marker):
     [
         (_EDITABLE_JSON, "linux", "uv sync --extra channel-feishu"),
         (_WHEEL_JSON, "linux", "install.sh"),
-        (_WHEEL_JSON, "win32", "install.ps1"),
+        (_WHEEL_JSON, "win32", "raw.githubusercontent.com"),
     ],
     ids=["editable", "wheel-unix", "wheel-win"],
 )


### PR DESCRIPTION
## Summary

The short URL `raven.evermind.ai/install.ps1` is served as an HTTP 308 (Permanent Redirect) to GitHub. Windows PowerShell 5.1 (the version built into Windows, whose `irm` runs on .NET Framework) does not follow 308 redirects and fails with `Permanent Redirect`, blocking a fresh Windows user at the very first install step. PowerShell 7+ follows 308 and works. The site host (Framer) cannot be configured to emit 301/302, so the fix points Windows users at the redirect-free raw URL.

- `README.md` / `README.zh-CN.md`: keep the branded short URL as the default and add the redirect-free command for Windows PowerShell 5.1 right below it.
- `raven/channels/manager.py`: the Windows missing-dependency hint used the same 308 short URL, so a PS 5.1 user copying it would hit the identical error; it now uses the raw URL.
- `tests/test_channels_manager.py`: assert the Windows hint points at the raw host.

`install.sh` (macOS/Linux) is unchanged: `curl -fsSL` follows 308, so it is unaffected.

## Type

- [x] Fix

## Verification

- `uv run pytest tests/test_channels_manager.py -q` -> 22 passed
- `bash .claude/scripts/preflight_ci.sh` -> all checks passed (commitlint, check_commit_messages, large-files, pre-commit, ruff lint/format, focused pytest 59 passed)
- `curl -sSI https://raw.githubusercontent.com/EverMind-AI/Raven/refs/heads/main/install.ps1` -> HTTP 200

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

## Risk

The raw URL is pinned to `refs/heads/main`, which matches the current Framer redirect target, so behavior is equivalent to the short URL and no new coupling is introduced. A follow-up will add a cross-platform command to install a missing channel dependency, so the manager hint no longer needs per-platform install commands.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

Fixes #148
