### PR TITLE
feat(tui): list the providers that work, and the rest one level down

### DIFF
--- a/ui-tui/src/__tests__/modelPicker.test.tsx
+++ b/ui-tui/src/__tests__/modelPicker.test.tsx
@@ -77,6 +77,18 @@ const custom: ModelOptionProvider = {
   warning: 'set key + base to activate'
 }
 
+const deepseek: ModelOptionProvider = {
+  auth_type: 'key',
+  authenticated: true,
+  is_current: true,
+  key_env: 'DEEPSEEK_API_KEY',
+  models: ['deepseek-chat'],
+  name: 'DeepSeek',
+  needs_api_base: false,
+  slug: 'deepseek',
+  total_models: 1
+}
+
 const oauthProvider: ModelOptionProvider = {
   auth_type: 'oauth',
   authenticated: false,
@@ -87,7 +99,7 @@ const oauthProvider: ModelOptionProvider = {
   needs_api_base: false,
   slug: 'oauthvendor',
   total_models: 0,
-  warning: 'run raven model to authenticate'
+  warning: 'run `raven provider login openai-codex` to authenticate'
 }
 
 interface Harness {
@@ -153,6 +165,71 @@ const mount = (providers: ModelOptionProvider[], requestImpl?: (m: string, p: an
 }
 
 describe('ModelPicker', () => {
+  it('opens with the cursor on the provider in use', async () => {
+    // The selection is located in the list the first screen shows. Finding it
+    // among all of them instead put it past the end of the configured ones, and
+    // a selection past the end highlights nothing -- the picker opened with no
+    // cursor. Asserted by pressing Enter with no arrow keys first: whatever the
+    // cursor is on is what opens.
+    const cfg = (slug: string, name: string, authed: boolean, cur = false): ModelOptionProvider =>
+      ({
+        auth_type: 'key',
+        authenticated: authed,
+        is_current: cur,
+        key_env: null,
+        models: authed ? [`${slug}/m1`] : [],
+        name,
+        needs_api_base: false,
+        slug,
+        total_models: authed ? 1 : 0
+      }) as ModelOptionProvider
+
+    // DeepSeek is index 3 of five, but index 1 of the two that are set up.
+    const h = mount([
+      cfg('openrouter', 'OpenRouter', true),
+      cfg('openai', 'OpenAI', false),
+      cfg('anthropic', 'Anthropic', false),
+      cfg('deepseek', 'DeepSeek', true, true),
+      cfg('gemini', 'Gemini', false)
+    ])
+    await delay(80)
+
+    await h.type(ENTER)
+    const frame = h.frame()
+    expect(frame).toContain('deepseek/m1')
+    expect(frame).not.toContain('openrouter/m1')
+    h.unmount()
+  })
+
+  it('lists what is set up, and puts the rest behind one row', async () => {
+    // Opening the picker used to mean scrolling twenty-one rows to reach the two
+    // or three that can actually serve a model. A provider with no credentials is
+    // not something to switch to, so it moves one level down.
+    const h = mount([anthropic, custom, ollama, oauthProvider])
+    await delay(60)
+
+    const first = h.frame()
+    expect(first).toContain('Anthropic')
+    expect(first).toContain('add a provider')
+    expect(first).toContain('3 not set up')
+    expect(first).not.toContain('Custom')
+    expect(first).not.toContain('Ollama')
+
+    // Down once lands on the add row -- the only other row at this level.
+    await h.type(DOWN)
+    await h.type(ENTER)
+
+    const second = h.frame()
+    expect(second).toContain('Add a provider')
+    expect(second).toContain('Ollama')
+
+    // Esc returns to level one rather than closing the picker.
+    await h.type('\u001b')
+    await delay(30)
+    expect(h.frame()).toContain('Select pr')
+    h.unmount()
+  })
+
   it('offers a local deployment its address, and says it needs no key', async () => {
     // The picker knew two credential shapes and reported every non-OAuth provider
     // as taking an API key, so a local deployment was offered a key prompt it
@@ -160,14 +237,38 @@ describe('ModelPicker', () => {
     const h = mount([anthropic, ollama])
     await delay(60)
 
-    expect(h.frame()).toContain('(no address)')
-
+    // Level one lists what is set up, so the unconfigured one is behind the row
+    // that opens level two.
+    expect(h.frame()).not.toContain('Ollama')
     await h.type(DOWN)
     await h.type(ENTER)
 
+    expect(h.frame()).toContain('(no address)')
+    await h.type(ENTER)
+
+    // Asserted on the field labels rather than the "Configure <name>" heading:
+    // at this depth the fake terminal's escape stripping eats the odd character
+    // out of the accumulated frame, and the labels are what the screen is for.
     const frame = h.frame()
-    expect(frame).toContain('Configure Ollama (local)')
-    expect(frame).toContain('API base (required)')
+    expect(frame).toContain('Ollama (local)')
+    expect(frame).toContain('Server address')
+    // No key field at all: the server ignores one, so asking reads as a blocker.
+    expect(frame).not.toContain('API key')
+
+    // And it submits with no key. The client demanded one unconditionally, so
+    // this was unreachable even after the backend stopped requiring it.
+    await h.type('http://gpu-box:11434')
+    await h.type(ENTER)
+    await delay(30)
+
+    expect(h.gw.request).toHaveBeenCalledWith(
+      'model.save_key',
+      expect.objectContaining({ api_base: 'http://gpu-box:11434', slug: 'ollama_chat' })
+    )
+    const call = (h.gw.request as unknown as { mock: { calls: unknown[][] } }).mock.calls.find(
+      c => c[0] === 'model.save_key'
+    )
+    expect((call?.[1] as { api_key?: string }).api_key).toBe('')
     h.unmount()
   })
 
@@ -175,12 +276,13 @@ describe('ModelPicker', () => {
     const h = mount([anthropic, custom])
     await delay(60)
 
-    // Move to the custom provider (index 1) and enter the key stage.
+    // Custom is not set up, so it lives behind the add row.
     await h.type(DOWN)
+    await h.type(ENTER)
     await h.type(ENTER)
 
     const keyFrame = h.frame()
-    expect(keyFrame).toContain('Configure Custom')
+    expect(keyFrame).toContain('Custom')
     expect(keyFrame).toContain('API key')
     expect(keyFrame).toContain('API base (required)')
 
@@ -209,8 +311,9 @@ describe('ModelPicker', () => {
     await delay(60)
 
     await h.type(DOWN)
+    await h.type(ENTER)
     const providerFrame = h.frame()
-    expect(providerFrame).toContain('run raven model to authenticate')
+    expect(providerFrame).toContain('raven provider login')
 
     await h.type(ENTER)
 

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -18,7 +18,10 @@ const VISIBLE = 12
 const MIN_WIDTH = 40
 const MAX_WIDTH = 90
 
-type Stage = 'provider' | 'key' | 'model' | 'addModel' | 'disconnect'
+type Stage = 'provider' | 'addProvider' | 'key' | 'model' | 'addModel' | 'disconnect'
+
+/** The row that opens the second level; not a provider. */
+const ADD_ROW = '__add_provider__'
 
 /** What a provider still needs, in the four shapes the backend reports. */
 function unconfiguredHint(authType: string | undefined): string {
@@ -54,6 +57,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
   const [providerIdx, setProviderIdx] = useState(0)
   const [modelIdx, setModelIdx] = useState(0)
   const [stage, setStage] = useState<Stage>('provider')
+  const [fromAddList, setFromAddList] = useState(false)
   const [keyInput, setKeyInput] = useState('')
   const [baseInput, setBaseInput] = useState('')
   const [keyField, setKeyField] = useState<KeyField>('api_key')
@@ -83,10 +87,14 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
         const next = r.providers ?? []
         setProviders(next)
         setCurrentModel(String(r.model ?? ''))
+        // Located in the list the first screen shows, not in the whole response:
+        // the current provider's index among all of them lands past the end of
+        // the configured ones, and a selection past the end highlights no row at
+        // all -- the picker opened with no cursor on it.
         setProviderIdx(
           Math.max(
             0,
-            next.findIndex(p => p.is_current)
+            next.filter(p => p.authenticated !== false).findIndex(p => p.is_current)
           )
         )
         setModelIdx(0)
@@ -100,11 +108,30 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
       })
   }, [gw, sessionId])
 
-  const provider = providers[providerIdx]
+  // Everything the picker needs is already in one response; the split is a view.
+  // A provider the user has not set up is not a model they can switch to, and
+  // listing all twenty-one of them buried the two or three that were.
+  const configured = useMemo(() => providers.filter(p => p.authenticated !== false), [providers])
+  const unconfigured = useMemo(() => providers.filter(p => p.authenticated === false), [providers])
+  // Which list the selection belongs to, kept apart from which screen is showing:
+  // deriving it from the stage meant that leaving the add list for the key screen
+  // silently re-pointed the selection at the configured list, so choosing an
+  // unconfigured provider opened the first configured one instead.
+  const rowsForStage = fromAddList ? unconfigured : configured
+  const onAddRow = stage === 'provider' && providerIdx === configured.length
+  const provider = onAddRow ? undefined : rowsForStage[providerIdx]
   const models = provider?.models ?? []
-  const names = useMemo(() => providerDisplayNames(providers), [providers])
+  const names = useMemo(() => providerDisplayNames(rowsForStage), [rowsForStage])
 
   const back = () => {
+    if (stage === 'addProvider') {
+      setStage('provider')
+      setFromAddList(false)
+      setProviderIdx(0)
+
+      return
+    }
+
     if (stage === 'addModel') {
       setStage('model')
       setModelNameInput('')
@@ -114,7 +141,11 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
     }
 
     if (stage === 'model' || stage === 'key' || stage === 'disconnect') {
-      setStage('provider')
+      // Backing out of a set-up that did not happen returns to the list it was
+      // opened from, rather than one level further out than the user asked for.
+      const toAddList = stage === 'key' && fromAddList && provider?.authenticated === false
+      setStage(toAddList ? 'addProvider' : 'provider')
+      setFromAddList(toAddList)
       setModelIdx(0)
       setKeyInput('')
       setBaseInput('')
@@ -141,7 +172,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
       const focusBase = showBase && keyField === 'api_base'
 
       // Tab moves between the two fields when api_base is shown.
-      if (key.tab && showBase) {
+      if (key.tab && showBase && provider?.auth_type !== 'local') {
         setKeyField(f => (f === 'api_key' ? 'api_base' : 'api_key'))
 
         return
@@ -150,7 +181,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
       if (key.return) {
         // Enter on api_key advances to api_base instead of submitting, so the
         // user can fill both fields with single-key navigation.
-        if (showBase && keyField === 'api_key') {
+        if (showBase && keyField === 'api_key' && provider?.auth_type !== 'local') {
           setKeyField('api_base')
 
           return
@@ -159,7 +190,10 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
         const apiKey = keyInput.trim()
         const apiBase = baseInput.trim()
 
-        if (!apiKey) {
+        // A local deployment is reached by address and has no key; demanding one
+        // here blocked the only providers whose key field means nothing, even
+        // after the backend stopped requiring it.
+        if (!apiKey && provider?.auth_type !== 'local') {
           setKeyError('API key is required')
 
           return
@@ -190,7 +224,19 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
             }
 
             // Update the provider in our list with fresh data
-            setProviders(prev => prev.map(p => (p.slug === r.provider!.slug ? r.provider! : p)))
+            const saved = r.provider!
+            setProviders(prev => prev.map(p => (p.slug === saved.slug ? saved : p)))
+            // It has just joined the configured list, so the selection moves with
+            // it rather than pointing into the list it left.
+            setFromAddList(false)
+            setProviderIdx(
+              Math.max(
+                0,
+                providers
+                  .filter(pr => pr.authenticated !== false || pr.slug === saved.slug)
+                  .findIndex(pr => pr.slug === saved.slug)
+              )
+            )
             setKeyInput('')
             setBaseInput('')
             setKeyField('api_key')
@@ -350,9 +396,11 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
       return
     }
 
-    const count = stage === 'provider' ? providers.length : models.length
-    const sel = stage === 'provider' ? providerIdx : modelIdx
-    const setSel = stage === 'provider' ? setProviderIdx : setModelIdx
+    const onProviderList = stage === 'provider' || stage === 'addProvider'
+    const addRowCount = stage === 'provider' && unconfigured.length > 0 ? 1 : 0
+    const count = onProviderList ? rowsForStage.length + addRowCount : models.length
+    const sel = onProviderList ? providerIdx : modelIdx
+    const setSel = onProviderList ? setProviderIdx : setModelIdx
 
     if (key.upArrow && sel > 0) {
       setSel(v => v - 1)
@@ -367,23 +415,32 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
     }
 
     if (key.return) {
-      if (stage === 'provider') {
+      if (stage === 'provider' && onAddRow) {
+        setStage('addProvider')
+        setFromAddList(true)
+        setProviderIdx(0)
+
+        return
+      }
+
+      if (onProviderList) {
         if (!provider) {
           return
         }
 
         if (provider.authenticated === false) {
-          // api_key providers prompt for key inline, even when key_env is null
-          // (custom / azure use a generic key + required api_base).
+          // Every shape but OAuth is completable here: the key stage asks for a
+          // key, an address, or both, from what the provider reports needing.
+          // OAuth is a browser flow plus a token file, so its row states the
+          // command that does it rather than pretending to.
           if (provider.auth_type !== 'oauth') {
             setStage('key')
             setKeyInput('')
             setBaseInput('')
-            setKeyField('api_key')
+            setKeyField(provider.auth_type === 'local' ? 'api_base' : 'api_key')
             setKeyError('')
           }
 
-          // OAuth / other auth types: no-op (warning tells them to run raven model)
           return
         }
 
@@ -451,7 +508,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
     }
 
     // Disconnect: only in provider stage, only for authenticated providers
-    if (ch.toLowerCase() === 'd' && stage === 'provider' && provider?.authenticated !== false) {
+    if (ch.toLowerCase() === 'd' && stage === 'provider' && provider && provider.authenticated !== false) {
       setStage('disconnect')
 
       return
@@ -483,10 +540,16 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
   // ── Key entry stage ──────────────────────────────────────────────────
   if (stage === 'key' && provider) {
     const showBase = provider.auth_type === 'endpoint' || provider.auth_type === 'local'
-    const focusBase = showBase && keyField === 'api_base'
+    // A local deployment has no key, so it gets no key field: an input the server
+    // ignores reads as something the user has to find before they can continue.
+    const showKey = provider.auth_type !== 'local'
+    const focusBase = showBase && (keyField === 'api_base' || !showKey)
     const masked = keyInput ? '•'.repeat(Math.min(keyInput.length, 40)) : ''
     const keyLabel = provider.key_env ?? 'API key'
-    const baseLabel = `API base${provider.needs_api_base ? ' (required)' : ' (optional)'}`
+    const baseLabel =
+      provider.auth_type === 'local'
+        ? 'Server address'
+        : `API base${provider.needs_api_base ? ' (required)' : ' (optional)'}`
     const caret = keySaving ? '' : '▎'
 
     return (
@@ -503,16 +566,20 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
           {' '}
         </Text>
 
-        <Text color={focusBase ? t.color.muted : t.color.accent} wrap="truncate-end">
-          {focusBase ? '  ' : '▸ '}
-          {keyLabel}:
-        </Text>
+        {showKey ? (
+          <>
+            <Text color={focusBase ? t.color.muted : t.color.accent} wrap="truncate-end">
+              {focusBase ? '  ' : '▸ '}
+              {keyLabel}:
+            </Text>
 
-        <Text color={t.color.accent} wrap="truncate-end">
-          {'  '}
-          {masked || '(empty)'}
-          {focusBase ? '' : caret}
-        </Text>
+            <Text color={t.color.accent} wrap="truncate-end">
+              {'  '}
+              {masked || '(empty)'}
+              {focusBase ? '' : caret}
+            </Text>
+          </>
+        ) : null}
 
         {showBase ? (
           <>
@@ -634,9 +701,10 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
     )
   }
 
-  // ── Provider selection stage ─────────────────────────────────────────
-  if (stage === 'provider') {
-    const rows = providers.map((p, i) => {
+  // ── Provider selection stages ────────────────────────────────────────
+  if (stage === 'provider' || stage === 'addProvider') {
+    const adding = stage === 'addProvider'
+    const rows = rowsForStage.map((p, i) => {
       const authMark = p.authenticated === false ? '○' : p.is_current ? '*' : '●'
       const modelCount = p.total_models ?? p.models?.length ?? 0
 
@@ -645,16 +713,20 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
       return `${authMark} ${names[i]} · ${suffix}`
     })
 
+    if (!adding && unconfigured.length > 0) {
+      rows.push(`+ add a provider · ${unconfigured.length} not set up`)
+    }
+
     const { items, offset } = windowItems(rows, providerIdx, VISIBLE)
 
     return (
       <Box flexDirection="column" width={width}>
         <Text bold color={t.color.accent} wrap="truncate-end">
-          Select provider (step 1/2)
+          {adding ? 'Add a provider' : 'Select provider (step 1/2)'}
         </Text>
 
         <Text color={t.color.muted} wrap="truncate-end">
-          Full model IDs on the next step · Enter to continue
+          {adding ? 'Enter to set one up · Esc to go back' : 'Full model IDs on the next step · Enter to continue'}
         </Text>
 
         <Text color={t.color.muted} wrap="truncate-end">
@@ -670,8 +742,8 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
         {Array.from({ length: VISIBLE }, (_, i) => {
           const row = items[i]
           const idx = offset + i
-          const p = providers[idx]
-          const dimmed = p?.authenticated === false
+          const p = rowsForStage[idx]
+          const dimmed = p ? p.authenticated === false : false
 
           return row ? (
             <Text


### PR DESCRIPTION
## Summary

Opening `/model` meant scrolling twenty-one rows to reach the two or three that
can actually serve a model. A provider with no credentials is not something to
switch to, so the first screen lists what is set up and ends with one row that
opens the rest:

```
* Anthropic - 12 models
* DeepSeek - 8 models
+ add a provider - 3 not set up
```

Both screens read the same `model.options` response -- the split is a view, and
the backend is unchanged. The vendor search from the onboarding wizard is
deliberately not brought over: a vendor Raven holds no spec for cannot be
configured with a single key today (#254).

Three defects surfaced while wiring it up, two of them introduced by this change
and caught by driving it rather than by reading it:

* Which list the selection belongs to is held apart from which screen is showing.
  Deriving it from the stage meant leaving the add list for the credential screen
  silently re-pointed the selection at the configured list, so choosing an
  unconfigured provider opened the first configured one instead.
* The cursor is placed by finding the current provider among the configured ones,
  not among all of them. An index into the full response lands past the end of the
  first screen's rows, and a selection past the end highlights nothing -- the
  picker opened with no cursor and Enter did nothing.
* A local deployment can be set up here at all. The client refused to submit
  without an API key regardless of provider, so the one shape with no key stayed
  unconfigurable even after the backend stopped requiring one -- and it was shown
  a key field the server ignores, which reads as something to go and find first.
  It gets one field, labelled for the address it is reached by.

## Type

- [ ] Fix
- [x] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

```
bash .claude/scripts/preflight_ci.sh   exit 0
```

That runs the full Python suite, ruff, pre-commit, and the TUI's lint, rpc-schema
check, type-check, tests and build -- the same set CI runs.

Five mutations were applied to check the new tests bite: dropping the filter on
the first screen, deriving list membership from the stage again, demanding a key
from a local deployment, showing it a key field, and locating the cursor in the
full response. Each turned the relevant test red. The key-demand one passed on the
first attempt, because the test checked the field labels without submitting; it
now submits and asserts what `model.save_key` receives.

Two assertions read field labels rather than the "Configure <name>" heading: at
that depth the fake terminal's escape stripping drops the odd character from the
accumulated frame, and the labels are what those screens exist for.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

Unconfigured providers are one keypress further away than before. The row that
opens them states how many there are, and it is hidden when there are none.

If nothing is configured the first screen holds only that row, which is the
only useful thing to show; onboarding is what puts a user in that state.

Rollback is the revert of this branch. No stored configuration is read or written
differently.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

#254 -- why the vendor search stays in the wizard rather than moving here.