### PR TITLE
fix(tui_rpc): stop a typed model id from keeping the wrong provider pinned

### DIFF
--- a/raven/tui_rpc/methods/config.py
+++ b/raven/tui_rpc/methods/config.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 from raven.cli._helpers import load_runtime_config, make_provider
-from raven.providers.registry import find_by_model
+from raven.providers.registry import find_by_model, find_by_name
 from raven.tui_rpc.errors import (
     ConfigFieldReadonlyError,
     ConfigValidationError,
@@ -273,6 +273,50 @@ async def config_set(
     return {"applied": True, "previous": previous}
 
 
+def _resolve_bare_model_against_pin(raw_value: str) -> str | None:
+    """Who serves this bare id, when its own text names nobody?
+
+    A bare id that matches no provider's keywords is what a vendor Raven holds no
+    spec for looks like, and the picker never produces one -- it always sends the
+    provider alongside. So this is the hand-typed path, where the only other
+    evidence is the provider currently pinned.
+
+    Rather than guess, ask whether that provider serves the model: its own curated
+    list first, then the catalogue. If it does, the pin was right and stays. A local
+    deployment stays too without asking -- its server names whatever models it
+    likes, and there is no key to mis-route.
+
+    With no such evidence the pin is not kept: it would send one vendor's key to
+    another, the mis-routing the prefix rules exist to prevent. Returning None
+    leaves the caller to say so rather than pick a vendor on the user's behalf.
+    """
+    forced = _get_nested(_load_config(), "agents.defaults.provider")
+    if not forced or forced == "auto":
+        return "auto"
+
+    spec = find_by_name(forced)
+    if spec is not None and spec.is_local:
+        return forced
+
+    from raven.config.update_providers import get_provider_config
+    from raven.providers.common_models import common_models_for, litellm_models_for
+    from raven.providers.registry import split_model_id
+
+    try:
+        configured = get_provider_config(forced, redact_secrets=True).get("models") or []
+    except KeyError:
+        configured = []
+    known = [*configured, *common_models_for(forced), *litellm_models_for(forced)]
+    for candidate in known:
+        # Stripping the prefix covers every spelling the sources use: the
+        # catalogue keys ids the way LiteLLM spells the vendor, a hand-added one
+        # sits in the provider's list bare.
+        _, bare = split_model_id(candidate)
+        if bare == raw_value or candidate == raw_value:
+            return forced
+    return None
+
+
 def _set_model(
     params: dict,
     raw_value: Any,
@@ -295,7 +339,8 @@ def _set_model(
             data={"field": "provider", "got": repr(new_provider)},
         )
     # Bare `/model <name>` carries no provider; derive it from the model so a
-    # previously-forced provider does not silently mis-route the new model.
+    # previously-forced provider does not silently mis-route the new model. The
+    # picker always sends one, so this is the hand-typed path.
     if new_provider is None:
         spec = find_by_model(raw_value)
         if spec is not None:
@@ -305,6 +350,13 @@ def _set_model(
             # keeping the previously forced provider would send that provider's
             # key to this other vendor, so hand routing back to auto-detection.
             new_provider = "auto"
+        else:
+            new_provider = _resolve_bare_model_against_pin(raw_value)
+            if new_provider is None:
+                raise ConfigValidationError(
+                    f"cannot tell which provider serves {raw_value!r}; qualify it as <provider>/{raw_value}",
+                    data={"field": "value", "got": raw_value},
+                )
 
     session_id = params.get("session_id")
     if isinstance(session_id, str) and session_id and is_turn_active(session_id):

--- a/tests/test_tui_rpc_config.py
+++ b/tests/test_tui_rpc_config.py
@@ -293,3 +293,125 @@ async def test_config_get_refuses_malformed_config(fake_home: Path) -> None:
     cfg.write_text('{\n  "tui": {"theme": "dark"},\n  // bad\n}\n', encoding="utf-8")
     with pytest.raises(ConfigValidationError):
         await config_get({"keys": ["tui.theme"]})
+
+
+def _pin(home: Path, provider: str, providers: dict | None = None) -> None:
+    """Write a config with a provider pinned, as the picker leaves it."""
+    cfg = home / ".raven"
+    cfg.mkdir(exist_ok=True)
+    (cfg / "config.json").write_text(
+        json.dumps(
+            {
+                "providers": providers if providers is not None else {"openai": {"api_key": "sk-openai"}},
+                "agents": {"defaults": {"model": "gpt-4o", "provider": provider}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    import raven.config.loader as loader
+
+    loader._current_config_path = None
+
+
+async def test_a_bare_id_the_pinned_provider_does_not_serve_is_refused(fake_home: Path) -> None:
+    """The pin decided routing for a model that names nobody, and it was wrong.
+
+    Selecting anything from the picker pins its provider, so by the time someone
+    types `/model <name>` there is almost always one. A bare id matching no
+    provider's keywords is what a vendor Raven holds no spec for looks like, and
+    keeping the pin sent that provider's key to a different vendor.
+
+    Nothing here can tell whose model it is, so it says so rather than picking.
+    """
+    _pin(fake_home, "openai")
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        await config_set(
+            {"key": "model", "value": "mistral-large-latest"},
+            agent_loop_factory=lambda: None,
+        )
+    assert "mistral-large-latest" in str(excinfo.value)
+
+    cfg = json.loads((fake_home / ".raven" / "config.json").read_text())
+    assert cfg["agents"]["defaults"]["model"] == "gpt-4o", "a refused switch must not write"
+    assert cfg["agents"]["defaults"]["provider"] == "openai"
+
+
+async def test_a_bare_id_the_pinned_provider_does_serve_keeps_the_pin(fake_home: Path) -> None:
+    """Refusing every bare id would break the case where the pin was right.
+
+    A user who configured a spec-less vendor and types one of its model names is
+    not being ambiguous -- that provider serves it. Asked of its own list and the
+    catalogue rather than assumed either way.
+    """
+    _pin(fake_home, "mistral", {"mistral": {"api_key": "sk-mistral"}})
+
+    result = await config_set(
+        {"key": "model", "value": "mistral-large-latest"},
+        agent_loop_factory=lambda: None,
+    )
+    assert result["applied"] is True
+    cfg = json.loads((fake_home / ".raven" / "config.json").read_text())
+    assert cfg["agents"]["defaults"]["provider"] == "mistral"
+    assert cfg["agents"]["defaults"]["model"] == "mistral-large-latest"
+
+
+async def test_a_local_deployment_keeps_its_pin_for_any_bare_id(fake_home: Path) -> None:
+    """Its server names whatever models it likes, and it holds no key to mis-route."""
+    _pin(fake_home, "ollama_chat", {"ollama_chat": {"api_base": "http://gpu-box:11434"}})
+
+    result = await config_set(
+        {"key": "model", "value": "some-local-build"},
+        agent_loop_factory=lambda: None,
+    )
+    assert result["applied"] is True
+    cfg = json.loads((fake_home / ".raven" / "config.json").read_text())
+    assert cfg["agents"]["defaults"]["provider"] == "ollama_chat"
+
+
+async def test_a_prefixed_id_no_spec_matches_still_hands_routing_back(fake_home: Path) -> None:
+    """Unchanged: the prefix names the vendor, so the pin has no claim on it."""
+    _pin(fake_home, "openai")
+
+    result = await config_set(
+        {"key": "model", "value": "mistral/mistral-large-latest"},
+        agent_loop_factory=lambda: None,
+    )
+    assert result["applied"] is True
+    cfg = json.loads((fake_home / ".raven" / "config.json").read_text())
+    assert cfg["agents"]["defaults"]["provider"] == "auto"
+
+
+async def test_an_explicit_provider_is_never_second_guessed(fake_home: Path) -> None:
+    """The picker sends one with every selection; that path must not reach the gate."""
+    _pin(fake_home, "openai")
+
+    result = await config_set(
+        {"key": "model", "value": "some-deployment", "provider": "azure_openai"},
+        agent_loop_factory=lambda: None,
+    )
+    assert result["applied"] is True
+    cfg = json.loads((fake_home / ".raven" / "config.json").read_text())
+    assert cfg["agents"]["defaults"]["provider"] == "azure_openai"
+
+
+async def test_a_bare_id_the_pinned_provider_lists_itself_keeps_the_pin(fake_home: Path) -> None:
+    """The provider's own curated list is evidence too, and it stores ids bare.
+
+    `model.add_model` writes what the user typed, so a hand-added id sits there
+    unprefixed. Reading only the catalogue's prefixed spelling would refuse a model
+    the user had already told us this provider serves.
+    """
+    _pin(
+        fake_home,
+        "mistral",
+        {"mistral": {"api_key": "sk-mistral", "models": ["some-private-tune"]}},
+    )
+
+    result = await config_set(
+        {"key": "model", "value": "some-private-tune"},
+        agent_loop_factory=lambda: None,
+    )
+    assert result["applied"] is True
+    cfg = json.loads((fake_home / ".raven" / "config.json").read_text())
+    assert cfg["agents"]["defaults"]["provider"] == "mistral"


### PR DESCRIPTION
## Summary

Selecting anything from the model picker pins its provider, so by the time someone
types `/model <name>` there is almost always one pinned. A bare id matching no
provider's keywords is what a vendor Raven holds no spec for looks like, and the
pin was kept for it -- sending that provider's key to a different vendor, the
mis-routing the prefix rules exist to prevent. The prefixed form of the same id was
already handed back to auto-detection for exactly this reason; the bare form fell
through.

Refusing every such id would break the two cases where the pin was right: a user
who configured a spec-less vendor and typed one of its model names, and a local
deployment, whose server names whatever models it likes and holds no key to
mis-route. So the pin is asked to justify itself instead. Its own curated list
counts as evidence -- that is where a hand-added id sits, unprefixed -- and so does
the catalogue; prefixes are stripped before comparing, which covers every spelling
the sources use. With no evidence either way the switch is refused, naming the
qualified form to type, rather than a vendor being picked on the user's behalf.

An explicit provider is never second-guessed, so the picker's own path is
untouched.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

```
uv run --all-extras pytest tests/ -q -p no:randomly
  5127 passed, 30 skipped, 13 deselected

uv run ruff check raven/ tests/    All checks passed
bash .claude/scripts/preflight_ci.sh   exit 0
```

Behaviour, driven through `config.set` end to end:

| Typed | Pinned | Result |
|---|---|---|
| `mistral-large-latest` | `openai` | refused, config untouched |
| `mistral-large-latest` | `mistral` | pin kept (the catalogue lists it) |
| `some-private-tune` | `mistral`, listed in its `models` | pin kept |
| `some-local-build` | `ollama_chat` | pin kept |
| `mistral/mistral-large-latest` | `openai` | `auto`, unchanged |
| `gpt-4o` | `mistral` | `openai`, unchanged |
| any, with `provider` sent | `openai` | the sent provider, gate not reached |

Each test was checked by breaking the code it covers and confirming it fails. One of
those runs found that the evidence check had two branches where one sufficed --
stripping the prefix already covers the spelling the second compared exactly -- so
the redundant branch is deleted rather than pinned.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

`/model <bare name>` can now be refused where it previously switched. It is refused
only when nothing indicates the pinned provider serves that model, which is the
case where the switch silently used the wrong credentials; the message names the
qualified form to type instead. Typing a prefixed id, or picking from the picker,
behaves as before.

Rollback is the revert of this branch.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A