### PR TITLE
refactor(cli): one meaning for Ctrl+C across the credential prompts

### DIFF
--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -712,10 +712,8 @@ def _prompt_local_api_base(spec: Any, *, current: str = "", allow_back: bool = F
         qmark=_QMARK,
     ).ask()
     if url is None:
-        # Same as every other prompt here: Ctrl+C quits. Returning None instead
-        # made each caller hold a different contract -- one translated it to an
-        # exit, the other to a menu redraw -- and a reader checking the module
-        # found two of three prompts raising and wrote the rule down wrong.
+        # Ctrl+C quits, like the sibling credential prompts. Returning None left
+        # each caller to decide what it meant, and they did not agree.
         raise typer.Exit(1)
     url = url.strip()
     if allow_back and not url:
@@ -1458,8 +1456,6 @@ def _collect_credentials(
             base_url = _prompt_local_api_base(spec, current=stored, allow_back=True)
             if base_url is _BACK:
                 return _BACK
-            if base_url is None:
-                raise typer.Exit(1)
         _write_provider_fields(provider, {"api_base": base_url})
         return None
 

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -712,7 +712,11 @@ def _prompt_local_api_base(spec: Any, *, current: str = "", allow_back: bool = F
         qmark=_QMARK,
     ).ask()
     if url is None:
-        return None
+        # Same as every other prompt here: Ctrl+C quits. Returning None instead
+        # made each caller hold a different contract -- one translated it to an
+        # exit, the other to a menu redraw -- and a reader checking the module
+        # found two of three prompts raising and wrote the rule down wrong.
+        raise typer.Exit(1)
     url = url.strip()
     if allow_back and not url:
         return _BACK
@@ -1567,11 +1571,6 @@ def _resolve_model_with_test(
                 except KeyError:
                     stored = ""
                 retyped = _prompt_local_api_base(spec, current=stored)
-                if retyped is None:
-                    # Ctrl+C means quit, as it does in the sibling "re-enter key"
-                    # branch. Returning None here would have been read as "switch
-                    # provider" and silently rolled the setup back instead.
-                    raise typer.Exit(1)
                 _write_provider_fields(provider, {"api_base": retyped})
                 continue
             if choice == "reauth" and not non_interactive:
@@ -1756,8 +1755,6 @@ def _manage_existing_providers(*, non_interactive: bool) -> None:
                 except KeyError:
                     stored = ""
                 retyped = _prompt_local_api_base(target_spec, current=stored)
-                if retyped is None:
-                    continue
                 _write_provider_fields(target, {"api_base": retyped})
             elif credential_kind(target) == CRED_ENDPOINT:
                 # A self-hosted endpoint is a key *and* the address it is sent

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -3085,8 +3085,14 @@ def test_removing_a_spec_less_provider_warns_when_it_serves_the_default_model(
     assert json.loads(tmp_env.read_text())["providers"]["mistral"].get("apiKey") == "sk-mistral"
 
 
-def test_every_prompt_in_the_wizard_means_the_same_thing_by_ctrl_c(monkeypatch: pytest.MonkeyPatch) -> None:
-    """One contract, so no call site has to remember which one it is holding.
+def test_every_credential_prompt_means_the_same_thing_by_ctrl_c(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One contract across the four credential prompts, so no call site has to
+    remember which one it is holding.
+
+    Scoped to those four deliberately. The vendor search and the provider row
+    picker return None on cancellation and their caller translates it; that is a
+    separate chain, and claiming the whole module here would be the same
+    overreach twice.
 
     Two of the three raised and one returned None, and each of its callers
     translated that None differently -- an exit in one branch, a menu redraw in
@@ -3118,8 +3124,31 @@ def test_every_prompt_in_the_wizard_means_the_same_thing_by_ctrl_c(monkeypatch: 
 
 
 def test_no_call_site_translates_a_cancelled_address_prompt() -> None:
-    """The translations the divergence made necessary are gone, not relocated."""
-    import inspect
+    """The translations the divergence made necessary are gone, not relocated.
 
-    source = inspect.getsource(onboard_commands)
-    assert "retyped is None" not in source, "a caller is still translating the prompt's cancellation; it raises now"
+    Bound to the call sites rather than to a variable name: the first version of
+    this test grepped for one spelling and stayed green while a third caller was
+    still translating under another -- the same local-agreement mistake the change
+    itself exists to remove.
+    """
+    import ast
+    from pathlib import Path as _Path
+
+    source = (_Path(__file__).resolve().parents[1] / "raven" / "cli" / "onboard_commands.py").read_text()
+    tree = ast.parse(source)
+
+    targets: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        callee = node.value.func
+        if getattr(callee, "id", None) != "_prompt_local_api_base":
+            continue
+        targets += [t.id for t in node.targets if isinstance(t, ast.Name)]
+    assert targets, "no call site found; this test would prove nothing"
+
+    lines = source.splitlines()
+    offenders = [
+        f"line {i}: {line.strip()}" for i, line in enumerate(lines, 1) for name in targets if f"{name} is None" in line
+    ]
+    assert not offenders, "the prompt raises now; nothing downstream should test for None:\n" + "\n".join(offenders)

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -2988,9 +2988,13 @@ def test_a_mistyped_local_address_can_be_retyped_without_losing_the_setup(
     assert result is not None, "a retyped address must not read as 'switch provider'"
     assert attempts[-1] == "http://gpu-box:11434", "the retyped address was not re-verified"
 
-    # Ctrl+C at that prompt quits, as it does in the sibling re-enter-key branch.
-    # Returning None would be read as "switch provider" and roll the setup back.
-    monkeypatch.setattr(onboard_commands, "_prompt_local_api_base", lambda *a, **kw: None)
+    # Ctrl+C at that prompt quits, the one contract every prompt in the module
+    # holds. It used to return None here and the caller translated it, which is
+    # how two call sites came to hold two different meanings for the same value.
+    def _cancelled(*a: Any, **kw: Any) -> Any:
+        raise typer.Exit(1)
+
+    monkeypatch.setattr(onboard_commands, "_prompt_local_api_base", _cancelled)
     monkeypatch.setattr(onboard_commands, "_failure_choice", lambda options, **kw: "rebase")
     monkeypatch.setattr(
         "raven.config.update_providers.test_provider",
@@ -3079,3 +3083,43 @@ def test_removing_a_spec_less_provider_warns_when_it_serves_the_default_model(
     assert "default model" in asked[0].lower() or "默认模型" in asked[0]
     # Declined, so the key is still there.
     assert json.loads(tmp_env.read_text())["providers"]["mistral"].get("apiKey") == "sk-mistral"
+
+
+def test_every_prompt_in_the_wizard_means_the_same_thing_by_ctrl_c(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One contract, so no call site has to remember which one it is holding.
+
+    Two of the three raised and one returned None, and each of its callers
+    translated that None differently -- an exit in one branch, a menu redraw in
+    the other. The divergence also read as absent to anyone who checked the module
+    and found two prompts agreeing.
+    """
+    from types import SimpleNamespace
+
+    from raven.providers.registry import find_by_name
+
+    class _Cancelled:
+        def ask(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        onboard_commands,
+        "_require_questionary",
+        lambda: SimpleNamespace(text=lambda *a, **kw: _Cancelled(), password=lambda *a, **kw: _Cancelled()),
+    )
+
+    for call in (
+        lambda: onboard_commands._prompt_api_key("deepseek"),
+        lambda: onboard_commands._prompt_base_url(),
+        lambda: onboard_commands._prompt_custom_model(),
+        lambda: onboard_commands._prompt_local_api_base(find_by_name("ollama_chat")),
+    ):
+        with pytest.raises(typer.Exit):
+            call()
+
+
+def test_no_call_site_translates_a_cancelled_address_prompt() -> None:
+    """The translations the divergence made necessary are gone, not relocated."""
+    import inspect
+
+    source = inspect.getsource(onboard_commands)
+    assert "retyped is None" not in source, "a caller is still translating the prompt's cancellation; it raises now"

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -3093,11 +3093,6 @@ def test_every_credential_prompt_means_the_same_thing_by_ctrl_c(monkeypatch: pyt
     picker return None on cancellation and their caller translates it; that is a
     separate chain, and claiming the whole module here would be the same
     overreach twice.
-
-    Two of the three raised and one returned None, and each of its callers
-    translated that None differently -- an exit in one branch, a menu redraw in
-    the other. The divergence also read as absent to anyone who checked the module
-    and found two prompts agreeing.
     """
     from types import SimpleNamespace
 
@@ -3126,10 +3121,11 @@ def test_every_credential_prompt_means_the_same_thing_by_ctrl_c(monkeypatch: pyt
 def test_no_call_site_translates_a_cancelled_address_prompt() -> None:
     """The translations the divergence made necessary are gone, not relocated.
 
-    Bound to the call sites rather than to a variable name: the first version of
-    this test grepped for one spelling and stayed green while a third caller was
-    still translating under another -- the same local-agreement mistake the change
-    itself exists to remove.
+    Scoped to the function each call sits in, and to comparisons against the name
+    that call assigned. An earlier version grepped one spelling across the file and
+    stayed green with a third caller translating under another name; scanning every
+    line for those names instead would go red on any unrelated `base_url is None`,
+    of which this module has room for plenty.
     """
     import ast
     from pathlib import Path as _Path
@@ -3137,18 +3133,31 @@ def test_no_call_site_translates_a_cancelled_address_prompt() -> None:
     source = (_Path(__file__).resolve().parents[1] / "raven" / "cli" / "onboard_commands.py").read_text()
     tree = ast.parse(source)
 
-    targets: list[str] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
-            continue
-        callee = node.value.func
-        if getattr(callee, "id", None) != "_prompt_local_api_base":
-            continue
-        targets += [t.id for t in node.targets if isinstance(t, ast.Name)]
-    assert targets, "no call site found; this test would prove nothing"
+    def _assigned_names(scope: ast.AST) -> list[str]:
+        """Names this scope binds from a call to the address prompt."""
+        out: list[str] = []
+        for node in ast.walk(scope):
+            if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+                continue
+            if getattr(node.value.func, "id", None) != "_prompt_local_api_base":
+                continue
+            out += [t.id for t in node.targets if isinstance(t, ast.Name)]
+        return out
 
-    lines = source.splitlines()
-    offenders = [
-        f"line {i}: {line.strip()}" for i, line in enumerate(lines, 1) for name in targets if f"{name} is None" in line
-    ]
-    assert not offenders, "the prompt raises now; nothing downstream should test for None:\n" + "\n".join(offenders)
+    functions = [n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
+    checked = 0
+    offenders: list[str] = []
+    for func in functions:
+        names = _assigned_names(func)
+        if not names:
+            continue
+        checked += 1
+        for node in ast.walk(func):
+            if not isinstance(node, ast.Compare) or not isinstance(node.ops[0], (ast.Is, ast.Eq)):
+                continue
+            left, right = node.left, node.comparators[0]
+            if getattr(left, "id", None) in names and isinstance(right, ast.Constant) and right.value is None:
+                offenders.append(f"{func.name} line {node.lineno}: {left.id} is None")
+
+    assert checked, "no function calls the prompt; this test would prove nothing"
+    assert not offenders, "the prompt raises now; its callers must not test for None:\n" + "\n".join(offenders)

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -2988,9 +2988,7 @@ def test_a_mistyped_local_address_can_be_retyped_without_losing_the_setup(
     assert result is not None, "a retyped address must not read as 'switch provider'"
     assert attempts[-1] == "http://gpu-box:11434", "the retyped address was not re-verified"
 
-    # Ctrl+C at that prompt quits, the one contract every prompt in the module
-    # holds. It used to return None here and the caller translated it, which is
-    # how two call sites came to hold two different meanings for the same value.
+    # Ctrl+C at that prompt quits, like the other credential prompts.
     def _cancelled(*a: Any, **kw: Any) -> Any:
         raise typer.Exit(1)
 


### PR DESCRIPTION
## Summary

Four credential prompts in the wizard, two contracts. The key, base-URL and
custom-model prompts raise on cancellation; the server-address prompt returned
None. So each of its three callers had to decide what that meant, and they did not
agree -- an exit in the retype-address branch, an exit in the local setup branch, a
menu redraw in the manage menu.

The address prompt now raises like its siblings, and all three translations are
deleted rather than moved. A guard test resolves the prompt's call sites and fails
if any of their results is tested for None, so it holds under a rename.

Scope is those four prompts, not the module: the vendor search and the provider row
picker also return None on cancellation and their caller translates it. That is a
separate chain, left alone here rather than claimed.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [x] Refactor
- [ ] Other

## Verification

```
make lint-python && make test-python
  ruff check / format --check   clean
  5151 passed, 30 skipped, 13 deselected

cd ui-tui && npm run lint && npm run lint:rpc && npm run type-check && npm test
  0 errors; generated.ts in sync; 951 passed
```

Mutations, all behaving as intended: returning None from the prompt again turns the
contract test red; re-adding a translation at any of the three call sites turns the
guard red, under either variable name those sites use; and an unrelated
`base_url is None` in a function that never calls the prompt leaves it green. The
first version of the guard failed the second of those and would have failed the
third.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

Cancelling the server-address prompt in the manage menu now leaves the wizard
instead of returning to the menu -- the same thing Ctrl+C does at every other
prompt in it. That is the behaviour change; it is the point of the change.

Production code shrinks by seven lines (+3 / -10). Rollback is the revert of this
branch.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A