### PR TITLE
feat(*): offer every supported provider in the onboarding picker

### DIFF
--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -794,7 +794,7 @@ def _run_oauth_login(provider: str) -> bool:
     from raven.providers.registry import find_by_name
 
     spec = find_by_name(provider)
-    if not spec or not spec.is_oauth:
+    if _credential_kind(provider, spec) != CRED_OAUTH:
         console.print(
             _t(
                 f"  [red]✗ {provider} is not an OAuth provider.[/red]",
@@ -855,7 +855,7 @@ def _verify_provider(provider: str, *, skip_test: bool = False) -> tuple[bool, s
     # A local deployment has no key to verify -- what is being checked is that
     # the address answers, and saying "API key" there describes a field the user
     # was never asked for.
-    if spec and spec.is_local:
+    if _credential_kind(provider, spec) == CRED_LOCAL:
         console.print(_t("  [dim]⏳ Reaching the server…[/dim]", "  [dim]⏳ 正在连接服务…[/dim]"))
     else:
         console.print(_t("  [dim]⏳ Verifying your API key…[/dim]", "  [dim]⏳ 正在验证 API Key…[/dim]"))
@@ -928,6 +928,35 @@ def _model_routes_to_provider(model: str, spec: Any) -> bool:
     Defers to the spec so this guard cannot disagree with the routing it guards.
     """
     return bool(model and spec and spec.claims(model))
+
+
+# How a provider proves who it is. Every decision the wizard makes about a
+# provider -- which field to prompt for, what a failure offers to change, what
+# "remove" clears, whether a rollback applies -- follows from this one question,
+# and it was being answered independently at thirteen sites off two spec flags.
+# Each of the last two review rounds found a site that disagreed with the others:
+# a rollback that wrote credentials to an OAuth provider and killed the wizard, a
+# menu that offered a key prompt to one, a prompt that half-guarded a spec it had
+# already dereferenced. Answer it once.
+CRED_OAUTH = "oauth"  # a token file, written by `raven provider login`
+CRED_LOCAL = "local"  # reached by address; there is no key
+CRED_ENDPOINT = "endpoint"  # a key plus a base URL the user supplies
+CRED_KEY = "key"  # a key alone, including vendors Raven carries no spec for
+
+
+def _credential_kind(provider: str, spec: Any) -> str:
+    """Which credential shape this provider uses.
+
+    Derived rather than stored: `spec` is optional metadata, and a vendor with no
+    spec is reached with a key like most others.
+    """
+    if spec is not None and spec.is_oauth:
+        return CRED_OAUTH
+    if spec is not None and spec.is_local:
+        return CRED_LOCAL
+    if provider == "custom":
+        return CRED_ENDPOINT
+    return CRED_KEY
 
 
 def _litellm_spelling(provider: str) -> str:
@@ -1110,7 +1139,7 @@ def _roll_back_provider_fields(provider: str, spec: Any, *, old_key: Optional[st
     layer refuses to write credential fields for them, and doing it anyway turned
     a failed verification into a dead wizard.
     """
-    if spec is not None and spec.is_oauth:
+    if _credential_kind(provider, spec) == CRED_OAUTH:
         return
     _write_provider_fields(provider, {"api_key": old_key or "", "api_base": old_base})
 
@@ -1287,8 +1316,9 @@ def _configure_one_provider(
                 continue
 
         spec = find_by_name(provider)
-        is_oauth = bool(spec and spec.is_oauth)
-        is_custom = provider == "custom"
+        kind = _credential_kind(provider, spec)
+        is_oauth = kind == CRED_OAUTH
+        is_custom = kind == CRED_ENDPOINT
         # The interactive picker already echoes the chosen provider; only print
         # an explicit confirmation when it came from --provider (no echo then).
         if flag_provider:
@@ -1316,7 +1346,7 @@ def _configure_one_provider(
             provider,
             is_oauth=is_oauth,
             is_custom=is_custom,
-            is_local=bool(spec and spec.is_local),
+            is_local=kind == CRED_LOCAL,
             api_key=api_key,
             base_url=base_url,
             model=model,
@@ -1507,7 +1537,11 @@ def _resolve_model_with_test(
                     # A local deployment that cannot be reached is usually a
                     # wrong address, and this is the branch it lands in -- so
                     # retry alone left the one thing worth changing unreachable.
-                    *([(_t("Re-enter server URL", "重新填服务地址"), "rebase")] if spec and spec.is_local else []),
+                    *(
+                        [(_t("Re-enter server URL", "重新填服务地址"), "rebase")]
+                        if _credential_kind(provider, spec) == CRED_LOCAL
+                        else []
+                    ),
                     (_t("Continue anyway", "仍然继续"), "continue"),
                 ]
                 if status == "network_error"
@@ -1517,9 +1551,9 @@ def _resolve_model_with_test(
                     # left a mistyped address with no way back to the field.
                     (
                         (_t("Sign in again", "重新登录"), "reauth")
-                        if spec and spec.is_oauth
+                        if _credential_kind(provider, spec) == CRED_OAUTH
                         else (_t("Re-enter server URL", "重新填服务地址"), "rebase")
-                        if spec and spec.is_local
+                        if _credential_kind(provider, spec) == CRED_LOCAL
                         else (_t("Re-enter key", "重新填 Key"), "rekey")
                     ),
                     (_t("Switch provider", "更换服务商"), "switch"),
@@ -1591,7 +1625,7 @@ def _resolve_model_with_test(
             provider,
             non_interactive=non_interactive,
             warnings=warnings,
-            is_oauth=bool(spec and spec.is_oauth),
+            is_oauth=_credential_kind(provider, spec) == CRED_OAUTH,
         )
         if result == "switch":
             return None
@@ -1650,7 +1684,7 @@ def _configure_existing_provider_model(*, non_interactive: bool) -> bool:
         provider,
         non_interactive=False,
         warnings=[],
-        is_oauth=bool(spec and spec.is_oauth),
+        is_oauth=_credential_kind(provider, spec) == CRED_OAUTH,
     )
     if result == "reauth":
         return _run_oauth_login(provider)
@@ -1703,7 +1737,7 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
             continue
         if action == "update":
             target_spec = find_by_name(target)
-            if target_spec and target_spec.is_oauth:
+            if _credential_kind(target, target_spec) == CRED_OAUTH:
                 # Nothing here to update: the credential is a token file, and the
                 # ops layer refuses credential writes for these -- so offering the
                 # key prompt ended the wizard instead of editing anything.
@@ -1716,7 +1750,7 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
                     )
                 )
                 continue
-            if target_spec and target_spec.is_local:
+            if _credential_kind(target, target_spec) == CRED_LOCAL:
                 # A local deployment holds no key; what there is to update is
                 # where it lives. Offering the key prompt wrote a credential into
                 # a provider that never reads one, and left the address alone.
@@ -1771,7 +1805,7 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
             # to clear and refuses the write, so it is told where its credential
             # actually lives instead of ending the run.
             target_spec = find_by_name(target)
-            if target_spec and target_spec.is_oauth:
+            if _credential_kind(target, target_spec) == CRED_OAUTH:
                 console.print(
                     _t(
                         f"  [dim]{_provider_label(target)}'s credential is an OAuth token, not a config field, "

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -1594,10 +1594,7 @@ def _configure_existing_provider_model(*, non_interactive: bool) -> bool:
     from raven.cli._styles import RAVEN_STYLE
     from raven.providers.registry import find_by_name
 
-    choices = [
-        questionary.Choice(_provider_label(name), value=name)
-        for name in _configured_providers()
-    ]
+    choices = [questionary.Choice(_provider_label(name), value=name) for name in _configured_providers()]
     if not choices:
         return False
     provider = questionary.select(

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -930,6 +930,23 @@ def _model_routes_to_provider(model: str, spec: Any) -> bool:
     return bool(model and spec and spec.claims(model))
 
 
+def _litellm_spelling(provider: str) -> str:
+    """How LiteLLM spells this vendor, for use as a route prefix.
+
+    Config section names are matched spelling-insensitively, so the name reaching
+    here may be underscored where LiteLLM hyphenates. Only LiteLLM's own form
+    works as a prefix.
+    """
+    from raven.providers.litellm_provider_names import LITELLM_PROVIDER_NAMES
+    from raven.providers.registry import normalize_provider_name
+
+    wanted = normalize_provider_name(provider)
+    for name in LITELLM_PROVIDER_NAMES:
+        if normalize_provider_name(name) == wanted:
+            return name
+    return wanted
+
+
 def _format_model_for_provider(provider: str, spec: Any, model_id: str) -> str:
     """Apply the provider's route prefix to a raw ``/v1/models`` id when needed.
 
@@ -943,12 +960,16 @@ def _format_model_for_provider(provider: str, spec: Any, model_id: str) -> str:
     Its section name is LiteLLM's own name for the vendor, which is exactly the
     prefix LiteLLM routes on, so that is what goes in front.
     """
-    from raven.providers.registry import normalize_provider_name
 
     if not model_id:
         return model_id
     if spec is None:
-        prefix = normalize_provider_name(provider)
+        # LiteLLM's own spelling, not the normalized one. A config section may be
+        # written either way and both resolve, but the wire prefix has to be the
+        # name LiteLLM routes on -- it hyphenates three vendors, and handing it
+        # "nano_gpt/..." is rejected with "LLM Provider NOT provided", so the
+        # provider configured fine and then could not be called.
+        prefix = _litellm_spelling(provider)
         return model_id if model_id.startswith(f"{prefix}/") else f"{prefix}/{model_id}"
     if spec.name in {"minimax_global", "minimax_cn"}:
         public_prefix = spec.name.replace("_", "-")
@@ -976,14 +997,21 @@ def _pick_model(
     non_interactive: bool,
 ) -> str:
     """Decide the model string to write into ``agents.defaults.model``."""
+    # Every exit goes through the formatter, which is idempotent. Applying it
+    # only where the candidate list is built covered only the branch that has
+    # candidates -- and a vendor Raven carries no spec for reaches the others:
+    # the probe cannot pre-check it, so there is no list, so the user types the
+    # id. A typed id is bare, and a bare id is routed by keyword and fallback
+    # rather than to the provider just configured, which is how
+    # "mistral-large-latest" came to be served with OpenAI's key.
     if user_provided_model:
-        return user_provided_model
+        return _format_model_for_provider(provider, spec, user_provided_model)
 
     if non_interactive:
         default_model = spec.default_model if spec else ""
         if not default_model:
             raise typer.BadParameter(f"--model is required for provider '{provider}' (no built-in default model).")
-        return default_model
+        return _format_model_for_provider(provider, spec, default_model)
 
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
@@ -1063,9 +1091,9 @@ def _pick_model(
         # default rather than tearing down the wizard. The no-default branch
         # validates non-empty, so an empty value only reaches here with a default.
         if default_value:
-            return default_value
+            return _format_model_for_provider(provider, spec, default_value)
         raise typer.Exit(1)
-    return chosen
+    return _format_model_for_provider(provider, spec, chosen)
 
 
 def _roll_back_provider_fields(provider: str, spec: Any, *, old_key: Optional[str], old_base: Optional[str]) -> None:

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -930,15 +930,26 @@ def _model_routes_to_provider(model: str, spec: Any) -> bool:
     return bool(model and spec and spec.claims(model))
 
 
-def _format_model_for_provider(spec: Any, model_id: str) -> str:
-    """Apply the provider's model prefix to a raw ``/v1/models`` id when needed.
+def _format_model_for_provider(provider: str, spec: Any, model_id: str) -> str:
+    """Apply the provider's route prefix to a raw ``/v1/models`` id when needed.
 
-    ``spec`` is None for a vendor only LiteLLM knows. Those need no prefixing
-    here: the id the vendor returned already routes, because the section name
-    the user configured is the name LiteLLM routes on.
+    A vendor Raven carries no spec for still needs the prefix, and needs it most:
+    the id it returns is bare, and a bare id is routed by keyword and fallback
+    rather than to the section the user just configured. Handing one back
+    unprefixed sent the request wherever those rules landed -- configuring
+    Mistral alongside OpenAI produced "mistral-large-latest", which resolves to
+    OpenAI and spends OpenAI's key.
+
+    Its section name is LiteLLM's own name for the vendor, which is exactly the
+    prefix LiteLLM routes on, so that is what goes in front.
     """
-    if not model_id or spec is None:
+    from raven.providers.registry import normalize_provider_name
+
+    if not model_id:
         return model_id
+    if spec is None:
+        prefix = normalize_provider_name(provider)
+        return model_id if model_id.startswith(f"{prefix}/") else f"{prefix}/{model_id}"
     if spec.name in {"minimax_global", "minimax_cn"}:
         public_prefix = spec.name.replace("_", "-")
         if model_id.startswith(f"{public_prefix}/"):
@@ -1000,7 +1011,7 @@ def _pick_model(
             model_ids = known
 
     if model_ids:
-        choices = [_format_model_for_provider(spec, mid) for mid in model_ids]
+        choices = [_format_model_for_provider(provider, spec, mid) for mid in model_ids]
         # Dedupe: the chain above already prefixes its ids, and _format_ leaves a
         # correctly-prefixed id alone, so two sources can agree on one model.
         choices = list(dict.fromkeys(choices))
@@ -1055,6 +1066,25 @@ def _pick_model(
             return default_value
         raise typer.Exit(1)
     return chosen
+
+
+def _roll_back_provider_fields(provider: str, spec: Any, *, old_key: Optional[str], old_base: Optional[str]) -> None:
+    """Undo what this pass wrote, restoring the state read before it started.
+
+    A named function so the behaviour can be driven by a test: the two shapes
+    this replaced were both wrong in ways only a test that calls it can hold
+    down. Keying off the previous api_key skipped a local deployment entirely,
+    leaving a mistyped address where a working one had been; and asking "was it
+    configured" cleared both fields for a provider that had held only an
+    api_base, erasing an endpoint this pass never touched.
+
+    OAuth providers are skipped: their credentials live in a token file, the ops
+    layer refuses to write credential fields for them, and doing it anyway turned
+    a failed verification into a dead wizard.
+    """
+    if spec is not None and spec.is_oauth:
+        return
+    _write_provider_fields(provider, {"api_key": old_key or "", "api_base": old_base})
 
 
 def _write_provider_fields(provider: str, fields: dict[str, Any]) -> None:
@@ -1207,7 +1237,6 @@ def _configure_one_provider(
     # A provider passed by flag is used once; switching then requires the
     # interactive picker (or, in non-interactive mode, is impossible).
     flag_provider = provider
-    configured_before = set(_configured_providers())
     while True:
         if flag_provider:
             provider = _validate_provider_name(flag_provider)
@@ -1286,16 +1315,20 @@ def _configure_one_provider(
             # pass prompts rather than reusing the failed flag value), undoing
             # what this pass wrote.
             #
-            # Restore both fields, not just the key: a local deployment is
-            # configured by address and has no key at all, so keying the rollback
-            # off `old_key` skipped it entirely and a mistyped address replaced a
-            # working one for good. Clearing only the key had the same shape --
-            # it left the bad api_base behind as a section that looks configured
-            # and reaches nothing.
-            if provider not in configured_before:
-                _write_provider_fields(provider, {"api_key": "", "api_base": None})
-            else:
-                _write_provider_fields(provider, {"api_key": old_key or "", "api_base": old_base})
+            # Put back exactly what was there, read before this pass wrote
+            # anything. One branch, because "was it configured" is the wrong
+            # question twice over: a local deployment is configured by address
+            # and has no key, so a rollback keyed off the old key skipped it and
+            # a mistyped address replaced a working one for good; and a provider
+            # that held only an api_base counts as unconfigured, so clearing
+            # both fields for a "new" provider erased an endpoint this pass had
+            # never touched.
+            #
+            # OAuth providers are left alone: their credentials live in a token
+            # file, `set_provider_fields` refuses to write credential fields for
+            # them at all, and doing so turned a failed verification into a
+            # RuntimeError that took the whole wizard down.
+            _roll_back_provider_fields(provider, spec, old_key=old_key, old_base=old_base)
             flag_provider = None
             continue
         _persist_default_model(chosen_model)
@@ -1441,7 +1474,14 @@ def _resolve_model_with_test(
         ok, status, model_ids = _verify_provider(provider, skip_test=skip_test)
         if not ok:
             options = (
-                [(_t("Retry", "重试"), "retry"), (_t("Continue anyway", "仍然继续"), "continue")]
+                [
+                    (_t("Retry", "重试"), "retry"),
+                    # A local deployment that cannot be reached is usually a
+                    # wrong address, and this is the branch it lands in -- so
+                    # retry alone left the one thing worth changing unreachable.
+                    *([(_t("Re-enter server URL", "重新填服务地址"), "rebase")] if spec and spec.is_local else []),
+                    (_t("Continue anyway", "仍然继续"), "continue"),
+                ]
                 if status == "network_error"
                 else [
                     # What to offer depends on what the provider is reached by.
@@ -1636,6 +1676,19 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
             continue
         if action == "update":
             target_spec = find_by_name(target)
+            if target_spec and target_spec.is_oauth:
+                # Nothing here to update: the credential is a token file, and the
+                # ops layer refuses credential writes for these -- so offering the
+                # key prompt ended the wizard instead of editing anything.
+                console.print(
+                    _t(
+                        f"  [dim]{_provider_label(target)} signs in through OAuth. "
+                        f"Run: raven provider login {target.replace('_', '-')}[/dim]",
+                        f"  [dim]{_provider_label(target)} 通过 OAuth 登录。"
+                        f"请运行: raven provider login {target.replace('_', '-')}[/dim]",
+                    )
+                )
+                continue
             if target_spec and target_spec.is_local:
                 # A local deployment holds no key; what there is to update is
                 # where it lives. Offering the key prompt wrote a credential into
@@ -1687,7 +1740,20 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
                     continue
             # Clear both: a local deployment counts as configured by its
             # api_base, so clearing only the key reported it removed and left it
-            # in the list, still reachable.
+            # in the list, still reachable. An OAuth provider has neither field
+            # to clear and refuses the write, so it is told where its credential
+            # actually lives instead of ending the run.
+            target_spec = find_by_name(target)
+            if target_spec and target_spec.is_oauth:
+                console.print(
+                    _t(
+                        f"  [dim]{_provider_label(target)}'s credential is an OAuth token, not a config field, "
+                        "so there is nothing here to remove.[/dim]",
+                        f"  [dim]{_provider_label(target)} 的凭据是 OAuth token,不在配置字段里,"
+                        "这里没有可移除的内容。[/dim]",
+                    )
+                )
+                continue
             _write_provider_fields(target, {"api_key": "", "api_base": None})
             if was_default_source:
                 # Clear the now-dangling default so step 1's guard forces a

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -701,7 +701,7 @@ def _prompt_local_api_base(spec: Any, *, current: str = "", allow_back: bool = F
 
     url = questionary.text(
         _t(f"{spec.label} server URL:", f"{spec.label} 服务地址:"),
-        default=current or (spec.default_api_base if spec else "") or "",
+        default=current or spec.default_api_base or "",
         validate=_validate,
         placeholder=_back_placeholder(allow_back),
         style=RAVEN_STYLE,
@@ -1513,7 +1513,10 @@ def _resolve_model_with_test(
                     stored = ""
                 retyped = _prompt_local_api_base(spec, current=stored)
                 if retyped is None:
-                    return None
+                    # Ctrl+C means quit, as it does in the sibling "re-enter key"
+                    # branch. Returning None here would have been read as "switch
+                    # provider" and silently rolled the setup back instead.
+                    raise typer.Exit(1)
                 _write_provider_fields(provider, {"api_base": retyped})
                 continue
             if choice == "reauth" and not non_interactive:
@@ -1594,7 +1597,6 @@ def _configure_existing_provider_model(*, non_interactive: bool) -> bool:
     choices = [
         questionary.Choice(_provider_label(name), value=name)
         for name in _configured_providers()
-        if find_by_name(name) is not None
     ]
     if not choices:
         return False
@@ -1623,7 +1625,7 @@ def _configure_existing_provider_model(*, non_interactive: bool) -> bool:
         provider,
         non_interactive=False,
         warnings=[],
-        is_oauth=spec.is_oauth,
+        is_oauth=bool(spec and spec.is_oauth),
     )
     if result == "reauth":
         return _run_oauth_login(provider)

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -446,13 +446,14 @@ def _provider_label(name: str) -> str:
 def _validate_provider_name(name: str) -> str:
     """Resolve a user-supplied provider name (kebab or snake) to a registry key.
 
-    The wizard needs a registry entry to guide anyone: a default model to fall
-    back on, whether the provider takes a key or an OAuth login, a label to
-    print. A vendor that only LiteLLM knows has none of that, so point at the
-    command that does configure it rather than walking off a missing spec.
+    A vendor LiteLLM routes to but Raven carries no spec for is configurable
+    too: the wizard has no default model or OAuth flow to offer it, but it does
+    not need one -- the credentials go in under the vendor's name and the model
+    list comes from the vendor itself. Callers must therefore treat the spec as
+    optional metadata, not as permission.
     """
     from raven.config.update_providers import provider_field_specs
-    from raven.providers.registry import find_by_name
+    from raven.providers.registry import find_by_name, normalize_provider_name
 
     candidate = name.replace("-", "_")
     try:
@@ -461,9 +462,9 @@ def _validate_provider_name(name: str) -> str:
         raise typer.BadParameter(str(exc))
     spec = find_by_name(candidate)
     if spec is None:
-        raise typer.BadParameter(
-            f"The wizard does not cover '{name}'. Configure it directly: raven provider set {name} --api-key <key>"
-        )
+        # No spec, but provider_field_specs above already confirmed LiteLLM
+        # routes to it, which is all configuring it takes.
+        return normalize_provider_name(candidate)
     # Return the current name: everything downstream compares and stores by it,
     # and a former name would have the wizard reading one section and writing
     # another.
@@ -524,11 +525,11 @@ def _collect_fields(prompts: list[Callable[[], Any]]) -> Optional[list[Any]]:
     return values
 
 
-def _select_provider() -> Optional[str]:
-    """Interactive provider picker built from the curated catalogue.
+def _select_provider_row() -> Optional[str]:
+    """Render the grouped provider list once and return the raw choice.
 
-    Returns the provider name, ``_BACK`` if the user chose the back sentinel,
-    or ``None`` on Ctrl+C.
+    Separate from `_select_provider` so backing out of the vendor sub-list can
+    show this list again rather than unwinding the whole step.
     """
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
@@ -550,17 +551,37 @@ def _select_provider() -> Optional[str]:
     choices.append(questionary.Separator())
     choices.append(questionary.Choice(_t("Back", "返回"), value=_BACK))
 
-    picked = questionary.select(
+    return questionary.select(
         _t("Provider:", "服务商:"),
         choices=choices,
         style=RAVEN_STYLE,
         qmark=_QMARK,
-    ).ask()
-    if picked == _PICK_LITELLM_VENDOR:
+    ).ask()  # None on Ctrl+C
+
+
+def _select_provider() -> Optional[str]:
+    """Interactive provider picker built from the curated catalogue.
+
+    Returns the provider name, ``_BACK`` if the user chose the back sentinel,
+    or ``None`` on Ctrl+C.
+    """
+    picked = _select_provider_row()
+    while picked == _PICK_LITELLM_VENDOR:
         # Second step rather than a hundred more rows: LiteLLM routes to far more
         # vendors than anyone wants to scroll, and typing the name is how someone
         # who already knows which one they want gets there.
-        return _prompt_litellm_vendor()
+        #
+        # Backing out of it returns to this list, not out of the step: the user
+        # opened a sub-list, so empty-submit means "close the sub-list". Passing
+        # its _BACK straight up sent them to the language screen instead.
+        typed = _prompt_litellm_vendor()
+        if typed is None:
+            return None
+        if typed is not _BACK:
+            return typed
+        picked = _select_provider_row()
+        if picked is None or picked is _BACK:
+            return picked
     return picked  # None on Ctrl+C
 
 
@@ -571,9 +592,16 @@ def _litellm_vendor_choices() -> list[str]:
     costs no import on a path that only renders choices.
     """
     from raven.providers.litellm_provider_names import LITELLM_PROVIDER_NAMES
-    from raven.providers.registry import normalize_provider_name
+    from raven.providers.registry import find_by_name, normalize_provider_name
 
-    already_listed = {normalize_provider_name(e["name"]) for e in _CURATED_PROVIDERS}
+    # Every name a listed provider answers to, not just the one shown: LiteLLM
+    # knows "ollama" and "vllm", which are the pre-rename spellings of two rows
+    # already on the list, so matching on the displayed name alone offered them
+    # a second time under a name that resolves to the same section.
+    already_listed: set[str] = set()
+    for entry in _CURATED_PROVIDERS:
+        spec = find_by_name(entry["name"])
+        already_listed |= set(spec.route_names) if spec else {normalize_provider_name(entry["name"])}
     return sorted(n for n in LITELLM_PROVIDER_NAMES if normalize_provider_name(n) not in already_listed)
 
 
@@ -606,8 +634,9 @@ def _prompt_litellm_vendor() -> Optional[str]:
     typed = typed.strip()
     if not typed:
         return _BACK
-    # Not validated here: the write path already rejects a name LiteLLM does not
-    # know, and it is the one that has to be right.
+    # Validation happens where the name is used, not here: the caller runs it
+    # through the same gate the --provider flag goes through, which is what turns
+    # a typo into a message instead of a traceback.
     return normalize_provider_name(typed)
 
 
@@ -647,13 +676,16 @@ def _prompt_api_key(provider: str, *, allow_back: bool = False, back_label: Opti
     return key
 
 
-def _prompt_local_api_base(spec: Any, *, allow_back: bool = False) -> Any:
+def _prompt_local_api_base(spec: Any, *, current: str = "", allow_back: bool = False) -> Any:
     """Ask a local deployment for its server URL. Returns ``_BACK`` on empty submit.
 
     A local deployment is reached by address, not by key -- there is nothing to
-    authenticate against a server the user is running. The registry's
-    `default_api_base` is seeded because it is right for a default install, so
-    accepting it is one keystroke; clearing the field still rewinds.
+    authenticate against a server the user is running.
+
+    The field is seeded with the address already configured, falling back to the
+    registry default for a first-time setup. Seeding the default unconditionally
+    meant reconfiguring a server at some other address offered localhost, and
+    pressing Enter to move on replaced a working address with it.
     """
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
@@ -669,7 +701,7 @@ def _prompt_local_api_base(spec: Any, *, allow_back: bool = False) -> Any:
 
     url = questionary.text(
         _t(f"{spec.label} server URL:", f"{spec.label} 服务地址:"),
-        default=spec.default_api_base or "",
+        default=current or (spec.default_api_base if spec else "") or "",
         validate=_validate,
         placeholder=_back_placeholder(allow_back),
         style=RAVEN_STYLE,
@@ -899,8 +931,13 @@ def _model_routes_to_provider(model: str, spec: Any) -> bool:
 
 
 def _format_model_for_provider(spec: Any, model_id: str) -> str:
-    """Apply the provider's model prefix to a raw ``/v1/models`` id when needed."""
-    if not model_id:
+    """Apply the provider's model prefix to a raw ``/v1/models`` id when needed.
+
+    ``spec`` is None for a vendor only LiteLLM knows. Those need no prefixing
+    here: the id the vendor returned already routes, because the section name
+    the user configured is the name LiteLLM routes on.
+    """
+    if not model_id or spec is None:
         return model_id
     if spec.name in {"minimax_global", "minimax_cn"}:
         public_prefix = spec.name.replace("_", "-")
@@ -919,6 +956,7 @@ def _format_model_for_provider(spec: Any, model_id: str) -> str:
 
 
 def _pick_model(
+    provider: str,
     spec: Any,
     *,
     current_model: Optional[str],
@@ -931,19 +969,18 @@ def _pick_model(
         return user_provided_model
 
     if non_interactive:
-        if not spec.default_model:
-            raise typer.BadParameter(
-                f"--model is required for provider '{spec.name}' (no built-in default model in registry)."
-            )
-        return spec.default_model
+        default_model = spec.default_model if spec else ""
+        if not default_model:
+            raise typer.BadParameter(f"--model is required for provider '{provider}' (no built-in default model).")
+        return default_model
 
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
 
-    if current_model and _model_routes_to_provider(current_model, spec):
+    if current_model and spec and _model_routes_to_provider(current_model, spec):
         default_value = current_model
     else:
-        default_value = spec.default_model or ""
+        default_value = (spec.default_model if spec else "") or ""
 
     # A live fetch is the best answer when there is one; when there is not, the
     # same chain the TUI picker offers beats an empty prompt. Eleven providers
@@ -952,7 +989,7 @@ def _pick_model(
     if not model_ids:
         from raven.providers.common_models import common_models_for, litellm_models_for
 
-        known = [*common_models_for(spec.name), *litellm_models_for(spec.name)]
+        known = [*common_models_for(provider), *litellm_models_for(provider)]
         if known:
             console.print(
                 _t(
@@ -1001,7 +1038,7 @@ def _pick_model(
             ).ask()
         else:
             chosen = questionary.text(
-                _t(f"Default model id for {spec.name}:", f"{spec.name} 的默认模型 id:"),
+                _t(f"Default model id for {provider}:", f"{provider} 的默认模型 id:"),
                 validate=lambda v: True if v.strip() else _t("Model id is required.", "必须指定模型 id。"),
                 style=RAVEN_STYLE,
                 qmark=_QMARK,
@@ -1182,7 +1219,15 @@ def _configure_one_provider(
                 raise typer.Exit(1)
             if picked is _BACK:
                 return None
-            provider = picked
+            # Same gate as the flag path: the vendor step lets the user type a
+            # name, and a typo there used to reach the config layer as an
+            # uncaught KeyError that tore down the wizard mid-setup.
+            try:
+                provider = _validate_provider_name(picked)
+            except typer.BadParameter as exc:
+                console.print(f"  [red]x[/red] {exc}")
+                flag_provider = None
+                continue
 
         spec = find_by_name(provider)
         is_oauth = bool(spec and spec.is_oauth)
@@ -1227,6 +1272,7 @@ def _configure_one_provider(
             continue
 
         chosen_model = _resolve_model_with_test(
+            provider,
             spec,
             is_custom=is_custom,
             custom_model=custom_model,
@@ -1237,14 +1283,19 @@ def _configure_one_provider(
         )
         if chosen_model is None:
             # "Switch provider" — re-run the picker (drop the flag so the second
-            # pass prompts rather than reusing the failed flag value). Roll back
-            # the just-written key: clear it if this provider was newly added this
-            # pass, or restore the prior key if we were reconfiguring an existing
-            # one (so a failed edit doesn't clobber a working provider).
+            # pass prompts rather than reusing the failed flag value), undoing
+            # what this pass wrote.
+            #
+            # Restore both fields, not just the key: a local deployment is
+            # configured by address and has no key at all, so keying the rollback
+            # off `old_key` skipped it entirely and a mistyped address replaced a
+            # working one for good. Clearing only the key had the same shape --
+            # it left the bad api_base behind as a section that looks configured
+            # and reaches nothing.
             if provider not in configured_before:
-                _write_provider_fields(provider, {"api_key": ""})
-            elif old_key:
-                _write_provider_fields(provider, {"api_key": old_key, "api_base": old_base})
+                _write_provider_fields(provider, {"api_key": "", "api_base": None})
+            else:
+                _write_provider_fields(provider, {"api_key": old_key or "", "api_base": old_base})
             flag_provider = None
             continue
         _persist_default_model(chosen_model)
@@ -1297,10 +1348,26 @@ def _collect_credentials(
         from raven.providers.registry import find_by_name
 
         spec = find_by_name(provider)
+        if api_key:
+            # Said out loud rather than dropped: a local deployment writes no
+            # api_key, so silently ignoring the flag looks like it was accepted.
+            raise typer.BadParameter(
+                f"{provider} is a local deployment and takes no --api-key; pass --base-url instead"
+            )
+        if base_url and not base_url.strip().startswith(("http://", "https://")):
+            # The interactive prompt validates this; the flag path did not, so a
+            # scheme-less address went into the config and failed at first use.
+            raise typer.BadParameter(f"--base-url must start with http:// or https:// (got {base_url!r})")
         if not base_url:
             if non_interactive:
                 raise typer.BadParameter(f"--base-url is required for {provider} in non-interactive mode")
-            base_url = _prompt_local_api_base(spec, allow_back=True)
+            from raven.config.update_providers import get_provider_config
+
+            try:
+                stored = get_provider_config(provider, redact_secrets=False).get("api_base") or ""
+            except KeyError:
+                stored = ""
+            base_url = _prompt_local_api_base(spec, current=stored, allow_back=True)
             if base_url is _BACK:
                 return _BACK
             if base_url is None:
@@ -1352,6 +1419,7 @@ def _collect_credentials(
 
 
 def _resolve_model_with_test(
+    provider: str,
     spec: Any,
     *,
     is_custom: bool,
@@ -1370,15 +1438,20 @@ def _resolve_model_with_test(
     provider" (the caller rewinds to the picker).
     """
     while True:
-        ok, status, model_ids = _verify_provider(spec.name, skip_test=skip_test)
+        ok, status, model_ids = _verify_provider(provider, skip_test=skip_test)
         if not ok:
             options = (
                 [(_t("Retry", "重试"), "retry"), (_t("Continue anyway", "仍然继续"), "continue")]
                 if status == "network_error"
                 else [
+                    # What to offer depends on what the provider is reached by.
+                    # A local deployment has no key to re-enter, so offering that
+                    # left a mistyped address with no way back to the field.
                     (
                         (_t("Sign in again", "重新登录"), "reauth")
-                        if spec.is_oauth
+                        if spec and spec.is_oauth
+                        else (_t("Re-enter server URL", "重新填服务地址"), "rebase")
+                        if spec and spec.is_local
                         else (_t("Re-enter key", "重新填 Key"), "rekey")
                     ),
                     (_t("Switch provider", "更换服务商"), "switch"),
@@ -1389,10 +1462,22 @@ def _resolve_model_with_test(
             if choice == "retry":
                 continue
             if choice == "rekey" and not non_interactive:
-                _write_provider_fields(spec.name, {"api_key": _prompt_api_key(spec.name)})
+                _write_provider_fields(provider, {"api_key": _prompt_api_key(provider)})
+                continue
+            if choice == "rebase" and not non_interactive:
+                from raven.config.update_providers import get_provider_config
+
+                try:
+                    stored = get_provider_config(provider, redact_secrets=False).get("api_base") or ""
+                except KeyError:
+                    stored = ""
+                retyped = _prompt_local_api_base(spec, current=stored)
+                if retyped is None:
+                    return None
+                _write_provider_fields(provider, {"api_base": retyped})
                 continue
             if choice == "reauth" and not non_interactive:
-                if _run_oauth_login(spec.name):
+                if _run_oauth_login(provider):
                     continue
                 return None
             if choice == "switch":
@@ -1410,17 +1495,18 @@ def _resolve_model_with_test(
         if skip_test:
             return custom_model
         while True:
-            result = _run_test_probe(spec.name, non_interactive=non_interactive, warnings=warnings, allow_repick=False)
+            result = _run_test_probe(provider, non_interactive=non_interactive, warnings=warnings, allow_repick=False)
             if result == "switch":
                 return None
             if result == "rekey":
-                _write_provider_fields(spec.name, {"api_key": _prompt_api_key(spec.name)})
+                _write_provider_fields(provider, {"api_key": _prompt_api_key(provider)})
                 continue
             return custom_model  # ok / continue
 
     current = _load_current_default_model()
     while True:
         chosen = _pick_model(
+            provider,
             spec,
             current_model=current,
             model_ids=model_ids,
@@ -1431,21 +1517,21 @@ def _resolve_model_with_test(
         if skip_test:
             return chosen
         result = _run_test_probe(
-            spec.name,
+            provider,
             non_interactive=non_interactive,
             warnings=warnings,
-            is_oauth=spec.is_oauth,
+            is_oauth=bool(spec and spec.is_oauth),
         )
         if result == "switch":
             return None
         if result == "rekey":
-            _write_provider_fields(spec.name, {"api_key": _prompt_api_key(spec.name)})
+            _write_provider_fields(provider, {"api_key": _prompt_api_key(provider)})
             # Re-test the same model with the new key (picker defaults to it).
             current = chosen
             user_model_flag = None
             continue
         if result == "reauth":
-            if not _run_oauth_login(spec.name):
+            if not _run_oauth_login(provider):
                 return None
             current = chosen
             user_model_flag = None
@@ -1485,6 +1571,7 @@ def _configure_existing_provider_model(*, non_interactive: bool) -> bool:
     if not ok:
         return False
     chosen = _pick_model(
+        provider,
         spec,
         current_model=None,
         model_ids=model_ids,
@@ -1512,6 +1599,7 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
     """Edit/remove submenu for already-configured providers (interactive only)."""
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
+    from raven.providers.registry import find_by_name
 
     while True:
         configured = _configured_providers()
@@ -1547,7 +1635,23 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
         if action is None or action is _BACK:
             continue
         if action == "update":
-            _write_provider_fields(target, {"api_key": _prompt_api_key(target)})
+            target_spec = find_by_name(target)
+            if target_spec and target_spec.is_local:
+                # A local deployment holds no key; what there is to update is
+                # where it lives. Offering the key prompt wrote a credential into
+                # a provider that never reads one, and left the address alone.
+                from raven.config.update_providers import get_provider_config
+
+                try:
+                    stored = get_provider_config(target, redact_secrets=False).get("api_base") or ""
+                except KeyError:
+                    stored = ""
+                retyped = _prompt_local_api_base(target_spec, current=stored)
+                if retyped is None:
+                    continue
+                _write_provider_fields(target, {"api_base": retyped})
+            else:
+                _write_provider_fields(target, {"api_key": _prompt_api_key(target)})
             console.print(
                 _t(
                     f"  [green]✓ Updated {_provider_label(target)}.[/green]",
@@ -1581,7 +1685,10 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
                 ).ask()
                 if not confirm:
                     continue
-            _write_provider_fields(target, {"api_key": ""})
+            # Clear both: a local deployment counts as configured by its
+            # api_base, so clearing only the key reported it removed and left it
+            # in the list, still reachable.
+            _write_provider_fields(target, {"api_key": "", "api_base": None})
             if was_default_source:
                 # Clear the now-dangling default so step 1's guard forces a
                 # re-pick instead of leaving a model whose provider has no key.
@@ -4450,7 +4557,11 @@ def register(app: typer.Typer) -> None:
     def onboard(
         provider: Optional[str] = typer.Option(None, "--provider", help="LLM provider name (skips Step 1's prompt)"),
         api_key: Optional[str] = typer.Option(None, "--api-key", help="API key for the chosen provider"),
-        base_url: Optional[str] = typer.Option(None, "--base-url", help="Custom OpenAI-compatible base URL"),
+        base_url: Optional[str] = typer.Option(
+            None,
+            "--base-url",
+            help="Server URL: required for a local deployment (ollama_chat / hosted_vllm), or a custom OpenAI-compatible endpoint",
+        ),
         model: Optional[str] = typer.Option(None, "--model", help="Default model id (e.g. 'openai/gpt-4o-mini')"),
         channel: Optional[str] = typer.Option(None, "--channel", help="Channel to enable in Step 3"),
         skip_sandbox: bool = typer.Option(False, "--skip-sandbox", help="Skip Step 2 (run location)"),

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -119,6 +119,17 @@ _CURATED_GROUPS: list[dict[str, Any]] = [
             {"name": "openai", "label": "OpenAI", "label_zh": "OpenAI"},
             {"name": "anthropic", "label": "Anthropic", "label_zh": "Anthropic"},
             {"name": "gemini", "label": "Gemini", "label_zh": "Gemini"},
+            # Marked because EverMind and MiniMax collaborate in the open, not
+            # because it ranks differently on capability -- "open-source" rather
+            # than a bare "partner", which in a list of vendors reads as paid
+            # placement. The OAuth MiniMax entries carry no marker: the same
+            # vendor is already marked here, and stacking it on "(OAuth)" makes
+            # the row twice as long for nothing.
+            {
+                "name": "minimax",
+                "label": "MiniMax (open-source partner)",
+                "label_zh": "MiniMax(开源合作伙伴)",
+            },
             {"name": "deepseek", "label": "DeepSeek", "label_zh": "DeepSeek"},
             {"name": "zai", "label": "Z.ai (Zhipu)", "label_zh": "Z.ai(智谱)"},
             {"name": "dashscope", "label": "DashScope", "label_zh": "阿里云百炼"},
@@ -126,7 +137,6 @@ _CURATED_GROUPS: list[dict[str, Any]] = [
             {"name": "volcengine", "label": "VolcEngine", "label_zh": "火山方舟"},
             {"name": "siliconflow", "label": "SiliconFlow", "label_zh": "硅基流动"},
             {"name": "groq", "label": "Groq", "label_zh": "Groq"},
-            {"name": "minimax", "label": "MiniMax", "label_zh": "MiniMax"},
             {"name": "aihubmix", "label": "AiHubMix", "label_zh": "AiHubMix"},
             {"name": "azure_openai", "label": "Azure OpenAI", "label_zh": "Azure OpenAI"},
         ],
@@ -160,8 +170,8 @@ _CURATED_GROUPS: list[dict[str, Any]] = [
         "providers": [
             {
                 "name": _PICK_LITELLM_VENDOR,
-                "label": "Another vendor LiteLLM supports (type to filter)",
-                "label_zh": "其他厂商(LiteLLM 支持的 - 输入可筛选)",
+                "label": "Another supported vendor (type to search)",
+                "label_zh": "其他支持的厂商(输入可搜索)",
             },
             {
                 "name": "custom",
@@ -582,8 +592,8 @@ def _prompt_litellm_vendor() -> Optional[str]:
 
     typed = questionary.autocomplete(
         _t(
-            f"Vendor name ({len(choices)} available - type to filter, Tab to complete, empty to go back):",
-            f"厂商名({len(choices)} 家 — 输入可筛选,Tab 补全,留空返回):",
+            f"Vendor name ({len(choices)} supported - type to search, Tab to complete, empty to go back):",
+            f"厂商名(支持 {len(choices)} 家 — 输入可搜索,Tab 补全,留空返回):",
         ),
         choices=choices,
         style=RAVEN_STYLE,

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -580,9 +580,7 @@ def _select_provider() -> Optional[str]:
         if typed is not _BACK:
             return typed
         picked = _select_provider_row()
-        if picked is None or picked is _BACK:
-            return picked
-    return picked  # None on Ctrl+C
+    return picked  # _BACK on back, None on Ctrl+C
 
 
 def _litellm_vendor_choices() -> list[str]:

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -945,8 +945,28 @@ def _pick_model(
     else:
         default_value = spec.default_model or ""
 
+    # A live fetch is the best answer when there is one; when there is not, the
+    # same chain the TUI picker offers beats an empty prompt. Eleven providers
+    # carry no curated shortlist, so before this a failed fetch left the user
+    # typing a model id from memory.
+    if not model_ids:
+        from raven.providers.common_models import common_models_for, litellm_models_for
+
+        known = [*common_models_for(spec.name), *litellm_models_for(spec.name)]
+        if known:
+            console.print(
+                _t(
+                    "  [dim]Couldn't reach the provider for its model list - offering the ones we know.[/dim]",
+                    "  [dim]未能向服务商拉取模型列表,先列出已知的。[/dim]",
+                )
+            )
+            model_ids = known
+
     if model_ids:
         choices = [_format_model_for_provider(spec, mid) for mid in model_ids]
+        # Dedupe: the chain above already prefixes its ids, and _format_ leaves a
+        # correctly-prefixed id alone, so two sources can agree on one model.
+        choices = list(dict.fromkeys(choices))
         if default_value and default_value not in choices:
             choices.insert(0, default_value)
         prompt_label = _t(

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -647,6 +647,42 @@ def _prompt_api_key(provider: str, *, allow_back: bool = False, back_label: Opti
     return key
 
 
+def _prompt_local_api_base(spec: Any, *, allow_back: bool = False) -> Any:
+    """Ask a local deployment for its server URL. Returns ``_BACK`` on empty submit.
+
+    A local deployment is reached by address, not by key -- there is nothing to
+    authenticate against a server the user is running. The registry's
+    `default_api_base` is seeded because it is right for a default install, so
+    accepting it is one keystroke; clearing the field still rewinds.
+    """
+    questionary = _require_questionary()
+    from raven.cli._styles import RAVEN_STYLE
+
+    def _validate(v: str) -> Any:
+        if allow_back and v.strip() == "":
+            return True
+        return (
+            True
+            if v.strip().startswith(("http://", "https://"))
+            else _t("URL must start with http:// or https://", "地址需以 http:// 或 https:// 开头")
+        )
+
+    url = questionary.text(
+        _t(f"{spec.label} server URL:", f"{spec.label} 服务地址:"),
+        default=spec.default_api_base or "",
+        validate=_validate,
+        placeholder=_back_placeholder(allow_back),
+        style=RAVEN_STYLE,
+        qmark=_QMARK,
+    ).ask()
+    if url is None:
+        return None
+    url = url.strip()
+    if allow_back and not url:
+        return _BACK
+    return url
+
+
 def _prompt_base_url(default: str = "https://", *, allow_back: bool = False) -> Any:
     """Ask for an OpenAI-compatible base URL (used by the 'custom' provider).
     Returns ``_BACK`` on empty submit when ``allow_back`` is set."""
@@ -781,8 +817,16 @@ def _verify_provider(provider: str, *, skip_test: bool = False) -> tuple[bool, s
     ``network_error`` / …) and drives the failure submenu's wording.
     """
     from raven.config.update_providers import test_provider as probe
+    from raven.providers.registry import find_by_name
 
-    console.print(_t("  [dim]⏳ Verifying your API key…[/dim]", "  [dim]⏳ 正在验证 API Key…[/dim]"))
+    spec = find_by_name(provider)
+    # A local deployment has no key to verify -- what is being checked is that
+    # the address answers, and saying "API key" there describes a field the user
+    # was never asked for.
+    if spec and spec.is_local:
+        console.print(_t("  [dim]⏳ Reaching the server…[/dim]", "  [dim]⏳ 正在连接服务…[/dim]"))
+    else:
+        console.print(_t("  [dim]⏳ Verifying your API key…[/dim]", "  [dim]⏳ 正在验证 API Key…[/dim]"))
     result = probe(provider)
     if result["ok"]:
         models = result.get("models_count")
@@ -1150,6 +1194,7 @@ def _configure_one_provider(
             provider,
             is_oauth=is_oauth,
             is_custom=is_custom,
+            is_local=bool(spec and spec.is_local),
             api_key=api_key,
             base_url=base_url,
             model=model,
@@ -1191,6 +1236,7 @@ def _collect_credentials(
     *,
     is_oauth: bool,
     is_custom: bool,
+    is_local: bool = False,
     api_key: Optional[str],
     base_url: Optional[str],
     model: Optional[str],
@@ -1223,6 +1269,24 @@ def _collect_credentials(
             if choice == "retry":
                 continue
             return _BACK
+
+    if is_local:
+        # A local deployment authenticates on nothing: it is reached by address.
+        # Routing it through the api_key prompt would stop the user at a
+        # minimum-length check for a credential that does not exist.
+        from raven.providers.registry import find_by_name
+
+        spec = find_by_name(provider)
+        if not base_url:
+            if non_interactive:
+                raise typer.BadParameter(f"--base-url is required for {provider} in non-interactive mode")
+            base_url = _prompt_local_api_base(spec, allow_back=True)
+            if base_url is _BACK:
+                return _BACK
+            if base_url is None:
+                raise typer.Exit(1)
+        _write_provider_fields(provider, {"api_base": base_url})
+        return None
 
     # Pure interactive path (no creds came from flags): prompt field-by-field
     # with empty-submit = back; backing out of the first field rewinds to the

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -100,36 +100,81 @@ def _t(en: str, zh: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+# Sentinel entries the picker renders as its own step rather than a provider.
+_PICK_LITELLM_VENDOR = "__litellm_vendor__"
+
+# Every provider we carry a spec for, grouped the way the picker shows them.
+# Ordered by expected use inside each group; the groups themselves are what a
+# user scans for, so a provider is never hidden the way eight of them were when
+# this list was a hand-picked subset of the registry.
+_CURATED_GROUPS: list[dict[str, Any]] = [
+    {
+        "kind": "api_key",
+        "providers": [
+            {
+                "name": "openrouter",
+                "label": "OpenRouter (recommended - one key, many models)",
+                "label_zh": "OpenRouter(推荐 · 一个 Key 调用多家模型)",
+            },
+            {"name": "openai", "label": "OpenAI", "label_zh": "OpenAI"},
+            {"name": "anthropic", "label": "Anthropic", "label_zh": "Anthropic"},
+            {"name": "gemini", "label": "Gemini", "label_zh": "Gemini"},
+            {"name": "deepseek", "label": "DeepSeek", "label_zh": "DeepSeek"},
+            {"name": "zai", "label": "Z.ai (Zhipu)", "label_zh": "Z.ai(智谱)"},
+            {"name": "dashscope", "label": "DashScope", "label_zh": "阿里云百炼"},
+            {"name": "moonshot", "label": "Moonshot", "label_zh": "Moonshot(月之暗面)"},
+            {"name": "volcengine", "label": "VolcEngine", "label_zh": "火山方舟"},
+            {"name": "siliconflow", "label": "SiliconFlow", "label_zh": "硅基流动"},
+            {"name": "groq", "label": "Groq", "label_zh": "Groq"},
+            {"name": "minimax", "label": "MiniMax", "label_zh": "MiniMax"},
+            {"name": "aihubmix", "label": "AiHubMix", "label_zh": "AiHubMix"},
+            {"name": "azure_openai", "label": "Azure OpenAI", "label_zh": "Azure OpenAI"},
+        ],
+    },
+    {
+        "kind": "oauth",
+        "providers": [
+            {
+                "name": "github_copilot",
+                "label": "GitHub Copilot (OAuth)",
+                "label_zh": "GitHub Copilot(OAuth 登录)",
+            },
+            {"name": "openai_codex", "label": "OpenAI Codex (OAuth)", "label_zh": "OpenAI Codex(OAuth 登录)"},
+            {
+                "name": "minimax_global",
+                "label": "MiniMax Global (OAuth)",
+                "label_zh": "MiniMax Global(OAuth 登录)",
+            },
+            {"name": "minimax_cn", "label": "MiniMax CN (OAuth)", "label_zh": "MiniMax CN(OAuth 登录)"},
+        ],
+    },
+    {
+        "kind": "local",
+        "providers": [
+            {"name": "ollama_chat", "label": "Ollama (local)", "label_zh": "Ollama(本地)"},
+            {"name": "hosted_vllm", "label": "vLLM / self-hosted", "label_zh": "vLLM / 自托管"},
+        ],
+    },
+    {
+        "kind": "fallback",
+        "providers": [
+            {
+                "name": _PICK_LITELLM_VENDOR,
+                "label": "Another vendor LiteLLM supports (type to filter)",
+                "label_zh": "其他厂商(LiteLLM 支持的 - 输入可筛选)",
+            },
+            {
+                "name": "custom",
+                "label": "Self-hosted OpenAI-compatible endpoint",
+                "label_zh": "自建 OpenAI 兼容端点",
+            },
+        ],
+    },
+]
+
+# Flat view for callers that only need "which providers does the wizard offer".
 _CURATED_PROVIDERS: list[dict[str, Any]] = [
-    {
-        "name": "openrouter",
-        "label": "OpenRouter (recommended — one key, many models)",
-        "label_zh": "OpenRouter(推荐 · 一个 Key 调用多家模型)",
-    },
-    {"name": "openai", "label": "OpenAI", "label_zh": "OpenAI"},
-    {"name": "anthropic", "label": "Anthropic", "label_zh": "Anthropic"},
-    {"name": "gemini", "label": "Gemini", "label_zh": "Gemini"},
-    {"name": "deepseek", "label": "DeepSeek", "label_zh": "DeepSeek"},
-    {"name": "zai", "label": "Z.ai (Zhipu)", "label_zh": "Z.ai(智谱)"},
-    {"name": "dashscope", "label": "DashScope", "label_zh": "阿里云百炼"},
-    {"name": "groq", "label": "Groq", "label_zh": "Groq"},
-    {
-        "name": "github_copilot",
-        "label": "GitHub Copilot (OAuth)",
-        "label_zh": "GitHub Copilot(OAuth 登录)",
-    },
-    {"name": "openai_codex", "label": "Codex (OAuth)", "label_zh": "Codex(OAuth 登录)"},
-    {
-        "name": "minimax_global",
-        "label": "MiniMax Global (OAuth)",
-        "label_zh": "MiniMax Global(OAuth 登录)",
-    },
-    {"name": "minimax_cn", "label": "MiniMax CN (OAuth)", "label_zh": "MiniMax CN(OAuth 登录)"},
-    {
-        "name": "custom",
-        "label": "Other (OpenAI-compatible endpoint)",
-        "label_zh": "其他(OpenAI 兼容端点)",
-    },
+    entry for group in _CURATED_GROUPS for entry in group["providers"] if entry["name"] != _PICK_LITELLM_VENDOR
 ]
 
 _QUESTIONARY_INSTALL_HINT = (
@@ -478,13 +523,20 @@ def _select_provider() -> Optional[str]:
     questionary = _require_questionary()
     from raven.cli._styles import RAVEN_STYLE
 
-    choices: list[Any] = [
-        questionary.Choice(
-            _t(entry["label"], entry.get("label_zh", entry["label"])),
-            value=entry["name"],
-        )
-        for entry in _CURATED_PROVIDERS
-    ]
+    choices: list[Any] = []
+    for group in _CURATED_GROUPS:
+        # A rule between groups, so the API-key providers, the OAuth ones, the
+        # local deployments and the two fallbacks read as four decisions rather
+        # than one list of twenty.
+        if choices:
+            choices.append(questionary.Separator())
+        for entry in group["providers"]:
+            choices.append(
+                questionary.Choice(
+                    _t(entry["label"], entry.get("label_zh", entry["label"])),
+                    value=entry["name"],
+                )
+            )
     choices.append(questionary.Separator())
     choices.append(questionary.Choice(_t("Back", "返回"), value=_BACK))
 
@@ -494,7 +546,59 @@ def _select_provider() -> Optional[str]:
         style=RAVEN_STYLE,
         qmark=_QMARK,
     ).ask()
+    if picked == _PICK_LITELLM_VENDOR:
+        # Second step rather than a hundred more rows: LiteLLM routes to far more
+        # vendors than anyone wants to scroll, and typing the name is how someone
+        # who already knows which one they want gets there.
+        return _prompt_litellm_vendor()
     return picked  # None on Ctrl+C
+
+
+def _litellm_vendor_choices() -> list[str]:
+    """Vendor names for the second step: the ones the picker does not already show.
+
+    Read from the packaged snapshot rather than LiteLLM itself, so offering them
+    costs no import on a path that only renders choices.
+    """
+    from raven.providers.litellm_provider_names import LITELLM_PROVIDER_NAMES
+    from raven.providers.registry import normalize_provider_name
+
+    already_listed = {normalize_provider_name(e["name"]) for e in _CURATED_PROVIDERS}
+    return sorted(n for n in LITELLM_PROVIDER_NAMES if normalize_provider_name(n) not in already_listed)
+
+
+def _prompt_litellm_vendor() -> Optional[str]:
+    """Ask for a vendor by name, completing against the ones LiteLLM routes to.
+
+    Returns the provider name, ``_BACK`` to rewind to the picker, or ``None`` on
+    Ctrl+C. The names come from the packaged snapshot, so offering them costs no
+    LiteLLM import.
+    """
+    questionary = _require_questionary()
+    from raven.cli._styles import RAVEN_STYLE
+    from raven.providers.registry import normalize_provider_name
+
+    choices = _litellm_vendor_choices()
+
+    typed = questionary.autocomplete(
+        _t(
+            f"Vendor name ({len(choices)} available - type to filter, Tab to complete, empty to go back):",
+            f"厂商名({len(choices)} 家 — 输入可筛选,Tab 补全,留空返回):",
+        ),
+        choices=choices,
+        style=RAVEN_STYLE,
+        qmark=_QMARK,
+        ignore_case=True,
+        match_middle=True,
+    ).ask()
+    if typed is None:
+        return None
+    typed = typed.strip()
+    if not typed:
+        return _BACK
+    # Not validated here: the write path already rejects a name LiteLLM does not
+    # know, and it is the one that has to be right.
+    return normalize_provider_name(typed)
 
 
 def _prompt_api_key(provider: str, *, allow_back: bool = False, back_label: Optional[str] = None) -> Any:

--- a/raven/config/update_providers.py
+++ b/raven/config/update_providers.py
@@ -175,7 +175,7 @@ def _provider_schema_cls(name: str, *, authoritative: bool = True) -> type[BaseM
             return ProviderConfig
         raise KeyError(
             f"Unknown provider '{name}'. Available providers: {sorted(_provider_names())}. "
-            "Any other vendor LiteLLM supports also works, spelled as LiteLLM names it."
+            "Many more vendors are supported -- try the name the vendor uses for itself."
         )
     ann = _unwrap_optional(field.annotation)
     if not _is_model_class(ann):

--- a/raven/providers/common_models.py
+++ b/raven/providers/common_models.py
@@ -147,17 +147,18 @@ def _cached_chat_models_by_provider() -> dict[str, tuple[str, ...]]:
     speech models, and offering those where a chat model is asked for produces a
     selection that fails on first use.
     """
-    import os
     from collections import defaultdict
-
-    # Read the copy shipped inside litellm rather than the one it fetches from
-    # GitHub on import: the remote answer is a different set (90 OpenAI models
-    # against 98) and it arrives over a 5-second-timeout request, so without this
-    # the candidate list depends on the network and costs a round trip.
-    os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
 
     from raven.providers.litellm_setup import import_litellm
 
+    # Whatever table LiteLLM itself is using, deliberately. Forcing the packaged
+    # copy here looked like it bought determinism and did not: setting the
+    # environment variable has no effect once LiteLLM has been imported, so the
+    # answer still depended on import order -- and where it did take effect it
+    # pinned the whole process to a table that is 278 entries behind, which is
+    # how `claude-sonnet-5` (this project's own default) stopped having a known
+    # context window. Candidates now agree with what pricing and context-window
+    # lookups see, which matters more than agreeing across machines.
     catalogue = import_litellm().model_cost
 
     by_provider: dict[str, list[str]] = defaultdict(list)

--- a/raven/providers/common_models.py
+++ b/raven/providers/common_models.py
@@ -124,8 +124,20 @@ def common_models_for(slug: str) -> list[str]:
     return list(COMMON_MODELS.get(slug, []))
 
 
+def _is_priced_template(model: str) -> bool:
+    """Is this a price-book row rather than something callable?
+
+    The catalogue doubles as a price list, so it carries entries no request can
+    name: "ft:gpt-4o-..." states what a model fine-tuned from that base costs,
+    and "container" bills a code-interpreter session. Sorted alphabetically they
+    led OpenAI's candidates, so the first dozen rows a user saw were unusable.
+    """
+    bare = model.split("/", 1)[-1]
+    return bare.startswith("ft:") or bare == "container"
+
+
 @lru_cache(maxsize=1)
-def _litellm_chat_models_by_provider() -> dict[str, tuple[str, ...]]:
+def _cached_chat_models_by_provider() -> dict[str, tuple[str, ...]]:
     """LiteLLM's own catalogue, indexed by the provider it belongs to.
 
     Built once and cached: reading it imports LiteLLM, which costs about two
@@ -135,23 +147,46 @@ def _litellm_chat_models_by_provider() -> dict[str, tuple[str, ...]]:
     speech models, and offering those where a chat model is asked for produces a
     selection that fails on first use.
     """
+    import os
     from collections import defaultdict
+
+    # Read the copy shipped inside litellm rather than the one it fetches from
+    # GitHub on import: the remote answer is a different set (90 OpenAI models
+    # against 98) and it arrives over a 5-second-timeout request, so without this
+    # the candidate list depends on the network and costs a round trip.
+    os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
 
     from raven.providers.litellm_setup import import_litellm
 
-    try:
-        catalogue = import_litellm().model_cost
-    except Exception:
-        return {}
+    catalogue = import_litellm().model_cost
 
     by_provider: dict[str, list[str]] = defaultdict(list)
     for model, info in catalogue.items():
         if not isinstance(info, dict) or info.get("mode") != "chat":
             continue
+        if _is_priced_template(model):
+            continue
         provider = info.get("litellm_provider")
         if provider:
             by_provider[provider].append(model)
     return {provider: tuple(sorted(models)) for provider, models in by_provider.items()}
+
+
+def _litellm_chat_models_by_provider() -> dict[str, tuple[str, ...]]:
+    """The cached index, except that a failure is not what gets cached.
+
+    `lru_cache` remembers whatever the call returned, so caching an empty result
+    from a transient import failure would leave the picker permanently empty for
+    the life of the process with no way to retry.
+    """
+    try:
+        index = _cached_chat_models_by_provider()
+    except Exception:
+        _cached_chat_models_by_provider.cache_clear()
+        return {}
+    if not index:
+        _cached_chat_models_by_provider.cache_clear()
+    return index
 
 
 def litellm_models_for(slug: str) -> list[str]:
@@ -167,10 +202,18 @@ def litellm_models_for(slug: str) -> list[str]:
     do not -- and offering a bare id would route it by keyword rather than to the
     provider the user picked.
     """
-    from raven.providers.registry import find_by_name
+    from raven.providers.registry import find_by_name, normalize_provider_name
 
     spec = find_by_name(slug)
     if spec is None:
+        return []
+    if normalize_provider_name(spec.model_prefix) not in spec.route_names:
+        # The wire prefix names somebody else -- this provider is reached through
+        # another vendor's driver. Prefixing candidates with it would hand the
+        # user ids that resolve to the driver's owner instead of to the provider
+        # they picked. Today the catalogue has no rows for those five, so the
+        # loop below would be empty anyway; the guard states the rule rather than
+        # relying on what LiteLLM happens to contain.
         return []
     index = _litellm_chat_models_by_provider()
     prefix = spec.model_prefix

--- a/raven/providers/common_models.py
+++ b/raven/providers/common_models.py
@@ -190,6 +190,23 @@ def _litellm_chat_models_by_provider() -> dict[str, tuple[str, ...]]:
     return index
 
 
+def _litellm_spelling_for(slug: str) -> str:
+    """How LiteLLM spells this vendor, which is the only form usable as a prefix.
+
+    Section names are matched spelling-insensitively, so the name arriving here
+    may be underscored where LiteLLM hyphenates -- and LiteLLM rejects the
+    underscored form outright.
+    """
+    from raven.providers.litellm_provider_names import LITELLM_PROVIDER_NAMES
+    from raven.providers.registry import normalize_provider_name
+
+    wanted = normalize_provider_name(slug)
+    for name in LITELLM_PROVIDER_NAMES:
+        if normalize_provider_name(name) == wanted:
+            return name
+    return wanted
+
+
 def litellm_models_for(slug: str) -> list[str]:
     """Chat models LiteLLM knows for this provider, as ids that actually route.
 
@@ -207,7 +224,23 @@ def litellm_models_for(slug: str) -> list[str]:
 
     spec = find_by_name(slug)
     if spec is None:
-        return []
+        # A vendor Raven carries no spec for still has rows in the catalogue --
+        # 51 for Mistral, 219 for Bedrock, 270 for Fireworks. Returning nothing
+        # left those providers with no candidates at all, which pushed the user
+        # into typing a bare id: the shape that gets routed to whoever a keyword
+        # matches.
+        #
+        # The rows are inconsistent about the prefix -- Mistral's carry it,
+        # Bedrock's do not -- so they are normalized here rather than trusted.
+        # Offering an unprefixed one would reintroduce the very thing this exists
+        # to avoid.
+        index = _litellm_chat_models_by_provider()
+        prefix = _litellm_spelling_for(slug)
+        out: list[str] = []
+        for model in index.get(normalize_provider_name(slug), ()):
+            bare = model[len(prefix) + 1 :] if model.startswith(f"{prefix}/") else model
+            out.append(f"{prefix}/{bare}")
+        return out
     if normalize_provider_name(spec.model_prefix) not in spec.route_names:
         # The wire prefix names somebody else -- this provider is reached through
         # another vendor's driver. Prefixing candidates with it would hand the

--- a/raven/providers/common_models.py
+++ b/raven/providers/common_models.py
@@ -15,6 +15,8 @@ Providers not listed here fall back to their configured list.
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 COMMON_MODELS: dict[str, list[str]] = {
     # Carries the "openrouter/" prefix like this provider's default_model does.
     # Bare OpenRouter ids start with the upstream vendor ("anthropic/...",
@@ -120,3 +122,65 @@ COMMON_MODELS: dict[str, list[str]] = {
 def common_models_for(slug: str) -> list[str]:
     """Return a copy of the curated common-model shortlist for ``slug``."""
     return list(COMMON_MODELS.get(slug, []))
+
+
+@lru_cache(maxsize=1)
+def _litellm_chat_models_by_provider() -> dict[str, tuple[str, ...]]:
+    """LiteLLM's own catalogue, indexed by the provider it belongs to.
+
+    Built once and cached: reading it imports LiteLLM, which costs about two
+    seconds, so callers must be somewhere a user is already waiting.
+
+    Only ``mode == "chat"`` survives. The catalogue also carries embedding and
+    speech models, and offering those where a chat model is asked for produces a
+    selection that fails on first use.
+    """
+    from collections import defaultdict
+
+    from raven.providers.litellm_setup import import_litellm
+
+    try:
+        catalogue = import_litellm().model_cost
+    except Exception:
+        return {}
+
+    by_provider: dict[str, list[str]] = defaultdict(list)
+    for model, info in catalogue.items():
+        if not isinstance(info, dict) or info.get("mode") != "chat":
+            continue
+        provider = info.get("litellm_provider")
+        if provider:
+            by_provider[provider].append(model)
+    return {provider: tuple(sorted(models)) for provider, models in by_provider.items()}
+
+
+def litellm_models_for(slug: str) -> list[str]:
+    """Chat models LiteLLM knows for this provider, as ids that actually route.
+
+    Looked up by every name the provider answers to, not just its own: LiteLLM
+    files vLLM under "hosted_vllm" and Ollama under "ollama", so a lookup by the
+    section name alone finds nothing for exactly the providers whose curated
+    shortlist is empty.
+
+    Ids come back spelled the way LiteLLM would have to receive them. The
+    catalogue is inconsistent -- Moonshot's entries carry their prefix, VolcEngine's
+    do not -- and offering a bare id would route it by keyword rather than to the
+    provider the user picked.
+    """
+    from raven.providers.registry import find_by_name
+
+    spec = find_by_name(slug)
+    if spec is None:
+        return []
+    index = _litellm_chat_models_by_provider()
+    prefix = spec.model_prefix
+    out: list[str] = []
+    seen: set[str] = set()
+    for route_name in sorted(spec.route_names):
+        for model in index.get(route_name, ()):
+            bare = model.split("/", 1)[1] if "/" in model else model
+            full = f"{prefix}/{bare}" if prefix else bare
+            if full not in seen:
+                seen.add(full)
+                out.append(full)
+    return out

--- a/raven/tui_rpc/methods/model.py
+++ b/raven/tui_rpc/methods/model.py
@@ -30,7 +30,11 @@ from raven.config.update_providers import (
     reset_provider,
     set_provider_fields,
 )
-from raven.providers.common_models import common_models_for, litellm_models_for
+from raven.providers.common_models import (
+    _litellm_chat_models_by_provider,
+    common_models_for,
+    litellm_models_for,
+)
 from raven.providers.registry import canonical_provider_name, find_by_model, find_by_name
 from raven.tui_rpc.errors import (
     ConfigValidationError,
@@ -132,6 +136,10 @@ def _current_selection() -> tuple[str, str | None]:
 
 async def model_options(params: dict) -> dict:
     _parse(ModelOptionsParams, params)
+    # Warm the catalogue off the loop. Reading it imports LiteLLM the first time,
+    # which takes seconds -- long enough that doing it inline would stall this
+    # session's token stream while the picker opens.
+    await asyncio.to_thread(_litellm_chat_models_by_provider)
     current_model, current_provider = _current_selection()
     entries = [_build_provider_entry(p["name"], current_provider=current_provider) for p in list_providers()]
     return {

--- a/raven/tui_rpc/methods/model.py
+++ b/raven/tui_rpc/methods/model.py
@@ -30,7 +30,7 @@ from raven.config.update_providers import (
     reset_provider,
     set_provider_fields,
 )
-from raven.providers.common_models import common_models_for
+from raven.providers.common_models import common_models_for, litellm_models_for
 from raven.providers.registry import canonical_provider_name, find_by_model, find_by_name
 from raven.tui_rpc.errors import (
     ConfigValidationError,
@@ -68,11 +68,19 @@ def _provider_models(slug: str) -> list[str]:
         cfg = {}
     configured = cfg.get("models", [])
     configured = list(configured) if isinstance(configured, list) else []
-    # Priority: the user's configured models first (manual entry via
-    # ``model.add_model`` writes here), then our curated "common" shortlist,
-    # deduped. Keeps the picker useful out of the box without a network call.
-    seen = set(configured)
-    return configured + [m for m in common_models_for(slug) if m not in seen]
+    # Priority: what the user configured (manual entry via ``model.add_model``
+    # writes here), then the curated shortlist, then LiteLLM's own catalogue.
+    # Curated before catalogue because the shortlist is a few models worth
+    # recommending and the catalogue is everything, deprecated snapshots
+    # included; catalogue after it because eleven providers have no shortlist at
+    # all, which is why the picker used to offer them nothing.
+    out: list[str] = []
+    seen: set[str] = set()
+    for candidate in (*configured, *common_models_for(slug), *litellm_models_for(slug)):
+        if candidate not in seen:
+            seen.add(candidate)
+            out.append(candidate)
+    return out
 
 
 def _build_provider_entry(slug: str, *, current_provider: str | None) -> dict[str, Any]:

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1972,3 +1972,40 @@ def test_the_vendor_step_offers_litellm_names_the_picker_does_not_already_list()
     assert result["has"] is True, "a vendor litellm supports is missing from the second step"
     assert result["excludes_listed"] is True, "the second step re-offers what the picker already lists"
     assert result["count"] > 50
+
+
+def test_minimax_precedes_deepseek_and_carries_the_open_source_partner_marker() -> None:
+    """A deliberate placement, so a later reordering cannot drop it silently.
+
+    "open-source partner" rather than a bare "partner": in a list of vendors the
+    short form reads as paid placement. Only the API-key entry is marked -- the
+    OAuth ones are the same vendor and already carry "(OAuth)".
+    """
+    from raven.cli.onboard_commands import _CURATED_GROUPS
+
+    api_key_group = next(g for g in _CURATED_GROUPS if g["kind"] == "api_key")
+    names = [entry["name"] for entry in api_key_group["providers"]]
+    assert names.index("minimax") == names.index("deepseek") - 1
+
+    minimax = api_key_group["providers"][names.index("minimax")]
+    assert minimax["label"] == "MiniMax (open-source partner)"
+    assert minimax["label_zh"] == "MiniMax(开源合作伙伴)"
+
+    oauth_group = next(g for g in _CURATED_GROUPS if g["kind"] == "oauth")
+    for entry in oauth_group["providers"]:
+        assert "partner" not in entry["label"], entry["label"]
+        assert "合作伙伴" not in entry["label_zh"], entry["label_zh"]
+
+
+def test_no_picker_label_names_the_routing_library() -> None:
+    """LiteLLM is how Raven reaches a vendor, not something a user configures.
+
+    A label that names it leaks an implementation detail and reads as though the
+    user needed an account with it.
+    """
+    from raven.cli.onboard_commands import _CURATED_GROUPS
+
+    for group in _CURATED_GROUPS:
+        for entry in group["providers"]:
+            for text in (entry["label"], entry.get("label_zh", "")):
+                assert "litellm" not in text.lower(), f"{entry['name']}: {text}"

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -692,9 +692,12 @@ def test_step1_picker_uses_catalog_when_available(tmp_env: Path, monkeypatch: py
         "anthropic/claude-opus-4-5",
     ]
     assert captured_choices["default"] == "anthropic/claude-opus-4-5"
-    # User's pick made it into config
+    # The pick made it into config, carrying the route prefix. The user may type
+    # a bare id -- autocomplete accepts free text -- and a bare id is routed by
+    # keyword and fallback rather than to the provider just configured, so the
+    # wizard adds the prefix on the way out instead of persisting what was typed.
     data = json.loads(tmp_env.read_text())
-    assert data["agents"]["defaults"]["model"] == "claude-haiku-4-5"
+    assert data["agents"]["defaults"]["model"] == "anthropic/claude-haiku-4-5"
 
 
 def _capture_password_validate(monkeypatch: pytest.MonkeyPatch, answer: str) -> dict[str, Any]:
@@ -2358,3 +2361,121 @@ def test_a_spec_less_provider_can_have_its_default_model_changed(monkeypatch, tm
 
     assert onboard_commands._configure_existing_provider_model(non_interactive=False) is True
     assert "mistral" in offered, f"a spec-less provider was filtered out: {offered}"
+
+
+@pytest.mark.parametrize(
+    ("typed", "expected"),
+    [
+        # What a user actually types: the vendor's own name for the model.
+        ("mistral-large-latest", "mistral/mistral-large-latest"),
+        ("mistral/mistral-large-latest", "mistral/mistral-large-latest"),
+    ],
+)
+def test_every_exit_of_the_model_step_prefixes_what_it_returns(typed: str, expected: str, monkeypatch) -> None:
+    """The invariant belongs on the exits, not on one branch.
+
+    It was applied where the candidate list is built, which is the one branch a
+    spec-less vendor never reaches: nothing can pre-check it, so there is no
+    list, so the id is typed -- and typed ids went to config as typed. Three
+    rounds of review found this same defect on three different branches, so this
+    drives each exit rather than asserting the formatter in isolation.
+    """
+    from raven.cli import onboard_commands
+
+    class _Prompt:
+        def __init__(self, _label, **_kw):
+            pass
+
+        def ask(self):
+            return typed
+
+    monkeypatch.setattr(
+        onboard_commands, "_require_questionary", lambda: SimpleNamespace(autocomplete=_Prompt, text=_Prompt)
+    )
+
+    # The flag exit.
+    assert (
+        onboard_commands._pick_model(
+            "mistral",
+            None,
+            current_model=None,
+            model_ids=None,
+            user_provided_model=typed,
+            non_interactive=True,
+        )
+        == expected
+    )
+    # The typed exit, reached when there is no candidate list at all.
+    assert (
+        onboard_commands._pick_model(
+            "mistral",
+            None,
+            current_model=None,
+            model_ids=None,
+            user_provided_model=None,
+            non_interactive=False,
+        )
+        == expected
+    )
+
+
+def test_what_the_model_step_returns_is_served_by_the_provider_it_was_configured_for() -> None:
+    """The consequence, taken from the production value rather than a literal.
+
+    Every earlier test on this fed an already-prefixed id in, so none of them
+    could tell whether the wizard produces one. This takes what the step returns
+    and asks who would be billed for it.
+    """
+    from raven.cli import onboard_commands
+    from raven.config.schema import Config
+
+    produced = onboard_commands._pick_model(
+        "mistral",
+        None,
+        current_model=None,
+        model_ids=None,
+        user_provided_model="mistral-large-latest",
+        non_interactive=True,
+    )
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"model": produced}},
+            "providers": {"mistral": {"apiKey": "sk-MISTRAL"}, "openai": {"apiKey": "sk-OPENAI"}},
+        }
+    )
+    assert config.get_provider_name(produced) == "mistral"
+    assert config.get_api_key(produced) == "sk-MISTRAL"
+
+
+def test_a_hyphenated_vendor_gets_the_prefix_litellm_will_accept() -> None:
+    """Config names are matched loosely; a wire prefix cannot be.
+
+    LiteLLM hyphenates three vendors. Prefixing with the normalized form produced
+    "nano_gpt/...", which LiteLLM rejects outright -- so the provider configured
+    successfully and then could not be called.
+    """
+    from raven.cli.onboard_commands import _format_model_for_provider
+    from raven.providers.litellm_setup import import_litellm
+
+    for typed_name in ("nano-gpt", "nano_gpt"):
+        model = _format_model_for_provider(typed_name, None, "gpt-4o")
+        assert model == "nano-gpt/gpt-4o", typed_name
+        # And LiteLLM agrees it can route it.
+        assert import_litellm().get_llm_provider(model)[1] == "nano-gpt"
+
+
+def test_a_spec_less_vendor_is_offered_the_catalogue_rows_it_has() -> None:
+    """Returning nothing for these is what forced the id to be typed.
+
+    Every offered id carries the prefix, which the catalogue itself does not
+    guarantee: Mistral's rows have it, Bedrock's do not. Offering an unprefixed
+    one would put the bare id straight back into config.
+    """
+    from raven.providers.common_models import litellm_models_for
+
+    for slug in ("mistral", "fireworks_ai", "bedrock"):
+        models = litellm_models_for(slug)
+        assert models, f"{slug}: no candidates offered"
+        assert all(m.startswith(f"{slug}/") for m in models), [m for m in models if not m.startswith(f"{slug}/")][:3]
+        # And no id was prefixed twice on the way through.
+        assert not any(m.startswith(f"{slug}/{slug}/") for m in models)

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -532,7 +533,7 @@ def test_onboard_interactive_uses_stubbed_pickers(
     monkeypatch.setattr(
         onboard_commands,
         "_pick_model",
-        lambda spec, **_: spec.default_model,
+        lambda provider, spec, **_: spec.default_model,
     )
     # Optional steps 2-4 are covered separately; no-op them here so the
     # interactive Step 1 path can be asserted without driving every screen.
@@ -1538,7 +1539,7 @@ def test_first_screen_back_does_not_skip_step1(
     monkeypatch.setattr(onboard_commands, "_pick_language", lambda: None)
     monkeypatch.setattr(onboard_commands, "_select_provider", lambda: next(picks))
     monkeypatch.setattr(onboard_commands, "_prompt_api_key", lambda provider, **kw: "sk-back-test")
-    monkeypatch.setattr(onboard_commands, "_pick_model", lambda spec, **_: spec.default_model)
+    monkeypatch.setattr(onboard_commands, "_pick_model", lambda provider, spec, **_: spec.default_model)
     # Optional steps are no-ops here; we only assert Step 1 wasn't skipped.
     monkeypatch.setattr(onboard_commands, "_step2_sandbox", lambda **_: None)
     monkeypatch.setattr(onboard_commands, "_step3_channel", lambda **_: None)
@@ -1584,7 +1585,7 @@ def test_switch_provider_returns_to_picker_keeps_steps(
     picks = iter(["anthropic", "openai"])
     monkeypatch.setattr(onboard_commands, "_select_provider", lambda: next(picks))
     monkeypatch.setattr(onboard_commands, "_prompt_api_key", lambda provider, **kw: f"sk-{provider}")
-    monkeypatch.setattr(onboard_commands, "_pick_model", lambda spec, **_: spec.default_model)
+    monkeypatch.setattr(onboard_commands, "_pick_model", lambda provider, spec, **_: spec.default_model)
     # On the failure submenu, choose "switch".
     monkeypatch.setattr(onboard_commands, "_failure_choice", lambda options, *, non_interactive: "switch")
     monkeypatch.setattr(onboard_commands, "_step2_sandbox", lambda **_: None)
@@ -1619,7 +1620,7 @@ def test_add_provider_keeps_existing(tmp_env: Path, monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ(next(entry_answers)))
     monkeypatch.setattr(onboard_commands, "_select_provider", lambda: "anthropic")
     monkeypatch.setattr(onboard_commands, "_prompt_api_key", lambda provider, **kw: "sk-second")
-    monkeypatch.setattr(onboard_commands, "_pick_model", lambda spec, **_: spec.default_model)
+    monkeypatch.setattr(onboard_commands, "_pick_model", lambda provider, spec, **_: spec.default_model)
 
     onboard_commands._step1_provider(
         provider=None,
@@ -1671,7 +1672,7 @@ def test_configure_existing_model_happy_path_persists_and_returns_true(
     monkeypatch.setattr(
         onboard_commands, "_verify_provider", lambda *a, **k: (True, "valid", ["minimax-global/MiniMax-M3"])
     )
-    monkeypatch.setattr(onboard_commands, "_pick_model", lambda spec, **_: "minimax-global/MiniMax-M3")
+    monkeypatch.setattr(onboard_commands, "_pick_model", lambda provider, spec, **_: "minimax-global/MiniMax-M3")
     persisted: list[str] = []
     monkeypatch.setattr(onboard_commands, "_persist_default_model", lambda m: persisted.append(m))
     monkeypatch.setattr(onboard_commands, "_run_test_probe", lambda *a, **k: "ok")
@@ -1697,7 +1698,7 @@ def test_configure_existing_model_reauth_delegates_to_oauth_login(monkeypatch: p
     """A probe asking for re-auth hands off to the OAuth login and returns its result."""
     _patch_single_provider_pick(monkeypatch, "minimax_global")
     monkeypatch.setattr(onboard_commands, "_verify_provider", lambda *a, **k: (True, "valid", []))
-    monkeypatch.setattr(onboard_commands, "_pick_model", lambda spec, **_: "minimax-global/MiniMax-M3")
+    monkeypatch.setattr(onboard_commands, "_pick_model", lambda provider, spec, **_: "minimax-global/MiniMax-M3")
     monkeypatch.setattr(onboard_commands, "_persist_default_model", lambda m: None)
     monkeypatch.setattr(onboard_commands, "_run_test_probe", lambda *a, **k: "reauth")
     login_calls: list[str] = []
@@ -2057,3 +2058,101 @@ def test_a_local_deployment_without_an_address_says_so(monkeypatch, tmp_path) ->
             model=None,
             non_interactive=True,
         )
+
+
+def test_a_vendor_with_no_spec_is_configured_by_the_wizard_not_rejected(monkeypatch, tmp_path) -> None:
+    """The second picker step offers 117 vendors Raven carries no spec for.
+
+    Every one of them used to reach `spec.name` on a None and tear the wizard
+    down after the key was already on disk. The gate that produced that -- "the
+    wizard does not cover this" -- was the older limitation: credentials go in
+    under the vendor's name and the model list comes from the vendor itself, so
+    a spec is metadata here, not permission.
+    """
+    from raven.cli import onboard_commands
+    from raven.providers.registry import find_by_name
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / ".raven").mkdir()
+
+    assert onboard_commands._validate_provider_name("mistral") == "mistral"
+    assert find_by_name("mistral") is None, "mistral gained a spec; pick another spec-less vendor"
+
+
+def test_a_typo_in_the_vendor_step_is_a_message_not_a_traceback(monkeypatch, tmp_path) -> None:
+    """Both entrances share one gate.
+
+    The flag path validated; the picker path assigned the raw string, so a
+    mistyped vendor name reached the config layer as an uncaught KeyError.
+    """
+    from raven.cli import onboard_commands
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    with pytest.raises(typer.BadParameter, match="mistrall"):
+        onboard_commands._validate_provider_name("mistrall")
+
+
+def test_resolve_model_with_test_runs_for_a_provider_with_no_spec(monkeypatch, tmp_path) -> None:
+    """Drives the path that crashed, rather than asserting a constant about it.
+
+    Thirteen tests asserted what the picker lists and none walked into it, which
+    is why a crash on every one of those vendors shipped green.
+    """
+    from raven.cli import onboard_commands
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / ".raven").mkdir()
+    monkeypatch.setattr(
+        onboard_commands,
+        "_verify_provider",
+        lambda provider, skip_test=False: (True, "valid", ["mistral-large-latest"]),
+    )
+    monkeypatch.setattr(onboard_commands, "_persist_default_model", lambda model: None)
+
+    chosen = onboard_commands._resolve_model_with_test(
+        "mistral",
+        None,  # no spec, which is the whole point
+        is_custom=False,
+        custom_model=None,
+        user_model_flag="mistral/mistral-large-latest",
+        non_interactive=True,
+        warnings=[],
+        skip_test=True,
+    )
+    assert chosen == "mistral/mistral-large-latest"
+
+
+def test_the_wizard_offers_known_models_when_the_provider_cannot_be_reached(monkeypatch, tmp_path) -> None:
+    """A failed fetch must not leave the user typing an id from memory.
+
+    Deleting this fallback left all 86 onboard tests green, so half of what the
+    candidate chain is for had nothing asserting it.
+    """
+    from raven.cli import onboard_commands
+    from raven.providers.registry import find_by_name
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    offered: dict[str, Any] = {}
+
+    class _Stub:
+        def __init__(self, label, **kw):
+            offered["choices"] = list(kw.get("choices") or [])
+
+        def ask(self):
+            return offered["choices"][0]
+
+    fake_questionary = SimpleNamespace(autocomplete=_Stub, text=_Stub)
+    monkeypatch.setattr(onboard_commands, "_require_questionary", lambda: fake_questionary)
+
+    chosen = onboard_commands._pick_model(
+        "moonshot",
+        find_by_name("moonshot"),
+        current_model=None,
+        model_ids=None,  # the fetch came back empty
+        user_provided_model=None,
+        non_interactive=False,
+    )
+
+    assert offered["choices"], "no candidates were offered after a failed fetch"
+    assert chosen == offered["choices"][0]
+    assert any(c.startswith("moonshot/") for c in offered["choices"]), offered["choices"][:3]

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -2479,3 +2479,141 @@ def test_a_spec_less_vendor_is_offered_the_catalogue_rows_it_has() -> None:
         assert all(m.startswith(f"{slug}/") for m in models), [m for m in models if not m.startswith(f"{slug}/")][:3]
         # And no id was prefixed twice on the way through.
         assert not any(m.startswith(f"{slug}/{slug}/") for m in models)
+
+
+def test_only_credential_kind_reads_the_spec_auth_flags() -> None:
+    """One answer to "how is this provider reached", not thirteen.
+
+    Every decision the wizard makes about a provider follows from that question,
+    and it was being derived independently at thirteen sites off two spec flags.
+    Each of the last two review rounds found a site that disagreed with the rest:
+    a rollback that wrote credential fields to an OAuth provider and ended the
+    run, a menu that offered it a key prompt, a prompt that guarded a spec on one
+    line and dereferenced it on the next. Deriving it again anywhere reopens that.
+    """
+    import ast
+    import re
+    from pathlib import Path as _Path
+
+    path = _Path(__file__).resolve().parents[1] / "raven" / "cli" / "onboard_commands.py"
+    source = path.read_text()
+    tree = ast.parse(source)
+    owner = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_credential_kind"
+    )
+    allowed = range(owner.lineno, (owner.end_lineno or owner.lineno) + 1)
+
+    offenders = [
+        f"line {i}: {line.strip()}"
+        for i, line in enumerate(source.splitlines(), 1)
+        if re.search(r"\bspec\.is_(oauth|local)\b", line) and not line.lstrip().startswith("#") and i not in allowed
+    ]
+    assert not offenders, "derive it from _credential_kind instead:\n" + "\n".join(offenders)
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [
+        ("github_copilot", "oauth"),
+        ("openai_codex", "oauth"),
+        ("minimax_global", "oauth"),
+        ("ollama_chat", "local"),
+        ("hosted_vllm", "local"),
+        ("custom", "endpoint"),
+        ("anthropic", "key"),
+        ("mistral", "key"),  # no spec at all
+    ],
+)
+def test_credential_kind_covers_every_shape(provider: str, expected: str) -> None:
+    from raven.cli.onboard_commands import _credential_kind
+    from raven.providers.registry import find_by_name
+
+    assert _credential_kind(provider, find_by_name(provider)) == expected
+
+
+def test_every_registered_provider_has_exactly_one_credential_kind() -> None:
+    """Sweep, so a provider added later cannot fall through the classification."""
+    from raven.cli.onboard_commands import CRED_ENDPOINT, CRED_KEY, CRED_LOCAL, CRED_OAUTH, _credential_kind
+    from raven.providers.registry import PROVIDERS
+
+    known = {CRED_OAUTH, CRED_LOCAL, CRED_ENDPOINT, CRED_KEY}
+    for spec in PROVIDERS:
+        assert _credential_kind(spec.name, spec) in known, spec.name
+
+
+def test_the_picker_result_goes_through_the_same_gate_as_the_flag(monkeypatch, tmp_path) -> None:
+    """N1: the joint that let 117 vendors crash, and stayed uncovered for three rounds.
+
+    The flag path validated its input; the picker path assigned it. Deleting the
+    validation call restores the original defect -- a typed name reaching the
+    config layer as an uncaught KeyError mid-setup -- so the call itself is what
+    needs holding down, not the validator in isolation.
+    """
+    from raven.cli import onboard_commands
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / ".raven").mkdir()
+    validated: list[str] = []
+    real = onboard_commands._validate_provider_name
+
+    def spy(name: str) -> str:
+        validated.append(name)
+        return real(name)
+
+    monkeypatch.setattr(onboard_commands, "_validate_provider_name", spy)
+    monkeypatch.setattr(onboard_commands, "_select_provider", lambda: "mistrall")  # a typo
+    printed: list[str] = []
+    monkeypatch.setattr(onboard_commands.console, "print", lambda *a, **k: printed.append(str(a[0]) if a else ""))
+    # Second pass: back out so the loop ends.
+    calls = {"n": 0}
+
+    def picker():
+        calls["n"] += 1
+        return "mistrall" if calls["n"] == 1 else onboard_commands._BACK
+
+    monkeypatch.setattr(onboard_commands, "_select_provider", picker)
+
+    assert (
+        onboard_commands._configure_one_provider(
+            provider=None, api_key=None, base_url=None, model=None, non_interactive=False, warnings=[]
+        )
+        is None
+    )
+    assert validated == ["mistrall"], "the picker result bypassed the gate"
+    assert any("mistrall" in line for line in printed), "the typo was not reported to the user"
+
+
+def test_a_failed_setup_calls_the_rollback(monkeypatch, tmp_path) -> None:
+    """N2: deleting this call silently undoes both rollback fixes.
+
+    `_roll_back_provider_fields` has its own tests, but nothing asserted the
+    failure path reaches it -- so removing the call left a mistyped address in
+    place of a working one with CI green.
+    """
+    from raven.cli import onboard_commands
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / ".raven").mkdir()
+    rolled: list[tuple[str, Any]] = []
+    monkeypatch.setattr(
+        onboard_commands,
+        "_roll_back_provider_fields",
+        lambda provider, spec, **kw: rolled.append((provider, kw)),
+    )
+    monkeypatch.setattr(onboard_commands, "_collect_credentials", lambda provider, **kw: None)
+    # The model step reports "switch provider", which is the failure path.
+    monkeypatch.setattr(onboard_commands, "_resolve_model_with_test", lambda provider, spec, **kw: None)
+    calls = {"n": 0}
+
+    def picker():
+        calls["n"] += 1
+        return "deepseek" if calls["n"] == 1 else onboard_commands._BACK
+
+    monkeypatch.setattr(onboard_commands, "_select_provider", picker)
+
+    onboard_commands._configure_one_provider(
+        provider=None, api_key=None, base_url=None, model=None, non_interactive=False, warnings=[]
+    )
+    assert rolled, "a failed setup did not roll back"
+    assert rolled[0][0] == "deepseek"
+    assert set(rolled[0][1]) == {"old_key", "old_base"}, rolled[0][1]

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -2308,3 +2308,53 @@ def test_managing_an_oauth_provider_explains_instead_of_exiting(monkeypatch, tmp
     assert spec is not None and spec.is_oauth
     # The shared guard both menu actions now use.
     _roll_back_provider_fields("github_copilot", spec, old_key=None, old_base=None)
+
+
+def test_a_spec_less_provider_can_have_its_default_model_changed(monkeypatch, tmp_path) -> None:
+    """Configuring a vendor and then editing its default model are one capability.
+
+    The "choose default model" menu filtered out anything without a registry
+    entry, so the new gate let a vendor be configured and then refused to let its
+    model be changed -- the only way back was to re-enter the key through "add a
+    provider". Removing that filter requires the spec dereference further down to
+    be guarded, or the menu crashes on the very providers it just started
+    offering; the two must move together, which is what this asserts.
+    """
+    from raven.cli import onboard_commands
+
+    cfg_dir = tmp_path / ".raven"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text(
+        json.dumps({"providers": {"mistral": {"apiKey": "sk-m"}, "openai": {"apiKey": "sk-o"}}})
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    offered: list[str] = []
+
+    class _Choice:
+        def __init__(self, _title, value=None):
+            self.value = value
+
+    class _Select:
+        def __init__(self, _label, **kw):
+            offered.extend(c.value for c in kw.get("choices") or [])
+
+        def ask(self):
+            return "mistral"
+
+    monkeypatch.setattr(
+        onboard_commands,
+        "_require_questionary",
+        lambda: SimpleNamespace(select=_Select, autocomplete=_Select, Choice=_Choice),
+    )
+    monkeypatch.setattr(
+        onboard_commands, "_verify_provider", lambda provider: (True, "valid", ["mistral-large-latest"])
+    )
+    monkeypatch.setattr(onboard_commands, "_pick_model", lambda provider, spec, **_: f"{provider}/probe")
+    monkeypatch.setattr(onboard_commands, "_persist_default_model", lambda model: None)
+    # Reaching this without an AttributeError is the second half of the fix: the
+    # probe is told whether the provider is OAuth, read off a spec that is None.
+    monkeypatch.setattr(onboard_commands, "_run_test_probe", lambda provider, **kw: "ok")
+
+    assert onboard_commands._configure_existing_provider_model(non_interactive=False) is True
+    assert "mistral" in offered, f"a spec-less provider was filtered out: {offered}"

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -2617,3 +2617,61 @@ def test_a_failed_setup_calls_the_rollback(monkeypatch, tmp_path) -> None:
     assert rolled, "a failed setup did not roll back"
     assert rolled[0][0] == "deepseek"
     assert set(rolled[0][1]) == {"old_key", "old_base"}, rolled[0][1]
+
+
+def test_reconfiguring_a_local_server_is_seeded_with_its_own_address(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """M6: the seeding fix is what stops a working address being replaced.
+
+    Seeding the registry default unconditionally meant someone whose server runs
+    somewhere other than localhost was offered localhost, and pressing Enter to
+    move past a field they had already filled in wrote it -- the same data loss as
+    the failed-setup rollback, reached by an ordinary keypress instead of a failure.
+    """
+    import questionary
+
+    from raven.providers.registry import find_by_name
+
+    captured: dict[str, Any] = {}
+
+    class _FQ:
+        def ask(self) -> str:
+            return "http://gpu-box.lan:11434"
+
+    def _text(message: Any, *, default: Any = None, **kwargs: Any) -> Any:
+        captured["default"] = default
+        return _FQ()
+
+    monkeypatch.setattr(questionary, "text", _text)
+    spec = find_by_name("ollama_chat")
+    assert spec is not None and spec.default_api_base
+
+    onboard_commands._prompt_local_api_base(spec, current="http://gpu-box.lan:11434")
+    assert captured["default"] == "http://gpu-box.lan:11434", (
+        "the configured address was replaced by the registry default"
+    )
+
+    onboard_commands._prompt_local_api_base(spec, current="")
+    assert captured["default"] == spec.default_api_base, "a first-time setup lost its default"
+
+
+def test_backing_out_of_the_vendor_sublist_returns_to_the_provider_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """U8: an empty submit closes the sub-list the user opened, one level.
+
+    Passing its ``_BACK`` straight up dropped them on the language screen -- three
+    steps back from where they were -- so the row that opened the sub-list has to
+    be redisplayed instead.
+    """
+    rows = iter([onboard_commands._PICK_LITELLM_VENDOR, "deepseek"])
+    monkeypatch.setattr(onboard_commands, "_select_provider_row", lambda: next(rows))
+    monkeypatch.setattr(onboard_commands, "_prompt_litellm_vendor", lambda: onboard_commands._BACK)
+
+    assert onboard_commands._select_provider() == "deepseek"
+
+    # Backing out of the provider list itself still leaves the step.
+    rows = iter([onboard_commands._PICK_LITELLM_VENDOR, onboard_commands._BACK])
+    monkeypatch.setattr(onboard_commands, "_select_provider_row", lambda: next(rows))
+    assert onboard_commands._select_provider() is onboard_commands._BACK

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1916,3 +1916,59 @@ def test_removal_guard_sees_a_model_saved_under_a_former_name() -> None:
     spec = find_by_name("zai")
     assert onboard_commands._model_routes_to_provider("zhipu/glm-4.6", spec) is True
     assert onboard_commands._model_routes_to_provider("zai/glm-4.6", spec) is True
+
+
+def test_the_wizard_offers_every_provider_the_registry_carries() -> None:
+    """The picker must not be a hand-picked subset of the registry.
+
+    Eight providers were configurable through the CLI and absent from the wizard,
+    so a new user could not reach them and had to guess at the generic
+    OpenAI-compatible flow instead.
+    """
+    from raven.cli.onboard_commands import _CURATED_PROVIDERS
+    from raven.providers.registry import PROVIDERS
+
+    offered = {entry["name"] for entry in _CURATED_PROVIDERS}
+    registered = {spec.name for spec in PROVIDERS}
+    assert registered - offered == set(), f"registry providers missing from the wizard: {sorted(registered - offered)}"
+    assert offered - registered == set(), f"wizard offers providers with no spec: {sorted(offered - registered)}"
+
+
+def test_the_curated_groups_cover_the_flat_list_and_carry_both_fallbacks() -> None:
+    """Grouping is what keeps twenty rows readable; the fallbacks close the set."""
+    from raven.cli.onboard_commands import _CURATED_GROUPS, _PICK_LITELLM_VENDOR
+
+    kinds = [group["kind"] for group in _CURATED_GROUPS]
+    assert kinds == ["api_key", "oauth", "local", "fallback"]
+    fallback = {entry["name"] for entry in _CURATED_GROUPS[-1]["providers"]}
+    assert fallback == {_PICK_LITELLM_VENDOR, "custom"}
+    # Local deployments are offered, which they were not: reaching Ollama meant
+    # the custom-endpoint path, which routes through the generic OpenAI driver
+    # and so loses the behaviour litellm applies to "ollama_chat/".
+    local = {entry["name"] for group in _CURATED_GROUPS if group["kind"] == "local" for entry in group["providers"]}
+    assert local == {"ollama_chat", "hosted_vllm"}
+
+
+def test_the_vendor_step_offers_litellm_names_the_picker_does_not_already_list() -> None:
+    """The second step exists so the first one stays short.
+
+    It must not re-offer what the picker already shows, and it must not import
+    LiteLLM to build the list -- that costs two seconds on a path that only
+    renders choices.
+    """
+    import subprocess
+    import sys
+
+    probe = (
+        "import sys, json\n"
+        "from raven.cli.onboard_commands import _litellm_vendor_choices\n"
+        "rest = _litellm_vendor_choices()\n"
+        "print(json.dumps({'litellm': 'litellm' in sys.modules, 'count': len(rest), 'has': 'mistral' in rest,"
+        " 'excludes_listed': 'openai' not in rest}))\n"
+    )
+    out = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=True)
+    result = json.loads(out.stdout.strip().splitlines()[-1])
+    assert result["litellm"] is False, "building the vendor list imported litellm"
+    assert result["has"] is True, "a vendor litellm supports is missing from the second step"
+    assert result["excludes_listed"] is True, "the second step re-offers what the picker already lists"
+    assert result["count"] > 50

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -756,20 +756,25 @@ def test_format_model_for_provider_prefix_rules() -> None:
 
     # Gateway with prefix: bare id gets prefixed
     assert (
-        onboard_commands._format_model_for_provider(openrouter, "anthropic/claude-sonnet-4-5")
+        onboard_commands._format_model_for_provider("openrouter", openrouter, "anthropic/claude-sonnet-4-5")
         == "openrouter/anthropic/claude-sonnet-4-5"
     )
     # Already prefixed by us → idempotent
     assert (
-        onboard_commands._format_model_for_provider(openrouter, "openrouter/anthropic/claude-sonnet-4-5")
+        onboard_commands._format_model_for_provider("openrouter", openrouter, "openrouter/anthropic/claude-sonnet-4-5")
         == "openrouter/anthropic/claude-sonnet-4-5"
     )
     # Standard provider: LiteLLM knows it under our own name, so that is the prefix
-    assert onboard_commands._format_model_for_provider(openai, "gpt-4o-mini") == "openai/gpt-4o-mini"
-    assert onboard_commands._format_model_for_provider(openai, "openai/gpt-4o-mini") == "openai/gpt-4o-mini"
+    assert onboard_commands._format_model_for_provider("openai", openai, "gpt-4o-mini") == "openai/gpt-4o-mini"
+    assert onboard_commands._format_model_for_provider("openai", openai, "openai/gpt-4o-mini") == "openai/gpt-4o-mini"
     # skip_prefixes match → no double-prefix
-    assert onboard_commands._format_model_for_provider(deepseek, "deepseek/deepseek-chat") == "deepseek/deepseek-chat"
-    assert onboard_commands._format_model_for_provider(deepseek, "deepseek-chat") == "deepseek/deepseek-chat"
+    assert (
+        onboard_commands._format_model_for_provider("deepseek", deepseek, "deepseek/deepseek-chat")
+        == "deepseek/deepseek-chat"
+    )
+    assert (
+        onboard_commands._format_model_for_provider("deepseek", deepseek, "deepseek-chat") == "deepseek/deepseek-chat"
+    )
 
 
 def test_model_routes_to_provider_heuristic() -> None:
@@ -824,7 +829,7 @@ def test_registry_default_models_present() -> None:
 def test_minimax_catalog_models_keep_public_provider_prefix(provider: str, model: str, expected: str) -> None:
     from raven.providers.registry import find_by_name
 
-    assert onboard_commands._format_model_for_provider(find_by_name(provider), model) == expected
+    assert onboard_commands._format_model_for_provider(provider, find_by_name(provider), model) == expected
 
 
 # --------------------------------------------------------------------------- fixtures (5-step)
@@ -2156,3 +2161,150 @@ def test_the_wizard_offers_known_models_when_the_provider_cannot_be_reached(monk
     assert offered["choices"], "no candidates were offered after a failed fetch"
     assert chosen == offered["choices"][0]
     assert any(c.startswith("moonshot/") for c in offered["choices"]), offered["choices"][:3]
+
+
+def test_a_spec_less_vendors_model_id_carries_its_route_prefix() -> None:
+    """A bare id is routed by keyword and fallback, not to the section configured.
+
+    Returning the vendor's id unprefixed produced "mistral-large-latest", which
+    resolves to OpenAI when OpenAI also holds a key -- so the wizard handed back
+    a default model that spends someone else's credential.
+    """
+    from raven.cli.onboard_commands import _format_model_for_provider
+
+    assert _format_model_for_provider("mistral", None, "mistral-large-latest") == "mistral/mistral-large-latest"
+    # Already prefixed stays put rather than being prefixed twice.
+    assert _format_model_for_provider("mistral", None, "mistral/mistral-large-latest") == "mistral/mistral-large-latest"
+
+
+def test_that_prefix_is_what_stops_the_key_going_elsewhere() -> None:
+    """The consequence, asserted where it lands rather than on the string.
+
+    This is the assertion the crash-fix needed and did not have: the id the
+    wizard writes must resolve to the provider it was configured for, with that
+    provider's credential, even when a keyword-matching vendor is also set up.
+    """
+    from raven.cli.onboard_commands import _format_model_for_provider
+    from raven.config.schema import Config
+
+    model = _format_model_for_provider("mistral", None, "mistral-large-latest")
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"model": model}},
+            "providers": {"mistral": {"apiKey": "sk-MISTRAL"}, "openai": {"apiKey": "sk-OPENAI"}},
+        }
+    )
+    assert config.get_provider_name(model) == "mistral"
+    assert config.get_api_key(model) == "sk-MISTRAL"
+
+
+def test_rolling_back_a_failed_setup_restores_what_was_there(monkeypatch, tmp_path) -> None:
+    """Restores the prior state, and does not touch an OAuth provider at all.
+
+    Two shapes were wrong: keying the rollback off the previous api_key skipped a
+    local deployment entirely, leaving a mistyped address in place of a working
+    one; and writing credential fields for an OAuth provider raises, which turned
+    a failed verification into a dead wizard.
+    """
+    from raven.cli.onboard_commands import _roll_back_provider_fields, _write_provider_fields
+    from raven.config.loader import set_config_path
+    from raven.config.update_providers import get_provider_config
+    from raven.providers.registry import find_by_name
+
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"providers": {"ollama_chat": {"apiBase": "http://my-nas:11434"}}}))
+    set_config_path(cfg)
+    try:
+        prior = get_provider_config("ollama_chat", redact_secrets=False)
+        _write_provider_fields("ollama_chat", {"api_base": "http://typo:9999"})
+        # The wizard's own rollback, called rather than re-implemented here.
+        _roll_back_provider_fields(
+            "ollama_chat",
+            find_by_name("ollama_chat"),
+            old_key=prior.get("api_key"),
+            old_base=prior.get("api_base"),
+        )
+        assert get_provider_config("ollama_chat", redact_secrets=False)["api_base"] == "http://my-nas:11434"
+
+        # And why the branch must not run for OAuth: the ops layer refuses these
+        # fields, and the wizard's wrapper turns that refusal into an exit -- so
+        # rolling back an OAuth provider ends the whole run.
+        from raven.config.update_providers import set_provider_fields
+
+        oauth = find_by_name("github_copilot")
+        assert oauth is not None and oauth.is_oauth
+        with pytest.raises(RuntimeError, match="OAuth"):
+            set_provider_fields("github_copilot", {"api_key": ""}, config_path=cfg)
+        with pytest.raises(typer.Exit):
+            _write_provider_fields("github_copilot", {"api_key": ""})
+        # So the rollback must not go near them -- calling it is a no-op.
+        _roll_back_provider_fields("github_copilot", oauth, old_key=None, old_base=None)
+    finally:
+        set_config_path(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("slug", "status", "expected", "absent"),
+    [
+        # Unreachable: a local deployment's usual cause is a wrong address, and
+        # this is the branch it lands in -- retry alone left it unreachable.
+        ("ollama_chat", "network_error", "rebase", "rekey"),
+        ("hosted_vllm", "network_error", "rebase", "rekey"),
+        # A vendor reached over the network gets retry only; the address is not
+        # the user's to change, and the key is not what failed.
+        ("deepseek", "network_error", "retry", "rebase"),
+        # Rejected credentials: the field to fix is the one the provider uses.
+        ("ollama_chat", "invalid_key", "rebase", "rekey"),
+        ("deepseek", "invalid_key", "rekey", "rebase"),
+        ("github_copilot", "invalid_key", "reauth", "rekey"),
+    ],
+)
+def test_the_failure_menu_offers_the_field_the_provider_actually_has(
+    slug: str, status: str, expected: str, absent: str, monkeypatch
+) -> None:
+    """What is worth changing after a failure depends on how the provider is reached.
+
+    A local deployment fails most often on a wrong address, and both failure
+    branches offered "re-enter key" for a provider that holds none -- so the one
+    field worth editing had no route back to it.
+    """
+    from raven.cli import onboard_commands
+    from raven.providers.registry import find_by_name
+
+    seen: list[list[str]] = []
+    monkeypatch.setattr(
+        onboard_commands,
+        "_failure_choice",
+        lambda options, non_interactive: (seen.append([v for _, v in options]), "switch")[1],
+    )
+    monkeypatch.setattr(onboard_commands, "_verify_provider", lambda provider, skip_test=False: (False, status, None))
+
+    result = onboard_commands._resolve_model_with_test(
+        slug,
+        find_by_name(slug),
+        is_custom=False,
+        custom_model=None,
+        user_model_flag=f"{slug}/probe",
+        non_interactive=False,
+        warnings=[],
+    )
+
+    assert result is None, "switch should unwind to the picker"
+    assert seen, "the failure menu was never shown"
+    assert expected in seen[0], f"{slug}/{status}: offered {seen[0]}"
+    assert absent not in seen[0], f"{slug}/{status}: should not offer {absent}, got {seen[0]}"
+
+
+def test_managing_an_oauth_provider_explains_instead_of_exiting(monkeypatch, tmp_path, capsys) -> None:
+    """Update and Remove both wrote credential fields, which OAuth providers refuse.
+
+    Generalising "not every provider has a key" only as far as local deployments
+    left the OAuth ones ending the wizard from a menu meant for editing.
+    """
+    from raven.cli.onboard_commands import _roll_back_provider_fields
+    from raven.providers.registry import find_by_name
+
+    spec = find_by_name("github_copilot")
+    assert spec is not None and spec.is_oauth
+    # The shared guard both menu actions now use.
+    _roll_back_provider_fields("github_copilot", spec, old_key=None, old_base=None)

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -2009,3 +2009,51 @@ def test_no_picker_label_names_the_routing_library() -> None:
         for entry in group["providers"]:
             for text in (entry["label"], entry.get("label_zh", "")):
                 assert "litellm" not in text.lower(), f"{entry['name']}: {text}"
+
+
+def test_a_local_deployment_is_configured_by_address_not_by_key(tmp_path, monkeypatch) -> None:
+    """Ollama and vLLM authenticate on nothing; they are reached by URL.
+
+    Sending them through the api_key prompt stopped the user at a minimum-length
+    check for a credential that does not exist, which is what made offering them
+    in the picker impossible before.
+    """
+    from raven.cli import onboard_commands
+
+    (tmp_path / ".raven").mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    written: dict[str, Any] = {}
+    monkeypatch.setattr(onboard_commands, "_write_provider_fields", lambda p, f: written.update({p: f}))
+
+    result = onboard_commands._collect_credentials(
+        "ollama_chat",
+        is_oauth=False,
+        is_custom=False,
+        is_local=True,
+        api_key=None,
+        base_url="http://127.0.0.1:11434",
+        model=None,
+        non_interactive=True,
+    )
+
+    assert result is None
+    assert written == {"ollama_chat": {"api_base": "http://127.0.0.1:11434"}}
+    assert "api_key" not in written["ollama_chat"], "a local deployment was asked for a key"
+
+
+def test_a_local_deployment_without_an_address_says_so(monkeypatch, tmp_path) -> None:
+    """The address is the one thing it cannot be configured without."""
+    from raven.cli import onboard_commands
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    with pytest.raises(typer.BadParameter, match="base-url"):
+        onboard_commands._collect_credentials(
+            "ollama_chat",
+            is_oauth=False,
+            is_custom=False,
+            is_local=True,
+            api_key=None,
+            base_url=None,
+            model=None,
+            non_interactive=True,
+        )

--- a/tests/test_config_provider_matching.py
+++ b/tests/test_config_provider_matching.py
@@ -277,3 +277,48 @@ def test_the_current_name_still_wins_a_real_conflict() -> None:
     assert section is not None
     assert section.api_key == "NEW", "the current name must win where both hold a value"
     assert section.api_base == "https://old/v1", "a field only the old section had must survive"
+
+
+def test_adding_a_second_provider_does_not_take_over_the_default_model() -> None:
+    """Which provider serves the default model is decided by the model id.
+
+    A wizard-written config names its provider in the model id, and a prefix is
+    authoritative -- so configuring a gateway later cannot quietly take over. It
+    holds for a bare id too, as long as the vendor it names is the configured one.
+
+    This is why `agents.defaults.provider` stays on `auto` after onboarding: the
+    alternative, pinning the answer, makes the forced branch beat the model id, so
+    changing the model later would send the pinned provider's key to whatever
+    vendor the new id names.
+    """
+    for model in ("deepseek/deepseek-chat", "deepseek-chat"):
+        alone = Config.model_validate(
+            {
+                "agents": {"defaults": {"model": model}},
+                "providers": {"deepseek": {"apiKey": "sk-ds"}},
+            }
+        )
+        plus_gateway = Config.model_validate(
+            {
+                "agents": {"defaults": {"model": model}},
+                "providers": {"deepseek": {"apiKey": "sk-ds"}, "openrouter": {"apiKey": "sk-or-v1-x"}},
+            }
+        )
+        assert alone._match_provider()[1] == "deepseek", model
+        assert plus_gateway._match_provider()[1] == "deepseek", f"a later gateway took over {model}"
+
+
+def test_a_pinned_provider_beats_the_model_id_which_is_why_onboarding_leaves_it_auto() -> None:
+    """Documents the hazard rather than the wish.
+
+    `provider` is an override, not a hint: it is answered before the model id is
+    consulted at all. Anything that writes it on the user's behalf has to accept
+    that a later model change will be served by the pinned provider's credentials.
+    """
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "deepseek", "model": "deepseek/deepseek-chat"}},
+            "providers": {"deepseek": {"apiKey": "sk-ds"}, "openrouter": {"apiKey": "sk-or-v1-x"}},
+        }
+    )
+    assert config._match_provider("openrouter/anthropic/claude-x")[1] == "deepseek"

--- a/tests/test_per_model_provider.py
+++ b/tests/test_per_model_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -197,3 +198,45 @@ async def test_each_endpoint_sends_its_own_api_base(monkeypatch):
         ("openai/small", "http://a/v1", "KA"),
         ("openai/large", "http://b/v1", "KB"),
     ]
+
+
+def test_building_knn_endpoints_leaves_the_process_environment_alone(monkeypatch) -> None:
+    """Several endpoints in one process must not fight over a shared env var.
+
+    Each endpoint's provider is built with ``provider_name="custom"``, and
+    ``custom`` is a gateway -- so it takes ``_setup_env``'s branch that *overwrites*
+    an existing variable rather than the one that defers to it. The only thing
+    stopping N endpoints from each writing their own key into one variable, last
+    one winning, is that the custom spec declares no ``env_key``.
+
+    That is a single empty field holding up a correctness property, and nothing
+    else asserts it: filling it in with "OPENAI_API_KEY" looks entirely
+    reasonable, and every other test would stay green.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "PRE-EXISTING")
+
+    fallback = LiteLLMProvider(api_key="FALLBACK", default_model="fb", provider_name="openrouter")
+    endpoints = [
+        ModelEndpoint(model="small", api_key="KEY-SMALL", api_base="http://small/v1"),
+        ModelEndpoint(model="large", api_key="KEY-LARGE", api_base="http://large/v1"),
+    ]
+
+    provider = PerModelProvider(endpoints, fallback)
+
+    assert os.environ["OPENAI_API_KEY"] == "PRE-EXISTING", "an endpoint key leaked into the process environment"
+    # Each endpoint still carries its own credentials, per call rather than per
+    # process -- which is what made one process able to hold several at all.
+    assert provider._by_model["small"].api_key == "KEY-SMALL"
+    assert provider._by_model["large"].api_key == "KEY-LARGE"
+
+
+def test_the_custom_spec_declares_no_env_var_to_write() -> None:
+    """States the field the test above depends on, so a change to it fails here
+    with the reason rather than somewhere unrelated."""
+    from raven.providers.registry import find_by_name
+
+    spec = find_by_name("custom")
+    assert spec is not None
+    assert spec.is_gateway is True, "if custom stopped being a gateway, re-derive which _setup_env branch applies"
+    assert spec.env_key == "", "custom must name no env var: knn builds one provider per endpoint under this spec"
+    assert spec.env_extras == ()

--- a/tests/test_tui_rpc_model.py
+++ b/tests/test_tui_rpc_model.py
@@ -67,9 +67,13 @@ async def test_options_authed_provider_lists_models(fake_home: Path) -> None:
     result = await model_options({})
     entry = _entry(result, "anthropic")
     assert entry["authenticated"] is True
-    # Configured models rank first; the curated shortlist follows (deduped).
+    # Configured models rank first, then the curated shortlist, then LiteLLM's
+    # catalogue (deduped). The order is the contract: recommendations stay at the
+    # top of a list the catalogue makes long.
     assert entry["models"][:2] == ["claude-opus-4-8", "claude-sonnet-4-5"]
-    assert entry["total_models"] == 2 + len(common_models_for("anthropic"))
+    curated = common_models_for("anthropic")
+    assert entry["models"][2 : 2 + len(curated)] == curated
+    assert entry["total_models"] > 2 + len(curated), "the catalogue tier added nothing"
     assert entry["auth_type"] == "api_key"
     assert entry["key_env"] == "ANTHROPIC_API_KEY"
 
@@ -81,8 +85,9 @@ async def test_options_unauthed_provider_marked(fake_home: Path) -> None:
     assert entry["authenticated"] is False
     # Curated shortlist is shown regardless of auth (as openrouter always has),
     # so the picker is never empty; the unauthed state is conveyed separately.
-    assert entry["models"] == common_models_for("openai")
-    assert entry["total_models"] == len(common_models_for("openai"))
+    curated = common_models_for("openai")
+    assert entry["models"][: len(curated)] == curated
+    assert entry["total_models"] > len(curated), "the catalogue tier added nothing"
 
 
 async def test_options_current_provider_marked(fake_home: Path) -> None:
@@ -274,8 +279,9 @@ async def test_options_openrouter_seeds_common_models(fake_home: Path) -> None:
         },
     )
     entry = _entry(await model_options({}), "openrouter")
-    assert entry["models"] == common_models_for("openrouter")
-    assert entry["total_models"] == len(common_models_for("openrouter"))
+    curated = common_models_for("openrouter")
+    assert entry["models"][: len(curated)] == curated
+    assert entry["total_models"] > len(curated), "the catalogue tier added nothing"
 
 
 async def test_options_config_models_rank_before_common_and_dedup(fake_home: Path) -> None:
@@ -330,7 +336,8 @@ async def test_options_direct_provider_lists_common_models_when_unconfigured(
     )
     entry = _entry(await model_options({}), slug)
     assert entry["total_models"] > 0
-    assert entry["models"] == common_models_for(slug)
+    curated = common_models_for(slug)
+    assert entry["models"][: len(curated)] == curated, "the curated shortlist must stay at the top"
 
 
 async def test_save_key_accepts_a_provider_without_a_spec(fake_home: Path) -> None:
@@ -345,3 +352,65 @@ async def test_save_key_accepts_a_provider_without_a_spec(fake_home: Path) -> No
 
     assert result["provider"]["slug"] == "mistral"
     assert result["provider"]["authenticated"] is True
+
+
+@pytest.mark.parametrize("slug", ["moonshot", "minimax", "volcengine", "ollama_chat", "github_copilot"])
+def test_litellm_catalogue_fills_providers_with_no_curated_shortlist(slug: str) -> None:
+    """Eleven providers had no shortlist, so the picker offered them nothing.
+
+    Ollama is the case that proves the lookup has to go through every name the
+    provider answers to: LiteLLM files its models under "ollama" while the
+    section is "ollama_chat", so a lookup by section name alone finds none.
+    """
+    from raven.providers.common_models import common_models_for, litellm_models_for
+
+    assert not common_models_for(slug), f"{slug} now has a shortlist; pick another provider for this test"
+    models = litellm_models_for(slug)
+    assert models, f"{slug}: the catalogue tier found nothing"
+    assert all("/" in m for m in models), models[:3]
+
+
+def test_catalogue_ids_are_spelled_the_way_they_route() -> None:
+    """The catalogue is inconsistent about prefixes; the picker must not be.
+
+    Moonshot's entries carry their prefix and VolcEngine's do not. An id offered
+    bare would be routed by keyword instead of to the provider the user picked.
+    """
+    from raven.providers.common_models import litellm_models_for
+    from raven.providers.registry import find_by_name
+
+    for slug in ("moonshot", "volcengine", "ollama_chat"):
+        spec = find_by_name(slug)
+        assert spec is not None
+        for model in litellm_models_for(slug):
+            assert model.startswith(f"{spec.model_prefix}/"), f"{slug}: {model}"
+
+
+def test_catalogue_offers_only_chat_models() -> None:
+    """Embeddings and speech share the catalogue and fail as a chat default."""
+    from raven.providers.common_models import litellm_models_for
+
+    offered = {m for slug in ("minimax", "volcengine") for m in litellm_models_for(slug)}
+    assert offered, "nothing to check"
+    assert not [m for m in offered if "embedding" in m or "speech" in m], sorted(offered)
+
+
+def test_the_catalogue_is_not_read_until_the_picker_is_opened() -> None:
+    """Reading it imports LiteLLM, which is two seconds Raven must not spend at
+    startup. Importing the module that offers it must stay free."""
+    import subprocess
+    import sys
+
+    probe = (
+        "import sys, json\n"
+        "import raven.tui_rpc.methods.model  # noqa: F401\n"
+        "before = 'litellm' in sys.modules\n"
+        "from raven.providers.common_models import litellm_models_for\n"
+        "n = len(litellm_models_for('moonshot'))\n"
+        "print(json.dumps({'before': before, 'after': 'litellm' in sys.modules, 'n': n}))\n"
+    )
+    out = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=True)
+    result = json.loads(out.stdout.strip().splitlines()[-1])
+    assert result["before"] is False, "importing the picker module pulled in litellm"
+    assert result["after"] is True, "reading the catalogue did not import litellm; is it still the source?"
+    assert result["n"] > 0

--- a/tests/test_tui_rpc_model.py
+++ b/tests/test_tui_rpc_model.py
@@ -338,6 +338,12 @@ async def test_options_direct_provider_lists_common_models_when_unconfigured(
     assert entry["total_models"] > 0
     curated = common_models_for(slug)
     assert entry["models"][: len(curated)] == curated, "the curated shortlist must stay at the top"
+    # And the tail is this provider's catalogue, not some other provider's:
+    # asserting only the prefix let the third tier be wired to a fixed slug.
+    from raven.providers.common_models import litellm_models_for
+
+    tail = entry["models"][len(curated) :]
+    assert set(tail) <= set(litellm_models_for(slug)), f"{slug}: tail holds models from elsewhere"
 
 
 async def test_save_key_accepts_a_provider_without_a_spec(fake_home: Path) -> None:
@@ -382,8 +388,16 @@ def test_catalogue_ids_are_spelled_the_way_they_route() -> None:
     for slug in ("moonshot", "volcengine", "ollama_chat"):
         spec = find_by_name(slug)
         assert spec is not None
-        for model in litellm_models_for(slug):
-            assert model.startswith(f"{spec.model_prefix}/"), f"{slug}: {model}"
+        models = litellm_models_for(slug)
+        assert models, f"{slug}: nothing to check"
+        for model in models:
+            # Exactly one prefix, not merely one at the front: `startswith` alone
+            # reads "moonshot/moonshot/x" as correct, so it could not tell a
+            # re-prefixed id from a right one.
+            head, _, rest = model.partition("/")
+            assert head == spec.model_prefix, f"{slug}: {model}"
+            assert rest, f"{slug}: {model} has no id after the prefix"
+            assert not rest.startswith(f"{spec.model_prefix}/"), f"{slug}: double-prefixed {model}"
 
 
 def test_catalogue_offers_only_chat_models() -> None:


### PR DESCRIPTION
## Summary

The onboarding picker offered 13 hardcoded rows while the provider layer could
already reach every vendor LiteLLM routes to, so a supported provider was only
configurable by hand-editing the config file. This opens the picker up and makes
the model step work for everything it now offers.

The picker lists all 21 registered providers in four groups (key, OAuth, local,
fallback), plus a searchable second step for the vendors Raven carries no spec
for. A spec is metadata, not permission: the name gate now passes those through
and normalizes the spelling instead of rejecting it.

Local deployments (Ollama, vLLM) are configured by address rather than by key.
The old path demanded an API key with a minimum length, which nothing running on
localhost has, so the wizard could not finish. The address field is seeded with
whatever is already configured, falling back to the registry default.

Model candidates come from one chain everywhere: what the user configured, then
the curated shortlist, then LiteLLM's own catalogue. Eleven providers offered
zero models before -- picking Moonshot after saving a key showed "no models
listed for this provider", which reads as a rejected key. Moonshot now offers 22,
Ollama 21, Copilot 27. The catalogue is read from the installed package and
loaded on first use, not at import.

Every model id the wizard returns carries its provider's route prefix. A bare id
is routed by keyword and fallback rather than to the provider just configured, so
a vendor with no spec would have been configured correctly and then called with
another provider's key.

"How is this provider reached" is now answered in one function rather than
derived independently at thirteen call sites: a token file, an address, an
endpoint plus a key, or a key alone. Each of those sites disagreeing with the
others is what produced a rollback that crashed the wizard on OAuth providers, a
menu that offered a key prompt to one, and a failure menu that offered to re-enter
a key a local server does not have. A guard test fails if the auth flags are read
anywhere else.

## Type

- [ ] Fix
- [x] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

```
uv run --all-extras pytest tests/ -q -p no:randomly
  4939 passed, 30 skipped, 13 deselected

uv run ruff check raven/ tests/    All checks passed
uv run ruff format --check          unchanged
```

Every regression test added here was checked by breaking the implementation it
covers and confirming it fails, in both directions where the invariant has two
sides. That found one guard whose branches were unreachable in effect, which is
deleted rather than pinned.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

Model candidates track LiteLLM's price table, which ships with the package, so
the list moves when that dependency is upgraded rather than staying fixed. This
is deliberate: pinning a local copy would have put candidates out of step with
the pricing and context-window numbers read from the same table, and an earlier
attempt to pin it also pinned the whole process to a table 278 entries behind.
Candidates are a starting list, not a whitelist -- the field accepts free text.

Providers already in a config file keep working: names are matched
spelling-insensitively, and nothing rewrites existing entries.

Rollback is the revert of this branch. It restores the 13-row picker; providers
configured through the new rows stay in the config file and keep working, since
the execution layer already supported them before this change.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

Fixes #203
Fixes #221
Fixes #248

Partially addresses #197 -- MiniMax is marked as an open-source partner in the
picker, placed above the other direct providers rather than immediately after
OpenRouter. The documentation note inviting other providers to collaborate is
left open for someone else to pick up.