### PR TITLE
fix(commitlint): align subject-case with conventional-commits standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,7 @@ No other languages anywhere in the message — not just the subject; body and fo
 feat(cli): rename cron show/remove to get/delete
 fix(channels): default allow_from to ['*'] instead of deny-all
 refactor(cli): replace --cron-expr with --cron and --every-seconds with --every
+feat(importer): add EverOS HTTP backend
 ```
 
 ❌ Bad:

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -14,7 +14,7 @@ const TYPES = [
 module.exports = {
   rules: {
     "header-max-length": [2, "always", 100],
-    "subject-case": [2, "always", ["lower-case"]],
+    "subject-case": [2, "never", ["sentence-case", "start-case", "pascal-case", "upper-case"]],
     "subject-empty": [2, "never"],
     "subject-full-stop": [2, "never", "."],
     "type-case": [2, "always", "lower-case"],


### PR DESCRIPTION
## Change description

The bespoke `subject-case: [2, "always", ["lower-case"]]` rule forced
all-lowercase subjects and rejected proper nouns (EverOS, HTTP), so a PR title
like "... with EverOS HTTP backend" passed the pre-merge PR-title check but
failed commit-lint on the squash commit after merge.

This switches `subject-case` to the standard `@commitlint/config-conventional`
value (forbid Title Case / ALL CAPS / Sentence case; allow lowercase subjects
with proper nouns), plus one matching example in AGENTS.md. It intentionally does
NOT `extends` config-conventional, to avoid newly enforcing body/footer
line-length rules on the squash body (= PR description).

Verified locally: proper-noun titles pass, Title Case / Sentence case / ALL CAPS
still rejected, `style:` still rejected (type-enum unchanged), long body lines
unaffected.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Document
- [ ] Others

## Related issues (if there is)

Closes #186

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
