### PR TITLE
chore: bump version to 0.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raven"
-version = "0.1.7"
+version = "0.1.8"
 description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3249,7 +3249,7 @@ wheels = [
 
 [[package]]
 name = "raven"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Bump version from 0.1.7 to 0.1.8. Release commit only touches `pyproject.toml` and `uv.lock` (kept in sync via `uv lock`).

Changes bundled into this release since v0.1.7:

- feat(importer): cold-start import from other AI tools with EverOS HTTP backend (#170)
- fix(build): pin locked dependency versions in installers (#185)
- fix(cli): stop blank api key exiting deep_research prompt (#184)
- fix: use redirect-free install.ps1 url on windows powershell 5.1 (#182)
- fix(tui): brighten selection highlight for readability (#175)
- fix(commitlint): align subject-case with conventional-commits standard (#187)

## Type

- [x] Other

## Verification

- [x] Relevant lint / type checks pass locally

```
python3 scripts/check_commit_messages.py origin/main..HEAD  # exit 0
git diff --stat  # pyproject.toml + uv.lock, 1 line each
```

## Risk

- [x] Backward compatibility considered

Version bump only; no source changes.

## Related Issues

N/A