### PR TITLE
docs: add authenticated star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,10 +450,6 @@ If Raven is the kind of agent harness you want to exist, star the repo. It
 helps more builders of self-improving agents discover the project and gives the
 EverMind ecosystem a stronger signal to keep investing in open agents.
 
-### GitHub Stars
-
-[![GitHub Stars](https://img.shields.io/github/stars/EverMind-AI/Raven?style=for-the-badge)](https://github.com/EverMind-AI/Raven)
-
 ### Star History
 
 <a href="https://www.star-history.com/?repos=EverMind-AI%2FRaven&type=date&legend=top-left">

--- a/README.md
+++ b/README.md
@@ -450,9 +450,19 @@ If Raven is the kind of agent harness you want to exist, star the repo. It
 helps more builders of self-improving agents discover the project and gives the
 EverMind ecosystem a stronger signal to keep investing in open agents.
 
+### GitHub Stars
+
+[![GitHub Stars](https://img.shields.io/github/stars/EverMind-AI/Raven?style=for-the-badge)](https://github.com/EverMind-AI/Raven)
+
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=EverMind-AI/raven&type=Date)](https://www.star-history.com/#EverMind-AI/raven&Date)
+<a href="https://www.star-history.com/?repos=EverMind-AI%2FRaven&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=EverMind-AI/Raven&type=date&theme=dark&legend=top-left&sealed_token=JtMAA1-LVID_EVBGWQFdVW7mwqmqOZX_CZOni27lunmJitTZvKKSHw22IhQvf-L6TcX0IiwnlFz75mCpVbwvnG-s8zYfGsickSwhmM2eZou5a4nlLTYBXjF2F932uRrttRiHCb84TaKUWeP-T_jWqLvgtk7tly3HKFmgmkywVnQFUOiRBZE2COsHL320" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=EverMind-AI/Raven&type=date&legend=top-left&sealed_token=JtMAA1-LVID_EVBGWQFdVW7mwqmqOZX_CZOni27lunmJitTZvKKSHw22IhQvf-L6TcX0IiwnlFz75mCpVbwvnG-s8zYfGsickSwhmM2eZou5a4nlLTYBXjF2F932uRrttRiHCb84TaKUWeP-T_jWqLvgtk7tly3HKFmgmkywVnQFUOiRBZE2COsHL320" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=EverMind-AI/Raven&type=date&legend=top-left&sealed_token=JtMAA1-LVID_EVBGWQFdVW7mwqmqOZX_CZOni27lunmJitTZvKKSHw22IhQvf-L6TcX0IiwnlFz75mCpVbwvnG-s8zYfGsickSwhmM2eZou5a4nlLTYBXjF2F932uRrttRiHCb84TaKUWeP-T_jWqLvgtk7tly3HKFmgmkywVnQFUOiRBZE2COsHL320" />
+ </picture>
+</a>
 
 <br>
 <div align="right">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -436,9 +436,19 @@ Raven 仍处于 pre-alpha，变化会很快。API 可能调整，但核心产品
 self-improving agent builders 发现项目，也会给 EverMind 生态一个更强的信号，
 继续投入开源 Agent。
 
+### GitHub Stars
+
+[![GitHub Stars](https://img.shields.io/github/stars/EverMind-AI/Raven?style=for-the-badge)](https://github.com/EverMind-AI/Raven)
+
 ### Star 趋势
 
-[![Star History Chart](https://api.star-history.com/svg?repos=EverMind-AI/raven&type=Date)](https://www.star-history.com/#EverMind-AI/raven&Date)
+<a href="https://www.star-history.com/?repos=EverMind-AI%2FRaven&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=EverMind-AI/Raven&type=date&theme=dark&legend=top-left&sealed_token=JtMAA1-LVID_EVBGWQFdVW7mwqmqOZX_CZOni27lunmJitTZvKKSHw22IhQvf-L6TcX0IiwnlFz75mCpVbwvnG-s8zYfGsickSwhmM2eZou5a4nlLTYBXjF2F932uRrttRiHCb84TaKUWeP-T_jWqLvgtk7tly3HKFmgmkywVnQFUOiRBZE2COsHL320" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=EverMind-AI/Raven&type=date&legend=top-left&sealed_token=JtMAA1-LVID_EVBGWQFdVW7mwqmqOZX_CZOni27lunmJitTZvKKSHw22IhQvf-L6TcX0IiwnlFz75mCpVbwvnG-s8zYfGsickSwhmM2eZou5a4nlLTYBXjF2F932uRrttRiHCb84TaKUWeP-T_jWqLvgtk7tly3HKFmgmkywVnQFUOiRBZE2COsHL320" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=EverMind-AI/Raven&type=date&legend=top-left&sealed_token=JtMAA1-LVID_EVBGWQFdVW7mwqmqOZX_CZOni27lunmJitTZvKKSHw22IhQvf-L6TcX0IiwnlFz75mCpVbwvnG-s8zYfGsickSwhmM2eZou5a4nlLTYBXjF2F932uRrttRiHCb84TaKUWeP-T_jWqLvgtk7tly3HKFmgmkywVnQFUOiRBZE2COsHL320" />
+ </picture>
+</a>
 
 <br>
 <div align="right">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -436,10 +436,6 @@ Raven 仍处于 pre-alpha，变化会很快。API 可能调整，但核心产品
 self-improving agent builders 发现项目，也会给 EverMind 生态一个更强的信号，
 继续投入开源 Agent。
 
-### GitHub Stars
-
-[![GitHub Stars](https://img.shields.io/github/stars/EverMind-AI/Raven?style=for-the-badge)](https://github.com/EverMind-AI/Raven)
-
 ### Star 趋势
 
 <a href="https://www.star-history.com/?repos=EverMind-AI%2FRaven&type=date&legend=top-left">


### PR DESCRIPTION
## Summary

- Replace the legacy anonymous Star History SVG with the official sealed-token embed in both English and Chinese READMEs.
- Support light and dark color schemes for the Star History chart.
- Keep the raw GitHub PAT out of the repository. The committed sealed token is the public embed value generated by Star History.

## Type

- [ ] Fix
- [ ] Feature
- [x] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- [ ] Relevant tests pass locally
- [ ] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

- `git diff --check origin/main...HEAD` passed.
- `make check-large-files` passed.
- The interactive Star History chart rendered with the configured token. The embed endpoint also accepted and decrypted the sealed token, but a direct cold request intermittently returned HTTP 500 when its server-side GitHub fetch exceeded 10 seconds.

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

The chart remains dependent on the remote Star History service rendering reliably on GitHub.

## Related Issues

Tracks #202
