### PR TITLE
docs: remove star history section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ task needs deeper investigation.
 - [Architecture](#architecture)
 - [Developer Workflow](#developer-workflow)
 - [Status](#status)
-- [Star Us](#star-us)
 - [EverMind Ecosystem](#evermind-ecosystem)
 - [Contributing](#contributing)
 
@@ -436,29 +435,6 @@ core product surfaces are already in the repository.
 | Tracing dashboard | Implemented |
 | Evolver pipeline | Implemented, benchmark adapters still evolving |
 | Eval engine | Partial |
-
-<br>
-<div align="right">
-
-[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
-
-</div>
-
-## Star Us
-
-If Raven is the kind of agent harness you want to exist, star the repo. It
-helps more builders of self-improving agents discover the project and gives the
-EverMind ecosystem a stronger signal to keep investing in open agents.
-
-### Star History
-
-<a href="https://www.star-history.com/?repos=EverMind-AI%2FRaven&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=EverMind-AI/Raven&type=date&theme=dark&legend=top-left&sealed_token=JtMAA1-LVID_EVBGWQFdVW7mwqmqOZX_CZOni27lunmJitTZvKKSHw22IhQvf-L6TcX0IiwnlFz75mCpVbwvnG-s8zYfGsickSwhmM2eZou5a4nlLTYBXjF2F932uRrttRiHCb84TaKUWeP-T_jWqLvgtk7tly3HKFmgmkywVnQFUOiRBZE2COsHL320" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=EverMind-AI/Raven&type=date&legend=top-left&sealed_token=JtMAA1-LVID_EVBGWQFdVW7mwqmqOZX_CZOni27lunmJitTZvKKSHw22IhQvf-L6TcX0IiwnlFz75mCpVbwvnG-s8zYfGsickSwhmM2eZou5a4nlLTYBXjF2F932uRrttRiHCb84TaKUWeP-T_jWqLvgtk7tly3HKFmgmkywVnQFUOiRBZE2COsHL320" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=EverMind-AI/Raven&type=date&legend=top-left&sealed_token=JtMAA1-LVID_EVBGWQFdVW7mwqmqOZX_CZOni27lunmJitTZvKKSHw22IhQvf-L6TcX0IiwnlFz75mCpVbwvnG-s8zYfGsickSwhmM2eZou5a4nlLTYBXjF2F932uRrttRiHCb84TaKUWeP-T_jWqLvgtk7tly3HKFmgmkywVnQFUOiRBZE2COsHL320" />
- </picture>
-</a>
 
 <br>
 <div align="right">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,7 +48,6 @@ Agent 可以在需要深度调查的任务中使用 MiroThinker-backed、多来�
 - [架构](#架构)
 - [开发工作流](#开发工作流)
 - [当前状态](#当前状态)
-- [Star 支持](#star-支持)
 - [EverMind 生态](#evermind-生态)
 - [参与贡献](#参与贡献)
 
@@ -422,29 +421,6 @@ Raven 仍处于 pre-alpha，变化会很快。API 可能调整，但核心产品
 | Tracing dashboard | 已实现 |
 | Evolver pipeline | 已实现，benchmark adapters 持续演进 |
 | Eval engine | 部分完成 |
-
-<br>
-<div align="right">
-
-[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
-
-</div>
-
-## Star 支持
-
-如果 Raven 是你希望存在的 Agent Harness，请 Star 这个仓库。它会帮助更多
-self-improving agent builders 发现项目，也会给 EverMind 生态一个更强的信号，
-继续投入开源 Agent。
-
-### Star 趋势
-
-<a href="https://www.star-history.com/?repos=EverMind-AI%2FRaven&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=EverMind-AI/Raven&type=date&theme=dark&legend=top-left&sealed_token=JtMAA1-LVID_EVBGWQFdVW7mwqmqOZX_CZOni27lunmJitTZvKKSHw22IhQvf-L6TcX0IiwnlFz75mCpVbwvnG-s8zYfGsickSwhmM2eZou5a4nlLTYBXjF2F932uRrttRiHCb84TaKUWeP-T_jWqLvgtk7tly3HKFmgmkywVnQFUOiRBZE2COsHL320" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=EverMind-AI/Raven&type=date&legend=top-left&sealed_token=JtMAA1-LVID_EVBGWQFdVW7mwqmqOZX_CZOni27lunmJitTZvKKSHw22IhQvf-L6TcX0IiwnlFz75mCpVbwvnG-s8zYfGsickSwhmM2eZou5a4nlLTYBXjF2F932uRrttRiHCb84TaKUWeP-T_jWqLvgtk7tly3HKFmgmkywVnQFUOiRBZE2COsHL320" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=EverMind-AI/Raven&type=date&legend=top-left&sealed_token=JtMAA1-LVID_EVBGWQFdVW7mwqmqOZX_CZOni27lunmJitTZvKKSHw22IhQvf-L6TcX0IiwnlFz75mCpVbwvnG-s8zYfGsickSwhmM2eZou5a4nlLTYBXjF2F932uRrttRiHCb84TaKUWeP-T_jWqLvgtk7tly3HKFmgmkywVnQFUOiRBZE2COsHL320" />
- </picture>
-</a>
 
 <br>
 <div align="right">


### PR DESCRIPTION
## Summary

- Remove the Star Us and Star History section from the English README.
- Remove the corresponding Star section from the Chinese README.
- Remove both sections from their tables of contents.

The embedded Star History chart still does not render reliably, so the promotional section is being removed instead of retaining a broken README surface.

## Type

- [ ] Fix
- [ ] Feature
- [x] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `make check-commits` passed.
- `PR_TITLE='docs: remove star history section' make check-pr-title` passed.
- `make check-large-files` passed.
- Python test target passed: 58 tests.
- The isolated ModelPicker test passed.
- The full TUI run passed 901 tests and failed 1 unrelated ModelPicker timing assertion. The failure reproduces only in the full suite and is outside this README-only diff.

- [ ] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A