### PR TITLE
fix(build): stop piped installs from falling back to the cwd

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -3,6 +3,9 @@
 # Remote:
 #   irm https://raven.evermind.ai/install.ps1 | iex
 #
+# A piped run always installs the published release wheel, even from inside a
+# clone. Set RAVEN_LOCAL_SRC=<dir> to force an editable install of a checkout.
+#
 # Goal: a clean Windows machine ends up able to run `raven` / `raven tui`
 # without admin rights. The script is idempotent: it reuses existing tools when
 # available and only fills the gaps:
@@ -223,10 +226,28 @@ function Resolve-RavenConstraints([string]$WheelUrl) {
     return $dest
 }
 
+function Test-RavenSource([string]$Dir) {
+    if (-not $Dir) { return $false }
+    $pyproject = Join-Path $Dir "pyproject.toml"
+    return (Test-Path $pyproject) -and (Select-String -Path $pyproject -Pattern '^name = "raven"' -Quiet)
+}
+
 function Install-Raven([string]$UvPath, [string]$NodePath) {
-    $scriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
-    $pyproject = Join-Path $scriptDir "pyproject.toml"
-    if ((Test-Path $pyproject) -and (Select-String -Path $pyproject -Pattern '^name = "raven"' -Quiet)) {
+    # $PSScriptRoot is set only when this script runs as a file. Piped through
+    # `irm ... | iex` it is empty, and falling back to the current directory
+    # turns a one-line install started from inside a clone into a silent
+    # editable install of that working tree. So local mode requires
+    # $PSScriptRoot; RAVEN_LOCAL_SRC is the explicit opt-in for a piped run.
+    $scriptDir = $null
+    if ($env:RAVEN_LOCAL_SRC) {
+        $resolved = Resolve-Path -LiteralPath $env:RAVEN_LOCAL_SRC -ErrorAction SilentlyContinue
+        if (-not $resolved) { Fail "RAVEN_LOCAL_SRC is not a directory: $($env:RAVEN_LOCAL_SRC)" }
+        $scriptDir = $resolved.Path
+        if (-not (Test-RavenSource $scriptDir)) { Fail "RAVEN_LOCAL_SRC is not a Raven source checkout: $scriptDir" }
+    } elseif ($PSScriptRoot -and (Test-RavenSource $PSScriptRoot)) {
+        $scriptDir = $PSScriptRoot
+    }
+    if ($scriptDir) {
         Write-Info "Detected local Raven source checkout; installing editable: $scriptDir"
         $entry = Join-Path $scriptDir "ui-tui\dist\entry.js"
         if (-not (Test-Path $entry)) {

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,9 @@
 #   Remote (website):   curl -fsSL https://raven.evermind.ai/install.sh | sh
 #   Local (dev clone):  git clone ... && cd raven && ./install.sh
 #
+# A piped run always installs the published release wheel, even from inside a
+# clone. Set RAVEN_LOCAL_SRC=<dir> to force an editable install of a checkout.
+#
 # Goal: a clean machine ends up able to run `raven` / `raven tui` from any
 # directory with no manual steps. The script is idempotent -- it detects what
 # is already present and only fills the gaps:
@@ -146,11 +149,32 @@ ensure_node() {
 }
 
 # --- 3. install raven ------------------------------------------------------
+# True when $1 holds a raven source checkout (its own pyproject, not a dep's).
+is_raven_source() {
+  [ -f "$1/pyproject.toml" ] && grep -q '^name = "raven"' "$1/pyproject.toml" 2>/dev/null
+}
+
 install_raven() {
   # Local mode: run from a raven source checkout -> editable install of the
-  # working tree (what a developer wants). Otherwise install from git.
-  script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-  if [ -f "$script_dir/pyproject.toml" ] && grep -q '^name = "raven"' "$script_dir/pyproject.toml" 2>/dev/null; then
+  # working tree (what a developer wants). Otherwise install the release wheel.
+  #
+  # "$0" names a real file only when this script runs as a file
+  # (./install.sh). Piped through `curl ... | sh` the script arrives on stdin,
+  # "$0" is "sh" and dirname "$0" is "." -- taking that as the source dir turns
+  # a one-line install started from inside a clone into a silent editable
+  # install of that working tree, whatever it happens to contain. So local mode
+  # requires "$0" to be a file; RAVEN_LOCAL_SRC is the explicit opt-in for a
+  # piped run.
+  script_dir=""
+  if [ -n "${RAVEN_LOCAL_SRC:-}" ]; then
+    script_dir="$(CDPATH= cd -- "$RAVEN_LOCAL_SRC" 2>/dev/null && pwd || true)"
+    [ -n "$script_dir" ] || die "RAVEN_LOCAL_SRC is not a directory: $RAVEN_LOCAL_SRC"
+    is_raven_source "$script_dir" || die "RAVEN_LOCAL_SRC is not a raven source checkout: $script_dir"
+  elif [ -f "$0" ]; then
+    script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+    is_raven_source "$script_dir" || script_dir=""
+  fi
+  if [ -n "$script_dir" ]; then
     info "Local raven source detected; editable install: $script_dir"
     # The TUI bundle must exist before first run. In a dev checkout it isn't
     # committed, so build it now if Node is available.


### PR DESCRIPTION
## Summary

The one-line install silently installed a local checkout instead of the published release wheel.

`install_raven` picked its mode from `dirname "$0"`. `$0` names a real file only when
the installer runs as a file (`./install.sh`); piped through `curl ... | sh` the script
arrives on stdin, `$0` is `sh` and its dirname is `.`, so the "is this a raven source
checkout?" test ran against the current working directory. Anyone running the documented
one-liner from inside a clone (a natural thing for a contributor to do) got a silent
editable install of that working tree: `raven --version` then reports whatever the
checkout is rather than the release, and the runtime reads a config that the checkout's
branch may not even support. The script prints `Local raven source detected`, but a user
who typed the official one-liner has no reason to read that as "I am not installing the
release".

Local mode now requires `$0` to be an existing file, so a piped run always resolves the
release wheel. `RAVEN_LOCAL_SRC=<dir>` is the explicit opt-in for a piped run, and a value
that is not a raven checkout fails loudly rather than falling through to remote mode.

`install.ps1` had the same fallback, through `(Get-Location).Path` when `$PSScriptRoot` is
empty under `irm ... | iex`; it is fixed the same way.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

Ran `install.sh` end to end against stub `uv` / `curl` / `node` / `npm` on the PATH, so the
chosen install command is observable without touching a real environment. Four cases, all
from inside a raven checkout:

| Invocation | Before | After |
|---|---|---|
| `cat install.sh \| sh` | editable install of the cwd checkout | `tool install --force raven[channels] @ .../raven-0.1.11-py3-none-any.whl` |
| `sh ./install.sh` | editable install | editable install (unchanged) |
| `RAVEN_LOCAL_SRC=<checkout>` piped | n/a | editable install of that checkout |
| `RAVEN_LOCAL_SRC=/nonexistent-dir` piped | n/a | `x RAVEN_LOCAL_SRC is not a directory: /nonexistent-dir`, exit 1 |

- [x] Relevant tests pass locally
- [ ] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

Notes on the unchecked box: the repo has no shell test suite and no shellcheck / shfmt hook,
so "tests" here means the stubbed end-to-end runs above; the pre-commit hooks that do exist
(ruff, prettier, eslint) do not cover `.sh` / `.ps1`. `install.ps1` was reviewed by reading,
not executed, since this was verified on macOS. Both installers document `RAVEN_LOCAL_SRC` in
their header comment; the README one-liner is unchanged and needs no edit.

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Notes: this narrows what a piped script will install from the machine it runs on, so it
removes a way for the installer to pick up unexpected local code. The documented developer
path (`./install.sh` inside a clone) is unchanged. The only behavior anyone could have relied
on is "pipe the installer while sitting in a clone and get an editable install"; that now
needs `RAVEN_LOCAL_SRC=.`. Rollback is a revert of this commit.

## Related Issues

N/A