### PR TITLE
chore: bump version to 0.1.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raven"
-version = "0.1.9"
+version = "0.1.10"
 description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3015,7 +3015,7 @@ wheels = [
 
 [[package]]
 name = "raven"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Bump the package version from 0.1.9 to 0.1.10 (patch release). 22 PRs merged since v0.1.9, no breaking changes.

Features:

- #260 feat(tui): list the providers that work, and the rest one level down
- #252 feat(*): offer every supported provider in the onboarding picker
- #251 feat(tools): read images with read_file, and fix four silent type-check bugs
- #239 feat: add shell command approval flow
- #217 feat: rework the TUI transcript into collapsible episodes
- #220 feat(cli): nudge raven upgrade in the tui status bar when behind
- #209 feat(providers): add MiniMax Global and CN OAuth

Refactors:

- #259 refactor(*): one answer to which credentials a provider needs
- #249 refactor(providers): unify provider management on litellm

The remaining PRs are fixes (#255, #256, #258, #253, #238, #226), test work (#236, #230, #224), docs (#250, #215, #200), and benchmark tooling (#207).

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

## Verification

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

Bump is limited to `pyproject.toml` and `uv.lock` (`uv lock` sync). Local preflight covers the branch CI checks (commit lint, PR title and body lint, ruff, large-file gate).

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Version-only change; no code or behavior change. Rollback is a revert of this commit.

## Related Issues

N/A