### PR TITLE
docs: closing keyword goes in the PR description, once per issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,4 +27,5 @@
 
 ## Related Issues
 
-<!-- Fixes #123, closes #123, or N/A -->
+<!-- Repeat the keyword for every issue: "Fixes #NNN, fixes #MMM". A comma list
+     closes only the first one. A bare "#NNN" references without closing. N/A if none. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,5 +27,4 @@
 
 ## Related Issues
 
-<!-- Repeat the keyword for every issue: "Fixes #NNN, fixes #MMM". A comma list
-     closes only the first one. A bare "#NNN" references without closing. N/A if none. -->
+<!-- Fixes #NNN, fixes #MMM (repeat the keyword per issue), a bare #NNN to reference, or N/A -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,7 @@ Filling rules:
 - `Type` — one box, mirroring the commit type (`feat`→Feature, `fix`→Fix, `docs`→Docs, `refactor`→Refactor, `ci`/`build`→CI / tooling, else Other). The checkbox is not a fresh judgement call;
 - `Verification` — the exact commands you ran and their result, not a claim that you ran them;
 - `Risk` — user-visible behaviour changes, and how to roll back;
-- `Related Issues` — `Fixes #NNN` for what this closes, a bare `#NNN` to reference without closing, `N/A` when there is none. **Repeat the keyword for every issue** (`Fixes #NNN, fixes #MMM`, or one per line): GitHub pairs one keyword with one reference, so `Fixes #NNN, #MMM` closes the first and merely mentions the second;
+- `Related Issues` — `Fixes #NNN` for what this closes (repeat the keyword per issue: `Fixes #NNN, fixes #MMM`), a bare `#NNN` to reference without closing, `N/A` when there is none;
 - check only the boxes you actually satisfied — leave the rest blank and explain in the description; never blanket-check;
 - anything the template has no section for but the reviewer needs (breaking change / cherry-pick option / mixed topics) → append to `Summary`.
 
@@ -264,13 +264,7 @@ Filling rules:
    ```
 2. show the full text for preview;
 3. only after the user edits/confirms, run `gh pr create --title "..." --body "$(cat /tmp/pr_description.md)"`;
-4. if the description closes any issue, **ask GitHub what it actually parsed** — a missing keyword is invisible in the rendered body and silently leaves the issue open after merge:
-   ```bash
-   gh pr view <n> --json closingIssuesReferences \
-     --template '{{range .closingIssuesReferences}}#{{.number}}{{"\n"}}{{end}}'
-   # one line per issue that will close. Fewer lines than you intended = a keyword is missing.
-   ```
-5. report the PR URL.
+4. report the PR URL.
 
 **Not allowed:**
 - pushing and walking away, leaving PR creation to the user;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,7 @@ Filling rules:
 - `Type` — one box, mirroring the commit type (`feat`→Feature, `fix`→Fix, `docs`→Docs, `refactor`→Refactor, `ci`/`build`→CI / tooling, else Other). The checkbox is not a fresh judgement call;
 - `Verification` — the exact commands you ran and their result, not a claim that you ran them;
 - `Risk` — user-visible behaviour changes, and how to roll back;
-- `Related Issues` — `Fixes #NNN` for what this closes, a bare `#NNN` to reference without closing, `N/A` when there is none;
+- `Related Issues` — `Fixes #NNN` for what this closes, a bare `#NNN` to reference without closing, `N/A` when there is none. **Repeat the keyword for every issue** (`Fixes #NNN, fixes #MMM`, or one per line): GitHub pairs one keyword with one reference, so `Fixes #NNN, #MMM` closes the first and merely mentions the second;
 - check only the boxes you actually satisfied — leave the rest blank and explain in the description; never blanket-check;
 - anything the template has no section for but the reviewer needs (breaking change / cherry-pick option / mixed topics) → append to `Summary`.
 
@@ -264,7 +264,13 @@ Filling rules:
    ```
 2. show the full text for preview;
 3. only after the user edits/confirms, run `gh pr create --title "..." --body "$(cat /tmp/pr_description.md)"`;
-4. report the PR URL.
+4. if the description closes any issue, **ask GitHub what it actually parsed** — a missing keyword is invisible in the rendered body and silently leaves the issue open after merge:
+   ```bash
+   gh pr view <n> --json closingIssuesReferences \
+     --template '{{range .closingIssuesReferences}}#{{.number}}{{"\n"}}{{end}}'
+   # one line per issue that will close. Fewer lines than you intended = a keyword is missing.
+   ```
+5. report the PR URL.
 
 **Not allowed:**
 - pushing and walking away, leaving PR creation to the user;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,8 +140,9 @@ self.logger = logger.bind(channel=self.name)
 **subject** — lowercase start; no trailing period; English. The whole header (`<type>(<scope>): <subject>`) must be ≤ 100 chars — the single length rule, enforced by commitlint `header-max-length`.
 
 **footer** (optional):
-- `BREAKING CHANGE: <desc>` — triggers a MAJOR bump once public;
-- `Closes #123` — auto-closes the issue on merge.
+- `BREAKING CHANGE: <desc>` — triggers a MAJOR bump once public.
+
+A closing keyword does not belong here: squash-merge drops individual commit bodies, so only the PR description can close an issue (§3.3, §3.7).
 
 ### §3.1.1 Top rule: the whole message is English (subject + body + footer)
 


### PR DESCRIPTION
## Summary

GitHub pairs one closing keyword with one reference. `Fixes #NNN, #MMM` closes
the first and merely mentions the second. PR #279 wrote seven issues after a
single keyword and left six of them open after merge; they were closed by hand.

Two one-line changes state the rule where a description actually gets written:

- `.github/pull_request_template.md` - the `Related Issues` hint.
- `AGENTS.md`, section 3.7 - the `Related Issues` filling rule.

A third drops `Closes #123` from the commit-footer list in section 3.1. That
line was wrong on its own terms: section 3.3 already records that this repo
squash-merges and drops individual commit bodies, so a closing keyword in a
commit footer never reaches `main` and closes nothing.

The template hint also stops naming `#123`, which is a live open issue here, and
a placeholder should not be a real number.

## Type

- [ ] Fix
- [ ] Feature
- [x] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

Documentation only; no code paths change.

```
uv run pre-commit run --from-ref origin/main --to-ref HEAD   -> all hooks Passed or Skipped
make lint-python                                             -> ruff check / format --check clean
make test-python                                             -> 5525 passed, 48 skipped,
                                                                13 deselected in 271.05s
npx commitlint --from origin/main --to HEAD --config commitlint.config.cjs   -> OK
PYTHONPATH=. uv run python scripts/check_commit_messages.py origin/main..HEAD -> OK
PYTHONPATH=. uv run python scripts/check_large_files.py origin/main..HEAD     -> OK

grep -nP "[^\x00-\x7F]" .github/pull_request_template.md     -> 0 matches. The template is
    embedded into every PR description, which CI lints as ASCII-only, so it has to stay ASCII.
```

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

## Risk

No behaviour change. The visible effect is a slightly longer hint under
`Related Issues` when a new PR opens.

Rollback is a revert of this branch.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A