### PR TITLE
chore: bump version to 0.1.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raven"
-version = "0.1.10"
+version = "0.1.11"
 description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3003,7 +3003,7 @@ wheels = [
 
 [[package]]
 name = "raven"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Bump version from 0.1.10 to 0.1.11 for the next release. Only pyproject.toml and uv.lock change.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

## Verification

- `uv lock` - resolved 193 packages, updated raven v0.1.10 -> v0.1.11
- `uv run python scripts/check_commit_messages.py origin/main..HEAD` - exit 0
- `git diff --stat origin/main..HEAD` - 2 files changed, 2 insertions(+), 2 deletions(-)

- [ ] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [ ] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Version-only bump; no code changes. Rollback: revert the squash commit.

## Related Issues

N/A
