### PR TITLE
fix(cli): make onboard readable on light-background terminals

### DIFF
--- a/raven/cli/_styles.py
+++ b/raven/cli/_styles.py
@@ -1,44 +1,16 @@
 """Shared :mod:`questionary` ``Style`` for all interactive CLI prompts.
 
-Centralizing the palette here lets future commands (sessions picker,
-provider login, etc.) stay visually consistent without re-declaring colors
-inline. Import is deferred to module load — callers that only need other
-helpers should still import lazily so a missing :mod:`questionary` install
-doesn't break the rest of the CLI.
+The palette and light/dark detection live in :mod:`raven.cli._theme`; this
+module just resolves the active scheme once and exposes the built style. Import
+stays lazy at call sites (a missing :mod:`questionary` install shouldn't break
+the rest of the CLI), and because every caller imports this lazily at runtime,
+detecting the scheme here does not run at process startup.
 """
 
 from __future__ import annotations
 
-from questionary import Style
+from raven.cli._theme import build_questionary_style, detect_scheme
 
-RAVEN_STYLE = Style(
-    [
-        # Leading "?" glyph + the question text.
-        ("qmark", "fg:#fbe23f bold"),
-        ("question", "bold"),
-        # The committed answer echoed after a prompt resolves.
-        ("answer", "fg:#fbe23f bold"),
-        # The "❯" pointer and the row it sits on (hover state).
-        ("pointer", "fg:#fbe23f bold"),
-        # Active row: same text color as the other rows, only bold — the yellow
-        # "❯" pointer is the sole selection cue, so every option reads in one
-        # consistent color. noreverse: prompt_toolkit's base style reverse-
-        # highlights the active row, which would otherwise paint a solid block.
-        ("highlighted", "fg:#FFF5EA bold noreverse"),
-        # A previously selected value (e.g. checkbox); noreverse for the same
-        # reason — show selection via the gold color, not a background block.
-        ("selected", "fg:#c8a900 noreverse"),
-        # Faint rule between option groups.
-        ("separator", "fg:#444444"),
-        # The "(Use arrow keys)" style hint after the question.
-        ("instruction", "fg:#6c6c6c italic"),
-        # Non-selectable rows.
-        ("disabled", "fg:#585858 italic"),
-        # Inline validation error toolbar.
-        ("validation-toolbar", "fg:#ff5f5f bold"),
-        # Free-text input the user is typing.
-        ("text", "fg:#FFF5EA"),
-    ]
-)
+RAVEN_STYLE = build_questionary_style(detect_scheme())
 
 __all__ = ["RAVEN_STYLE"]

--- a/raven/cli/_theme.py
+++ b/raven/cli/_theme.py
@@ -96,6 +96,11 @@ def _can_probe() -> bool:
         return False
     if os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY"):
         return False
+    # GNU screen neither answers OSC 11 nor swallows the query, so the probe
+    # bytes echo as visible garbage; tmux defaults to TERM=screen-256color and
+    # can't answer a bare query either. Both fall back to COLORFGBG/dark.
+    if os.environ.get("TERM", "").startswith("screen"):
+        return False
     try:
         return sys.stdin.isatty() and sys.stdout.isatty()
     except (ValueError, OSError):

--- a/raven/cli/_theme.py
+++ b/raven/cli/_theme.py
@@ -1,0 +1,215 @@
+"""Light/dark theme detection and palette for the interactive CLI.
+
+Dark values are the CLI's existing literals, so dark rendering is unchanged.
+Light values are chosen for legibility on white (body text must clear WCAG AA
+4.5:1); most are drawn from the TUI source of truth ``ui-tui/src/theme.ts`` (TS
+and Python cannot share code), but the mapping is not 1:1:
+  - accent / selected light use ``#935F00`` (theme.ts yellow ramp .700), not the
+    brand accent ``#B87900`` (only 3.64:1 on white) -- the CLI uses accent as
+    inline body text, not large glyphs.
+  - border stays a gold accent (matching the CLI's gold panel borders), whereas
+    theme.ts ``border`` is a neutral grey; separator reuses that grey ``#d0d7de``.
+
+Detection is kept out of import time and runs on the first themed render (see
+``onboard_commands._ThemedConsole``). Only truecolor values are provided;
+rich/prompt_toolkit downgrade to 256/16 automatically.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Literal
+
+Scheme = Literal["light", "dark"]
+
+_LUMA_LIGHT_THRESHOLD = 0.6
+
+PALETTE: dict[Scheme, dict[str, str]] = {
+    "dark": {
+        "accent": "#fbe23f",
+        "text": "#FFF5EA",
+        "heading": "white",
+        "selected": "#c8a900",
+        "border": "#c8a900",
+        "muted": "#6c6c6c",
+        "separator": "#444444",
+        "disabled": "#585858",
+        "error": "#ff5f5f",
+    },
+    "light": {
+        "accent": "#935F00",
+        "text": "#24201a",
+        "heading": "#24201a",
+        "selected": "#935F00",
+        "border": "#935F00",
+        "muted": "#57606a",
+        "separator": "#d0d7de",
+        "disabled": "#6e7681",
+        "error": "#cf222e",
+    },
+}
+
+_cache: Scheme | None = None
+
+
+def _parse_hex(value: str) -> tuple[int, int, int] | None:
+    v = value.strip().lstrip("#")
+    if len(v) == 3:
+        v = "".join(c * 2 for c in v)
+    if len(v) != 6:
+        return None
+    try:
+        return int(v[0:2], 16), int(v[2:4], 16), int(v[4:6], 16)
+    except ValueError:
+        return None
+
+
+def _is_light_rgb(rgb: tuple[int, int, int]) -> bool:
+    r, g, b = rgb
+    luma = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
+    return luma >= _LUMA_LIGHT_THRESHOLD
+
+
+def _osc_reply_to_rgb(data: str) -> tuple[int, int, int] | None:
+    # Terminal answers OSC 11 as e.g. "rgb:ffff/f5f5/eaea" (16-bit per channel)
+    # or "#rrggbb"; tolerate a trailing BEL/ST.
+    marker = "rgb:"
+    idx = data.find(marker)
+    if idx != -1:
+        parts = data[idx + len(marker) :].strip().strip("\a\033\\").split("/")
+        if len(parts) >= 3:
+            try:
+                return tuple(int(p[:2], 16) for p in parts[:3])  # type: ignore[return-value]
+            except ValueError:
+                return None
+    hidx = data.find("#")
+    if hidx != -1:
+        return _parse_hex(data[hidx : hidx + 7])
+    return None
+
+
+def _can_probe() -> bool:
+    if os.name != "posix":
+        return False
+    if os.environ.get("CI"):
+        return False
+    if os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY"):
+        return False
+    try:
+        return sys.stdin.isatty() and sys.stdout.isatty()
+    except (ValueError, OSError):
+        return False
+
+
+def _probe_osc11() -> tuple[int, int, int] | None:
+    try:
+        import select
+        import termios
+        import tty
+    except ImportError:
+        return None
+
+    fd = sys.stdin.fileno()
+    try:
+        old = termios.tcgetattr(fd)
+    except termios.error:
+        return None
+    try:
+        tty.setraw(fd)
+        sys.stdout.write("\033]11;?\033\\")
+        sys.stdout.flush()
+        ready, _, _ = select.select([fd], [], [], 0.1)
+        if not ready:
+            return None
+        raw = os.read(fd, 64).decode("ascii", "replace")
+    except (OSError, ValueError):
+        return None
+    finally:
+        try:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+        except termios.error:
+            pass
+    return _osc_reply_to_rgb(raw)
+
+
+def _detect() -> tuple[Scheme, bool]:
+    """Return (scheme, definitive). Non-definitive results (the dark fallback)
+    are not cached, so a later call from an interactive path can re-detect."""
+    override = os.environ.get("RAVEN_THEME", "").strip().lower()
+    if override in ("light", "dark"):
+        return override, True  # type: ignore[return-value]
+
+    hint = os.environ.get("RAVEN_TERM_BACKGROUND", "")
+    rgb = _parse_hex(hint) if hint else None
+    if rgb is not None:
+        return ("light" if _is_light_rgb(rgb) else "dark"), True
+
+    if _can_probe():
+        rgb = _probe_osc11()
+        if rgb is not None:
+            return ("light" if _is_light_rgb(rgb) else "dark"), True
+
+    fgbg = os.environ.get("COLORFGBG", "")
+    if fgbg:
+        last = fgbg.split(";")[-1].strip()
+        if last in ("7", "15"):
+            return "light", True
+        if last.isdigit():
+            return "dark", True
+
+    return "dark", False
+
+
+def detect_scheme() -> Scheme:
+    global _cache
+    if _cache is not None:
+        return _cache
+    scheme, definitive = _detect()
+    if definitive:
+        _cache = scheme
+    return scheme
+
+
+def _style_str(color: str, *attrs: str) -> str:
+    return " ".join([color, *attrs]) if attrs else color
+
+
+def build_rich_theme(scheme: Scheme):
+    from rich.theme import Theme
+
+    p = PALETTE[scheme]
+    return Theme(
+        {
+            "accent": p["accent"],
+            "text": p["text"],
+            "heading": _style_str(p["heading"], "bold"),
+            "selected": p["selected"],
+            "border": p["border"],
+            "muted": p["muted"],
+            "separator": p["separator"],
+            "disabled": p["disabled"],
+            "error": p["error"],
+        }
+    )
+
+
+def build_questionary_style(scheme: Scheme):
+    from questionary import Style
+
+    p = PALETTE[scheme]
+    return Style(
+        [
+            ("qmark", f"fg:{p['accent']} bold"),
+            ("question", "bold"),
+            ("answer", f"fg:{p['accent']} bold"),
+            ("pointer", f"fg:{p['accent']} bold"),
+            ("highlighted", f"fg:{p['text']} bold noreverse"),
+            ("selected", f"fg:{p['selected']} noreverse"),
+            ("separator", f"fg:{p['separator']}"),
+            ("instruction", f"fg:{p['muted']} italic"),
+            ("disabled", f"fg:{p['disabled']} italic"),
+            ("validation-toolbar", f"fg:{p['error']} bold"),
+            ("text", f"fg:{p['text']}"),
+        ]
+    )

--- a/raven/cli/cron_commands.py
+++ b/raven/cli/cron_commands.py
@@ -803,7 +803,7 @@ def cron_config_get(
     if not selected:
         table = Table(title="cron config (effective values)", show_lines=False)
         table.add_column("key", style="cyan")
-        table.add_column("value", style="white")
+        table.add_column("value")
         for k, handler in _KEY_HANDLERS.items():
             value = getattr(config.cron, k)
             table.add_row(k, handler["display"](value))

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -42,7 +42,29 @@ from raven.cli._helpers import (
     send_probe,
 )
 
-console = Console()
+
+class _ThemedConsole(Console):
+    """Console that applies the light/dark theme on its first render.
+
+    Theming is deferred to the first ``print`` (never at import) so plain
+    ``raven ...`` commands don't detect or probe the terminal. Because every
+    onboard render goes through ``print`` on this instance, there is no
+    "push the theme before rendering" ordering constraint and no dependence on
+    which entry point (wizard, ``raven deep-research enable``, ...) ran first.
+    """
+
+    _themed: bool = False
+
+    def print(self, *args: Any, **kwargs: Any) -> None:
+        if not self._themed:
+            from raven.cli._theme import build_rich_theme, detect_scheme
+
+            self.push_theme(build_rich_theme(detect_scheme()))
+            self._themed = True
+        super().print(*args, **kwargs)
+
+
+console = _ThemedConsole()
 
 _TOTAL_STEPS = 6
 
@@ -110,10 +132,10 @@ _CURATED_PROVIDERS: list[dict[str, Any]] = [
 ]
 
 _QUESTIONARY_INSTALL_HINT = (
-    "[red]Missing dependency:[/red] [#fbe23f]questionary[/#fbe23f] is required for "
+    "[red]Missing dependency:[/red] [accent]questionary[/accent] is required for "
     "interactive onboarding.\n"
-    "Install it with: [#fbe23f]uv add 'questionary>=2.0,<3.0'[/#fbe23f]\n"
-    "Or re-run with [#fbe23f]--non-interactive[/#fbe23f] plus the relevant flags."
+    "Install it with: [accent]uv add 'questionary>=2.0,<3.0'[/accent]\n"
+    "Or re-run with [accent]--non-interactive[/accent] plus the relevant flags."
 )
 
 
@@ -186,11 +208,11 @@ def _pick_language() -> None:
     console.print()
     console.print(
         Panel(
-            "[bold white]Let's set up Raven — first, choose your language.[/bold white]\n"
+            "[heading]Let's set up Raven — first, choose your language.[/heading]\n"
             "[dim]开始配置 Raven — 请先选择语言。[/dim]",
-            title="[bold #fbe23f]Raven setup[/bold #fbe23f]",
+            title="[bold][accent]Raven setup[/accent][/bold]",
             title_align="left",
-            border_style="#c8a900",
+            border_style="border",
             padding=(1, 2),
         )
     )
@@ -219,16 +241,16 @@ def _pick_language() -> None:
 
 def _step_header(n: int, title: str) -> None:
     # Progress dots: filled for done/current steps, hollow for upcoming ones.
-    dots = " ".join("[#fbe23f]●[/#fbe23f]" if i <= n else "[grey37]○[/grey37]" for i in range(1, _TOTAL_STEPS + 1))
+    dots = " ".join("[accent]●[/accent]" if i <= n else "[grey37]○[/grey37]" for i in range(1, _TOTAL_STEPS + 1))
     console.print()
     console.print(
         Panel(
-            f"[bold white]{title}[/bold white]",
-            title=f"[bold #fbe23f]{_t('Step', '步骤')} {n}/{_TOTAL_STEPS}[/bold #fbe23f]",
+            f"[heading]{title}[/heading]",
+            title=f"[bold][accent]{_t('Step', '步骤')} {n}/{_TOTAL_STEPS}[/accent][/bold]",
             title_align="left",
             subtitle=dots,
             subtitle_align="right",
-            border_style="#c8a900",
+            border_style="border",
             padding=(0, 2),
         )
     )
@@ -243,7 +265,7 @@ def _check_tty_or_die(non_interactive: bool) -> None:
         console.print(
             "[red]Non-interactive terminal detected.[/red]\n"
             "Re-run with: "
-            "[#fbe23f]raven onboard --non-interactive --provider <name> --api-key <key>[/#fbe23f]"
+            "[accent]raven onboard --non-interactive --provider <name> --api-key <key>[/accent]"
         )
         raise typer.Exit(2)
 
@@ -302,9 +324,9 @@ def _handle_existing_config(*, reset: bool, yes: bool, non_interactive: bool) ->
             console.print("[dim]Existing config detected; --yes set, proceeding with overwrite.[/dim]")
             return
         console.print(
-            "[red]Existing config detected.[/red] Pass [#fbe23f]--reset[/#fbe23f] (or "
-            "[#fbe23f]--yes[/#fbe23f]) to overwrite, or edit in place with "
-            "[#fbe23f]raven provider set[/#fbe23f] / [#fbe23f]raven channels enable[/#fbe23f]."
+            "[red]Existing config detected.[/red] Pass [accent]--reset[/accent] (or "
+            "[accent]--yes[/accent]) to overwrite, or edit in place with "
+            "[accent]raven provider set[/accent] / [accent]raven channels enable[/accent]."
         )
         raise typer.Exit(2)
     # Interactive: fall through to the wizard (per-step "Keep current" handles
@@ -589,8 +611,8 @@ def _run_oauth_login(provider: str) -> bool:
         raise typer.Exit(1)
     console.print(
         _t(
-            f"  [#fbe23f]Starting OAuth login for {spec.label}…[/#fbe23f]\n",
-            f"  [#fbe23f]正在为 {spec.label} 启动 OAuth 登录…[/#fbe23f]\n",
+            f"  [accent]Starting OAuth login for {spec.label}…[/accent]\n",
+            f"  [accent]正在为 {spec.label} 启动 OAuth 登录…[/accent]\n",
         )
     )
     console.print(
@@ -961,8 +983,8 @@ def _configure_one_provider(
         if flag_provider:
             console.print(
                 _t(
-                    f"  [dim]Provider:[/dim] [#fbe23f]{_provider_label(provider)}[/#fbe23f]",
-                    f"  [dim]服务商:[/dim] [#fbe23f]{_provider_label(provider)}[/#fbe23f]",
+                    f"  [dim]Provider:[/dim] [accent]{_provider_label(provider)}[/accent]",
+                    f"  [dim]服务商:[/dim] [accent]{_provider_label(provider)}[/accent]",
                 )
             )
 
@@ -1031,8 +1053,8 @@ def _collect_credentials(
         if non_interactive:
             console.print(
                 "[red]OAuth providers require an interactive browser flow.[/red]\n"
-                "Run [#fbe23f]raven provider login "
-                f"{provider.replace('_', '-')}[/#fbe23f] separately, then re-run "
+                "Run [accent]raven provider login "
+                f"{provider.replace('_', '-')}[/accent] separately, then re-run "
                 "onboard."
             )
             raise typer.Exit(2)
@@ -1981,7 +2003,7 @@ def _step3_channel(*, channel: Optional[str], skip: bool, non_interactive: bool)
             console.print(
                 f"[red]--channel {channel} given but non-interactive mode can't "
                 "prompt for credential fields.[/red]\n"
-                f"Run [#fbe23f]raven channels enable {channel} --<field> <value> ...[/#fbe23f] "
+                f"Run [accent]raven channels enable {channel} --<field> <value> ...[/accent] "
                 "after onboard finishes."
             )
             raise typer.Exit(2)
@@ -3068,10 +3090,10 @@ def _config_everos_role(
     # (parens/numbers/words) and make an informational hint read like an error.
     console.print(
         _t(
-            f"  [bold #fbe23f]{label_en}[/bold #fbe23f]"
+            f"  [bold][accent]{label_en}[/accent][/bold]"
             + (f" [dim]({tag})[/dim]" if optional else "")
             + f"\n  [dim]{purpose_en}[/dim]",
-            f"  [bold #fbe23f]{label_zh}[/bold #fbe23f]"
+            f"  [bold][accent]{label_zh}[/accent][/bold]"
             + (f" [dim]({tag})[/dim]" if optional else "")
             + f"\n  [dim]{purpose_zh}[/dim]",
         ),
@@ -3442,8 +3464,8 @@ def _print_next_steps(*, warnings: list[str]) -> None:
                 + f"{', '.join(warnings)}\n"
                 + _t(
                     "[dim]Fix them before relying on the related features "
-                    "(re-run [/dim][#fbe23f]raven onboard[/#fbe23f][dim] to reconfigure).[/dim]",
-                    "[dim]在依赖相关功能前请先修复(重新运行 [/dim][#fbe23f]raven onboard[/#fbe23f][dim] 重新配置)。[/dim]",
+                    "(re-run [/dim][accent]raven onboard[/accent][dim] to reconfigure).[/dim]",
+                    "[dim]在依赖相关功能前请先修复(重新运行 [/dim][accent]raven onboard[/accent][dim] 重新配置)。[/dim]",
                 ),
                 border_style="yellow",
                 padding=(1, 2),
@@ -3489,7 +3511,7 @@ def _print_next_steps(*, warnings: list[str]) -> None:
     )
 
     table = Table(show_header=False, box=None, padding=(0, 3, 0, 0))
-    table.add_column(style="#fbe23f", no_wrap=True)
+    table.add_column(style="accent", no_wrap=True)
     table.add_column(style="dim")
     table.add_row("raven", _t("launch the native TUI (default)", "启动原生 TUI(默认)"))
     table.add_row("raven gateway", _t("run the gateway (serve channels)", "运行网关(对接渠道)"))
@@ -3503,7 +3525,7 @@ def _print_next_steps(*, warnings: list[str]) -> None:
             table,
             title=f"[bold]{_t('Get started', '开始使用')}[/bold]",
             title_align="left",
-            border_style="#c8a900",
+            border_style="border",
             padding=(1, 2),
         )
     )
@@ -3695,13 +3717,13 @@ def _step5_import_body(
         # -- Tier selection --
         console.print(
             _t(
-                "\n  [bold #fbe23f]Memory files only[/bold #fbe23f]  "
+                "\n  [bold][accent]Memory files only[/accent][/bold]  "
                 "[dim]Fast (minutes). Imports preferences, rules, and project knowledge. Low LLM cost.[/dim]\n\n"
-                "  [bold #fbe23f]Full import[/bold #fbe23f]  "
+                "  [bold][accent]Full import[/accent][/bold]  "
                 "[dim]Slow (may take hours). Imports memory files + all conversation history. Higher LLM cost.[/dim]",
-                "\n  [bold #fbe23f]仅记忆文件[/bold #fbe23f]  "
+                "\n  [bold][accent]仅记忆文件[/accent][/bold]  "
                 "[dim]快速（分钟级）。导入偏好、规则和项目知识。LLM 开销较少。[/dim]\n\n"
-                "  [bold #fbe23f]完整导入[/bold #fbe23f]  "
+                "  [bold][accent]完整导入[/accent][/bold]  "
                 "[dim]较慢（可能数小时）。导入记忆文件 + 全部对话历史。LLM 开销较多。[/dim]",
             ),
             highlight=False,
@@ -3842,11 +3864,9 @@ def _step5_import_body(
             console.print(
                 _t(
                     f"\n  Import started in background.\n"
-                    f"  Check progress: [#fbe23f]raven import status[/#fbe23f]\n"
+                    f"  Check progress: [accent]raven import status[/accent]\n"
                     f"  Log: {log_path}",
-                    f"\n  导入已在后台启动。\n"
-                    f"  查看进度: [#fbe23f]raven import status[/#fbe23f]\n"
-                    f"  详细日志: {log_path}",
+                    f"\n  导入已在后台启动。\n  查看进度: [accent]raven import status[/accent]\n  详细日志: {log_path}",
                 )
             )
             return None
@@ -3994,20 +4014,20 @@ def _run_wizard_body(
     console.print(
         Panel(
             _t(
-                "[bold #fbe23f]✨ Welcome to the Raven setup wizard[/bold #fbe23f]\n\n"
+                "[bold][accent]✨ Welcome to the Raven setup wizard[/accent][/bold]\n\n"
                 "[dim]We'll configure, in order:[/dim]\n"
-                "  [#fbe23f]①[/#fbe23f] LLM      [#fbe23f]②[/#fbe23f] Run location      "
-                "[#fbe23f]③[/#fbe23f] Chat channel      [#fbe23f]④[/#fbe23f] Long-term memory      "
-                "[#fbe23f]⑤[/#fbe23f] Deep research      [#fbe23f]⑥[/#fbe23f] Import history\n\n"
+                "  [accent]①[/accent] LLM      [accent]②[/accent] Run location      "
+                "[accent]③[/accent] Chat channel      [accent]④[/accent] Long-term memory      "
+                "[accent]⑤[/accent] Deep research      [accent]⑥[/accent] Import history\n\n"
                 "[dim]↑↓ select · Enter confirm · Ctrl+C quit anytime — anything already written is kept.[/dim]",
-                "[bold #fbe23f]✨ 欢迎使用 Raven 配置向导[/bold #fbe23f]\n\n"
+                "[bold][accent]✨ 欢迎使用 Raven 配置向导[/accent][/bold]\n\n"
                 "[dim]我们将依次配置:[/dim]\n"
-                "  [#fbe23f]①[/#fbe23f] LLM      [#fbe23f]②[/#fbe23f] 运行位置      "
-                "[#fbe23f]③[/#fbe23f] 聊天渠道      [#fbe23f]④[/#fbe23f] 长期记忆      "
-                "[#fbe23f]⑤[/#fbe23f] 深度研究      [#fbe23f]⑥[/#fbe23f] 历史导入\n\n"
+                "  [accent]①[/accent] LLM      [accent]②[/accent] 运行位置      "
+                "[accent]③[/accent] 聊天渠道      [accent]④[/accent] 长期记忆      "
+                "[accent]⑤[/accent] 深度研究      [accent]⑥[/accent] 历史导入\n\n"
                 "[dim]↑↓ 选择 · Enter 确认 · 随时 Ctrl+C 退出 — 已写入的配置会保留。[/dim]",
             ),
-            border_style="#c8a900",
+            border_style="border",
             padding=(1, 2),
         )
     )

--- a/raven/cli/skill_commands.py
+++ b/raven/cli/skill_commands.py
@@ -55,7 +55,7 @@ def skill_list(
     table = Table(title=f"Skills ({len(metas)})")
     table.add_column("Name", style="cyan")
     table.add_column("Source", style="green")
-    table.add_column("Description", style="white", overflow="fold")
+    table.add_column("Description", overflow="fold")
     for m in metas:
         desc = (m.description or "")[:120]
         table.add_row(m.name, m.source, desc)

--- a/tests/test_cli_theme.py
+++ b/tests/test_cli_theme.py
@@ -1,0 +1,291 @@
+"""Tests for CLI light/dark theme detection and palette (issue #169).
+
+Covers: luminance classification, OSC 11 reply parsing, env precedence and
+fallback, non-TTY / Windows / SSH short-circuit, dark byte-for-byte parity,
+light-scheme readability regression, reduced-color-depth readability, and the
+rich-theme crash-protection path (every onboard markup token resolves).
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from raven.cli import _theme
+
+# capture the real predicate before the autouse fixture stubs it out
+_REAL_CAN_PROBE = _theme._can_probe
+
+
+@pytest.fixture(autouse=True)
+def _reset_theme_cache(monkeypatch):
+    _theme._cache = None
+    for var in ("RAVEN_THEME", "RAVEN_TERM_BACKGROUND", "COLORFGBG", "CI", "SSH_CONNECTION", "SSH_TTY"):
+        monkeypatch.delenv(var, raising=False)
+    # keep detection deterministic: never actually probe the terminal in tests
+    monkeypatch.setattr(_theme, "_can_probe", lambda: False)
+    yield
+    _theme._cache = None
+
+
+def _wcag_contrast(hex_fg: str, hex_bg: str) -> float:
+    def rel_lum(h: str) -> float:
+        h = h.lstrip("#")
+        chans = [int(h[i : i + 2], 16) / 255 for i in (0, 2, 4)]
+        lin = [c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4 for c in chans]
+        return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2]
+
+    l1, l2 = rel_lum(hex_fg), rel_lum(hex_bg)
+    hi, lo = max(l1, l2), min(l1, l2)
+    return (hi + 0.05) / (lo + 0.05)
+
+
+# --- luminance classification -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hex_bg, expected_light",
+    [("#ffffff", True), ("#000000", False), ("#fff", True), ("#1e1e1e", False)],
+)
+def test_luminance_classification(hex_bg, expected_light):
+    assert _theme._is_light_rgb(_theme._parse_hex(hex_bg)) is expected_light
+
+
+def test_luminance_threshold_boundary():
+    # gray at the 0.6 luma edge: just-below stays dark, just-above flips light
+    assert _theme._is_light_rgb((150, 150, 150)) is False
+    assert _theme._is_light_rgb((160, 160, 160)) is True
+
+
+def test_parse_hex_rejects_garbage():
+    assert _theme._parse_hex("nothex") is None
+    assert _theme._parse_hex("#12") is None
+
+
+# --- OSC 11 reply parsing -----------------------------------------------------
+
+
+def test_osc_reply_rgb_16bit():
+    assert _theme._osc_reply_to_rgb("\033]11;rgb:ffff/f5f5/eaea\033\\") == (255, 245, 234)
+
+
+def test_osc_reply_hex():
+    assert _theme._osc_reply_to_rgb("\033]11;#fff5ea\a") == (255, 245, 234)
+
+
+# --- env precedence + fallback ------------------------------------------------
+
+
+@pytest.mark.parametrize("value, expected", [("light", "light"), ("dark", "dark"), ("LIGHT", "light")])
+def test_raven_theme_env_wins(monkeypatch, value, expected):
+    monkeypatch.setenv("RAVEN_THEME", value)
+    monkeypatch.setenv("COLORFGBG", "0;0")  # would say dark; explicit env must win
+    assert _theme.detect_scheme() == expected
+
+
+def test_raven_term_background_hint(monkeypatch):
+    monkeypatch.setenv("RAVEN_TERM_BACKGROUND", "#ffffff")
+    assert _theme.detect_scheme() == "light"
+
+
+@pytest.mark.parametrize("colorfgbg, expected", [("15;7", "light"), ("7", "light"), ("15;0", "dark"), ("0", "dark")])
+def test_colorfgbg(monkeypatch, colorfgbg, expected):
+    monkeypatch.setenv("COLORFGBG", colorfgbg)
+    assert _theme.detect_scheme() == expected
+
+
+def test_fallback_dark_when_no_signal():
+    assert _theme.detect_scheme() == "dark"
+
+
+def test_fallback_is_not_cached(monkeypatch):
+    # a fallback (non-definitive) result must not poison a later definitive call
+    assert _theme.detect_scheme() == "dark"
+    monkeypatch.setenv("RAVEN_THEME", "light")
+    assert _theme.detect_scheme() == "light"
+
+
+# --- short-circuit (no probe) -------------------------------------------------
+
+
+def test_no_probe_on_non_tty(monkeypatch):
+    monkeypatch.setattr(_theme.os, "name", "posix")
+    monkeypatch.setattr(_theme.sys.stdin, "isatty", lambda: False, raising=False)
+    monkeypatch.setattr(_theme.sys.stdout, "isatty", lambda: False, raising=False)
+    assert _REAL_CAN_PROBE() is False
+
+
+def test_no_probe_on_windows(monkeypatch):
+    monkeypatch.setattr(_theme.os, "name", "nt")
+    assert _REAL_CAN_PROBE() is False
+
+
+def test_no_probe_under_ssh(monkeypatch):
+    monkeypatch.setattr(_theme.os, "name", "posix")
+    monkeypatch.setattr(_theme.sys.stdin, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr(_theme.sys.stdout, "isatty", lambda: True, raising=False)
+    monkeypatch.setenv("SSH_CONNECTION", "1.2.3.4 5 6.7.8.9 22")
+    assert _REAL_CAN_PROBE() is False
+
+
+def test_no_probe_under_ci(monkeypatch):
+    monkeypatch.setattr(_theme.os, "name", "posix")
+    monkeypatch.setattr(_theme.sys.stdin, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr(_theme.sys.stdout, "isatty", lambda: True, raising=False)
+    monkeypatch.setenv("CI", "true")
+    assert _REAL_CAN_PROBE() is False
+
+
+# --- dark byte-for-byte parity (D2: dark rendering unchanged) -----------------
+
+
+def test_dark_questionary_style_byte_identical():
+    expected = {
+        "qmark": "fg:#fbe23f bold",
+        "question": "bold",
+        "answer": "fg:#fbe23f bold",
+        "pointer": "fg:#fbe23f bold",
+        "highlighted": "fg:#FFF5EA bold noreverse",
+        "selected": "fg:#c8a900 noreverse",
+        "separator": "fg:#444444",
+        "instruction": "fg:#6c6c6c italic",
+        "disabled": "fg:#585858 italic",
+        "validation-toolbar": "fg:#ff5f5f bold",
+        "text": "fg:#FFF5EA",
+    }
+    got = dict(_theme.build_questionary_style("dark").style_rules)
+    assert got == expected
+
+
+# --- light readability (regression for #169) ----------------------------------
+
+
+def test_light_text_is_not_a_light_color():
+    # #169: list rows / input used #FFF5EA (near-white) and vanished on white.
+    assert _theme.PALETTE["light"]["text"] == "#24201a"
+    rules = dict(_theme.build_questionary_style("light").style_rules)
+    assert rules["text"] == "fg:#24201a"
+    assert rules["highlighted"] == "fg:#24201a bold noreverse"
+
+
+@pytest.mark.parametrize("token", ["accent", "text", "selected", "border", "muted", "error", "disabled"])
+def test_light_body_tokens_pass_wcag_on_white(token):
+    assert _wcag_contrast(_theme.PALETTE["light"][token], "#ffffff") >= 4.5
+
+
+@pytest.mark.parametrize("token", ["accent", "text", "selected", "error"])
+def test_dark_body_tokens_pass_wcag_on_black(token):
+    assert _wcag_contrast(_theme.PALETTE["dark"][token], "#1e1e1e") >= 4.5
+
+
+# --- reduced color depth readability (D1 sentinel) ----------------------------
+
+
+@pytest.mark.parametrize("token", ["accent", "text", "error"])
+def test_light_tokens_readable_after_256_downgrade(token):
+    from rich.color import Color, ColorSystem
+
+    hex_val = _theme.PALETTE["light"][token]
+    approx = Color.parse(hex_val).downgrade(ColorSystem.EIGHT_BIT).get_truecolor().hex
+    assert _wcag_contrast(approx, "#ffffff") >= 4.0
+
+
+# --- crash protection: every onboard markup token resolves --------------------
+
+
+def test_rich_theme_defines_all_onboard_tokens():
+    """Every rich style word in onboard's string literals resolves in the theme.
+
+    Scans only string-literal contents (via ast) so Python subscripts / type
+    hints like ``list[str]`` are not mistaken for markup tags.
+    """
+    import ast
+    import re
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[1] / "raven" / "cli" / "onboard_commands.py"
+    tree = ast.parse(src.read_text(encoding="utf-8"))
+    literals: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            literals.append(node.value)
+    blob = "\n".join(literals)
+    # negative lookbehind skips rich-escaped brackets like ``\[sandbox]``
+    tags = set(re.findall(r"(?<!\\)\[/?([a-z]+(?: [a-z]+)?)\]", blob))
+    theme_names = set(_theme.build_rich_theme("light").styles.keys())
+    builtin = {"dim", "bold", "red", "green", "yellow", "italic", "i", "b", "u", "reverse"}
+    words = {w for tag in tags for w in tag.split()} - builtin
+    missing = {w for w in words if w not in theme_names}
+    assert not missing, f"onboard markup uses undefined theme tokens: {missing}"
+
+
+@pytest.mark.parametrize("scheme", ["light", "dark"])
+def test_onboard_panels_render_without_missing_style(scheme):
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.table import Table
+
+    theme = _theme.build_rich_theme(scheme)
+    console = Console(theme=theme, file=io.StringIO(), force_terminal=True)
+    console.print("[accent]x[/accent] [bold][accent]y[/accent][/bold] [heading]z[/heading]")
+    console.print(Panel("b", title="[bold][accent]t[/accent][/bold]", border_style="border"))
+    console.print(Panel("recap", border_style="#8a6d00"))  # preserved literal
+    table = Table()
+    table.add_column("h", style="accent", no_wrap=True)
+    table.add_column("d", style="dim")
+    table.add_row("a", "b")
+    console.print(table)  # would raise MissingStyle if 'accent' unresolved
+
+
+_THEME_KEYS = {"accent", "text", "heading", "selected", "border", "muted", "separator", "disabled", "error"}
+
+
+def test_no_compound_markup_mixes_theme_key():
+    """A theme style name must be its own markup tag. rich cannot resolve a
+    custom theme name combined with another word: ``[bold accent]`` silently
+    renders as bare text (no bold, no color, no exception). Nested tags
+    ``[bold][accent]...[/accent][/bold]`` are the correct form.
+    """
+    import ast
+    import re
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[1] / "raven" / "cli" / "onboard_commands.py"
+    tree = ast.parse(src.read_text(encoding="utf-8"))
+    literals = [n.value for n in ast.walk(tree) if isinstance(n, ast.Constant) and isinstance(n.value, str)]
+    blob = "\n".join(literals)
+    bad = set()
+    for tag in re.findall(r"(?<!\\)\[/?([a-z][a-z ]*)\]", blob):
+        words = tag.split()
+        if len(words) > 1 and _THEME_KEYS & set(words):
+            bad.add(tag)
+    assert not bad, f"compound markup mixes a theme key with another word (renders unstyled): {bad}"
+
+
+def test_bold_accent_renders_styled_not_bare():
+    """Byte-level guard: nested [bold][accent] emits bold + the accent color,
+    not bare text (the silent-degrade failure mode of a bad compound tag)."""
+    from rich.console import Console
+
+    con = Console(
+        theme=_theme.build_rich_theme("dark"), file=io.StringIO(), force_terminal=True, color_system="truecolor"
+    )
+    con.print("[bold][accent]X[/accent][/bold]", end="")
+    out = con.file.getvalue()
+    assert "1;38;2;251;226;63" in out, f"expected bold + accent(#fbe23f) ANSI, got {out!r}"
+
+
+def test_themed_console_self_themes_on_first_print():
+    """Regression: onboard's console themes itself on first print, so any render
+    path (any wizard helper, deep-research, etc.) resolves theme tokens without a
+    prior push — no order-coupling, no MissingStyle. A plain Console would raise.
+    """
+    from rich.panel import Panel
+
+    from raven.cli.onboard_commands import _ThemedConsole
+
+    con = _ThemedConsole(file=io.StringIO(), force_terminal=True)
+    assert con._themed is False
+    con.print(Panel("[accent]x[/accent] [heading]y[/heading]", border_style="border"))
+    assert con._themed is True

--- a/tests/test_cli_theme.py
+++ b/tests/test_cli_theme.py
@@ -137,6 +137,16 @@ def test_no_probe_under_ci(monkeypatch):
     assert _REAL_CAN_PROBE() is False
 
 
+def test_no_probe_under_screen(monkeypatch):
+    # GNU screen echoes the OSC 11 query as visible garbage; default tmux is
+    # TERM=screen-256color and can't answer a bare query. Skip the probe.
+    monkeypatch.setattr(_theme.os, "name", "posix")
+    monkeypatch.setattr(_theme.sys.stdin, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr(_theme.sys.stdout, "isatty", lambda: True, raising=False)
+    monkeypatch.setenv("TERM", "screen-256color")
+    assert _REAL_CAN_PROBE() is False
+
+
 # --- dark byte-for-byte parity (D2: dark rendering unchanged) -----------------
 
 


### PR DESCRIPTION
## Summary

`raven onboard` was unreadable on light-background terminals: the palette was
hardcoded for a dark background and the CLI had no light/dark detection, so
near-white / bright-yellow text vanished on white (issue #169, reproduced on a
released build).

This adds `raven/cli/_theme.py`: light/dark detection (env `RAVEN_THEME` /
`RAVEN_TERM_BACKGROUND` hint / OSC 11 background probe / `COLORFGBG`, falling
back to dark) plus a scheme-aware palette, wired into the onboarding wizard and
the shared questionary style.

- Dark rendering is byte-for-byte unchanged (dark token values are the current
  literals; verified by a rendering diff and a parity test).
- Light values clear WCAG AA 4.5:1 on white; most mirror `ui-tui/src/theme.ts`.
- Detection runs on first themed render, never at import, so plain `raven ...`
  commands do not probe the terminal.
- Also drops two hardcoded `white` table columns (`skill` / `cron`) that were
  invisible on light backgrounds.

Scope is deliberately limited to what fails on light: named ANSI colors
(`red`/`green`/`cyan`...) elsewhere are terminal-adaptive and were left as-is.

## Type

- [x] Fix

## Verification

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally

```
uv run pytest tests/test_cli_theme.py            # 44 passed (new)
uv run pytest tests/test_cli_onboard_commands.py # 64 passed
uv run pytest tests/test_cli_deep_research_commands.py \
  tests/test_cli_skill_commands.py tests/test_cli_cron_commands.py \
  tests/test_cli_smoke.py                        # 142 passed
uv run ruff check / ruff format --check          # clean
```

Note for reviewers: the OSC 11 terminal probe can only be exercised on a real
TTY (not in CI). Please confirm on a light-background terminal that
`raven onboard` is now legible, and on a dark terminal that it is unchanged
(`RAVEN_THEME=dark` / `RAVEN_THEME=light` force a scheme).

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Dark output is unchanged; the new env vars are additive; rollback is a single
commit revert.

## Related Issues

Closes #169
