### PR TITLE
docs: split release install by platform, warn on draft links

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -6,15 +6,45 @@
 
 ## Install
 
+New install on Linux, macOS, or WSL2:
+
 ```bash
 curl -fsSL https://raven.evermind.ai/install.sh | bash
 ```
 
-Then reload your shell and run:
+New install on native Windows, in PowerShell:
+
+```powershell
+irm https://raven.evermind.ai/install.ps1 | iex
+```
+
+Windows PowerShell 5.1 (the version built into Windows) rejects that URL with
+`Permanent Redirect`; use the direct one instead:
+
+```powershell
+irm https://raw.githubusercontent.com/EverMind-AI/Raven/refs/heads/main/install.ps1 | iex
+```
+
+Open a new terminal, then run:
 
 ```bash
 raven onboard
 ```
+
+## Upgrade
+
+Already running Raven? Upgrade in place -- configuration, sessions, and memory
+are preserved:
+
+```bash
+raven upgrade
+```
+
+`raven upgrade` installs the latest stable release, so it does not pick up a
+pre-release; rerun the installer above for that. Editable source checkouts are
+never overwritten -- pull the checkout and rerun its development setup. On
+native Windows the upgrade finishes in an external helper; wait for its
+completion message before running Raven again.
 
 ## Release Status
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,10 +132,20 @@ jobs:
             id=""
           fi
           if [ -z "$id" ]; then
-            gh release create "$tag" dist/*.whl dist/*.tar.gz dist/raven-constraints.txt \
-              --title "Raven $ver ($today)" --notes-file "$RUNNER_TEMP/notes.md" --draft $pre
+            draft_url=$(gh release create "$tag" dist/*.whl dist/*.tar.gz dist/raven-constraints.txt \
+              --title "Raven $ver ($today)" --notes-file "$RUNNER_TEMP/notes.md" --draft $pre)
+            # A draft lives at releases/tag/untagged-<hash> and keeps serving that
+            # stale page after publication, with no redirect to the real tag. Print
+            # both URLs so nobody shares the draft one by copying the address bar.
+            {
+              echo "### Release $tag"
+              echo ""
+              echo "- Draft (temporary, do not share): $draft_url"
+              echo "- Public URL once published: https://github.com/$repo/releases/tag/$tag"
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "Release $tag already published (id=$id); leaving as-is."
+            echo "Release $tag already published: https://github.com/$repo/releases/tag/$tag" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       # (Optional, wire up when ready) publish to PyPI on tag:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,8 +31,13 @@ Highlights before publishing. Structure:
 - <user-facing change>
 
 ## Install
-  curl -fsSL https://raven.evermind.ai/install.sh | bash
+  install.sh one-liner for Linux / macOS / WSL2
+  install.ps1 one-liner for native Windows (plus the PowerShell 5.1 direct URL)
   then: raven onboard
+
+## Upgrade
+  raven upgrade, with its limits (latest stable only, editable checkouts
+  untouched, external helper on native Windows)
 
 ## Release Status
 - Version: `X.Y.Z`
@@ -58,6 +63,15 @@ Highlights before publishing. Structure:
    attached, titled and prefilled from the template.
 4. Fill the summary + Highlights in the draft, then click **Publish**.
    Publishing makes it `/releases/latest`, which `install.sh` serves.
+
+While a release is a draft, GitHub addresses it as
+`releases/tag/untagged-<hash>` -- even though the tag already exists, since CI
+only runs after the tag is pushed. Publishing moves the release to
+`releases/tag/vX.Y.Z` and leaves the old URL serving its own stale page with no
+redirect. So never share the draft URL: a reader who opens it after publication
+sees "untagged" and concludes the tag is missing or the release never went out.
+Link `releases/tag/vX.Y.Z` or `/releases/latest` instead; the release job prints
+both URLs in its step summary.
 
 ## Pre-releases
 


### PR DESCRIPTION
## Summary

Two fixes to how a release is presented, both found while cutting 0.1.10.

**Install / Upgrade in the release notes.** The template shipped a single
`curl | bash` line, so every release page told native Windows readers nothing
about `install.ps1` and told existing users nothing about upgrading -- even
though a release page is mostly read by people who already run Raven. Install
now has one block per platform, mirroring README: `install.sh` for
Linux / macOS / WSL2, `install.ps1` for native Windows plus the PowerShell 5.1
direct-URL note (the short URL fails there with `Permanent Redirect`). A new
Upgrade section gives `raven upgrade` and its three limits: latest stable only,
so a pre-release still needs the installer (rc tags are published with
`--prerelease` and never become `/releases/latest`); editable checkouts are
never overwritten; on native Windows an external helper finishes the job.

**The draft-link trap.** GitHub addresses a draft release as
`releases/tag/untagged-<hash>`, even when the tag already exists -- CI only runs
after the tag is pushed. Publishing moves the release to `releases/tag/vX.Y.Z`
and leaves the old URL serving its own stale page with no redirect. With 0.1.10
that draft link had been shared, so after publication two readers hit the stale
page and concluded, once that the tag was never pushed and once that publishing
had not taken effect; both were wrong. RELEASING.md now states this at the
publish step, and the release job prints the draft URL next to the public one in
its step summary, so whoever cuts the release has the correct link at hand
instead of copying the address bar. The notes skeleton in RELEASING.md is also
brought in line with the new template.

## Type

- [ ] Fix
- [ ] Feature
- [x] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `sed "s/__VERSION__/0.1.11/g; s/__TAG__/v0.1.11/g" .github/release-notes-template.md`
  -> both placeholders substituted, no leftover `__` markers
- Applied the same Install / Upgrade section to the pending 0.1.10 draft release
  and reviewed the rendered GitHub page before committing; that draft's summary,
  Highlights, Release Status, and Notes were left untouched
- `release.yml` parsed with `yaml.safe_load`, and the modified `run:` block
  checked with `bash -n`
- Every CI check reproduced locally, all green: `npx commitlint --from origin/main
  --to HEAD --config commitlint.config.cjs`,
  `uv run --extra dev python scripts/check_commit_messages.py origin/main..HEAD`,
  `uv run --extra dev python scripts/check_large_files.py origin/main..HEAD`,
  `uv run pre-commit run --from-ref origin/main --to-ref HEAD`, `make lint-python`,
  `make test-python` (5143 passed, 30 skipped), plus
  `scripts/check_pr_title.py` and `scripts/check_pr_body.py` on this title and body

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

## Risk

Documentation, plus one added step-summary write in the release workflow. No
runtime code path changes; already-published release notes are unaffected. The
workflow change only adds output -- the release-creation logic is untouched, and
the `else` branch (release already published) keeps its existing behaviour.
Rollback is reverting the two commits.

- [ ] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A