### PR TITLE
fix(agent): clamp context_percent to 100 when the window is a guess

### DIFF
--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -2012,7 +2012,12 @@ class AgentLoop:
                 usage_sink["cost_usd"] = usage_snapshot.estimated_cost_usd
                 usage_sink["context_max"] = context_max
                 usage_sink["context_used"] = context_used
-                usage_sink["context_percent"] = round(100 * context_used / context_max) if context_max else 0
+                # context_max is a real provider window when resolve_context_window()
+                # succeeds, but otherwise a guessed default (self.context_window_tokens)
+                # that can be smaller than the model's true window. Clamp so the gauge
+                # never reports past full: an unresolved model must not render as
+                # "over budget" while the request is still well within its real limit.
+                usage_sink["context_percent"] = min(100, round(100 * context_used / context_max)) if context_max else 0
 
             # Context-window overflow recovery: the structured classifier flags
             # should_compress (a smaller window won't help, but eliding the bulk

--- a/tests/test_agent_loop_usage_sink.py
+++ b/tests/test_agent_loop_usage_sink.py
@@ -336,3 +336,31 @@ def test_refresh_context_window_on_an_openrouter_model_never_touches_the_network
 
     assert agent.context_window_tokens == rates.DEFAULT_CONTEXT_WINDOW_TOKENS
     assert counter["calls"] == 0
+
+
+@pytest.mark.asyncio
+async def test_usage_sink_context_percent_clamps_when_window_is_a_guess(workspace):
+    """Usage past the configured fallback window must not render past 100%.
+
+    ``stub`` never resolves via resolve_context_window(), so context_max here is
+    the configured (guessed) default. Real usage can legitimately exceed that
+    guess while staying under the model's true, unresolved window, so the
+    reported percent must clamp rather than imply an impossible over-budget bar.
+    """
+    provider = UsageProvider("stub", prompt_tokens=6000, completion_tokens=2000)
+    agent = _make_agent(workspace, provider, model="stub", window=1000)
+    sink: dict = {}
+
+    await agent._process_message(
+        TurnRequest(
+            origin=Origin.USER,
+            source=Source(channel="test", chat_id="c1", sender_id="user", chat_type=ChatType.DM),
+            text="hi",
+        ),
+        session_key="s1",
+        usage_sink=sink,
+    )
+
+    assert sink["context_max"] == 1000
+    assert sink["context_used"] == 8000
+    assert sink["context_percent"] == 100


### PR DESCRIPTION
Root cause: `resolve_context_window()` returns `None` whenever a model isn't in litellm's static map or OpenRouter's live `/models` table, and the per-turn usage handler in `raven/agent/loop/main.py` falls back to `self.context_window_tokens` (65536 by default) as the denominator for `context_percent`. That fallback is a guess, not the model's real window. Real usage can legitimately pass 65536 tokens while staying well under a model's true window (128k/200k/1M), so the computed percent renders past 100% even though the request keeps succeeding.

Fix: clamp `context_percent` to 100. `context_max` and `context_used` are unchanged (still the real numbers behind the used/max label); only the derived percent is bounded, so the gauge never implies an over-budget state that isn't real.

`raven/tui_rpc/methods/session.py`'s `_baseline_usage` uses the same fallback-window pattern but always pairs it with `context_used=0` (the docstring: "Usage starts at zero for a fresh session by design... counters refresh on the next turn"), so it can't itself produce a percent over 100 and needed no change.

Verified in a clean `python:3.12-slim` container (uv-managed venv, `uv sync --frozen --extra dev --dev`):
- Added `test_usage_sink_context_percent_clamps_when_window_is_a_guess`, which drives the real `_process_message` usage-sink path with a `stub` model (never resolves via `resolve_context_window`) and a configured window smaller than actual usage.
- Confirmed it fails on unpatched `main` (`800 == 100`, i.e. the raw unclamped ratio) and passes with the fix.
- `uv run --extra dev pytest tests/test_agent_loop_usage_sink.py tests/test_tui_rpc_session_init_bundle.py -q` -> 17 passed.
- `ruff check` / `ruff format --check` on both changed files, and `pre-commit run --files raven/agent/loop/main.py tests/test_agent_loop_usage_sink.py` (ruff, trailing-whitespace, end-of-file-fixer, large-files, merge-conflict, private-key) all pass.

Not changed: the reporter's other suggestion (mark the window as estimated/unknown to the UI instead of clamping) would need a new wire field in `raven/tui_rpc/models.py` plus TUI/bridge changes to consume it, which is a separate, larger concern; happy to follow up if that's wanted.

Fixes #124

Co-authored-by: Claude (claude-sonnet-5) <noreply@anthropic.com>
