### PR TITLE
chore: bump version to 0.1.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raven"
-version = "0.1.8"
+version = "0.1.9"
 description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3249,7 +3249,7 @@ wheels = [
 
 [[package]]
 name = "raven"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Bump the package version from 0.1.8 to 0.1.9 (patch release). All five PRs merged since v0.1.8 are fixes, no new features:

- #204 fix: add configurable llm_call_timeout to bound stalled LLM calls
- #199 fix(cli): make onboard readable on light-background terminals
- #189 fix(cli): pick the first node >= 22 across all PATH entries
- #196 fix(commitlint): unify commit/PR length to header-max-length
- #190 fix(tui): surface the real turn-failure detail, not just the code

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

## Verification

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

Bump is limited to `pyproject.toml` and `uv.lock` (`uv lock` sync). Commit message lint passes locally.

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Version-only change; no code or behavior change.

## Related Issues

N/A