### PR TITLE
feat(cli): nudge raven upgrade in the tui status bar when behind

### DIFF
--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -990,6 +990,14 @@ def tui(
         )
         raise typer.Exit(code=1)
 
+    # Refresh the cached latest-release version in the background (once per
+    # launch, throttled, best-effort) so the status bar can nudge
+    # `raven upgrade`. The gateway reads that cache when it builds the session
+    # info bundle.
+    from raven.cli.update_notice import maybe_refresh_async
+
+    maybe_refresh_async()
+
     # `--dev` runs tsx from the source tree, so it requires the ui-tui/ checkout.
     # The production path resolves a packaged or source-built bundle separately
     # (see resolve_dist_entry), so it must NOT hard-require the source tree —

--- a/raven/cli/update_notice.py
+++ b/raven/cli/update_notice.py
@@ -42,8 +42,31 @@ def _disabled() -> bool:
     return os.environ.get(_OPT_OUT_ENV, "").strip().lower() in _TRUTHY
 
 
+def _release_prefix(value: str) -> str:
+    """Reduce ``0.2.0rc1`` / ``0.1.9.dev1`` to the ``X.Y.Z`` it builds on.
+
+    The strict parser matches the whole string, so a prerelease or dev suffix
+    would read as unparseable and silence the hint for anyone running one. The
+    suffix is dropped rather than ordered: an rc of a release compares equal to
+    it, so an rc user is not nagged to "upgrade" to the version they are
+    already testing.
+    """
+    raw = value.strip().lstrip("vV")
+    parts = []
+    for part in raw.split(".")[:3]:
+        digits = ""
+        for ch in part:
+            if not ch.isdigit():
+                break
+            digits += ch
+        if not digits:
+            return raw
+        parts.append(digits)
+    return ".".join(parts) if len(parts) == 3 else raw
+
+
 def _version_key(value: str) -> tuple[int, int, int] | None:
-    """Parse ``1.2.3`` / ``v1.2.3`` leniently, ``None`` when unparseable.
+    """Parse ``1.2.3`` / ``v1.2.3`` / ``1.2.3rc1``, ``None`` when unparseable.
 
     ``upgrade_commands._version_key`` is the single source of truth for the
     grammar; it raises for anything it cannot read, which here just means
@@ -53,7 +76,7 @@ def _version_key(value: str) -> tuple[int, int, int] | None:
     from raven.cli.upgrade_commands import _version_key as strict_key
 
     try:
-        return strict_key(value.strip())
+        return strict_key(_release_prefix(value))
     except (UpgradeError, AttributeError):
         return None
 
@@ -104,9 +127,10 @@ def maybe_refresh_async() -> None:
 
     Fire-and-forget: spawns a daemon thread only when the cache is missing or
     older than the TTL, so a normal launch touches the network at most once a
-    day and never blocks.
+    day and never blocks. Installs that cannot run ``raven upgrade`` skip the
+    fetch entirely -- they would never be shown the result.
     """
-    if _disabled():
+    if _disabled() or not _upgrade_command_works():
         return
 
     cache = _read_cache()

--- a/raven/cli/update_notice.py
+++ b/raven/cli/update_notice.py
@@ -1,53 +1,81 @@
 """Startup update nudge for the TUI status bar.
 
 The status bar's right slot shows an "update available" hint in place of the
-cwd/branch label when the session init bundle carries ``update_behind`` /
+cwd/branch label when the session init bundle carries ``update_available`` /
 ``update_command`` (see ``ui-tui/src/components/appChrome.tsx``); this module
 is what fills those in.
 
 The live check hits the GitHub releases API, which is too slow to run on the
-session-create hot path, so we keep a small cache in ``~/.raven`` and refresh
-it in a daemon thread at most once a day. A launch therefore shows the notice
-based on the *cached* latest version; the first launch after a release lands
-refreshes the cache and the notice appears on the next launch. Any network or
-parse failure is swallowed -- an update nudge must never break startup.
+session-create hot path, so we keep a small cache in the runtime cache dir and
+refresh it in a daemon thread at most once a day. A launch therefore shows the
+notice based on the *cached* latest version; the first launch after a release
+lands refreshes the cache and the notice appears on the next launch. Any
+network or parse failure is swallowed -- an update nudge must never break
+startup.
+
+Set ``RAVEN_NO_UPDATE_CHECK=1`` to opt out of both the fetch and the hint.
 """
 
 from __future__ import annotations
 
 import json
-import re
-import threading
+import os
 import time
 from pathlib import Path
 
-_CACHE_PATH = Path.home() / ".raven" / "update_check.json"
+_CACHE_NAME = "update_check.json"
 _REFRESH_TTL_SECONDS = 24 * 60 * 60
 _UPGRADE_COMMAND = "raven upgrade"
-_VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)")
+_OPT_OUT_ENV = "RAVEN_NO_UPDATE_CHECK"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _cache_path() -> Path:
+    # Resolved per call, not at import: get_cache_dir() follows the active
+    # config path, which set_config_path() can move after this module loads.
+    from raven.config import paths
+
+    return paths.get_cache_dir() / _CACHE_NAME
+
+
+def _disabled() -> bool:
+    return os.environ.get(_OPT_OUT_ENV, "").strip().lower() in _TRUTHY
 
 
 def _version_key(value: str) -> tuple[int, int, int] | None:
-    match = _VERSION_RE.match(value.strip())
-    if match is None:
+    """Parse ``1.2.3`` / ``v1.2.3`` leniently, ``None`` when unparseable.
+
+    ``upgrade_commands._version_key`` is the single source of truth for the
+    grammar; it raises for anything it cannot read, which here just means
+    "show no notice".
+    """
+    from raven.cli.upgrade_commands import UpgradeError
+    from raven.cli.upgrade_commands import _version_key as strict_key
+
+    try:
+        return strict_key(value.strip())
+    except (UpgradeError, AttributeError):
         return None
-    return int(match.group(1)), int(match.group(2)), int(match.group(3))
 
 
 def _read_cache() -> dict | None:
     try:
-        return json.loads(_CACHE_PATH.read_text(encoding="utf-8"))
+        parsed = json.loads(_cache_path().read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
 
+    # A hand-edited cache can be valid JSON and still not an object; without
+    # this guard the .get() below raises and takes `raven tui` down with it.
+    return parsed if isinstance(parsed, dict) else None
 
-def _write_cache(latest_version: str, *, now: float) -> None:
+
+def _write_cache(latest_version: str | None, *, now: float) -> None:
+    payload: dict[str, object] = {"checked_at": now}
+    if latest_version is not None:
+        payload["latest_version"] = latest_version
     try:
-        _CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        _CACHE_PATH.write_text(
-            json.dumps({"checked_at": now, "latest_version": latest_version}),
-            encoding="utf-8",
-        )
+        path = _cache_path()
+        path.write_text(json.dumps(payload), encoding="utf-8")
     except OSError:
         pass
 
@@ -55,14 +83,20 @@ def _write_cache(latest_version: str, *, now: float) -> None:
 def _refresh() -> None:
     # Imported lazily: the GitHub client pulls in httpx, which we keep off the
     # session-create hot path (this runs in a daemon thread).
+    cache = _read_cache() or {}
+    previous = cache.get("latest_version")
+    keep = previous if isinstance(previous, str) else None
+
     try:
         from raven.cli.upgrade_commands import _fetch_latest_release
 
         release = _fetch_latest_release()
         _write_cache(release.version, now=time.time())
     except Exception:
-        # Network error, rate limit, parse failure -- try again next TTL.
-        pass
+        # Offline, rate-limited, or the latest release is a draft/prerelease.
+        # Stamp checked_at anyway so we back off for a full TTL instead of
+        # refetching on every launch, and keep whatever version we had.
+        _write_cache(keep, now=time.time())
 
 
 def maybe_refresh_async() -> None:
@@ -72,31 +106,59 @@ def maybe_refresh_async() -> None:
     older than the TTL, so a normal launch touches the network at most once a
     day and never blocks.
     """
+    if _disabled():
+        return
+
     cache = _read_cache()
     if cache is not None:
         checked_at = cache.get("checked_at")
         if isinstance(checked_at, (int, float)) and (time.time() - checked_at) < _REFRESH_TTL_SECONDS:
             return
+
+    import threading
+
     threading.Thread(target=_refresh, daemon=True).start()
 
 
-def update_notice(current_version: str) -> tuple[int, str] | None:
-    """Return ``(behind, command)`` when the cached latest release is newer.
+def _upgrade_command_works() -> bool:
+    """Whether ``raven upgrade`` can actually do anything on this install.
 
-    ``behind`` is a positive flag (the status bar shows a version-agnostic
-    "Update available", not a count). Returns ``None`` when up to date, when
-    the cache is absent, or when either version is unparseable.
+    It refuses to run for editable and non-uv-tool installs, so nudging those
+    users points them at a command that always exits 1.
     """
+    try:
+        from raven.cli.upgrade_commands import _is_uv_tool_install
+
+        return _is_uv_tool_install()
+    except Exception:
+        # A malformed uv receipt raises UpgradeError; treat unknown as "no".
+        return False
+
+
+def update_notice(current_version: str) -> tuple[bool, str] | None:
+    """Return ``(available, command)`` when the cached latest release is newer.
+
+    Returns ``None`` when up to date, when the cache is absent or unreadable,
+    when either version is unparseable, or when ``raven upgrade`` would fail on
+    this install anyway.
+    """
+    if _disabled():
+        return None
+
     cache = _read_cache()
     if not cache:
         return None
+
     latest = cache.get("latest_version")
     if not isinstance(latest, str):
         return None
+
     latest_key = _version_key(latest)
     current_key = _version_key(current_version)
-    if latest_key is None or current_key is None:
+    if latest_key is None or current_key is None or latest_key <= current_key:
         return None
-    if latest_key > current_key:
-        return 1, _UPGRADE_COMMAND
-    return None
+
+    if not _upgrade_command_works():
+        return None
+
+    return True, _UPGRADE_COMMAND

--- a/raven/cli/update_notice.py
+++ b/raven/cli/update_notice.py
@@ -1,0 +1,102 @@
+"""Startup update nudge for the TUI status bar.
+
+The status bar's right slot shows an "update available" hint in place of the
+cwd/branch label when the session init bundle carries ``update_behind`` /
+``update_command`` (see ``ui-tui/src/components/appChrome.tsx``); this module
+is what fills those in.
+
+The live check hits the GitHub releases API, which is too slow to run on the
+session-create hot path, so we keep a small cache in ``~/.raven`` and refresh
+it in a daemon thread at most once a day. A launch therefore shows the notice
+based on the *cached* latest version; the first launch after a release lands
+refreshes the cache and the notice appears on the next launch. Any network or
+parse failure is swallowed -- an update nudge must never break startup.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+import time
+from pathlib import Path
+
+_CACHE_PATH = Path.home() / ".raven" / "update_check.json"
+_REFRESH_TTL_SECONDS = 24 * 60 * 60
+_UPGRADE_COMMAND = "raven upgrade"
+_VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)")
+
+
+def _version_key(value: str) -> tuple[int, int, int] | None:
+    match = _VERSION_RE.match(value.strip())
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def _read_cache() -> dict | None:
+    try:
+        return json.loads(_CACHE_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _write_cache(latest_version: str, *, now: float) -> None:
+    try:
+        _CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _CACHE_PATH.write_text(
+            json.dumps({"checked_at": now, "latest_version": latest_version}),
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+
+
+def _refresh() -> None:
+    # Imported lazily: the GitHub client pulls in httpx, which we keep off the
+    # session-create hot path (this runs in a daemon thread).
+    try:
+        from raven.cli.upgrade_commands import _fetch_latest_release
+
+        release = _fetch_latest_release()
+        _write_cache(release.version, now=time.time())
+    except Exception:
+        # Network error, rate limit, parse failure -- try again next TTL.
+        pass
+
+
+def maybe_refresh_async() -> None:
+    """Refresh the cached latest version in the background if it is stale.
+
+    Fire-and-forget: spawns a daemon thread only when the cache is missing or
+    older than the TTL, so a normal launch touches the network at most once a
+    day and never blocks.
+    """
+    cache = _read_cache()
+    if cache is not None:
+        checked_at = cache.get("checked_at")
+        if isinstance(checked_at, (int, float)) and (time.time() - checked_at) < _REFRESH_TTL_SECONDS:
+            return
+    threading.Thread(target=_refresh, daemon=True).start()
+
+
+def update_notice(current_version: str) -> tuple[int, str] | None:
+    """Return ``(behind, command)`` when the cached latest release is newer.
+
+    ``behind`` is a positive flag (the status bar shows a version-agnostic
+    "Update available", not a count). Returns ``None`` when up to date, when
+    the cache is absent, or when either version is unparseable.
+    """
+    cache = _read_cache()
+    if not cache:
+        return None
+    latest = cache.get("latest_version")
+    if not isinstance(latest, str):
+        return None
+    latest_key = _version_key(latest)
+    current_key = _version_key(current_version)
+    if latest_key is None or current_key is None:
+        return None
+    if latest_key > current_key:
+        return 1, _UPGRADE_COMMAND
+    return None

--- a/raven/tui_rpc/methods/session.py
+++ b/raven/tui_rpc/methods/session.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from loguru import logger
 
+from raven.cli.update_notice import update_notice
 from raven.config.loader import load_config
 from raven.session.export import default_export_path, write_transcript
 from raven.session.manager import SessionManager, new_chat_id
@@ -135,7 +136,7 @@ def _default_session_info(
     zero usage, ``lazy=True``); version is always real (cached at module load).
     """
     model_id = config.agents.defaults.model
-    return {
+    info: dict[str, Any] = {
         "model": model_id,
         "model_id": model_id,
         "provider": config.agents.defaults.provider,
@@ -148,6 +149,16 @@ def _default_session_info(
         "cwd": os.getcwd(),
         "mcp_servers": [],
     }
+
+    # Nudge the status bar to run `raven upgrade` when the cached latest release
+    # is newer. Reading the cache is pure/fast; the cache is refreshed once per
+    # launch from the `raven tui` entrypoint (see cli/tui_commands.py), so a
+    # freshly published release shows up on the next launch.
+    notice = update_notice(_RAVEN_VERSION)
+    if notice is not None:
+        info["update_behind"], info["update_command"] = notice
+
+    return info
 
 
 def _get_or_build_manager(config: "Config") -> SessionManager:

--- a/raven/tui_rpc/methods/session.py
+++ b/raven/tui_rpc/methods/session.py
@@ -156,7 +156,7 @@ def _default_session_info(
     # freshly published release shows up on the next launch.
     notice = update_notice(_RAVEN_VERSION)
     if notice is not None:
-        info["update_behind"], info["update_command"] = notice
+        info["update_available"], info["update_command"] = notice
 
     return info
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,24 @@ def _restore_loguru_enabled_state():
 
 
 @pytest.fixture(autouse=True)
+def _no_update_check(tmp_path, monkeypatch):
+    """Keep the startup update check off the network and off the real disk.
+
+    ``raven tui`` fires ``maybe_refresh_async()`` and ``session.create`` reads
+    the cache, so any test reaching either path would otherwise fetch the
+    GitHub releases API and write ``<cache dir>/update_check.json`` under the
+    real home. Redirecting the cache dir alone still leaves an empty cache,
+    which is exactly the state that spawns the fetch -- so opt out by env for
+    the whole suite. Tests that exercise the notice clear the variable.
+    """
+    from raven.cli import update_notice
+
+    monkeypatch.setenv(update_notice._OPT_OUT_ENV, "1")
+    monkeypatch.setattr(update_notice, "_cache_path", lambda: tmp_path / "update_check.json")
+    yield
+
+
+@pytest.fixture(autouse=True)
 def _no_openrouter_network(tmp_path):
     """Keep the OpenRouter catalog fetch off the network and off the real disk.
 

--- a/tests/test_cli_update_notice.py
+++ b/tests/test_cli_update_notice.py
@@ -62,18 +62,48 @@ def test_v_prefix_is_tolerated(cache):
     assert un.update_notice("v0.1.9") == (True, "raven upgrade")
 
 
+@pytest.mark.parametrize("installed", ["0.1.9rc1", "0.1.9.dev1", "0.1.9+local"])
+def test_prerelease_installs_still_get_the_notice(cache, installed):
+    # The strict grammar matches the whole string, so without normalising the
+    # suffix these users would silently never see the hint.
+    _write(cache, "0.2.0")
+    assert un.update_notice(installed) == (True, "raven upgrade")
+
+
+def test_prerelease_of_the_latest_release_is_not_nagged(cache):
+    # 0.2.0rc1 compares equal to 0.2.0: the suffix is dropped, not ordered.
+    _write(cache, "0.2.0")
+    assert un.update_notice("0.2.0rc1") is None
+
+
+def test_refresh_skipped_when_upgrade_command_would_fail(cache, monkeypatch):
+    # An install that cannot run `raven upgrade` never sees the result, so it
+    # should not pay for the fetch either.
+    monkeypatch.setattr(un, "_upgrade_command_works", lambda: False)
+    spawned = []
+    monkeypatch.setattr("threading.Thread", lambda *a, **k: spawned.append(k) or _FakeThread())
+    un.maybe_refresh_async()
+    assert spawned == []
+
+
 def test_corrupt_cache_is_ignored(cache):
     cache.write_text("{not json", encoding="utf-8")
     assert un.update_notice("0.1.9") is None
 
 
 @pytest.mark.parametrize("payload", ['"0.2.0"', "[1]", "42", "null"])
-def test_non_object_cache_is_ignored(cache, payload):
+def test_non_object_cache_is_ignored(cache, monkeypatch, payload):
     # Valid JSON that is not an object used to raise AttributeError out of
     # update_notice(), which took `raven tui` and session.create down with it.
+    #
+    # A non-object reads back as "no cache", so the refresh call below would
+    # spawn a real thread whose write lands after monkeypatch has restored
+    # _cache_path -- i.e. on the real home. The assertion only needs "does not
+    # raise", so the thread is stubbed.
+    monkeypatch.setattr("threading.Thread", lambda *a, **k: _FakeThread())
     cache.write_text(payload, encoding="utf-8")
     assert un.update_notice("0.1.9") is None
-    un.maybe_refresh_async()  # must not raise either
+    un.maybe_refresh_async()
 
 
 def test_no_notice_when_upgrade_command_would_fail(cache, monkeypatch):

--- a/tests/test_cli_update_notice.py
+++ b/tests/test_cli_update_notice.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import time
 
 import pytest
@@ -12,8 +13,15 @@ from raven.cli import update_notice as un
 
 @pytest.fixture
 def cache(tmp_path, monkeypatch):
+    """Point the module at a temp cache and let the notice run.
+
+    The suite-wide autouse fixture opts every test out of the update check;
+    this is the one place that exercises it, so it clears the flag.
+    """
     path = tmp_path / "update_check.json"
-    monkeypatch.setattr(un, "_CACHE_PATH", path)
+    monkeypatch.delenv(un._OPT_OUT_ENV, raising=False)
+    monkeypatch.setattr(un, "_cache_path", lambda: path)
+    monkeypatch.setattr(un, "_upgrade_command_works", lambda: True)
     return path
 
 
@@ -28,7 +36,7 @@ def test_no_cache_yields_no_notice(cache):
 
 def test_newer_cached_release_yields_notice(cache):
     _write(cache, "0.2.0")
-    assert un.update_notice("0.1.9") == (1, "raven upgrade")
+    assert un.update_notice("0.1.9") == (True, "raven upgrade")
 
 
 def test_same_version_yields_no_notice(cache):
@@ -51,7 +59,7 @@ def test_unparseable_versions_are_ignored(cache):
 
 def test_v_prefix_is_tolerated(cache):
     _write(cache, "v0.2.0")
-    assert un.update_notice("v0.1.9") == (1, "raven upgrade")
+    assert un.update_notice("v0.1.9") == (True, "raven upgrade")
 
 
 def test_corrupt_cache_is_ignored(cache):
@@ -59,10 +67,36 @@ def test_corrupt_cache_is_ignored(cache):
     assert un.update_notice("0.1.9") is None
 
 
+@pytest.mark.parametrize("payload", ['"0.2.0"', "[1]", "42", "null"])
+def test_non_object_cache_is_ignored(cache, payload):
+    # Valid JSON that is not an object used to raise AttributeError out of
+    # update_notice(), which took `raven tui` and session.create down with it.
+    cache.write_text(payload, encoding="utf-8")
+    assert un.update_notice("0.1.9") is None
+    un.maybe_refresh_async()  # must not raise either
+
+
+def test_no_notice_when_upgrade_command_would_fail(cache, monkeypatch):
+    _write(cache, "0.2.0")
+    monkeypatch.setattr(un, "_upgrade_command_works", lambda: False)
+    assert un.update_notice("0.1.9") is None
+
+
+def test_opt_out_env_silences_notice_and_fetch(cache, monkeypatch):
+    _write(cache, "0.2.0")
+    monkeypatch.setenv(un._OPT_OUT_ENV, "1")
+    assert un.update_notice("0.1.9") is None
+
+    spawned = []
+    monkeypatch.setattr("threading.Thread", lambda *a, **k: spawned.append(k) or _FakeThread())
+    un.maybe_refresh_async()
+    assert spawned == []
+
+
 def test_refresh_skipped_when_cache_is_fresh(cache, monkeypatch):
     _write(cache, "0.1.9", checked_at=time.time())
     spawned = []
-    monkeypatch.setattr(un.threading, "Thread", lambda *a, **k: spawned.append((a, k)) or _FakeThread())
+    monkeypatch.setattr("threading.Thread", lambda *a, **k: spawned.append((a, k)) or _FakeThread())
     un.maybe_refresh_async()
     assert spawned == []
 
@@ -70,7 +104,7 @@ def test_refresh_skipped_when_cache_is_fresh(cache, monkeypatch):
 def test_refresh_spawned_when_cache_is_stale(cache, monkeypatch):
     _write(cache, "0.1.9", checked_at=time.time() - un._REFRESH_TTL_SECONDS - 1)
     spawned = []
-    monkeypatch.setattr(un.threading, "Thread", lambda *a, **k: spawned.append(k) or _FakeThread())
+    monkeypatch.setattr("threading.Thread", lambda *a, **k: spawned.append(k) or _FakeThread())
     un.maybe_refresh_async()
     assert len(spawned) == 1
     assert spawned[0]["daemon"] is True
@@ -78,11 +112,55 @@ def test_refresh_spawned_when_cache_is_stale(cache, monkeypatch):
 
 def test_refresh_spawned_when_cache_absent(cache, monkeypatch):
     spawned = []
-    monkeypatch.setattr(un.threading, "Thread", lambda *a, **k: spawned.append(k) or _FakeThread())
+    monkeypatch.setattr("threading.Thread", lambda *a, **k: spawned.append(k) or _FakeThread())
     un.maybe_refresh_async()
     assert len(spawned) == 1
+
+
+def test_failed_refresh_still_backs_off_and_keeps_version(cache, monkeypatch):
+    # Offline / rate-limited / draft-release: stamping checked_at is what stops
+    # every launch from refetching, and the known version must survive.
+    _write(cache, "0.2.0", checked_at=0.0)
+
+    def _boom():
+        raise RuntimeError("offline")
+
+    monkeypatch.setitem(sys.modules, "raven.cli.upgrade_commands", _FakeUpgrade(_boom))
+    un._refresh()
+
+    saved = json.loads(cache.read_text(encoding="utf-8"))
+    assert saved["latest_version"] == "0.2.0"
+    assert time.time() - saved["checked_at"] < 60
+
+
+def test_successful_refresh_records_fetched_version(cache, monkeypatch):
+    monkeypatch.setitem(sys.modules, "raven.cli.upgrade_commands", _FakeUpgrade(lambda: _Release("0.3.0")))
+    un._refresh()
+
+    saved = json.loads(cache.read_text(encoding="utf-8"))
+    assert saved["latest_version"] == "0.3.0"
 
 
 class _FakeThread:
     def start(self):  # noqa: D102 - test double
         pass
+
+
+class _Release:
+    def __init__(self, version: str) -> None:
+        self.version = version
+
+
+class _FakeUpgrade:
+    """Stands in for raven.cli.upgrade_commands during _refresh()."""
+
+    UpgradeError = RuntimeError
+
+    def __init__(self, fetch) -> None:
+        self._fetch = fetch
+
+    def _fetch_latest_release(self):  # noqa: D102 - test double
+        return self._fetch()
+
+    def _version_key(self, value):  # noqa: D102 - test double
+        raise RuntimeError(value)

--- a/tests/test_cli_update_notice.py
+++ b/tests/test_cli_update_notice.py
@@ -1,0 +1,88 @@
+"""Tests for the TUI startup update nudge (raven/cli/update_notice.py)."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from raven.cli import update_notice as un
+
+
+@pytest.fixture
+def cache(tmp_path, monkeypatch):
+    path = tmp_path / "update_check.json"
+    monkeypatch.setattr(un, "_CACHE_PATH", path)
+    return path
+
+
+def _write(path, latest, *, checked_at=None):
+    payload = {"latest_version": latest, "checked_at": time.time() if checked_at is None else checked_at}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_no_cache_yields_no_notice(cache):
+    assert un.update_notice("0.1.9") is None
+
+
+def test_newer_cached_release_yields_notice(cache):
+    _write(cache, "0.2.0")
+    assert un.update_notice("0.1.9") == (1, "raven upgrade")
+
+
+def test_same_version_yields_no_notice(cache):
+    _write(cache, "0.1.9")
+    assert un.update_notice("0.1.9") is None
+
+
+def test_older_cached_release_yields_no_notice(cache):
+    # A local dev build ahead of the latest release must not nag.
+    _write(cache, "0.1.9")
+    assert un.update_notice("0.2.0") is None
+
+
+def test_unparseable_versions_are_ignored(cache):
+    _write(cache, "not-a-version")
+    assert un.update_notice("0.1.9") is None
+    _write(cache, "0.2.0")
+    assert un.update_notice("garbage") is None
+
+
+def test_v_prefix_is_tolerated(cache):
+    _write(cache, "v0.2.0")
+    assert un.update_notice("v0.1.9") == (1, "raven upgrade")
+
+
+def test_corrupt_cache_is_ignored(cache):
+    cache.write_text("{not json", encoding="utf-8")
+    assert un.update_notice("0.1.9") is None
+
+
+def test_refresh_skipped_when_cache_is_fresh(cache, monkeypatch):
+    _write(cache, "0.1.9", checked_at=time.time())
+    spawned = []
+    monkeypatch.setattr(un.threading, "Thread", lambda *a, **k: spawned.append((a, k)) or _FakeThread())
+    un.maybe_refresh_async()
+    assert spawned == []
+
+
+def test_refresh_spawned_when_cache_is_stale(cache, monkeypatch):
+    _write(cache, "0.1.9", checked_at=time.time() - un._REFRESH_TTL_SECONDS - 1)
+    spawned = []
+    monkeypatch.setattr(un.threading, "Thread", lambda *a, **k: spawned.append(k) or _FakeThread())
+    un.maybe_refresh_async()
+    assert len(spawned) == 1
+    assert spawned[0]["daemon"] is True
+
+
+def test_refresh_spawned_when_cache_absent(cache, monkeypatch):
+    spawned = []
+    monkeypatch.setattr(un.threading, "Thread", lambda *a, **k: spawned.append(k) or _FakeThread())
+    un.maybe_refresh_async()
+    assert len(spawned) == 1
+
+
+class _FakeThread:
+    def start(self):  # noqa: D102 - test double
+        pass

--- a/ui-tui/src/__tests__/branding.test.tsx
+++ b/ui-tui/src/__tests__/branding.test.tsx
@@ -31,7 +31,7 @@ describe('SessionPanel', () => {
       model: 'anthropic/claude-sonnet-4-6',
       skills: {},
       tools: {},
-      update_behind: 1,
+      update_available: true,
       update_command: 'raven upgrade'
     }
     const { lastFrame } = render(<SessionPanel info={info} maxCols={80} sid="test" t={DEFAULT_THEME} />)

--- a/ui-tui/src/__tests__/branding.test.tsx
+++ b/ui-tui/src/__tests__/branding.test.tsx
@@ -26,16 +26,17 @@ describe('Branding', () => {
 })
 
 describe('SessionPanel', () => {
-  it('recommends the real raven upgrade command', () => {
+  it('does not render the update nudge in the banner (it lives in the status bar)', () => {
     const info: SessionInfo = {
       model: 'anthropic/claude-sonnet-4-6',
       skills: {},
       tools: {},
-      update_behind: 1
+      update_behind: 1,
+      update_command: 'raven upgrade'
     }
     const { lastFrame } = render(<SessionPanel info={info} maxCols={80} sid="test" t={DEFAULT_THEME} />)
-    expect(lastFrame()).toContain('raven upgrade')
-    expect(lastFrame()).not.toContain('raven update')
+    expect(lastFrame()).not.toContain('Update available')
+    expect(lastFrame()).not.toContain('upgrade')
   })
 })
 

--- a/ui-tui/src/__tests__/statusRule.test.tsx
+++ b/ui-tui/src/__tests__/statusRule.test.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 EverMind.
+// See NOTICES.md.
+
+import { render } from 'ink-testing-library'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import type { Usage } from '../types.js'
+
+import { StatusRule } from '../components/appChrome.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const USAGE: Usage = { calls: 0, input: 0, output: 0, total: 0 }
+
+const base = {
+  bgCount: 0,
+  busy: false,
+  cols: 100,
+  cwdLabel: '~/proj (main)',
+  model: 'minimax/m3',
+  showCost: false,
+  status: 'ready',
+  statusColor: DEFAULT_THEME.color.accent,
+  t: DEFAULT_THEME,
+  usage: USAGE
+}
+
+const frameOf = (extra: Record<string, unknown>) =>
+  stripAnsi(render(<StatusRule {...base} {...extra} />).lastFrame() ?? '')
+
+describe('StatusRule update nudge', () => {
+  it('shows the cwd/branch label when no update is available', () => {
+    const frame = frameOf({})
+    expect(frame).toContain('~/proj (main)')
+    expect(frame).not.toContain('Update available')
+  })
+
+  it('replaces the cwd/branch label with the upgrade nudge when an update is available', () => {
+    const frame = frameOf({ updateAvailable: true, updateCommand: 'raven upgrade' })
+    expect(frame).toContain('Update available')
+    expect(frame).toContain('raven upgrade')
+    expect(frame).not.toContain('~/proj (main)')
+  })
+})

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -295,6 +295,8 @@ export function StatusRule({
   sessionStartedAt,
   showCost,
   turnStartedAt,
+  updateAvailable,
+  updateCommand,
   t
 }: StatusRuleProps) {
   const pct = usage.context_percent
@@ -307,7 +309,10 @@ export function StatusRule({
       : ''
 
   const bar = usage.context_max ? ctxBar(pct) : ''
-  const leftWidth = Math.max(12, cols - cwdLabel.length - 3)
+  // When an update is available, the bottom-right slot shows the upgrade nudge
+  // in place of the cwd/branch label (dynamic, no extra line).
+  const rightLabel = updateAvailable ? `↑ Update available — run ${updateCommand || 'raven upgrade'}` : cwdLabel
+  const leftWidth = Math.max(12, cols - rightLabel.length - 3)
 
   return (
     <Box height={1}>
@@ -354,7 +359,7 @@ export function StatusRule({
       </Box>
 
       <Text color={t.color.border}> ─ </Text>
-      <Text color={t.color.label}>{cwdLabel}</Text>
+      <Text color={updateAvailable ? t.color.warn : t.color.label}>{rightLabel}</Text>
     </Box>
   )
 }
@@ -471,6 +476,8 @@ interface StatusRuleProps {
   statusColor: string
   t: Theme
   turnStartedAt?: null | number
+  updateAvailable?: boolean
+  updateCommand?: string
   usage: Usage
 }
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -391,7 +391,7 @@ const StatusRulePane = memo(function StatusRulePane({
         cols={composer.cols}
         cwdLabel={status.cwdLabel}
         model={ui.info?.model ?? ''}
-        updateAvailable={Boolean(ui.info?.update_behind && ui.info.update_behind > 0)}
+        updateAvailable={Boolean(ui.info?.update_available)}
         updateCommand={ui.info?.update_command || 'raven upgrade'}
         modelFast={ui.info?.fast || ui.info?.service_tier === 'priority'}
         modelReasoningEffort={ui.info?.reasoning_effort}

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -391,6 +391,8 @@ const StatusRulePane = memo(function StatusRulePane({
         cols={composer.cols}
         cwdLabel={status.cwdLabel}
         model={ui.info?.model ?? ''}
+        updateAvailable={Boolean(ui.info?.update_behind && ui.info.update_behind > 0)}
+        updateCommand={ui.info?.update_command || 'raven upgrade'}
         modelFast={ui.info?.fast || ui.info?.service_tier === 'priority'}
         modelReasoningEffort={ui.info?.reasoning_effort}
         sessionStartedAt={status.sessionStartedAt}

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -436,30 +436,6 @@ export function SessionPanel({ info, maxCols, sid, t }: SessionPanelProps) {
               {footerMeta}
             </Text>
           </Box>
-
-          {typeof info.update_behind === 'number' && info.update_behind > 0 && (
-            <>
-              <Box>
-                <Text color={t.color.border} wrap="truncate">
-                  {'─'.repeat(Math.max(1, w))}
-                </Text>
-              </Box>
-              <Text bold color={t.color.warn}>
-                ! {info.update_behind} {info.update_behind === 1 ? 'commit' : 'commits'} behind
-                <Text bold={false} color={t.color.warn} dimColor>
-                  {' '}
-                  - run{' '}
-                </Text>
-                <Text bold color={t.color.warn}>
-                  {info.update_command || 'raven upgrade'}
-                </Text>
-                <Text bold={false} color={t.color.warn} dimColor>
-                  {' '}
-                  to update
-                </Text>
-              </Text>
-            </>
-          )}
         </Box>
 
         <Box marginTop={1}>

--- a/ui-tui/src/demo/gallery.tsx
+++ b/ui-tui/src/demo/gallery.tsx
@@ -99,8 +99,6 @@ const sessionInfo: SessionInfo = {
     core_tools: ['read', 'write', 'edit', 'bash'],
     search_tools: ['grep', 'glob']
   },
-  update_behind: 2,
-  update_command: 'raven upgrade',
   version: '0.0.1'
 }
 
@@ -188,6 +186,24 @@ function AppChromePage() {
           statusColor={t.color.statusWarn}
           t={t}
           turnStartedAt={now - 5_000}
+          usage={usage}
+        />
+      </Demo>
+      <Demo title="StatusRule — update available (right slot takes over)">
+        <StatusRule
+          bgCount={0}
+          busy={false}
+          cols={cols}
+          cwdLabel="~/raven"
+          model="anthropic/claude-opus-4-8"
+          sessionStartedAt={now - 125_000}
+          showCost={false}
+          status="ready"
+          statusColor={t.color.statusGood}
+          t={t}
+          turnStartedAt={null}
+          updateAvailable
+          updateCommand="raven upgrade"
           usage={usage}
         />
       </Demo>

--- a/ui-tui/src/lib/stubGatewayFixtures.ts
+++ b/ui-tui/src/lib/stubGatewayFixtures.ts
@@ -28,8 +28,7 @@ export const STUB_SESSION_INFO: SessionInfo = {
   model: 'claude-sonnet-4-6',
   skills: {},
   tools: {},
-  // Raven Agent fork: independent version line, "X commits behind" semantic n/a.
-  update_behind: null
+  update_available: null
 }
 
 export const STUB_SESSION_LIST_ITEM: SessionListItem = {

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -163,7 +163,7 @@ export interface SessionInfo {
   skills: Record<string, string[]>
   system_prompt?: string
   tools: Record<string, string[]>
-  update_behind?: number | null
+  update_available?: boolean | null
   update_command?: string
   usage?: Usage
   version?: string


### PR DESCRIPTION
## Summary

The TUI already read `update_behind` / `update_command` out of the session init
bundle, but nothing on the Python side ever filled those fields, so the hint
never appeared. This wires up the missing half and moves where it shows.

**The check**

`raven/cli/update_notice.py` compares the running version against a small
cache in `~/.raven/update_check.json`:

- `raven tui` calls `maybe_refresh_async()` once per launch. It spawns a daemon
  thread only when the cache is missing or older than 24h, so a normal launch
  touches the network at most once a day and never blocks startup.
- The gateway only *reads* that cache when it builds the session info bundle
  (`_default_session_info`). Reading is pure and fast; no network on the
  session-create path, which is why the check is cached rather than live.
- Every failure path is swallowed: no cache, unparseable version, corrupt JSON,
  network error, rate limit. An update hint must never break startup.

The tradeoff is staleness by one launch: the first launch after a release
lands refreshes the cache, and the hint shows on the next launch.

**Where it shows**

The status bar's right slot, in the warn color, replacing the cwd/branch label
while an update is available. No extra line, no layout shift.

The old banner block in `branding.tsx` is removed. The banner is the first
thing on screen at startup and an upgrade nudge does not deserve that weight.
`update_behind` is now a flag rather than a commit count, so the text is
version-agnostic (`Update available - run raven upgrade`) instead of the old
`N commits behind`.

## Type

- [ ] Fix
- [x] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

```
uv run ruff check raven/ tests/                  # All checks passed
uv run ruff format --check raven/ tests/         # 760 files already formatted
uv run pytest tests/test_cli_update_notice.py \
  tests/test_cli_tui_commands.py \
  tests/test_tui_rpc_session.py -q               # 95 passed
cd ui-tui && npm run type-check                  # clean
cd ui-tui && npm test                            # 904 passed | 3 skipped
cd ui-tui && npm run lint                        # 0 errors
cd ui-tui && npx prettier --check "src/**/*.{ts,tsx}"   # clean
```

New tests cover the cache read/write and refresh throttle
(`tests/test_cli_update_notice.py`), the status-bar slot swap
(`ui-tui/src/__tests__/statusRule.test.tsx`), and the banner no longer
rendering the block (`branding.test.tsx`).

Also exercised the five edge cases by hand: absent cache, newer cached
release, cache equal to current, unparseable version string, and a corrupt
cache file. Only the second one returns a notice; the rest return `None`.

The lint warning reported on `appChrome.tsx` (`react-hooks/exhaustive-deps`,
line 275) is pre-existing on `main` and untouched by this change.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

The GitHub releases fetch reuses `upgrade_commands._fetch_latest_release`, so
no new network surface or credential handling. The cache file holds a version
string and a timestamp only.

Wire-compatible: `update_behind` / `update_command` were already optional
fields in the info bundle, and a client that never receives them behaves as
before. Rollback is reverting this commit; the feature degrades to its current
state, which is showing nothing.

To see it locally:

```
printf '{"latest_version":"9.9.9","checked_at":%s}' "$(date +%s)" > ~/.raven/update_check.json
```

## Related Issues

N/A