### PR TITLE
fix(tui_rpc): surface the cause of an internal_error, not just the code

### DIFF
--- a/raven/tui_rpc/dispatcher.py
+++ b/raven/tui_rpc/dispatcher.py
@@ -26,6 +26,7 @@ from raven.tui_rpc.errors import (
     METHOD_NOT_FOUND,
     PARSE_ERROR,
     RpcError,
+    error_data,
 )
 
 Handler = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
@@ -106,10 +107,9 @@ class Dispatcher:
                 "code": exc.code,
                 "message": exc.message,
             }
-            if exc.data is not None:
-                err_payload["data"] = exc.data
-            elif exc.detail:
-                err_payload["data"] = {"detail": exc.detail}
+            payload_data = error_data(exc)
+            if payload_data is not None:
+                err_payload["data"] = payload_data
             return {"jsonrpc": "2.0", "id": frame_id, "error": err_payload}
         except SystemExit as exc:
             # Click/Typer can leak SystemExit even with standalone_mode=False;

--- a/raven/tui_rpc/errors.py
+++ b/raven/tui_rpc/errors.py
@@ -61,6 +61,20 @@ class RpcError(Exception):
         return self.MESSAGE
 
 
+def error_data(exc: RpcError) -> dict[str, Any] | None:
+    """Wire ``error.data`` for an exception: ``data`` with ``detail`` folded in.
+
+    ``message`` is a fixed code name, so ``detail`` is the only place the cause
+    is spelled out; callers that set both must not lose it. Shared by the
+    dispatcher's error frames and the per-turn error events so both carry the
+    same context.
+    """
+    data = dict(exc.data) if exc.data is not None else {}
+    if exc.detail:
+        data.setdefault("detail", exc.detail)
+    return data or None
+
+
 class SessionNotFoundError(RpcError):
     CODE = -32001
     MESSAGE = "session_not_found"

--- a/raven/tui_rpc/methods/turn.py
+++ b/raven/tui_rpc/methods/turn.py
@@ -140,6 +140,13 @@ def _build_error_detail(exc: RpcError) -> str | None:
     ``message`` is only the code name (``internal_error``), so without this the
     TUI shows a turn failing for no stated reason. ``log_path`` rides along
     because an init crash is usually only fully diagnosable from the log.
+
+    It rides in *front* of the cause, not behind it: the TUI renders the first
+    line of this string and nothing else (``chatStream.ts``), and the crash this
+    exists for -- a config the running build cannot parse -- raises a
+    ``ValidationError`` whose ``str()`` is always multi-line (7 lines for two bad
+    fields). Appended, the pointer landed on the last line and never reached
+    anyone; the one case that needs the log was the one case that lost it.
     """
     data = error_data(exc) or {}
     detail = data.get("detail") or data.get("exception_message")
@@ -147,7 +154,7 @@ def _build_error_detail(exc: RpcError) -> str | None:
         return None
     log_path = data.get("log_path")
     if isinstance(log_path, str) and log_path.strip():
-        return f"{detail.strip()} (details in {log_path.strip()})"
+        return f"(details in {log_path.strip()}) {detail.strip()}"
     return detail.strip()
 
 

--- a/raven/tui_rpc/methods/turn.py
+++ b/raven/tui_rpc/methods/turn.py
@@ -26,7 +26,7 @@ from pydantic import ValidationError
 
 from raven.spine import ChatType, Media, Origin, Source, TurnHandle, TurnRequest
 from raven.spine.scheduler import Scheduler, SchedulerDrainingError
-from raven.tui_rpc.errors import RpcError, TurnInProgressError
+from raven.tui_rpc.errors import RpcError, TurnInProgressError, error_data
 from raven.tui_rpc.models import (
     TurnCancelParams,
     TurnSendParams,
@@ -134,16 +134,38 @@ def _resolve_model(parsed: TurnSendParams) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _build_error_detail(exc: RpcError) -> str | None:
+    """Human-readable cause of a latched init crash.
+
+    ``message`` is only the code name (``internal_error``), so without this the
+    TUI shows a turn failing for no stated reason. ``log_path`` rides along
+    because an init crash is usually only fully diagnosable from the log.
+    """
+    data = error_data(exc) or {}
+    detail = data.get("detail") or data.get("exception_message")
+    if not isinstance(detail, str) or not detail.strip():
+        return None
+    log_path = data.get("log_path")
+    if isinstance(log_path, str) and log_path.strip():
+        return f"{detail.strip()} (details in {log_path.strip()})"
+    return detail.strip()
+
+
 async def _emit_start_then_error(
-    emitter: SubscriptionEmitter, session_key: str, turn_id: str, code: int, message: str
+    emitter: SubscriptionEmitter,
+    session_key: str,
+    turn_id: str,
+    code: int,
+    message: str,
+    detail: str | None = None,
 ) -> None:
     # message.start first so the front-end has a turn to clear, then the error
     # clears it (its onError resets turnId) — same shape the old per-turn task used.
     await emitter.emit(session_key, {"type": "message.start", "payload": {"turn_id": turn_id}})
-    await emitter.emit(
-        session_key,
-        {"type": "error", "payload": {"code": code, "message": message, "reason": "internal"}},
-    )
+    payload: dict[str, Any] = {"code": code, "message": message, "reason": "internal"}
+    if detail:
+        payload["detail"] = detail
+    await emitter.emit(session_key, {"type": "error", "payload": payload})
 
 
 async def turn_send(
@@ -182,7 +204,12 @@ async def turn_send(
         if emitter is not None:
             if build_error is not None:
                 await _emit_start_then_error(
-                    emitter, parsed.session_key, turn_id, build_error.code, build_error.message
+                    emitter,
+                    parsed.session_key,
+                    turn_id,
+                    build_error.code,
+                    build_error.message,
+                    _build_error_detail(build_error),
                 )
             else:
                 await _emit_start_then_error(emitter, parsed.session_key, turn_id, -32008, "model_not_available")

--- a/tests/test_tui_rpc_system.py
+++ b/tests/test_tui_rpc_system.py
@@ -17,7 +17,7 @@ import time
 import pytest
 
 from raven.tui_rpc.dispatcher import Dispatcher
-from raven.tui_rpc.errors import ConfigValidationError
+from raven.tui_rpc.errors import ConfigValidationError, InternalError
 from raven.tui_rpc.methods.system import (
     register_system_methods,
     system_hello,
@@ -160,6 +160,26 @@ async def test_dispatcher_internal_error_maps_to_32603():
     # Traceback tail should be included for debuggability
     assert "data" in resp["error"]
     assert "traceback_tail" in resp["error"]["data"]
+
+
+async def test_dispatcher_keeps_detail_alongside_structured_data():
+    # `message` is only a code name, so dropping `detail` when a raiser also set
+    # `data` leaves the client with nothing to show. Both must reach the wire.
+    d = Dispatcher()
+
+    async def boom(params: dict) -> dict:
+        raise InternalError(
+            detail="Config at ~/.raven/config.json fails schema validation",
+            data={"reason": "tui_init_crash", "log_path": "~/.raven/logs/tui.log"},
+        )
+
+    d.register("test.boom", boom)
+    resp = await d.dispatch({"jsonrpc": "2.0", "id": 7, "method": "test.boom", "params": {}})
+
+    assert resp["error"]["code"] == -32603
+    assert resp["error"]["data"]["detail"] == "Config at ~/.raven/config.json fails schema validation"
+    assert resp["error"]["data"]["reason"] == "tui_init_crash"
+    assert resp["error"]["data"]["log_path"] == "~/.raven/logs/tui.log"
 
 
 async def test_dispatcher_parse_response_id_echoed():

--- a/tests/test_tui_rpc_turn_send.py
+++ b/tests/test_tui_rpc_turn_send.py
@@ -188,6 +188,47 @@ async def test_turn_send_without_scheduler_surfaces_build_error_code() -> None:
     assert emitter.emitted[-1][1]["payload"]["code"] == -32603
 
 
+async def test_turn_send_emits_the_build_error_cause_not_just_its_code() -> None:
+    # -32603 internal_error names no cause on its own; the init crash detail and
+    # the log path are what make the failure diagnosable in the transcript.
+    class _BuildErr(RpcError):
+        CODE = -32603
+        MESSAGE = "internal_error"
+
+    emitter = FakeEmitter()
+    build_error = _BuildErr(
+        "Config at ~/.raven/config.json fails schema validation",
+        {"reason": "tui_init_crash", "log_path": "~/.raven/logs/tui.log"},
+    )
+    await turn_send(
+        {"session_key": "tui:default", "content": "x"},
+        emitter=emitter,
+        scheduler=None,
+        build_error=build_error,
+    )
+
+    payload = emitter.emitted[-1][1]["payload"]
+    assert payload["detail"] == (
+        "Config at ~/.raven/config.json fails schema validation (details in ~/.raven/logs/tui.log)"
+    )
+
+
+async def test_turn_send_omits_detail_when_the_build_error_has_no_cause() -> None:
+    class _BuildErr(RpcError):
+        CODE = -32603
+        MESSAGE = "internal_error"
+
+    emitter = FakeEmitter()
+    await turn_send(
+        {"session_key": "tui:default", "content": "x"},
+        emitter=emitter,
+        scheduler=None,
+        build_error=_BuildErr(),
+    )
+
+    assert "detail" not in emitter.emitted[-1][1]["payload"]
+
+
 # --- Params validation ---
 
 

--- a/tests/test_tui_rpc_turn_send.py
+++ b/tests/test_tui_rpc_turn_send.py
@@ -209,8 +209,32 @@ async def test_turn_send_emits_the_build_error_cause_not_just_its_code() -> None
 
     payload = emitter.emitted[-1][1]["payload"]
     assert payload["detail"] == (
-        "Config at ~/.raven/config.json fails schema validation (details in ~/.raven/logs/tui.log)"
+        "(details in ~/.raven/logs/tui.log) Config at ~/.raven/config.json fails schema validation"
     )
+
+
+async def test_the_log_path_survives_the_transcript_renderer_on_a_multiline_cause() -> None:
+    # The TUI renders the first line of `detail` and nothing else. The crash this
+    # detail exists for is an unparseable config, whose ValidationError str() runs
+    # to several lines -- so a trailing pointer was dropped for exactly the case
+    # that needs it. Asserts the surviving slice, not just the whole string.
+    class _BuildErr(RpcError):
+        CODE = -32603
+        MESSAGE = "internal_error"
+
+    emitter = FakeEmitter()
+    multiline = "2 validation errors for RavenConfig\nagents.defaults.model\n  Input should be a valid string"
+    await turn_send(
+        {"session_key": "tui:default", "content": "x"},
+        emitter=emitter,
+        scheduler=None,
+        build_error=_BuildErr(multiline, {"reason": "tui_init_crash", "log_path": "~/.raven/logs/tui.log"}),
+    )
+
+    detail = emitter.emitted[-1][1]["payload"]["detail"]
+    rendered = detail.split("\n")[0][:200]  # ui-tui/src/app/chatStream.ts
+    assert "~/.raven/logs/tui.log" in rendered
+    assert "2 validation errors for RavenConfig" in rendered
 
 
 async def test_turn_send_omits_detail_when_the_build_error_has_no_cause() -> None:

--- a/ui-tui/src/__tests__/rpc.test.ts
+++ b/ui-tui/src/__tests__/rpc.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
+import { RpcError, rpcErrorFromFrame, SessionNotFoundError } from '../rpc/errors.js'
 
 describe('asRpcResult', () => {
   it('keeps plain object payloads', () => {
@@ -23,5 +24,64 @@ describe('rpcErrorMessage', () => {
   it('falls back for unknown errors', () => {
     expect(rpcErrorMessage('broken')).toBe('broken')
     expect(rpcErrorMessage({ code: 500 })).toBe('request failed')
+  })
+})
+
+describe('rpcErrorFromFrame', () => {
+  it('keeps the bare code name when the frame carries no context', () => {
+    const err = rpcErrorFromFrame({ code: -32603, message: 'internal_error' })
+    expect(err.message).toBe('[rpc -32603] internal_error')
+  })
+
+  it('surfaces the cause the server put in data, plus where to read more', () => {
+    const err = rpcErrorFromFrame({
+      code: -32603,
+      message: 'internal_error',
+      data: {
+        reason: 'tui_init_crash',
+        detail: 'Config at ~/.raven/config.json fails schema validation',
+        log_path: '~/.raven/logs/tui.log'
+      }
+    })
+    expect(err.message).toBe(
+      '[rpc -32603] internal_error: Config at ~/.raven/config.json fails schema validation\n' +
+        '(details in ~/.raven/logs/tui.log)'
+    )
+  })
+
+  it('reads exception_message and reason when detail is absent', () => {
+    expect(
+      rpcErrorFromFrame({ code: -32603, message: 'internal_error', data: { exception_message: 'boom' } }).message
+    ).toBe('[rpc -32603] internal_error: boom')
+    expect(rpcErrorFromFrame({ code: -32603, message: 'internal_error', data: { reason: 'uncaught' } }).message).toBe(
+      '[rpc -32603] internal_error: uncaught'
+    )
+  })
+
+  it('keeps a multi-line cause readable below the summary', () => {
+    const err = rpcErrorFromFrame({
+      code: -32011,
+      message: 'config_validation_error',
+      data: { detail: '2 validation errors\nsubagents: extra inputs are not permitted' }
+    })
+    expect(err.message).toBe(
+      '[rpc -32011] config_validation_error:\n2 validation errors\nsubagents: extra inputs are not permitted'
+    )
+  })
+
+  it('ignores non-object and blank data without losing the code name', () => {
+    for (const data of [undefined, null, ['detail'], 'detail', { detail: '   ' }, { detail: 7 }]) {
+      expect(rpcErrorFromFrame({ code: -32603, message: 'internal_error', data }).message).toBe(
+        '[rpc -32603] internal_error'
+      )
+    }
+  })
+
+  it('still selects the typed subclass and exposes raw data', () => {
+    const err = rpcErrorFromFrame({ code: -32001, message: 'session_not_found', data: { detail: 'no such key' } })
+    expect(err).toBeInstanceOf(SessionNotFoundError)
+    expect(err).toBeInstanceOf(RpcError)
+    expect(err.code).toBe(-32001)
+    expect(err.data).toEqual({ detail: 'no such key' })
   })
 })

--- a/ui-tui/src/rpc/errors.ts
+++ b/ui-tui/src/rpc/errors.ts
@@ -7,13 +7,45 @@
 
 import type { JsonRpcErrorObject } from './generated.js'
 
+/** Fields the server puts in `error.data` to explain a failure (see
+ *  `raven/tui_rpc/errors.py` and `_build_tui_agent_loop`). `frame.message` is a
+ *  fixed code name like `internal_error`, so without these the user is told
+ *  nothing actionable. */
+const DETAIL_KEYS = ['detail', 'exception_message', 'reason'] as const
+
+const readString = (data: Record<string, unknown>, key: string): string | undefined => {
+  const value = data[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+/** `[rpc -32603] internal_error: <cause> (see ~/.raven/logs/tui.log)`.
+ *  Callers render `err.message` directly, so the cause has to live there. */
+export function formatRpcError(frame: JsonRpcErrorObject): string {
+  let text = `[rpc ${frame.code}] ${frame.message}`
+  if (typeof frame.data !== 'object' || frame.data === null || Array.isArray(frame.data)) {
+    return text
+  }
+  const data = frame.data as Record<string, unknown>
+  const detail = DETAIL_KEYS.map(key => readString(data, key)).find(Boolean)
+  // A one-line detail reads inline; a multi-line one (a config error listing
+  // every offending field, say) keeps its shape below the summary.
+  if (detail) {
+    text += detail.includes('\n') ? `:\n${detail}` : `: ${detail}`
+  }
+  const logPath = readString(data, 'log_path')
+  if (logPath) {
+    text += `\n(details in ${logPath})`
+  }
+  return text
+}
+
 /** Base class for all JSON-RPC error responses surfaced to callers. */
 export class RpcError extends Error {
   readonly code: number
   readonly data: unknown
 
   constructor(frame: JsonRpcErrorObject) {
-    super(`[rpc ${frame.code}] ${frame.message}`)
+    super(formatRpcError(frame))
     this.name = 'RpcError'
     this.code = frame.code
     this.data = frame.data


### PR DESCRIPTION
## Summary

A -32603 reached the user as exactly this, and nothing else:

```
error: [rpc -32603] internal_error
```

No cause, no file, no log path. The information existed the whole time and was discarded
three separate times:

1. **The dispatcher dropped `detail`.** `raven/tui_rpc/dispatcher.py` used
   `if exc.data is not None: ... elif exc.detail: ...`, so a raiser that set both lost the
   detail. `_build_tui_agent_loop` always sets both.
2. **`turn.send` emitted only `{code, message}`** for a latched init crash, although the
   `ErrorEvent` schema already has a `detail` field and `chatStream.onError` already renders
   it.
3. **The client formatted `[rpc <code>] <message>`**, where `message` is a fixed code name
   (`internal_error`), and every call site prints `err.message`.

So an AgentLoop that cannot start produced a dead end. A real instance: a config file
containing a key the running branch does not know about fails validation, `_build_tui_agent_loop`
raises `InternalError` with the full pydantic message and `log_path`, and the TUI showed the
line above.

The fix keeps `message` protocol-faithful and puts the cause where callers already look:

- `error_data(exc)` in `raven/tui_rpc/errors.py` folds `detail` into `data`, and both the
  dispatcher and the turn error events use it, so the two paths carry the same context.
- `turn.send` passes the init-crash detail plus its `log_path` into the emitted event.
- `formatRpcError` in `ui-tui/src/rpc/errors.ts` builds the message from `detail`,
  `exception_message` or `reason`, and appends the log path. A multi-line cause (a config
  error listing each offending field) keeps its line breaks below the summary line.

Same failure after the change, rendered by feeding a real dispatcher frame through the client
path:

```
error: [rpc -32603] internal_error:
Config at /Users/admin/.raven/config.json fails schema validation:
1 validation error for Config
subagents
  Extra inputs are not permitted
(details in ~/.raven/logs/tui.log)
```

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

`uv run pytest tests/ -k "tui_rpc or dispatcher or tui_bootstrap"` -> 523 passed. New cases:
the dispatcher keeps `detail` next to `reason` and `log_path` in one frame; `turn.send` emits
the build-error cause with its log path; and it omits `detail` entirely when the error has no
cause to report.

`npx vitest run` in `ui-tui/` -> 86 files, 988 tests passed, including six new
`rpcErrorFromFrame` cases: a bare frame keeps the old one-line form; `data` context is
surfaced with the log path; `exception_message` and `reason` are read when `detail` is absent;
a multi-line cause keeps its shape; non-object or blank `data` cannot corrupt the message; and
typed subclass selection plus raw `data` access are unchanged.

`npm run type-check`, `npx eslint`, `npx prettier --check`, `ruff check`, `ruff format --check`
all clean.

End to end, the exact production shape: an `InternalError` raised the way
`_build_tui_agent_loop` raises it was dispatched to a JSON-RPC frame, and that frame was fed
through `rpcErrorFromFrame` with `tsx`, producing the output shown above.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Notes: `error.code` and `error.message` are unchanged on the wire, so nothing that branches on
them is affected; the added `data.detail` and `payload.detail` are both already in the schema.
`err.message` gains a suffix, which the one message-matching call site
(`SESSION_BUSY_RE` in `useSubmission.ts`) is unaffected by, since it matches text that still
appears. Detail text originates from server-side exceptions and is already written to
`~/.raven/logs/tui.log`, so this exposes nothing new to the client; the client accepts it only
when it is a string and ignores any other shape. Rollback is a revert of this commit.

## Related Issues

N/A