### PR TITLE
fix(tui): surface the real turn-failure detail, not just the code

### DIFF
--- a/raven/tui_rpc/models.py
+++ b/raven/tui_rpc/models.py
@@ -203,6 +203,7 @@ class ErrorEventPayload(_Strict):
     code: int
     message: str
     reason: Literal["cancelled_by_client", "internal"] | None = None
+    detail: str | None = None
 
 
 class ErrorEvent(_Strict):

--- a/raven/tui_rpc/spine.py
+++ b/raven/tui_rpc/spine.py
@@ -182,11 +182,11 @@ class TuiOutlet:
             {"type": "message.complete", "payload": {"turn_id": turn_id, "usage": usage}},
         )
 
-    async def emit_error(self, conversation_id: str, code: int, message: str, reason: str) -> None:
-        await self._emitter.emit(
-            conversation_id,
-            {"type": "error", "payload": {"code": code, "message": message, "reason": reason}},
-        )
+    async def emit_error(self, conversation_id: str, code: int, message: str, reason: str, detail: str = "") -> None:
+        payload: dict[str, Any] = {"code": code, "message": message, "reason": reason}
+        if detail:
+            payload["detail"] = detail
+        await self._emitter.emit(conversation_id, {"type": "error", "payload": payload})
 
 
 def _make_tui_sink(
@@ -237,7 +237,13 @@ def _make_tui_sink(
             # A cancelled turn's error is emitted by turn.cancel, not here, to
             # avoid a double error event.
             if not event.cancelled:
-                await outlet.emit_error(event.conversation_id, _TURN_FAILED_CODE, "turn_failed", "internal")
+                await outlet.emit_error(
+                    event.conversation_id,
+                    _TURN_FAILED_CODE,
+                    "turn_failed",
+                    "internal",
+                    event.error or "",
+                )
             return
         if isinstance(event, TurnStarted):
             # message.start is emitted by turn.send (it owns the turn_id).

--- a/tests/test_tui_rpc_spine.py
+++ b/tests/test_tui_rpc_spine.py
@@ -244,6 +244,26 @@ async def test_outlet_emit_complete_and_error_shapes():
     ]
 
 
+async def test_outlet_emit_error_includes_detail_when_present():
+    emitter = FakeEmitter()
+    outlet = TuiOutlet("tui", emitter)
+    await outlet.emit_error("tui:c1", -32099, "turn_failed", "internal", "No module named 'orjson'")
+    assert emitter.emitted == [
+        (
+            "tui:c1",
+            {
+                "type": "error",
+                "payload": {
+                    "code": -32099,
+                    "message": "turn_failed",
+                    "reason": "internal",
+                    "detail": "No module named 'orjson'",
+                },
+            },
+        ),
+    ]
+
+
 # --- build_tui: real Scheduler + DeliveryHub + TuiOutlet, only the edges faked ---
 # (faking the spine path would make the ordering / deadlock tests pass trivially;
 #  message.complete-after-token and the empty-turn finalize only hold on the real

--- a/ui-tui/rpc-schema/openrpc.json
+++ b/ui-tui/rpc-schema/openrpc.json
@@ -1646,7 +1646,8 @@
               "reason": {
                 "type": "string",
                 "enum": ["cancelled_by_client", "internal"]
-              }
+              },
+              "detail": { "type": "string" }
             }
           }
         }

--- a/ui-tui/src/__tests__/chatStream.test.ts
+++ b/ui-tui/src/__tests__/chatStream.test.ts
@@ -312,6 +312,28 @@ describe('createChatStream — cancel preserves streamed content', () => {
     expect(assistant!.text).toContain('[interrupted]')
   })
 
+  it('appends the failure detail to the error line when present', async () => {
+    const sysCalls: string[] = []
+    const fake = makeFakeRpc()
+    const stream = createChatStream({
+      appendMessage: () => {},
+      rpcClient: fake,
+      sessionKey: 'tui:default',
+      sys: m => sysCalls.push(m)
+    })
+    await stream.attach()
+    patchUiState({ busy: true })
+    await stream.send('question')
+
+    fake.__pushEvent({ type: 'message.start', payload: { turn_id: 'turn-1' } })
+    fake.__pushEvent({
+      type: 'error',
+      payload: { code: -32099, message: 'turn_failed', reason: 'internal', detail: "No module named 'orjson'" }
+    })
+
+    expect(sysCalls).toContain("error: turn_failed (code=-32099): No module named 'orjson'")
+  })
+
   it('keeps the streamed partial in the transcript on a local forceReset', async () => {
     const appended: Msg[] = []
     const fake = makeFakeRpc()

--- a/ui-tui/src/app/chatStream.ts
+++ b/ui-tui/src/app/chatStream.ts
@@ -208,16 +208,19 @@ const onError = (
   sys?: (msg: string) => void,
   appendMessage?: (msg: Msg) => void
 ): void => {
-  const { reason, message, code } = ev.payload
+  const { reason, message, code, detail } = ev.payload
   state.turnId = null
   if (reason === 'cancelled_by_client') {
     restoreInputPrompt(appendMessage, sys)
     return
   }
   // Non-cancellation error: surface a sys note, idle the turn, and reset
-  // the live anchor so the user can submit again.
+  // the live anchor so the user can submit again. Append the real failure
+  // detail (e.g. the underlying exception) when present, so a generic
+  // `turn_failed` code is not the only thing the user sees.
   if (sys) {
-    sys(`error: ${message} (code=${code})`)
+    const extra = detail ? `: ${detail.split('\n')[0].slice(0, 200)}` : ''
+    sys(`error: ${message} (code=${code})${extra}`)
   }
   turnController.recordError()
   patchUiState({ busy: false, status: `error: ${message.slice(0, 80)}` })

--- a/ui-tui/src/rpc/generated.ts
+++ b/ui-tui/src/rpc/generated.ts
@@ -359,6 +359,7 @@ export interface ErrorEvent {
     code: number;
     message: string;
     reason?: 'cancelled_by_client' | 'internal';
+    detail?: string;
   };
 }
 /**


### PR DESCRIPTION
## Change description

Closes #114.

Every failed agent turn surfaces in the TUI as the same opaque line -- `error: turn_failed (code=-32099)` -- regardless of the real cause (a missing dependency, a provider error, a Node version problem, ...). That made #119 (missing `orjson`) impossible to diagnose from the UI and forced a from-scratch reproduction.

Root cause: `TurnFailed` already carries the underlying error (`error=str(exc)` in the scheduler), but the spine sink discarded it -- `raven/tui_rpc/spine.py` called `emit_error(..., "turn_failed", "internal")` with the detail hardcoded, so `TurnFailed.error` never reached the wire or the UI.

## Fix

Thread the failure detail end to end:
- `ui-tui/rpc-schema/openrpc.json`: add an optional `detail` string to the `ErrorEvent` payload (single source of truth).
- `ui-tui/src/rpc/generated.ts`: regenerated from the schema (`npm run lint:rpc` confirms it is in sync).
- `raven/tui_rpc/models.py`: add `detail: str | None = None` to `ErrorEventPayload`.
- `raven/tui_rpc/spine.py`: `emit_error` accepts an optional `detail` and includes it only when non-empty; the `TurnFailed` sink passes `event.error`.
- `ui-tui/src/app/chatStream.ts`: `onError` appends the first line of `detail` (capped) to the error line, so the user sees e.g. `error: turn_failed (code=-32099): No module named 'orjson'`.

`code` / `message` / `reason` are unchanged, so the `cancelled_by_client` path and existing consumers are unaffected; `detail` is omitted when empty (back-compat).

## Tests

- `tests/test_tui_rpc_spine.py`: `emit_error` with a detail includes it in the payload; the existing no-detail test still asserts it is omitted.
- `ui-tui/src/__tests__/chatStream.test.ts`: an error event carrying `detail` renders `error: turn_failed (code=-32099): <detail>`.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Document
- [ ] Others

## Checklists

### Development
- [x] Lint rules pass locally (ruff, eslint, prettier, tsc, lint:rpc)
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass (python spine + tui chatStream + full `npm test`)

### Code review
- [x] Pull request has a descriptive title and context useful to a reviewer