### PR TITLE
fix(cli): keep the wizard flags to the pass they were typed for

### DIFF
--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -957,23 +957,6 @@ def _credential_kind(provider: str, spec: Any) -> str:
     return CRED_KEY
 
 
-def _litellm_spelling(provider: str) -> str:
-    """How LiteLLM spells this vendor, for use as a route prefix.
-
-    Config section names are matched spelling-insensitively, so the name reaching
-    here may be underscored where LiteLLM hyphenates. Only LiteLLM's own form
-    works as a prefix.
-    """
-    from raven.providers.litellm_provider_names import LITELLM_PROVIDER_NAMES
-    from raven.providers.registry import normalize_provider_name
-
-    wanted = normalize_provider_name(provider)
-    for name in LITELLM_PROVIDER_NAMES:
-        if normalize_provider_name(name) == wanted:
-            return name
-    return wanted
-
-
 def _format_model_for_provider(provider: str, spec: Any, model_id: str) -> str:
     """Apply the provider's route prefix to a raw ``/v1/models`` id when needed.
 
@@ -996,7 +979,9 @@ def _format_model_for_provider(provider: str, spec: Any, model_id: str) -> str:
         # name LiteLLM routes on -- it hyphenates three vendors, and handing it
         # "nano_gpt/..." is rejected with "LLM Provider NOT provided", so the
         # provider configured fine and then could not be called.
-        prefix = _litellm_spelling(provider)
+        from raven.providers.registry import litellm_spelling
+
+        prefix = litellm_spelling(provider)
         return model_id if model_id.startswith(f"{prefix}/") else f"{prefix}/{model_id}"
     if spec.name in {"minimax_global", "minimax_cn"}:
         public_prefix = spec.name.replace("_", "-")
@@ -1020,6 +1005,7 @@ def _pick_model(
     *,
     current_model: Optional[str],
     model_ids: Optional[list[str]],
+    probe_status: str,
     user_provided_model: Optional[str],
     non_interactive: bool,
 ) -> str:
@@ -1057,8 +1043,18 @@ def _pick_model(
 
         known = [*common_models_for(provider), *litellm_models_for(provider)]
         if known:
+            # openai / anthropic / deepseek / gemini have no /models endpoint to
+            # pre-check, so there is no list on a perfectly healthy run. Saying
+            # "couldn't reach the provider" there contradicted the line printed
+            # just above it and read as a failure to a user for whom nothing
+            # had failed.
             console.print(
                 _t(
+                    "  [dim]This provider has no model list to fetch - offering the ones we know.[/dim]",
+                    "  [dim]该服务商没有可拉取的模型列表,先列出已知的。[/dim]",
+                )
+                if probe_status == "skipped"
+                else _t(
                     "  [dim]Couldn't reach the provider for its model list - offering the ones we know.[/dim]",
                     "  [dim]未能向服务商拉取模型列表,先列出已知的。[/dim]",
                 )
@@ -1292,6 +1288,20 @@ def _configure_one_provider(
     # A provider passed by flag is used once; switching then requires the
     # interactive picker (or, in non-interactive mode, is impossible).
     flag_provider = provider
+
+    def _rewind() -> None:
+        """Discard the flag values before the next pass through the picker.
+
+        All of them, not just the provider: they were typed for the provider
+        that just failed. A stale --api-key was written to the newly picked
+        provider without a prompt, a stale --base-url pointed it at the previous
+        provider's machine, and picking a local deployment -- which rejects
+        --api-key by design -- ended the whole wizard on a usage error, losing
+        the later steps this loop exists to keep.
+        """
+        nonlocal flag_provider, api_key, base_url, model
+        flag_provider = api_key = base_url = model = None
+
     while True:
         if flag_provider:
             provider = _validate_provider_name(flag_provider)
@@ -1310,7 +1320,7 @@ def _configure_one_provider(
                 provider = _validate_provider_name(picked)
             except typer.BadParameter as exc:
                 console.print(f"  [red]x[/red] {exc}")
-                flag_provider = None
+                _rewind()
                 continue
 
         spec = find_by_name(provider)
@@ -1352,8 +1362,8 @@ def _configure_one_provider(
         )
         if custom_model is _BACK:
             # User backed out of the first credential field — rewind to the
-            # provider picker (drop any flag so the picker actually shows).
-            flag_provider = None
+            # provider picker (drop the flags so the picker actually shows).
+            _rewind()
             continue
 
         chosen_model = _resolve_model_with_test(
@@ -1367,9 +1377,9 @@ def _configure_one_provider(
             skip_test=skip_test,
         )
         if chosen_model is None:
-            # "Switch provider" — re-run the picker (drop the flag so the second
-            # pass prompts rather than reusing the failed flag value), undoing
-            # what this pass wrote.
+            # "Switch provider" — re-run the picker (drop the flags so the second
+            # pass prompts rather than reusing the failed values), undoing what
+            # this pass wrote.
             #
             # Put back exactly what was there, read before this pass wrote
             # anything. One branch, because "was it configured" is the wrong
@@ -1385,7 +1395,7 @@ def _configure_one_provider(
             # them at all, and doing so turned a failed verification into a
             # RuntimeError that took the whole wizard down.
             _roll_back_provider_fields(provider, spec, old_key=old_key, old_base=old_base)
-            flag_provider = None
+            _rewind()
             continue
         _persist_default_model(chosen_model)
         return {"provider": provider, "model": chosen_model}
@@ -1613,6 +1623,7 @@ def _resolve_model_with_test(
             spec,
             current_model=current,
             model_ids=model_ids,
+            probe_status=status,
             user_provided_model=user_model_flag,
             non_interactive=non_interactive,
         )
@@ -1666,7 +1677,7 @@ def _configure_existing_provider_model(*, non_interactive: bool) -> bool:
     if not provider:
         raise typer.Exit(1)
     spec = find_by_name(provider)
-    ok, _status, model_ids = _verify_provider(provider)
+    ok, status, model_ids = _verify_provider(provider)
     if not ok:
         return False
     chosen = _pick_model(
@@ -1674,6 +1685,7 @@ def _configure_existing_provider_model(*, non_interactive: bool) -> bool:
         spec,
         current_model=None,
         model_ids=model_ids,
+        probe_status=status,
         user_provided_model=None,
         non_interactive=False,
     )
@@ -1762,6 +1774,21 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
                 if retyped is None:
                     continue
                 _write_provider_fields(target, {"api_base": retyped})
+            elif _credential_kind(target, target_spec) == CRED_ENDPOINT:
+                # A self-hosted endpoint is a key *and* the address it is sent
+                # to. Updating only the key left the one field that moves when
+                # the user redeploys -- the URL -- unreachable from this menu.
+                from raven.config.update_providers import get_provider_config
+
+                try:
+                    stored = get_provider_config(target, redact_secrets=False).get("api_base") or ""
+                except KeyError:
+                    stored = ""
+                retyped_key = _prompt_api_key(target)
+                retyped_url = _prompt_base_url(stored or "https://")
+                if retyped_url is None:
+                    continue
+                _write_provider_fields(target, {"api_key": retyped_key, "api_base": retyped_url})
             else:
                 _write_provider_fields(target, {"api_key": _prompt_api_key(target)})
             console.print(

--- a/raven/providers/common_models.py
+++ b/raven/providers/common_models.py
@@ -190,23 +190,6 @@ def _litellm_chat_models_by_provider() -> dict[str, tuple[str, ...]]:
     return index
 
 
-def _litellm_spelling_for(slug: str) -> str:
-    """How LiteLLM spells this vendor, which is the only form usable as a prefix.
-
-    Section names are matched spelling-insensitively, so the name arriving here
-    may be underscored where LiteLLM hyphenates -- and LiteLLM rejects the
-    underscored form outright.
-    """
-    from raven.providers.litellm_provider_names import LITELLM_PROVIDER_NAMES
-    from raven.providers.registry import normalize_provider_name
-
-    wanted = normalize_provider_name(slug)
-    for name in LITELLM_PROVIDER_NAMES:
-        if normalize_provider_name(name) == wanted:
-            return name
-    return wanted
-
-
 def litellm_models_for(slug: str) -> list[str]:
     """Chat models LiteLLM knows for this provider, as ids that actually route.
 
@@ -220,7 +203,7 @@ def litellm_models_for(slug: str) -> list[str]:
     do not -- and offering a bare id would route it by keyword rather than to the
     provider the user picked.
     """
-    from raven.providers.registry import find_by_name, normalize_provider_name
+    from raven.providers.registry import find_by_name, litellm_spelling, normalize_provider_name
 
     spec = find_by_name(slug)
     if spec is None:
@@ -234,10 +217,13 @@ def litellm_models_for(slug: str) -> list[str]:
         # Bedrock's do not -- so they are normalized here rather than trusted.
         # Offering an unprefixed one would reintroduce the very thing this exists
         # to avoid.
+        # The index is keyed by LiteLLM's own spelling, so it has to be read by
+        # that spelling too -- looking it up normalized found nothing for any
+        # vendor LiteLLM hyphenates.
         index = _litellm_chat_models_by_provider()
-        prefix = _litellm_spelling_for(slug)
+        prefix = litellm_spelling(slug)
         out: list[str] = []
-        for model in index.get(normalize_provider_name(slug), ()):
+        for model in index.get(prefix, ()):
             bare = model[len(prefix) + 1 :] if model.startswith(f"{prefix}/") else model
             out.append(f"{prefix}/{bare}")
         return out

--- a/raven/providers/registry.py
+++ b/raven/providers/registry.py
@@ -533,6 +533,24 @@ def normalize_provider_name(name: str | None) -> str:
     return (name or "").strip().lower().replace("-", "_")
 
 
+def litellm_spelling(name: str | None) -> str:
+    """How LiteLLM spells this vendor, which is the only form usable as a prefix.
+
+    Names are matched spelling-insensitively everywhere else, so the one arriving
+    here may be underscored where LiteLLM hyphenates -- and LiteLLM rejects the
+    underscored form outright ("nano_gpt/..." comes back as "LLM Provider NOT
+    provided"), which turns a provider that configured cleanly into one that
+    cannot be called.
+    """
+    from raven.providers.litellm_provider_names import LITELLM_PROVIDER_NAMES
+
+    wanted = normalize_provider_name(name)
+    for candidate in LITELLM_PROVIDER_NAMES:
+        if normalize_provider_name(candidate) == wanted:
+            return candidate
+    return wanted
+
+
 def names_same_provider(key: str, name: str) -> bool:
     """Do these two strings name the same provider?
 

--- a/raven/tui_rpc/methods/model.py
+++ b/raven/tui_rpc/methods/model.py
@@ -30,11 +30,7 @@ from raven.config.update_providers import (
     reset_provider,
     set_provider_fields,
 )
-from raven.providers.common_models import (
-    _litellm_chat_models_by_provider,
-    common_models_for,
-    litellm_models_for,
-)
+from raven.providers.common_models import common_models_for, litellm_models_for
 from raven.providers.registry import canonical_provider_name, find_by_model, find_by_name
 from raven.tui_rpc.errors import (
     ConfigValidationError,
@@ -113,6 +109,28 @@ def _build_provider_entry(slug: str, *, current_provider: str | None) -> dict[st
     }
 
 
+async def _entry_off_loop(slug: str, current_provider: str | None) -> dict[str, Any]:
+    """Build one picker row without blocking the event loop.
+
+    Reading the candidate chain imports LiteLLM the first time, which takes
+    seconds -- long enough to stall this session's token stream. Every handler
+    that returns a row goes through here rather than warming the cache in one
+    and reading it inline in the others: the cache is cold whenever a first read
+    failed (failures are deliberately not cached), and handler order is up to
+    the client.
+    """
+    return await asyncio.to_thread(_build_provider_entry, slug, current_provider=current_provider)
+
+
+async def _entries_off_loop(current_provider: str | None) -> list[dict[str, Any]]:
+    """Build every picker row in one thread hop rather than one hop per row."""
+
+    def _build() -> list[dict[str, Any]]:
+        return [_build_provider_entry(p["name"], current_provider=current_provider) for p in list_providers()]
+
+    return await asyncio.to_thread(_build)
+
+
 def _current_selection() -> tuple[str, str | None]:
     from raven.cli._helpers import load_runtime_config
 
@@ -136,12 +154,8 @@ def _current_selection() -> tuple[str, str | None]:
 
 async def model_options(params: dict) -> dict:
     _parse(ModelOptionsParams, params)
-    # Warm the catalogue off the loop. Reading it imports LiteLLM the first time,
-    # which takes seconds -- long enough that doing it inline would stall this
-    # session's token stream while the picker opens.
-    await asyncio.to_thread(_litellm_chat_models_by_provider)
     current_model, current_provider = _current_selection()
-    entries = [_build_provider_entry(p["name"], current_provider=current_provider) for p in list_providers()]
+    entries = await _entries_off_loop(current_provider)
     return {
         "model": current_model,
         "provider": current_provider or "",
@@ -182,7 +196,7 @@ async def model_save_key(params: dict) -> dict:
 
     _, current_provider = _current_selection()
     return {
-        "provider": _build_provider_entry(parsed.slug, current_provider=current_provider),
+        "provider": await _entry_off_loop(parsed.slug, current_provider),
     }
 
 
@@ -203,7 +217,7 @@ async def model_add_model(params: dict) -> dict:
         raise ConfigValidationError(str(exc), data={"slug": parsed.slug}) from exc
     _, current_provider = _current_selection()
     return {
-        "provider": _build_provider_entry(parsed.slug, current_provider=current_provider),
+        "provider": await _entry_off_loop(parsed.slug, current_provider),
     }
 
 
@@ -215,7 +229,7 @@ async def model_remove_model(params: dict) -> dict:
         raise ConfigValidationError(str(exc), data={"slug": parsed.slug}) from exc
     _, current_provider = _current_selection()
     return {
-        "provider": _build_provider_entry(parsed.slug, current_provider=current_provider),
+        "provider": await _entry_off_loop(parsed.slug, current_provider),
     }
 
 

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -2157,6 +2157,7 @@ def test_the_wizard_offers_known_models_when_the_provider_cannot_be_reached(monk
         find_by_name("moonshot"),
         current_model=None,
         model_ids=None,  # the fetch came back empty
+        probe_status="network_error",
         user_provided_model=None,
         non_interactive=False,
     )
@@ -2400,6 +2401,7 @@ def test_every_exit_of_the_model_step_prefixes_what_it_returns(typed: str, expec
             None,
             current_model=None,
             model_ids=None,
+            probe_status="skipped",
             user_provided_model=typed,
             non_interactive=True,
         )
@@ -2412,6 +2414,7 @@ def test_every_exit_of_the_model_step_prefixes_what_it_returns(typed: str, expec
             None,
             current_model=None,
             model_ids=None,
+            probe_status="skipped",
             user_provided_model=None,
             non_interactive=False,
         )
@@ -2434,6 +2437,7 @@ def test_what_the_model_step_returns_is_served_by_the_provider_it_was_configured
         None,
         current_model=None,
         model_ids=None,
+        probe_status="skipped",
         user_provided_model="mistral-large-latest",
         non_interactive=True,
     )
@@ -2506,7 +2510,10 @@ def test_only_credential_kind_reads_the_spec_auth_flags() -> None:
     offenders = [
         f"line {i}: {line.strip()}"
         for i, line in enumerate(source.splitlines(), 1)
-        if re.search(r"\bspec\.is_(oauth|local)\b", line) and not line.lstrip().startswith("#") and i not in allowed
+        # Any receiver, not just one spelled `spec`: `target_spec.is_oauth` has no
+        # word boundary before "spec", so a name-anchored pattern read as a
+        # guarantee while missing the manage menu entirely.
+        if re.search(r"\.is_(oauth|local)\b", line) and not line.lstrip().startswith("#") and i not in allowed
     ]
     assert not offenders, "derive it from _credential_kind instead:\n" + "\n".join(offenders)
 
@@ -2675,3 +2682,157 @@ def test_backing_out_of_the_vendor_sublist_returns_to_the_provider_list(
     rows = iter([onboard_commands._PICK_LITELLM_VENDOR, onboard_commands._BACK])
     monkeypatch.setattr(onboard_commands, "_select_provider_row", lambda: next(rows))
     assert onboard_commands._select_provider() is onboard_commands._BACK
+
+
+def test_switching_provider_discards_every_flag_not_just_the_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Flag values belong to the pass they were typed for.
+
+    They were carried into the next one, so switching from a failed keyed
+    provider to a local deployment hit the guard that rejects --api-key for one
+    and ended the wizard on a usage error, losing the steps this loop exists to
+    keep. The quieter halves of the same bug: the stale key was written to the
+    newly picked provider with no prompt, and the stale base URL pointed it at
+    the previous provider's machine.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / ".raven").mkdir()
+    seen: list[tuple[str, Any, Any, Any]] = []
+
+    def _collect(provider: str, **kw: Any) -> Any:
+        seen.append((provider, kw.get("api_key"), kw.get("base_url"), kw.get("model")))
+        return onboard_commands._BACK if provider == "ollama_chat" else None
+
+    picks = iter(["ollama_chat", onboard_commands._BACK])
+    monkeypatch.setattr(onboard_commands, "_select_provider", lambda: next(picks))
+    monkeypatch.setattr(onboard_commands, "_collect_credentials", _collect)
+    monkeypatch.setattr(onboard_commands, "_resolve_model_with_test", lambda *a, **k: None)
+
+    # No exception: reaching the local deployment used to raise BadParameter here.
+    assert (
+        onboard_commands._configure_one_provider(
+            provider="deepseek",
+            api_key="sk-stale",
+            base_url="http://previous-box:1234",
+            model="deepseek-chat",
+            non_interactive=False,
+            warnings=[],
+        )
+        is None
+    )
+    assert seen[0] == ("deepseek", "sk-stale", "http://previous-box:1234", "deepseek-chat"), (
+        "the flags have to apply on the pass they were given for"
+    )
+    assert seen[1] == ("ollama_chat", None, None, None), f"a flag survived the switch: {seen[1]}"
+
+
+def test_no_rewind_clears_the_flags_by_hand() -> None:
+    """One answer to "what does a rewind discard", three call sites.
+
+    Each of the three used to answer it separately and all three answered it the
+    same incomplete way -- only the provider flag -- which is the shape of bug
+    this branch exists to remove.
+    """
+    import ast
+    from pathlib import Path as _Path
+
+    path = _Path(__file__).resolve().parents[1] / "raven" / "cli" / "onboard_commands.py"
+    source = path.read_text()
+    tree = ast.parse(source)
+    outer = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_configure_one_provider"
+    )
+    rewind = next(node for node in ast.walk(outer) if isinstance(node, ast.FunctionDef) and node.name == "_rewind")
+    lines = source.splitlines()
+    allowed = range(rewind.lineno, (rewind.end_lineno or rewind.lineno) + 1)
+    body = range(outer.lineno, (outer.end_lineno or outer.lineno) + 1)
+
+    offenders = [
+        f"line {i}: {lines[i - 1].strip()}"
+        for i in body
+        if "flag_provider = " in lines[i - 1] and "flag_provider = provider" not in lines[i - 1] and i not in allowed
+    ]
+    assert not offenders, "call _rewind() instead:\n" + "\n".join(offenders)
+
+
+def test_a_provider_with_no_model_endpoint_is_not_reported_as_unreachable(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """openai / anthropic / deepseek / gemini reach this with nothing wrong.
+
+    They ship no api_base, so the pre-check is skipped rather than failed and
+    there is no model list on a healthy run. The step printed "couldn't reach the
+    provider" straight after the line saying the check had been skipped, so the
+    first thing the user saw on the happy path was two contradictory sentences.
+    """
+    from raven.providers.registry import find_by_name
+
+    offered: dict[str, Any] = {}
+
+    class _Stub:
+        def __init__(self, label: Any, **kw: Any) -> None:
+            offered["choices"] = list(kw.get("choices") or [])
+
+        def ask(self) -> Any:
+            return offered["choices"][0]
+
+    monkeypatch.setattr(
+        onboard_commands, "_require_questionary", lambda: SimpleNamespace(autocomplete=_Stub, text=_Stub)
+    )
+
+    for status, unreachable_expected in (("skipped", False), ("network_error", True)):
+        capsys.readouterr()
+        onboard_commands._pick_model(
+            "anthropic",
+            find_by_name("anthropic"),
+            current_model=None,
+            model_ids=None,
+            probe_status=status,
+            user_provided_model=None,
+            non_interactive=False,
+        )
+        out = capsys.readouterr().out.lower()
+        assert ("couldn't reach" in out or "could not reach" in out) is unreachable_expected, (
+            f"status={status!r} printed: {out.strip()}"
+        )
+
+
+def test_updating_a_self_hosted_endpoint_can_change_its_address(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A key plus the address it is sent to; the menu only re-asked for the key.
+
+    The URL is the field that moves when the user redeploys, and it was the one
+    this menu could not reach -- leaving the stored address pointing at a machine
+    that is gone, with no way out but editing the config file.
+    """
+    from raven.config.update_providers import set_provider_fields
+
+    set_provider_fields("custom", {"api_key": "sk-old", "api_base": "http://old-box:8000/v1"})
+
+    import questionary
+
+    class _FQ:
+        def __init__(self, a: Any) -> None:
+            self._a = a
+
+        def ask(self) -> Any:
+            return self._a
+
+    select_answers = iter(["custom", "update", onboard_commands._BACK])
+    monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ(next(select_answers)))
+    monkeypatch.setattr(onboard_commands, "_prompt_api_key", lambda provider, **kw: "sk-new")
+
+    seeded: dict[str, Any] = {}
+
+    def _base_url(default: str = "https://", **kw: Any) -> Any:
+        seeded["default"] = default
+        return "http://new-box:9000/v1"
+
+    monkeypatch.setattr(onboard_commands, "_prompt_base_url", _base_url)
+
+    onboard_commands._manage_existing_providers(non_interactive=False)
+
+    section = json.loads(tmp_env.read_text())["providers"]["custom"]
+    assert section.get("apiBase") == "http://new-box:9000/v1", section
+    assert section.get("apiKey") == "sk-new", section
+    assert seeded["default"] == "http://old-box:8000/v1", "the stored address was not offered back"

--- a/tests/test_tui_rpc_model.py
+++ b/tests/test_tui_rpc_model.py
@@ -15,6 +15,7 @@ import pytest
 
 from raven.providers.common_models import common_models_for
 from raven.tui_rpc.errors import ConfigValidationError, NotSupportedInV01Error
+from raven.tui_rpc.methods import model as model_module
 from raven.tui_rpc.methods.model import (
     model_add_model,
     model_disconnect,
@@ -428,3 +429,43 @@ def test_the_catalogue_is_not_read_until_the_picker_is_opened() -> None:
     assert result["before"] is False, "importing the picker module pulled in litellm"
     assert result["after"] is True, "reading the catalogue did not import litellm; is it still the source?"
     assert result["n"] > 0
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(lambda: model_options({}), id="options"),
+        pytest.param(lambda: model_save_key({"slug": "deepseek", "api_key": "sk-test-key"}), id="save_key"),
+        pytest.param(lambda: model_add_model({"slug": "deepseek", "model": "deepseek-chat"}), id="add_model"),
+        pytest.param(lambda: model_remove_model({"slug": "deepseek", "model": "deepseek-chat"}), id="remove_model"),
+        pytest.param(lambda: model_options({}), id="options_again"),
+    ],
+)
+async def test_no_handler_reads_the_catalogue_on_the_event_loop(fake_home: Path, monkeypatch, call) -> None:
+    """Reading it imports LiteLLM the first time, which takes seconds.
+
+    Only ``model.options`` warmed the cache off the loop; the three write
+    handlers built their response row inline. That is the stall the warm-up
+    exists to prevent, and it is reachable whenever the cache is cold -- a failed
+    read is deliberately not cached, and the client decides the call order.
+    """
+    import asyncio
+    import threading
+
+    _write_config(fake_home, {"providers": {"deepseek": {"api_key": "sk-existing"}}})
+
+    loop_thread = threading.get_ident()
+    seen: list[int] = []
+    real = model_module.litellm_models_for
+
+    def _spy(slug: str):
+        seen.append(threading.get_ident())
+        return real(slug)
+
+    monkeypatch.setattr(model_module, "litellm_models_for", _spy)
+    await call()
+
+    assert seen, "the handler never consulted the catalogue, so this proves nothing"
+    on_loop = [t for t in seen if t == loop_thread]
+    assert not on_loop, f"{len(on_loop)}/{len(seen)} catalogue reads ran on the event loop"
+    assert asyncio.get_running_loop() is not None


### PR DESCRIPTION
## Summary

Review follow-up to #252. These fixes were written and verified before that PR
merged but were never pushed to it, so they land here instead.

Switching provider after a failed verification carried the credential flags into
the next pass. Picking a local deployment then hit the guard that rejects
--api-key for one, and the wizard ended on a usage error with steps 2-4 lost --
the outcome the switch loop exists to prevent. Two quieter halves of the same
bug: the stale key was written to the newly picked provider with no prompt, and
the stale base URL pointed it at the previous provider's machine.

Three rewind sites each answered "what does a rewind discard" separately, and
all three answered it the same incomplete way -- the provider flag only, while
the comment claimed the failed values would not be reused. One `_rewind` answers
it now, and a guard test fails if a rewind clears anything by hand.

Every handler returning a picker row builds it off the event loop, instead of
one warming the catalogue and three reading it inline. The read imports LiteLLM
the first time, the cache is cold whenever an earlier read failed (failures are
deliberately not cached), and call order belongs to the client.

openai / anthropic / deepseek / gemini no longer report themselves unreachable
on a healthy run: their pre-check is skipped rather than failed, so the model
step printed "couldn't reach the provider" directly beneath the line saying the
check had been skipped.

A self-hosted endpoint is a key and the address it is sent to. Its manage-menu
update re-asked only for the key, so the field that moves when the user
redeploys could not be reached from that menu -- and the address it already has
is offered back rather than replaced with a placeholder.

Two consolidations: how LiteLLM spells a vendor was the same function in two
modules and is now one, in the module that owns provider naming; and the
catalogue index is read by that spelling rather than the normalized one, which
would find nothing for any vendor LiteLLM hyphenates.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

```
uv run --all-extras pytest tests/ -q -p no:randomly
uv run ruff check raven/ tests/
```

Each fix was checked by breaking it and confirming the new test fails, in both
directions where the invariant has two sides. Two of those runs found more than
they were aimed at: the endpoint-update fix had no test until a mutation stayed
green, and writing one exposed a second defect (the stored address was not
offered back); and tightening the auth-flag guard to match any receiver was
confirmed against the exact spelling the old pattern missed.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

The wizard's --api-key / --base-url / --model flags now apply only to the first
provider attempted. Passing them and then switching provider prompts for
credentials instead of reusing the values typed for the provider that failed.

Rollback is the revert of this branch; it restores the behaviour above.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A -- follow-up to the review on #252.