### PR TITLE
fix(commitlint): unify commit/PR length to header-max-length

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -2,6 +2,7 @@ name: Commit lint
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
   push:
     branches: [main]
 
@@ -59,6 +60,13 @@ jobs:
           fi
           npx commitlint --from "$BASE" --to HEAD --config commitlint.config.cjs
           PYTHONPATH=. python3 scripts/check_commit_messages.py "$BASE..HEAD"
+
+      - name: Validate prospective squash header
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: printf '%s (#%s)\n' "$PR_TITLE" "$PR_NUMBER" | npx commitlint --config commitlint.config.cjs
 
   repository-files:
     name: repository files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ self.logger = logger.bind(channel=self.name)
 
 **scope** — a top-level subpackage of `raven/`. See the `Repo layout` section of `README.md` for the canonical list. Spanning multiple scopes → omit the scope, or use `(*)`.
 
-**subject** — lowercase start; ≤ 72 chars; no trailing period; English.
+**subject** — lowercase start; no trailing period; English. The whole header (`<type>(<scope>): <subject>`) must be ≤ 100 chars — the single length rule, enforced by commitlint `header-max-length`.
 
 **footer** (optional):
 - `BREAKING CHANGE: <desc>` — triggers a MAJOR bump once public;
@@ -149,7 +149,7 @@ No other languages anywhere in the message — not just the subject; body and fo
 
 | Part | Rule |
 |---|---|
-| subject | English, lowercase start, ≤ 72 chars, no period |
+| subject | English, lowercase start, no period; whole header ≤ 100 chars |
 | body | **All English**; when citing a non-English plan / discussion, **translate** it, don't paste |
 | punctuation | **ASCII-only** — not just no full-width punctuation (`：`,`，`,`。`,`「」`,`""` …) but also no em-dash `—`, curly quotes, or ellipsis `…` (all non-ASCII, all rejected by CI); no `§`-numbering, no non-English path names; the latin part of a §N.M anchor is fine |
 | trailer | `Co-authored-by: ...` is ASCII by format |
@@ -231,7 +231,7 @@ feat(importer): add EverOS HTTP backend
 
 After pushing a new feature branch, **proactively ask** whether to open the PR with `gh pr create` — don't leave the user to do it in the web UI.
 
-**Title:** same Conventional-Commits grammar as commits (`<type>(<scope>): <subject>`), subject reflecting the PR's overall goal, not any single commit. **Title length may relax to ≤ 90 chars** (the 72 limit is for `git log --oneline` wrapping; web-UI titles don't wrap) — but shorter is better.
+**Title:** same Conventional-Commits grammar as commits (`<type>(<scope>): <subject>`), subject reflecting the PR's overall goal, not any single commit. **Length:** the title plus the ` (#NN)` GitHub appends on squash must keep the header ≤ 100 chars — CI validates the title as that prospective squash header, so a title that passes will not fail commit-lint after merge. Shorter is better.
 
 **Description must be all English** (same as §3.1.1): no other languages / full-width punctuation / `§` numbering anywhere (subject + body + tables + checklist).
 

--- a/scripts/commit_lint.py
+++ b/scripts/commit_lint.py
@@ -20,12 +20,6 @@ HEADER_RE = re.compile(r"^(?P<type>[a-z]+)(?:\((?P<scope>[a-z0-9_*.-]+)\))?: (?P
 
 
 @dataclass(frozen=True)
-class CommitLintConfig:
-    subject_limit: int = 72
-    pr_title_subject_limit: int = 90
-
-
-@dataclass(frozen=True)
 class LintResult:
     errors: list[str]
 
@@ -34,12 +28,12 @@ class LintResult:
         return not self.errors
 
 
-def check_commit_message(message: str, config: CommitLintConfig | None = None) -> LintResult:
-    return _check_message(message, subject_limit=(config or CommitLintConfig()).subject_limit)
+def check_commit_message(message: str) -> LintResult:
+    return _check_message(message)
 
 
-def check_pr_title(title: str, config: CommitLintConfig | None = None) -> LintResult:
-    return _check_message(title, subject_limit=(config or CommitLintConfig()).pr_title_subject_limit)
+def check_pr_title(title: str) -> LintResult:
+    return _check_message(title)
 
 
 def check_pr_body(body: str) -> LintResult:
@@ -54,7 +48,7 @@ def check_pr_body(body: str) -> LintResult:
     return LintResult(errors)
 
 
-def _check_message(message: str, *, subject_limit: int) -> LintResult:
+def _check_message(message: str) -> LintResult:
     errors: list[str] = []
     text = message.strip()
     header = text.splitlines()[0] if text else ""
@@ -80,9 +74,6 @@ def _check_message(message: str, *, subject_limit: int) -> LintResult:
 
     if commit_type not in ALLOWED_TYPES:
         errors.append(f"type must be one of: {', '.join(sorted(ALLOWED_TYPES))}")
-
-    if len(subject) > subject_limit:
-        errors.append(f"subject must be {subject_limit} characters or fewer")
 
     first_alpha = next((ch for ch in subject if ch.isalpha()), "")
     if first_alpha and not first_alpha.islower():

--- a/tests/test_commit_lint.py
+++ b/tests/test_commit_lint.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from scripts import check_commit_file
 from scripts.commit_lint import (
-    CommitLintConfig,
     check_commit_message,
     check_pr_body,
     check_pr_title,
@@ -41,12 +40,12 @@ def test_rejects_uppercase_subject_and_trailing_period() -> None:
     assert "subject must not end with punctuation" in result.errors
 
 
-def test_rejects_subject_over_commit_limit() -> None:
-    subject = "a" * 73
-    result = check_commit_message(f"docs: {subject}")
+def test_python_checker_does_not_enforce_length() -> None:
+    # Length is owned solely by commitlint (header-max-length); the Python
+    # checker must not re-impose a subject-length cap of its own.
+    result = check_commit_message("docs: " + "a" * 200)
 
-    assert not result.ok
-    assert "subject must be 72 characters or fewer" in result.errors
+    assert result.ok
 
 
 def test_rejects_fixup_and_merge_subjects() -> None:
@@ -59,19 +58,9 @@ def test_rejects_fixup_and_merge_subjects() -> None:
     assert "merge commits are not allowed in PR ranges" in merge.errors
 
 
-def test_pr_title_allows_longer_subject_limit() -> None:
-    subject = "add launch-ready readme and contributor checks"
-    result = check_pr_title(f"docs: {subject}", CommitLintConfig(pr_title_subject_limit=90))
-
-    assert result.ok
-
-
-def test_pr_title_rejects_subject_over_pr_limit() -> None:
-    subject = "a" * 91
-    result = check_pr_title(f"docs: {subject}", CommitLintConfig(pr_title_subject_limit=90))
-
-    assert not result.ok
-    assert "subject must be 90 characters or fewer" in result.errors
+def test_pr_title_matches_commit_message_rules() -> None:
+    assert check_pr_title("docs(readme): sharpen launch positioning").ok
+    assert not check_pr_title("update README").ok
 
 
 def test_pr_body_accepts_ascii_markdown() -> None:


### PR DESCRIPTION
## Change description

Follow-up to #187 (which fixed the subject-case dimension). The length dimension
had the same "passes the PR, fails after merge" flaw: `scripts/commit_lint.py`
capped the subject at 72 (commits) / 90 (PR titles) while commitlint capped the
whole header at 100, so a PR title with a 73-90 char subject passed the pre-merge
PR-title check but failed commit-lint on the squash commit after merge.

This makes commitlint `header-max-length` (100) the single length authority (the
config-conventional standard) and removes the bespoke Python 72/90 caps. CI now
validates the PR title as the prospective squash header `<title> (#NN)` (in the
commit-messages job, which already has Node), so a title that passes cannot fail
after merge; the `edited` trigger re-checks title edits. Deliberately NOT
`extends @commitlint/config-conventional`, to avoid pulling in body/footer
line-length rules.

Verified locally: proper-noun titles pass, a 79-char subject (header 102) is now
rejected at PR stage, header exactly 100 passes and 101 fails, Title Case still
rejected, `tests/test_commit_lint.py` green.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Document
- [ ] Others

## Related issues (if there is)

Closes #195

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
