### PR TITLE
refactor(*): one answer to which credentials a provider needs

### DIFF
--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -41,6 +41,12 @@ from raven.cli._helpers import (
     print_probe_troubleshooting,
     send_probe,
 )
+from raven.providers.registry import (
+    CRED_ENDPOINT,
+    CRED_LOCAL,
+    CRED_OAUTH,
+    credential_kind,
+)
 
 
 class _ThemedConsole(Console):
@@ -792,7 +798,7 @@ def _run_oauth_login(provider: str) -> bool:
     from raven.providers.registry import find_by_name
 
     spec = find_by_name(provider)
-    if _credential_kind(provider, spec) != CRED_OAUTH:
+    if credential_kind(provider) != CRED_OAUTH:
         console.print(
             _t(
                 f"  [red]✗ {provider} is not an OAuth provider.[/red]",
@@ -853,7 +859,7 @@ def _verify_provider(provider: str, *, skip_test: bool = False) -> tuple[bool, s
     # A local deployment has no key to verify -- what is being checked is that
     # the address answers, and saying "API key" there describes a field the user
     # was never asked for.
-    if _credential_kind(provider, spec) == CRED_LOCAL:
+    if credential_kind(provider) == CRED_LOCAL:
         console.print(_t("  [dim]⏳ Reaching the server…[/dim]", "  [dim]⏳ 正在连接服务…[/dim]"))
     else:
         console.print(_t("  [dim]⏳ Verifying your API key…[/dim]", "  [dim]⏳ 正在验证 API Key…[/dim]"))
@@ -936,29 +942,6 @@ def _model_routes_to_provider(model: str, spec: Any) -> bool:
 # a rollback that wrote credentials to an OAuth provider and killed the wizard, a
 # menu that offered a key prompt to one, a prompt that half-guarded a spec it had
 # already dereferenced. Answer it once.
-CRED_OAUTH = "oauth"  # a token file, written by `raven provider login`
-CRED_LOCAL = "local"  # reached by address; there is no key
-CRED_ENDPOINT = "endpoint"  # a key plus a base URL the user supplies
-CRED_KEY = "key"  # a key alone, including vendors Raven carries no spec for
-
-
-def _credential_kind(provider: str, spec: Any) -> str:
-    """Which credential shape this provider uses.
-
-    Derived rather than stored: `spec` is optional metadata, and a vendor with no
-    spec is reached with a key like most others.
-    """
-    if spec is not None and spec.is_oauth:
-        return CRED_OAUTH
-    if spec is not None and spec.is_local:
-        return CRED_LOCAL
-    if spec is not None and spec.requires_api_base:
-        # Not a name check any more: Azure needs the same pair and was asked only
-        # for a key, so it was configured with no endpoint and could not be
-        # called. The TUI already knew -- it kept its own list of the two -- which
-        # is the same fact answered twice, once wrongly.
-        return CRED_ENDPOINT
-    return CRED_KEY
 
 
 def _format_model_for_provider(provider: str, spec: Any, model_id: str) -> str:
@@ -1137,7 +1120,7 @@ def _roll_back_provider_fields(provider: str, spec: Any, *, old_key: Optional[st
     layer refuses to write credential fields for them, and doing it anyway turned
     a failed verification into a dead wizard.
     """
-    if _credential_kind(provider, spec) == CRED_OAUTH:
+    if credential_kind(provider) == CRED_OAUTH:
         return
     _write_provider_fields(provider, {"api_key": old_key or "", "api_base": old_base})
 
@@ -1328,7 +1311,7 @@ def _configure_one_provider(
                 continue
 
         spec = find_by_name(provider)
-        kind = _credential_kind(provider, spec)
+        kind = credential_kind(provider)
         is_oauth = kind == CRED_OAUTH
         is_custom = kind == CRED_ENDPOINT
         # The interactive picker already echoes the chosen provider; only print
@@ -1551,7 +1534,7 @@ def _resolve_model_with_test(
                     # retry alone left the one thing worth changing unreachable.
                     *(
                         [(_t("Re-enter server URL", "重新填服务地址"), "rebase")]
-                        if _credential_kind(provider, spec) == CRED_LOCAL
+                        if credential_kind(provider) == CRED_LOCAL
                         else []
                     ),
                     (_t("Continue anyway", "仍然继续"), "continue"),
@@ -1563,9 +1546,9 @@ def _resolve_model_with_test(
                     # left a mistyped address with no way back to the field.
                     (
                         (_t("Sign in again", "重新登录"), "reauth")
-                        if _credential_kind(provider, spec) == CRED_OAUTH
+                        if credential_kind(provider) == CRED_OAUTH
                         else (_t("Re-enter server URL", "重新填服务地址"), "rebase")
-                        if _credential_kind(provider, spec) == CRED_LOCAL
+                        if credential_kind(provider) == CRED_LOCAL
                         else (_t("Re-enter key", "重新填 Key"), "rekey")
                     ),
                     (_t("Switch provider", "更换服务商"), "switch"),
@@ -1638,7 +1621,7 @@ def _resolve_model_with_test(
             provider,
             non_interactive=non_interactive,
             warnings=warnings,
-            is_oauth=_credential_kind(provider, spec) == CRED_OAUTH,
+            is_oauth=credential_kind(provider) == CRED_OAUTH,
         )
         if result == "switch":
             return None
@@ -1698,7 +1681,7 @@ def _configure_existing_provider_model(*, non_interactive: bool) -> bool:
         provider,
         non_interactive=False,
         warnings=[],
-        is_oauth=_credential_kind(provider, spec) == CRED_OAUTH,
+        is_oauth=credential_kind(provider) == CRED_OAUTH,
     )
     if result == "reauth":
         return _run_oauth_login(provider)
@@ -1751,7 +1734,7 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
             continue
         if action == "update":
             target_spec = find_by_name(target)
-            if _credential_kind(target, target_spec) == CRED_OAUTH:
+            if credential_kind(target) == CRED_OAUTH:
                 # Nothing here to update: the credential is a token file, and the
                 # ops layer refuses credential writes for these -- so offering the
                 # key prompt ended the wizard instead of editing anything.
@@ -1764,7 +1747,7 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
                     )
                 )
                 continue
-            if _credential_kind(target, target_spec) == CRED_LOCAL:
+            if credential_kind(target) == CRED_LOCAL:
                 # A local deployment holds no key; what there is to update is
                 # where it lives. Offering the key prompt wrote a credential into
                 # a provider that never reads one, and left the address alone.
@@ -1778,7 +1761,7 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
                 if retyped is None:
                     continue
                 _write_provider_fields(target, {"api_base": retyped})
-            elif _credential_kind(target, target_spec) == CRED_ENDPOINT:
+            elif credential_kind(target) == CRED_ENDPOINT:
                 # A self-hosted endpoint is a key *and* the address it is sent
                 # to. Updating only the key left the one field that moves when
                 # the user redeploys -- the URL -- unreachable from this menu.
@@ -1834,7 +1817,7 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
             # to clear and refuses the write, so it is told where its credential
             # actually lives instead of ending the run.
             target_spec = find_by_name(target)
-            if _credential_kind(target, target_spec) == CRED_OAUTH:
+            if credential_kind(target) == CRED_OAUTH:
                 console.print(
                     _t(
                         f"  [dim]{_provider_label(target)}'s credential is an OAuth token, not a config field, "

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -853,9 +853,7 @@ def _verify_provider(provider: str, *, skip_test: bool = False) -> tuple[bool, s
     ``network_error`` / …) and drives the failure submenu's wording.
     """
     from raven.config.update_providers import test_provider as probe
-    from raven.providers.registry import find_by_name
 
-    spec = find_by_name(provider)
     # A local deployment has no key to verify -- what is being checked is that
     # the address answers, and saying "API key" there describes a field the user
     # was never asked for.

--- a/raven/providers/registry.py
+++ b/raven/providers/registry.py
@@ -554,6 +554,37 @@ def normalize_provider_name(name: str | None) -> str:
     return (name or "").strip().lower().replace("-", "_")
 
 
+CRED_OAUTH = "oauth"  # a token file, written by `raven provider login`
+CRED_LOCAL = "local"  # reached by address; there is no key
+CRED_ENDPOINT = "endpoint"  # a key plus a base URL the user supplies
+CRED_KEY = "key"  # a key alone, including vendors Raven carry no spec for
+
+
+def credential_kind(provider: str | None) -> str:
+    """Which of the four credential shapes this provider uses.
+
+    Every decision about how a provider is set up follows from this: whether to
+    ask for a key, an address, both, or neither. It lives here because it is a
+    fact about the provider, and because the two places that need it -- the
+    wizard and the model picker -- had answered it separately, with the picker
+    knowing only two shapes: it offered a local deployment a key prompt it cannot
+    use and no address field, which is the one thing it needs.
+
+    Derived rather than stored: a spec is optional metadata, and a vendor Raven
+    holds no spec for is reached with a key like most others.
+    """
+    spec = find_by_name(provider) if provider else None
+    if spec is None:
+        return CRED_KEY
+    if spec.is_oauth:
+        return CRED_OAUTH
+    if spec.is_local:
+        return CRED_LOCAL
+    if spec.requires_api_base:
+        return CRED_ENDPOINT
+    return CRED_KEY
+
+
 def litellm_spelling(name: str | None) -> str:
     """How LiteLLM spells this vendor, which is the only form usable as a prefix.
 

--- a/raven/tui_rpc/methods/model.py
+++ b/raven/tui_rpc/methods/model.py
@@ -31,7 +31,15 @@ from raven.config.update_providers import (
     set_provider_fields,
 )
 from raven.providers.common_models import common_models_for, litellm_models_for
-from raven.providers.registry import canonical_provider_name, find_by_model, find_by_name
+from raven.providers.registry import (
+    CRED_ENDPOINT,
+    CRED_LOCAL,
+    CRED_OAUTH,
+    canonical_provider_name,
+    credential_kind,
+    find_by_model,
+    find_by_name,
+)
 from raven.tui_rpc.errors import (
     ConfigValidationError,
     NotSupportedInV01Error,
@@ -46,17 +54,6 @@ from raven.tui_rpc.models import (
 
 if TYPE_CHECKING:
     from raven.tui_rpc.dispatcher import Dispatcher
-
-
-def _needs_api_base(slug: str) -> bool:
-    """Does this provider have no usable endpoint until the user gives one?
-
-    Read from the registry rather than listed here: the wizard answered the same
-    question from the spec and the two drifted, leaving Azure configurable with no
-    endpoint at all.
-    """
-    spec = find_by_name(slug)
-    return bool(spec is not None and spec.requires_api_base)
 
 
 def _parse(model_cls: type, params: dict) -> Any:
@@ -96,7 +93,8 @@ def _build_provider_entry(slug: str, *, current_provider: str | None) -> dict[st
     providers = {p["name"]: p for p in list_providers()}
     info = providers.get(slug, {})
 
-    is_oauth = bool(spec and spec.is_oauth)
+    kind = credential_kind(slug)
+    is_oauth = kind == CRED_OAUTH
     configured = bool(info.get("configured"))
     warning = ""
     if is_oauth and not configured:
@@ -108,11 +106,11 @@ def _build_provider_entry(slug: str, *, current_provider: str | None) -> dict[st
         "name": info.get("display_name") or (spec.label if spec else slug),
         "authenticated": configured,
         "is_current": slug == current_provider,
-        "auth_type": "oauth" if is_oauth else "api_key",
+        "auth_type": kind,
         "key_env": (spec.env_key or None) if spec else None,
         "models": models,
         "total_models": len(models),
-        "needs_api_base": _needs_api_base(slug),
+        "needs_api_base": kind in (CRED_ENDPOINT, CRED_LOCAL),
         "warning": warning,
     }
 
@@ -185,13 +183,30 @@ async def model_save_key(params: dict) -> dict:
             f"{label} uses OAuth; run `raven provider login {parsed.slug.replace('_', '-')}`",
             data={"slug": parsed.slug},
         )
-    if _needs_api_base(parsed.slug) and not parsed.api_base:
+    kind = credential_kind(parsed.slug)
+    if kind in (CRED_ENDPOINT, CRED_LOCAL) and not parsed.api_base:
         raise ConfigValidationError(
             f"{label} requires an api_base",
             data={"slug": parsed.slug, "field": "api_base"},
         )
+    if kind == CRED_LOCAL and parsed.api_key:
+        # Said out loud rather than dropped: a local deployment writes no key, so
+        # storing one silently would look like it had been accepted.
+        raise ConfigValidationError(
+            f"{label} is a local deployment and takes no api_key; send api_base instead",
+            data={"slug": parsed.slug, "field": "api_key"},
+        )
+    if kind != CRED_LOCAL and not parsed.api_key:
+        raise ConfigValidationError(
+            f"{label} requires an api_key",
+            data={"slug": parsed.slug, "field": "api_key"},
+        )
 
-    fields: dict[str, Any] = {"api_key": parsed.api_key}
+    # A local deployment is reached by address and has no key, said explicitly
+    # rather than by omission: leaving the field alone kept whatever was there,
+    # so a section that once held a key would still be sending it to the user's
+    # own server.
+    fields: dict[str, Any] = {"api_key": "" if kind == CRED_LOCAL else parsed.api_key}
     if parsed.api_base:
         fields["api_base"] = parsed.api_base
 

--- a/raven/tui_rpc/models.py
+++ b/raven/tui_rpc/models.py
@@ -547,7 +547,9 @@ class ModelOptionsResult(_Strict):
 
 class ModelSaveKeyParams(_Strict):
     slug: str
-    api_key: str
+    # Empty for a local deployment, which is reached by address and has no key.
+    # The handler rejects an empty one for every other credential shape.
+    api_key: str = ""
     api_base: str | None = None
     session_id: str | None = None
 

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -2530,37 +2530,27 @@ def test_a_spec_less_vendor_is_offered_the_catalogue_rows_it_has() -> None:
         assert not any(m.startswith(f"{slug}/{slug}/") for m in models)
 
 
-def test_only_credential_kind_reads_the_spec_auth_flags() -> None:
-    """One answer to "how is this provider reached", not thirteen.
+def test_the_wizard_never_reads_a_spec_auth_flag_itself() -> None:
+    """One answer to "how is this provider reached", and it does not live here.
 
     Every decision the wizard makes about a provider follows from that question,
-    and it was being derived independently at thirteen sites off two spec flags.
-    Each of the last two review rounds found a site that disagreed with the rest:
-    a rollback that wrote credential fields to an OAuth provider and ended the
-    run, a menu that offered it a key prompt, a prompt that guarded a spec on one
-    line and dereferenced it on the next. Deriving it again anywhere reopens that.
+    and it was derived independently at thirteen sites off the spec flags. Each of
+    two review rounds found a site that disagreed with the rest: a rollback that
+    wrote credential fields to an OAuth provider and ended the run, a menu that
+    offered it a key prompt, a prompt that guarded a spec on one line and
+    dereferenced it on the next. It is a registry function now, because the model
+    picker needed the same answer and had been keeping a coarser one of its own.
     """
-    import ast
     import re
     from pathlib import Path as _Path
 
     path = _Path(__file__).resolve().parents[1] / "raven" / "cli" / "onboard_commands.py"
-    source = path.read_text()
-    tree = ast.parse(source)
-    owner = next(
-        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_credential_kind"
-    )
-    allowed = range(owner.lineno, (owner.end_lineno or owner.lineno) + 1)
-
     offenders = [
         f"line {i}: {line.strip()}"
-        for i, line in enumerate(source.splitlines(), 1)
-        # Any receiver, not just one spelled `spec`: `target_spec.is_oauth` has no
-        # word boundary before "spec", so a name-anchored pattern read as a
-        # guarantee while missing the manage menu entirely.
-        if re.search(r"\.is_(oauth|local)\b", line) and not line.lstrip().startswith("#") and i not in allowed
+        for i, line in enumerate(path.read_text().splitlines(), 1)
+        if re.search(r"\.is_(oauth|local)\b|\.requires_api_base\b", line) and not line.lstrip().startswith("#")
     ]
-    assert not offenders, "derive it from _credential_kind instead:\n" + "\n".join(offenders)
+    assert not offenders, "ask credential_kind() instead:\n" + "\n".join(offenders)
 
 
 @pytest.mark.parametrize(
@@ -2577,20 +2567,18 @@ def test_only_credential_kind_reads_the_spec_auth_flags() -> None:
     ],
 )
 def test_credential_kind_covers_every_shape(provider: str, expected: str) -> None:
-    from raven.cli.onboard_commands import _credential_kind
-    from raven.providers.registry import find_by_name
+    from raven.providers.registry import credential_kind
 
-    assert _credential_kind(provider, find_by_name(provider)) == expected
+    assert credential_kind(provider) == expected
 
 
 def test_every_registered_provider_has_exactly_one_credential_kind() -> None:
     """Sweep, so a provider added later cannot fall through the classification."""
-    from raven.cli.onboard_commands import CRED_ENDPOINT, CRED_KEY, CRED_LOCAL, CRED_OAUTH, _credential_kind
-    from raven.providers.registry import PROVIDERS
+    from raven.providers.registry import CRED_ENDPOINT, CRED_KEY, CRED_LOCAL, CRED_OAUTH, PROVIDERS, credential_kind
 
     known = {CRED_OAUTH, CRED_LOCAL, CRED_ENDPOINT, CRED_KEY}
     for spec in PROVIDERS:
-        assert _credential_kind(spec.name, spec) in known, spec.name
+        assert credential_kind(spec.name) in known, spec.name
 
 
 def test_the_picker_result_goes_through_the_same_gate_as_the_flag(monkeypatch, tmp_path) -> None:
@@ -2891,30 +2879,32 @@ def test_a_provider_whose_endpoint_only_the_user_knows_is_asked_for_it() -> None
     "api_base is required" on the first call. Picking it from the curated list
     could not produce a working provider.
     """
-    from raven.providers.registry import PROVIDERS, find_by_name
+    from raven.providers.registry import CRED_ENDPOINT, PROVIDERS, credential_kind
 
-    assert (
-        onboard_commands._credential_kind("azure_openai", find_by_name("azure_openai"))
-        == onboard_commands.CRED_ENDPOINT
-    )
+    assert credential_kind("azure_openai") == CRED_ENDPOINT
     for spec in PROVIDERS:
-        expected = onboard_commands.CRED_ENDPOINT if spec.requires_api_base else None
+        expected = CRED_ENDPOINT if spec.requires_api_base else None
         if expected is not None:
-            assert onboard_commands._credential_kind(spec.name, spec) == expected, spec.name
+            assert credential_kind(spec.name) == expected, spec.name
 
 
-def test_the_wizard_and_the_model_picker_agree_on_who_needs_an_endpoint() -> None:
-    """The same question, asked in two places, and one of them was wrong.
+def test_the_model_picker_reports_the_same_credential_shape_as_the_wizard() -> None:
+    """The picker knew only two shapes and offered a local deployment a key prompt.
 
-    The picker kept a literal set of the two providers; the wizard derived it from
-    the name. They drifted, and the wizard's answer was the one users hit.
+    It kept its own literal list of who needs an endpoint, and reported every
+    non-OAuth provider as taking an API key -- so Ollama was asked for a key it
+    cannot use and never asked for the address it needs. The RPC surface reports
+    the shared answer now; this reads it back off the payload rather than
+    re-deriving it.
     """
-    from raven.providers.registry import PROVIDERS
-    from raven.tui_rpc.methods.model import _needs_api_base
+    from raven.providers.registry import CRED_ENDPOINT, CRED_LOCAL, PROVIDERS, credential_kind
+    from raven.tui_rpc.methods.model import _build_provider_entry
 
     for spec in PROVIDERS:
-        wizard = onboard_commands._credential_kind(spec.name, spec) == onboard_commands.CRED_ENDPOINT
-        assert wizard == _needs_api_base(spec.name), f"{spec.name}: wizard={wizard} picker={_needs_api_base(spec.name)}"
+        entry = _build_provider_entry(spec.name, current_provider=None)
+        kind = credential_kind(spec.name)
+        assert entry["auth_type"] == kind, spec.name
+        assert entry["needs_api_base"] is (kind in (CRED_ENDPOINT, CRED_LOCAL)), spec.name
 
 
 def test_configuring_azure_stores_the_endpoint_it_was_given(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_tui_rpc_model.py
+++ b/tests/test_tui_rpc_model.py
@@ -75,7 +75,7 @@ async def test_options_authed_provider_lists_models(fake_home: Path) -> None:
     curated = common_models_for("anthropic")
     assert entry["models"][2 : 2 + len(curated)] == curated
     assert entry["total_models"] > 2 + len(curated), "the catalogue tier added nothing"
-    assert entry["auth_type"] == "api_key"
+    assert entry["auth_type"] == "key"
     assert entry["key_env"] == "ANTHROPIC_API_KEY"
 
 
@@ -469,3 +469,44 @@ async def test_no_handler_reads_the_catalogue_on_the_event_loop(fake_home: Path,
     on_loop = [t for t in seen if t == loop_thread]
     assert not on_loop, f"{len(on_loop)}/{len(seen)} catalogue reads ran on the event loop"
     assert asyncio.get_running_loop() is not None
+
+
+async def test_save_key_configures_a_local_deployment_by_address(fake_home: Path) -> None:
+    """It is reached by address and has no key; the handler demanded one.
+
+    `api_key` was a required field, and the picker reported every non-OAuth
+    provider as taking one, so a local deployment could not be configured from the
+    TUI at all -- and an empty key written into its section would have made it look
+    configured while nothing had been set.
+    """
+    # Seeded with a key it should never have had, so "no key" is asserted as a
+    # write rather than as an omission: leaving the field alone kept the old value.
+    _write_config(fake_home, {"providers": {"ollama_chat": {"api_key": "sk-leftover"}}})
+
+    result = await model_save_key({"slug": "ollama_chat", "api_base": "http://gpu-box:11434"})
+
+    assert result["provider"]["slug"] == "ollama_chat"
+    section = json.loads((fake_home / ".raven" / "config.json").read_text())["providers"]["ollama_chat"]
+    assert section.get("apiBase") == "http://gpu-box:11434"
+    assert section.get("apiKey") == "", f"a stale key survived: {section}"
+
+
+async def test_save_key_refuses_a_key_for_a_local_deployment(fake_home: Path) -> None:
+    """Said out loud rather than dropped, so it does not look accepted."""
+    with pytest.raises(ConfigValidationError) as excinfo:
+        await model_save_key({"slug": "ollama_chat", "api_key": "sk-nope", "api_base": "http://x:11434"})
+    assert "api_key" in str(excinfo.value)
+
+
+async def test_save_key_still_requires_a_key_for_a_keyed_provider(fake_home: Path) -> None:
+    """Relaxing the field for local deployments must not relax it for the rest."""
+    with pytest.raises(ConfigValidationError) as excinfo:
+        await model_save_key({"slug": "deepseek", "api_key": ""})
+    assert "api_key" in str(excinfo.value)
+
+
+async def test_save_key_requires_an_address_for_a_local_deployment(fake_home: Path) -> None:
+    """Neither field given is not a configured provider."""
+    with pytest.raises(ConfigValidationError) as excinfo:
+        await model_save_key({"slug": "ollama_chat"})
+    assert "api_base" in str(excinfo.value)

--- a/ui-tui/rpc-schema/openrpc.json
+++ b/ui-tui/rpc-schema/openrpc.json
@@ -704,7 +704,8 @@
         },
         {
           "name": "api_key",
-          "required": true,
+          "description": "Empty for a local deployment, which is reached by address and has no key. Required for every other credential shape, and refused for a local one.",
+          "required": false,
           "schema": { "type": "string" }
         },
         {

--- a/ui-tui/src/__tests__/modelPicker.test.tsx
+++ b/ui-tui/src/__tests__/modelPicker.test.tsx
@@ -40,7 +40,7 @@ const ENTER = '\r'
 const DOWN = '[B'
 
 const anthropic: ModelOptionProvider = {
-  auth_type: 'api_key',
+  auth_type: 'key',
   authenticated: true,
   is_current: true,
   key_env: 'ANTHROPIC_API_KEY',
@@ -51,8 +51,21 @@ const anthropic: ModelOptionProvider = {
   total_models: 1
 }
 
+const ollama: ModelOptionProvider = {
+  auth_type: 'local',
+  authenticated: false,
+  is_current: false,
+  key_env: null,
+  models: [],
+  name: 'Ollama (local)',
+  needs_api_base: true,
+  slug: 'ollama_chat',
+  total_models: 0,
+  warning: 'enter the server address to activate'
+}
+
 const custom: ModelOptionProvider = {
-  auth_type: 'api_key',
+  auth_type: 'endpoint',
   authenticated: false,
   is_current: false,
   key_env: null,
@@ -140,6 +153,24 @@ const mount = (providers: ModelOptionProvider[], requestImpl?: (m: string, p: an
 }
 
 describe('ModelPicker', () => {
+  it('offers a local deployment its address, and says it needs no key', async () => {
+    // The picker knew two credential shapes and reported every non-OAuth provider
+    // as taking an API key, so a local deployment was offered a key prompt it
+    // cannot use and never the address it is reached by -- the one thing it needs.
+    const h = mount([anthropic, ollama])
+    await delay(60)
+
+    expect(h.frame()).toContain('(no address)')
+
+    await h.type(DOWN)
+    await h.type(ENTER)
+
+    const frame = h.frame()
+    expect(frame).toContain('Configure Ollama (local)')
+    expect(frame).toContain('API base (required)')
+    h.unmount()
+  })
+
   it('shows the api_base field and requires it for a needs_api_base provider', async () => {
     const h = mount([anthropic, custom])
     await delay(60)

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -19,6 +19,31 @@ const MIN_WIDTH = 40
 const MAX_WIDTH = 90
 
 type Stage = 'provider' | 'key' | 'model' | 'addModel' | 'disconnect'
+
+/** What a provider still needs, in the four shapes the backend reports. */
+function unconfiguredHint(authType: string | undefined): string {
+  if (authType === 'oauth') {
+    return '(sign in)'
+  }
+  if (authType === 'local') {
+    return '(no address)'
+  }
+  if (authType === 'endpoint') {
+    return '(no endpoint)'
+  }
+  return '(no key)'
+}
+
+/** A local deployment has no key to paste, and OAuth is a terminal command. */
+function unconfiguredWarning(p: ModelOptionProvider): string {
+  if (p.auth_type === 'oauth') {
+    return `run \`raven provider login ${p.slug.replace(/_/g, '-')}\``
+  }
+  if (p.auth_type === 'local') {
+    return 'enter the server address to activate'
+  }
+  return p.key_env ? `paste ${p.key_env} to activate` : 'enter a key to activate'
+}
 type KeyField = 'api_key' | 'api_base'
 
 export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPickerProps) {
@@ -112,7 +137,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
         return
       }
 
-      const showBase = provider?.auth_type === 'api_key'
+      const showBase = provider?.auth_type === 'endpoint' || provider?.auth_type === 'local'
       const focusBase = showBase && keyField === 'api_base'
 
       // Tab moves between the two fields when api_base is shown.
@@ -298,7 +323,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
                         authenticated: false,
                         models: [],
                         total_models: 0,
-                        warning: p.key_env ? `paste ${p.key_env} to activate` : 'run `raven model` to configure'
+                        warning: unconfiguredWarning(p)
                       }
                     : p
                 )
@@ -350,7 +375,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
         if (provider.authenticated === false) {
           // api_key providers prompt for key inline, even when key_env is null
           // (custom / azure use a generic key + required api_base).
-          if (provider.auth_type === 'api_key') {
+          if (provider.auth_type !== 'oauth') {
             setStage('key')
             setKeyInput('')
             setBaseInput('')
@@ -457,7 +482,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
 
   // ── Key entry stage ──────────────────────────────────────────────────
   if (stage === 'key' && provider) {
-    const showBase = provider.auth_type === 'api_key'
+    const showBase = provider.auth_type === 'endpoint' || provider.auth_type === 'local'
     const focusBase = showBase && keyField === 'api_base'
     const masked = keyInput ? '•'.repeat(Math.min(keyInput.length, 40)) : ''
     const keyLabel = provider.key_env ?? 'API key'
@@ -615,8 +640,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
       const authMark = p.authenticated === false ? '○' : p.is_current ? '*' : '●'
       const modelCount = p.total_models ?? p.models?.length ?? 0
 
-      const suffix =
-        p.authenticated === false ? (p.auth_type === 'api_key' ? '(no key)' : '(needs setup)') : `${modelCount} models`
+      const suffix = p.authenticated === false ? unconfiguredHint(p.auth_type) : `${modelCount} models`
 
       return `${authMark} ${names[i]} · ${suffix}`
     })

--- a/ui-tui/src/lib/stubGatewayFixtures.ts
+++ b/ui-tui/src/lib/stubGatewayFixtures.ts
@@ -75,7 +75,7 @@ export const STUB_MODEL_OPTIONS: ModelOptionsResponse = {
   provider: 'anthropic',
   providers: [
     {
-      auth_type: 'api_key',
+      auth_type: 'key',
       authenticated: true,
       is_current: true,
       key_env: 'ANTHROPIC_API_KEY',
@@ -86,7 +86,7 @@ export const STUB_MODEL_OPTIONS: ModelOptionsResponse = {
       total_models: 1
     },
     {
-      auth_type: 'api_key',
+      auth_type: 'key',
       authenticated: false,
       is_current: false,
       key_env: 'OPENAI_API_KEY',
@@ -98,7 +98,7 @@ export const STUB_MODEL_OPTIONS: ModelOptionsResponse = {
       warning: 'paste OPENAI_API_KEY to activate'
     },
     {
-      auth_type: 'api_key',
+      auth_type: 'endpoint',
       authenticated: false,
       is_current: false,
       key_env: null,

--- a/ui-tui/src/rpc/generated.ts
+++ b/ui-tui/src/rpc/generated.ts
@@ -788,7 +788,7 @@ export interface ModelOptionsResult {
  */
 export interface ModelSaveKeyParams {
   slug: string;
-  api_key: string;
+  api_key?: string;
   api_base?: string;
   session_id?: string;
 }


### PR DESCRIPTION
## Summary

The wizard asks a provider which of four credential shapes it uses -- a token
file, an address, an endpoint plus a key, or a key alone -- and every decision
about setting it up follows from that. The model picker kept a coarser answer of
its own: two shapes, plus a literal list of the two providers it knew need an
endpoint.

So a local deployment was reported as taking an API key and needing no address,
which is exactly backwards. Ollama and vLLM could not be configured from the TUI
at all: the key prompt asks for something they do not have, the address they are
reached by was never asked for, and `model.save_key` required a key. The decision
lives in the registry now -- where the facts it reads live -- and both sides
derive from it.

Three things fall out of that:

* Saving a local deployment writes an empty key rather than leaving the field
  alone. Omitting it kept whatever was there, so a section that had once held a
  key would go on sending it to the user's own server.
* An unconfigured provider says what it is missing -- an address, an endpoint, a
  key, or a sign-in -- instead of "(no key)" for all four.
* An OAuth provider names `raven provider login <slug>`, not a `raven model`
  flow that does not exist.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [x] Refactor
- [ ] Other

## Verification

```
uv run --all-extras pytest tests/ -q -p no:randomly
  5143 passed, 30 skipped, 13 deselected
uv run ruff check raven/ tests/                     All checks passed

cd ui-tui
  npm run lint         0 errors
  npm run type-check   clean
  npm run lint:rpc     generated.ts in sync
  npm test             951 passed, 83 files
  npx prettier --check "src/**/*.{ts,tsx}"          clean

bash .claude/scripts/preflight_ci.sh   exit 0
```

Seven mutations were applied to check the new tests bite, five on the Python side
and two on the TypeScript side; each turned the relevant test red. One of them
found the code rather than the test: writing no key field for a local deployment
left a stale one in place, which is why it now writes an empty one.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

Two wire changes, both reflected in `openrpc.json` and the generated types:

| | Before | After |
|---|---|---|
| `auth_type` | `oauth` \| `api_key` | `oauth` \| `local` \| `endpoint` \| `key` |
| `model.save_key.api_key` | required | optional |

A TUI built before this change will not recognise the new `auth_type` values. It
does not break -- the branches fall through to their default -- but a local
deployment shows as needing a key rather than an address. The bundled TUI is built
from this tree, so that applies only to a mismatched pair.

`api_key` is still refused when empty for every shape that needs one, and now
refused when present for a local deployment, which writes no key.

Rollback is the revert of this branch. Provider sections already on disk are
untouched.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A