### PR TITLE
fix(*): make everos ownership explicit and stop memory failures from stalling a session

### DIFF
--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -439,6 +439,9 @@ class AgentLoop:
         # Writes that outran their turn budget and are still running. Held so
         # teardown can drain them instead of dropping whatever was slowest.
         self._store_inflight: set[asyncio.Task] = set()
+        # Writes refused because indexing never caught up. Reported at teardown:
+        # a dropped write is a turn the user will not be able to recall.
+        self._store_dropped = 0
 
         # Tools contributed by activated plugins; registered into the
         # ToolRegistry by ``_register_default_tools``.
@@ -1325,15 +1328,36 @@ class AgentLoop:
         task = asyncio.create_task(_store())
         self._store_inflight.add(task)
         task.add_done_callback(self._store_inflight.discard)
-        if len(self._store_inflight) > _STORE_MAX_INFLIGHT:
-            # Backpressure rather than unbounded growth: a service slow enough
-            # to accumulate this many outstanding writes is one whose queue
-            # should stop growing, not one to keep feeding.
-            await asyncio.wait(set(self._store_inflight), return_when=asyncio.FIRST_COMPLETED)
         # Deliberately not cancelled on timeout: the point is to stop *waiting*,
         # not to abandon the write. A turn that indexes quickly still does so
         # inline, which keeps ordering intact in the common case.
         await asyncio.wait({task}, timeout=_STORE_TURN_BUDGET_S)
+
+        if len(self._store_inflight) > _STORE_MAX_INFLIGHT:
+            # Backpressure rather than unbounded growth: a service slow enough
+            # to accumulate this many outstanding writes is one whose queue
+            # should stop growing, not one to keep feeding.
+            #
+            # Bounded by the turn's own budget, and that bound is the whole
+            # point. Unbounded, this waited on the slowest outstanding write
+            # instead -- and since flush_every_turns defaults to 1, every
+            # interactive turn is a final flush carrying the six-minute
+            # extraction budget, so reaching the cap stalled a turn for
+            # minutes. That is the stall this method exists to remove.
+            await asyncio.wait(set(self._store_inflight), timeout=_STORE_TURN_BUDGET_S)
+            if len(self._store_inflight) > _STORE_MAX_INFLIGHT:
+                # Still saturated. The queue is what gives, not the turn: this
+                # write is dropped and said out loud at teardown, rather than
+                # held open behind writes that are already over their time.
+                task.cancel()
+                self._store_inflight.discard(task)
+                self._store_dropped += 1
+                logger.warning(
+                    "backend.store dropped for session {}: {} writes still in flight after {}s",
+                    session_key,
+                    len(self._store_inflight),
+                    _STORE_TURN_BUDGET_S,
+                )
 
     async def drain_backend_stores(self, timeout: float = _STORE_DRAIN_BUDGET_S) -> None:
         """Let detached writes finish before the process goes away.
@@ -1343,9 +1367,13 @@ class AgentLoop:
         silent and biased kind of data loss.
         """
         pending = {t for t in self._store_inflight if not t.done()}
-        if not pending:
-            return
-        await asyncio.wait(pending, timeout=timeout)
+        if pending:
+            await asyncio.wait(pending, timeout=timeout)
+        if self._store_dropped:
+            logger.warning(
+                "{} turn(s) were not indexed: the memory service never caught up",
+                self._store_dropped,
+            )
 
     def _collect_injected_skill_ids(
         self,

--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -53,6 +53,15 @@ from raven.spine.turn import Origin
 from raven.tracing import semconv, trace
 from raven.utils.helpers import estimate_prompt_tokens, is_image_part, is_inline_image
 
+# How long a turn is willing to wait on plugin-side indexing before letting the
+# write finish on its own. A budget, not a deadline: the task keeps running.
+_STORE_TURN_BUDGET_S: float = 5.0
+# Outstanding detached writes past which a turn waits for one to land, so a slow
+# memory service cannot grow an unbounded queue behind a fast typist.
+_STORE_MAX_INFLIGHT: int = 4
+# Teardown's total budget for letting those writes finish.
+_STORE_DRAIN_BUDGET_S: float = 15.0
+
 _ABORTED_ACTION_REPLY = (
     "The operation was not completed, and no alternative method will be attempted. "
     "Would you like me to continue with the remaining parts of the task that do not "
@@ -427,6 +436,9 @@ class AgentLoop:
         # pipeline unchanged. See ``_dispatch_backend_store`` for the call
         # site that consumes it.
         self.backend: "MemoryBackend | None" = backend
+        # Writes that outran their turn budget and are still running. Held so
+        # teardown can drain them instead of dropping whatever was slowest.
+        self._store_inflight: set[asyncio.Task] = set()
 
         # Tools contributed by activated plugins; registered into the
         # ToolRegistry by ``_register_default_tools``.
@@ -1299,13 +1311,41 @@ class AgentLoop:
             return
         if not messages_slice:
             return
-        try:
-            await self.backend.store(session_key, messages_slice)
-        except Exception:
-            logger.exception(
-                "backend.store failed for session {}; turn data preserved in session log, plugin-side indexing skipped",
-                session_key,
-            )
+
+        async def _store() -> None:
+            try:
+                await self.backend.store(session_key, messages_slice)  # type: ignore[union-attr]
+            except Exception:
+                logger.exception(
+                    "backend.store failed for session {}; turn data preserved in session log, "
+                    "plugin-side indexing skipped",
+                    session_key,
+                )
+
+        task = asyncio.create_task(_store())
+        self._store_inflight.add(task)
+        task.add_done_callback(self._store_inflight.discard)
+        if len(self._store_inflight) > _STORE_MAX_INFLIGHT:
+            # Backpressure rather than unbounded growth: a service slow enough
+            # to accumulate this many outstanding writes is one whose queue
+            # should stop growing, not one to keep feeding.
+            await asyncio.wait(set(self._store_inflight), return_when=asyncio.FIRST_COMPLETED)
+        # Deliberately not cancelled on timeout: the point is to stop *waiting*,
+        # not to abandon the write. A turn that indexes quickly still does so
+        # inline, which keeps ordering intact in the common case.
+        await asyncio.wait({task}, timeout=_STORE_TURN_BUDGET_S)
+
+    async def drain_backend_stores(self, timeout: float = _STORE_DRAIN_BUDGET_S) -> None:
+        """Let detached writes finish before the process goes away.
+
+        Writes that outran their turn budget are still in flight. Exiting on top
+        of them loses exactly the turns that were slowest to index, which is a
+        silent and biased kind of data loss.
+        """
+        pending = {t for t in self._store_inflight if not t.done()}
+        if not pending:
+            return
+        await asyncio.wait(pending, timeout=timeout)
 
     def _collect_injected_skill_ids(
         self,

--- a/raven/cli/agent_commands.py
+++ b/raven/cli/agent_commands.py
@@ -338,6 +338,9 @@ def register(app: typer.Typer) -> None:
             finally:
                 if backend is not None:
                     try:
+                        # Detached indexing writes first: stopping the backend
+                        # closes the HTTP client they still need.
+                        await agent_loop.drain_backend_stores()
                         await backend.stop()
                     except Exception:
                         logger.exception(

--- a/raven/cli/doctor_commands.py
+++ b/raven/cli/doctor_commands.py
@@ -261,7 +261,13 @@ def _probe_memory(config: "RavenConfig") -> MemoryInfo:
     # either; not touching it is the promise. What the server says about itself
     # is the only honest source, and when it is down there is no source at all.
     info.root = None
-    info.configured = [s for s in (*REQUIRED_SECTIONS, *DEGRADING_SECTIONS) if report.available(s) is True]
+    # Every section the server has an opinion about -- built or failed. Taking
+    # only the built ones made ``unbuilt`` (the failed subset of this list)
+    # structurally empty, so ``broken`` and the exit code could never fire and
+    # a server that could not build its LLM reported healthy. Raven cannot read
+    # their toml to learn what they configured, and does not need to: a section
+    # the server reports as unavailable is one it tried to build and could not.
+    info.configured = [s for s in (*REQUIRED_SECTIONS, *DEGRADING_SECTIONS) if report.available(s) is not None]
     info.retrieval = None
     if report.reports_capabilities:
         info.retrieval = "semantic" if report.available("embedding") is True else "keyword-only"

--- a/raven/cli/doctor_commands.py
+++ b/raven/cli/doctor_commands.py
@@ -72,6 +72,9 @@ class MemoryInfo:
     """
 
     backend: Optional[str] = None
+    root: Optional[str] = None
+    owned: bool = True
+    address: Optional[str] = None
     server_running: bool = False
     reports_capabilities: bool = False
     configured: list[str] = field(default_factory=list)
@@ -223,13 +226,21 @@ def _probe_memory(config: "RavenConfig") -> MemoryInfo:
     info = MemoryInfo(backend=backend)
     if backend != "everos":
         return info
-    from raven.config.update_everos import everos_role_configured
+    from raven.config.update_everos import everos_owned, everos_role_configured, everos_root
     from raven.plugin.memory.everos._health import (
         DEGRADING_SECTIONS,
         REQUIRED_SECTIONS,
         configured_base_url,
         probe_capabilities,
     )
+
+    # Which memories, and whose. Neither was reachable from any command before:
+    # the wizard printed the path once while converging and nothing showed it
+    # again, so "where are my memories" had no answer short of reading
+    # config.json by hand. This is the place that question gets asked.
+    info.root = str(everos_root())
+    info.owned = everos_owned()
+    info.address = configured_base_url(config)
 
     info.configured = [s for s in (*REQUIRED_SECTIONS, *DEGRADING_SECTIONS) if everos_role_configured(s)]
     # Recall quality is decided by the embedding role in the user-level
@@ -261,6 +272,10 @@ def _render_memory_capabilities(memory: MemoryInfo) -> None:
 
     if memory.backend != "everos":
         return
+    console.print(f"  Memories:   {memory.root}")
+    if not memory.owned:
+        console.print("  [dim]Managed by you -- Raven reads this one and never writes or restarts it.[/dim]")
+    console.print(f"  Address:    {memory.address}")
     if not memory.server_running:
         console.print("  Server:     [dim]not running  (starts on demand)[/dim]")
         if memory.configured:

--- a/raven/cli/doctor_commands.py
+++ b/raven/cli/doctor_commands.py
@@ -238,18 +238,33 @@ def _probe_memory(config: "RavenConfig") -> MemoryInfo:
     # the wizard printed the path once while converging and nothing showed it
     # again, so "where are my memories" had no answer short of reading
     # config.json by hand. This is the place that question gets asked.
-    info.root = str(everos_root())
     info.owned = everos_owned()
     info.address = configured_base_url(config)
-
-    info.configured = [s for s in (*REQUIRED_SECTIONS, *DEGRADING_SECTIONS) if everos_role_configured(s)]
-    # Recall quality is decided by the embedding role in the user-level
-    # everos.toml: with it recall matches meaning, without it only keywords.
-    info.retrieval = "semantic" if "embedding" in info.configured else "keyword-only"
     report = probe_capabilities(configured_base_url(config))
     info.server_running = report.reachable
     info.reports_capabilities = report.reports_capabilities
     info.capabilities = dict(report.capabilities)
+
+    if info.owned:
+        info.root = str(everos_root())
+        info.configured = [s for s in (*REQUIRED_SECTIONS, *DEGRADING_SECTIONS) if everos_role_configured(s)]
+        # Recall quality is decided by the embedding role in the user-level
+        # everos.toml: with it recall matches meaning, without it only keywords.
+        info.retrieval = "semantic" if "embedding" in info.configured else "keyword-only"
+        return info
+
+    # A root the user runs. Nothing here may come from the local filesystem:
+    # no root is recorded for it, so ``everos_root()`` would answer with the
+    # fallback -- a directory that is not theirs and holds none of their
+    # memories -- and the roles read out of that directory's toml would
+    # describe an install nobody is using. Reading their toml is not an option
+    # either; not touching it is the promise. What the server says about itself
+    # is the only honest source, and when it is down there is no source at all.
+    info.root = None
+    info.configured = [s for s in (*REQUIRED_SECTIONS, *DEGRADING_SECTIONS) if report.available(s) is True]
+    info.retrieval = None
+    if report.reports_capabilities:
+        info.retrieval = "semantic" if report.available("embedding") is True else "keyword-only"
     return info
 
 
@@ -272,9 +287,13 @@ def _render_memory_capabilities(memory: MemoryInfo) -> None:
 
     if memory.backend != "everos":
         return
-    console.print(f"  Memories:   {memory.root}")
+    if memory.root:
+        console.print(f"  Memories:   {memory.root}")
     if not memory.owned:
-        console.print("  [dim]Managed by you -- Raven reads this one and never writes or restarts it.[/dim]")
+        console.print(
+            "  [dim]Managed by you -- Raven reads it at the address below and never writes,\n"
+            "  starts or stops it, so it does not track where on disk it keeps them.[/dim]"
+        )
     console.print(f"  Address:    {memory.address}")
     if not memory.server_running:
         console.print("  Server:     [dim]not running  (starts on demand)[/dim]")
@@ -410,6 +429,8 @@ def _render_human_output(report: DoctorReport) -> None:
             console.print("  Retrieval:  semantic")
         elif memory.retrieval:
             console.print("  Retrieval:  [dim]keyword-only  (no embedding key)[/dim]")
+        elif not memory.owned:
+            console.print("  Retrieval:  [dim]unknown  (the server you run is not answering)[/dim]")
         _render_memory_capabilities(memory)
 
     if report.probe is not None:

--- a/raven/cli/gateway_commands.py
+++ b/raven/cli/gateway_commands.py
@@ -592,6 +592,7 @@ def register(app: typer.Typer) -> None:
                 # spawned during AgentLoop teardown can complete.
                 if backend is not None:
                     try:
+                        await agent.drain_backend_stores()
                         await backend.stop()
                     except Exception:
                         _logger.exception(

--- a/raven/cli/import_commands.py
+++ b/raven/cli/import_commands.py
@@ -97,6 +97,32 @@ class ImportRunResult:
     skill_error: str = ""
 
 
+def _require_memory_service_ready(backend: object) -> None:
+    """Refuse to import when the memory service is not actually there.
+
+    ``backend.start()`` no longer raises: a session that cannot reach EverOS
+    degrades and keeps probing, which is right for a session and wrong here.
+    An import is one deliberate batch, and running it against nothing writes
+    nothing while consuming the source list.
+
+    Backends that do not report a state -- anything other than the everos one
+    -- are left alone rather than locked out.
+    """
+    state = getattr(backend, "_state", None)
+    if state is None:
+        return
+    from raven.plugin.memory.everos.backend import ServiceState
+
+    if state is ServiceState.READY:
+        return
+    from raven.plugin.memory.everos._server import server_log_path
+
+    console.print(f"[red]Memory service is not available ({state.value}); nothing would be imported.[/red]")
+    console.print(f"[dim]Check the server log: {server_log_path()}[/dim]")
+    console.print("[dim]Retry: raven import run[/dim]")
+    raise typer.Exit(1)
+
+
 async def _build_and_run(
     items: list[tuple[Scanner, ScanResult]],
     state: ImportState,
@@ -118,15 +144,10 @@ async def _build_and_run(
         )
         raise typer.Exit(1)
 
-    try:
-        await backend.start()
-    except Exception as e:
-        from raven.plugin.memory.everos._server import server_log_path
-
-        console.print(f"[red]Failed to start EverOS memory server: {e}[/red]")
-        console.print(f"[dim]Check the server log: {server_log_path()}[/dim]")
-        console.print("[dim]Retry: raven import run[/dim]")
-        raise typer.Exit(1)
+    await backend.start()
+    # Asked after start rather than caught around it: start reports through the
+    # backend's state now, so an except here would never fire.
+    _require_memory_service_ready(backend)
     try:
         summary = await run_import(items, backend, state, on_progress=on_progress, cancel_path=cancel_path)
         # Both phases below are additive and run after the EverOS pass, so a

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -1392,6 +1392,35 @@ def _ask_managed_port() -> int:
     return int(answer)
 
 
+def _retry_or_skip_address() -> str:
+    """After a bad address: type another, or give up on memory for now.
+
+    Both ways this is reached -- a port with a typo in it, a server not started
+    yet -- are fixed by one more line of input, so ending the step over either
+    would send the user back through the whole wizard for a digit. Giving up
+    stays available and is what the caller turns into "memory off"; what is not
+    on offer is being redirected into a managed setup nobody asked for.
+    """
+    questionary = oc._require_questionary()
+    from raven.cli._styles import RAVEN_STYLE
+
+    choice = questionary.select(
+        oc._t("What now?", "怎么办？"),
+        choices=[
+            questionary.Choice(oc._t("Enter a different address", "重新填写地址"), value="retry"),
+            questionary.Choice(
+                oc._t("Skip (start it later and re-run `raven onboard`)", "跳过（稍后启动它，再重跑 raven onboard）"),
+                value="skip",
+            ),
+        ],
+        style=RAVEN_STYLE,
+        qmark=oc._QMARK,
+    ).ask()
+    if choice is None:
+        raise typer.Exit(1)
+    return str(choice)
+
+
 def _use_self_managed_everos() -> bool:
     """Point raven at an EverOS the user runs. Returns False if it is unreachable.
 
@@ -1412,25 +1441,29 @@ def _use_self_managed_everos() -> bool:
     from raven.config.update import set_plugin_config_fields
     from raven.plugin.memory.everos._server import ProbeResult, probe_health
 
-    host = _prompt_text(oc._t("Host (e.g. 127.0.0.1):", "主机(如 127.0.0.1):"), default="localhost")
-    port = _prompt_text(oc._t("Port:", "端口:"))
-    if not port.isdigit():
-        oc.console.print(oc._t(f"  [red]x Not a port: {port}[/red]", f"  [red]✗ 不是合法端口：{port}[/red]"))
-        return False
+    while True:
+        host = _prompt_text(oc._t("Host (e.g. 127.0.0.1):", "主机(如 127.0.0.1):"), default="localhost")
+        port = _prompt_text(oc._t("Port:", "端口:"))
+        if not port.isdigit():
+            oc.console.print(oc._t(f"  [red]x Not a port: {port}[/red]", f"  [red]✗ 不是合法端口：{port}[/red]"))
+            if _retry_or_skip_address() == "retry":
+                continue
+            return False
 
-    base_url = f"http://{host}:{port}"
-    oc.console.print(oc._t(f"  [dim]Checking {base_url}...[/dim]", f"  [dim]正在检查 {base_url}...[/dim]"))
-    result = probe_health(base_url)
-    if result is not ProbeResult.OK:
+        base_url = f"http://{host}:{port}"
+        oc.console.print(oc._t(f"  [dim]Checking {base_url}...[/dim]", f"  [dim]正在检查 {base_url}...[/dim]"))
+        result = probe_health(base_url)
+        if result is ProbeResult.OK:
+            break
         oc.console.print(
             oc._t(
-                f"  [red]x No EverOS answered at {base_url} ({result.value}).[/red]\n"
-                "  [dim]Start it, then run `raven onboard` again.[/dim]",
-                f"  [red]✗ {base_url} 上没有 EverOS 响应（{result.value}）。[/red]\n"
-                "  [dim]先启动它，然后重新运行 raven onboard。[/dim]",
+                f"  [red]x No EverOS answered at {base_url} ({result.value}).[/red]",
+                f"  [red]✗ {base_url} 上没有 EverOS 响应（{result.value}）。[/red]",
             ),
             highlight=False,
         )
+        if _retry_or_skip_address() == "retry":
+            continue
         return False
 
     set_plugin_config_fields(

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -1371,7 +1371,15 @@ def _use_self_managed_everos() -> bool:
         )
         return False
 
-    set_plugin_config_fields("everos-memory", {"owned": False, "base_url": base_url})
+    set_plugin_config_fields(
+        "everos-memory",
+        {"owned": False, "base_url": base_url},
+        # A merging write cannot express "this no longer applies", and a root
+        # left behind from a previous managed setup is still exported as
+        # EVEROS_ROOT -- pointing raven at a directory it just promised to stop
+        # touching. Not recording a path is what makes the promise structural.
+        remove=("root", "port"),
+    )
     _set_memory_backend("everos")
     caps = " ".join(_capability_lines(base_url))
     oc.console.print(
@@ -1702,17 +1710,11 @@ def _adopt_running_address(running_at: str | None) -> None:
 
     Both halves matter: ``base_url`` so this session connects, and ``port`` so
     the next run compares against the same intent instead of asking again.
+    :func:`_set_base_url` writes both.
     """
-    from urllib.parse import urlparse
-
-    from raven.config.update import set_plugin_config_fields
-
     if not running_at:
         return
     _set_base_url(running_at)
-    port = urlparse(running_at).port
-    if port:
-        set_plugin_config_fields("everos-memory", {"port": int(port)})
 
 
 def _stop_failure_line(outcome: Any, *, keeping: str | None) -> str:
@@ -1782,15 +1784,28 @@ def _restart_here(root: Any, target: str) -> bool:
 
 
 def _set_base_url(base_url: str) -> None:
-    """Cache the address in raven's config.
+    """Cache the address in raven's config, and record the port as the intent.
 
-    A cache, not the truth: ``<root>/everos.toml`` is what the server reads, and
-    this follows it so the runtime does not have to scan for a root on every
-    session.
+    ``base_url`` is a cache -- ``<root>/everos.toml`` is what the server reads,
+    and this follows it so the runtime does not have to scan for a root on
+    every session. ``port`` is the other half: where a managed server is
+    *meant* to listen, which is what convergence compares against.
+
+    Written together on purpose. Left to separate callers, the intent was
+    recorded by exactly one branch, so every ordinary converge produced an
+    address with no intent beside it and the comparison fell back to the
+    shipped constant -- reintroducing the behaviour the intent was added to
+    prevent.
     """
+    from urllib.parse import urlparse
+
     from raven.config.update import set_plugin_config_fields
 
-    set_plugin_config_fields("everos-memory", {"base_url": base_url})
+    fields: dict[str, Any] = {"base_url": base_url}
+    port = urlparse(base_url).port
+    if port:
+        fields["port"] = int(port)
+    set_plugin_config_fields("everos-memory", fields)
 
 
 _OWN_ROOT_INSTEAD = object()

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -86,18 +86,16 @@ def _configured_target_url() -> str:
     """
     from raven.plugin.memory.everos._server import DEFAULT_EVEROS_BASE_URL
 
-    slice_ = _recorded_memory_slice()
-    port = slice_.get("port")
+    port = _recorded_memory_slice().get("port")
     if isinstance(port, int) and port > 0:
         return f"http://localhost:{port}"
-    # No recorded intent, but an address recorded by a raven that predates the
-    # field still says where this install has been running. Reading it as the
-    # intent is what stops an upgrade from silently relocating a service the
-    # user never asked to move -- the constant is the answer only when there is
-    # nothing at all to go on.
-    recorded = slice_.get("base_url")
-    if isinstance(recorded, str) and urlparse(recorded).port:
-        return recorded
+    # Deliberately not falling back to the recorded address. That address is
+    # where the service *is*; convergence compares the two, so reading one as
+    # the other makes every pre-upgrade install look like it is already where
+    # it belongs and the "keep it or move it" question never fires -- leaving
+    # the upgrade quietly parked on the old port with the standard one never
+    # mentioned. No intent recorded means the default is the target, and the
+    # user gets asked.
     return DEFAULT_EVEROS_BASE_URL
 
 
@@ -1422,7 +1420,14 @@ def _ask_managed_port(root: Path | str) -> int:
     """
     from raven.plugin.memory.everos._server import DEFAULT_EVEROS_BASE_URL
 
-    current = urlparse(_configured_target_url()).port or urlparse(DEFAULT_EVEROS_BASE_URL).port or 18791
+    # Creating a root is the other question, and here a recorded address is the
+    # best answer available: ignoring it is what "start the everos server at
+    # its configured address, not the default" was about.
+    slice_ = _recorded_memory_slice()
+    recorded = slice_.get("port")
+    if not (isinstance(recorded, int) and recorded > 0):
+        recorded = urlparse(str(slice_.get("base_url") or "")).port
+    current = recorded or urlparse(DEFAULT_EVEROS_BASE_URL).port or 18791
     if _port_is_free(current):
         return int(current)
     # A bind test cannot tell a stranger from our own service. When the holder

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -1409,7 +1409,7 @@ def _retry_or_skip_address() -> str:
         choices=[
             questionary.Choice(oc._t("Enter a different address", "重新填写地址"), value="retry"),
             questionary.Choice(
-                oc._t("Skip (start it later and re-run `raven onboard`)", "跳过（稍后启动它，再重跑 raven onboard）"),
+                oc._t("Skip", "跳过"),
                 value="skip",
             ),
         ],
@@ -2017,13 +2017,10 @@ def _step4_memory(
             # line printed a moment earlier told them to start their server and
             # re-run. A refused address is a server not started or a port
             # mistyped, not a change of mind.
+            # Nothing printed here: the user picked "skip" one line ago and the
+            # option said what that means. Restating it is noise on a screen the
+            # step is already leaving.
             _set_memory_backend(None)
-            oc.console.print(
-                oc._t(
-                    "  [dim]Long-term memory stays off until that server is reachable.[/dim]",
-                    "  [dim]在那个服务可达之前，长期记忆保持关闭。[/dim]",
-                )
-            )
             return None
 
     if _memory_enabled():

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -1452,15 +1452,18 @@ def _converge_owned_root(state: Any) -> bool:
         oc.console.print()
         oc.console.print(
             oc._t(
-                f"  [green]✓ Found Raven's EverOS service, running[/green]\n"
-                f"      memory dir  {state.root}\n"
-                f"      address     {state.declared_url}   [dim]<- a port an earlier "
-                f"Raven version used[/dim]\n"
-                f"  [dim]Moving it to the standard address {target}...[/dim]",
-                f"  [green]✓ 找到 Raven 管理的 EverOS 服务，正在运行[/green]\n"
-                f"      记忆目录   {state.root}\n"
-                f"      地址       {state.declared_url}   [dim]<- 早期版本用过的端口[/dim]\n"
-                f"  [dim]正在统一到标准端口 {target}...[/dim]",
+                # No memory dir here: nothing on this screen is the user's to
+                # decide -- convergence is automatic -- so a path they never
+                # chose and cannot act on is noise. `raven doctor` answers
+                # "where are my memories". The address and why it is moving stay,
+                # because they are what justifies stopping a running service.
+                f"  [green]✓ Found Raven's EverOS service, running at "
+                f"{state.declared_url}[/green]\n"
+                f"  [dim]That is a port an earlier Raven version used. "
+                f"Moving it to {target}...[/dim]",
+                f"  [green]✓ 找到 Raven 管理的 EverOS 服务，正在运行于 "
+                f"{state.declared_url}[/green]\n"
+                f"  [dim]那是早期版本用过的端口，正在统一到 {target}...[/dim]",
             ),
             highlight=False,
         )

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -1974,11 +1974,24 @@ def _step4_memory(
         ).ask()
         if source is None:
             raise typer.Exit(1)
-        if source == "self" and _use_self_managed_everos():
+        if source == "self":
+            if _use_self_managed_everos():
+                return None
+            # The step ends here. Falling through to the managed path would
+            # have walked someone who just said "I run my own EverOS" through
+            # configuring four model roles and a key for a setup they did not
+            # ask for, and left a root on disk they will not use -- while the
+            # line printed a moment earlier told them to start their server and
+            # re-run. A refused address is a server not started or a port
+            # mistyped, not a change of mind.
+            _set_memory_backend(None)
+            oc.console.print(
+                oc._t(
+                    "  [dim]Long-term memory stays off until that server is reachable.[/dim]",
+                    "  [dim]在那个服务可达之前，长期记忆保持关闭。[/dim]",
+                )
+            )
             return None
-        # A refused address falls through to the managed path rather than
-        # ending the step: the user still wants memory, and this is the way
-        # that does not depend on a server they have to go and start.
 
     if _memory_enabled():
         action = questionary.select(

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -12,6 +12,7 @@ whichever module a caller patches through.
 from __future__ import annotations
 
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 import typer
 
@@ -84,9 +85,18 @@ def _configured_target_url() -> str:
     """
     from raven.plugin.memory.everos._server import DEFAULT_EVEROS_BASE_URL
 
-    port = _recorded_memory_slice().get("port")
+    slice_ = _recorded_memory_slice()
+    port = slice_.get("port")
     if isinstance(port, int) and port > 0:
         return f"http://localhost:{port}"
+    # No recorded intent, but an address recorded by a raven that predates the
+    # field still says where this install has been running. Reading it as the
+    # intent is what stops an upgrade from silently relocating a service the
+    # user never asked to move -- the constant is the answer only when there is
+    # nothing at all to go on.
+    recorded = slice_.get("base_url")
+    if isinstance(recorded, str) and urlparse(recorded).port:
+        return recorded
     return DEFAULT_EVEROS_BASE_URL
 
 
@@ -1330,6 +1340,58 @@ def _same_address(a: str | None, b: str | None) -> bool:
     return ha in _LOOPBACK_NAMES and hb in _LOOPBACK_NAMES
 
 
+def _port_is_free(port: int) -> bool:
+    """Whether a local TCP port can still be bound."""
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("127.0.0.1", port))
+        except OSError:
+            return False
+    return True
+
+
+def _ask_managed_port() -> int:
+    """Where a raven-managed server should listen.
+
+    Silent while the intended port is free, which is nearly always. 18791 is a
+    recommendation rather than a fixed address, but turning that into a screen
+    on every fresh install asks for a decision almost nobody has to make. The
+    case that had no way forward is the occupied one: the start failed and the
+    wizard had nothing to offer, so that is where the question belongs.
+
+    The default offered is whatever is already recorded, not the shipped
+    constant, so a second run does not quietly undo a port the user moved to by
+    inviting them to press Enter on the old one.
+    """
+    from raven.plugin.memory.everos._server import DEFAULT_EVEROS_BASE_URL
+
+    current = urlparse(_configured_target_url()).port or urlparse(DEFAULT_EVEROS_BASE_URL).port or 18791
+    if _port_is_free(current):
+        return int(current)
+    oc.console.print(
+        oc._t(
+            f"  [yellow]! Port {current} is already in use by something else.[/yellow]",
+            f"  [yellow]⚠ 端口 {current} 已被别的程序占用。[/yellow]",
+        )
+    )
+    answer = _prompt_text(
+        oc._t("Memory service port:", "记忆服务端口:"),
+        default=str(current),
+    )
+    if not str(answer).isdigit():
+        oc.console.print(
+            oc._t(
+                f"  [dim]Not a port ({answer}); keeping {current}.[/dim]",
+                f"  [dim]不是合法端口（{answer}），仍用 {current}。[/dim]",
+            )
+        )
+        return int(current)
+    return int(answer)
+
+
 def _use_self_managed_everos() -> bool:
     """Point raven at an EverOS the user runs. Returns False if it is unreachable.
 
@@ -1970,6 +2032,12 @@ def _step4_memory(
     _record_root(root, owned=True)
     configure_everos_env(root)
     ensure_everos_home(root)
+
+    # Only when the default is taken. A port screen on every fresh install
+    # would be a decision almost nobody has to make; the case that had no way
+    # forward is the occupied one, where the start simply failed and the wizard
+    # had nowhere to send the user.
+    _set_base_url(f"http://localhost:{_ask_managed_port()}")
 
     # Configure required models FIRST, then flip the backend on — so a Ctrl+C
     # mid-configuration leaves backend at its prior (disabled) value rather

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -1443,9 +1443,9 @@ def _converge_owned_root(state: Any) -> bool:
     from raven.plugin.memory.everos._server import StopOutcome, find_recorded_server, stop_recorded_server
 
     target = _discover.default_new_root_url()
-    _set_base_url(state.declared_url or target)
 
     if state.serving and state.declared_url == target:
+        _set_base_url(target)
         return True
 
     if state.serving and state.declared_url != target:
@@ -1466,36 +1466,10 @@ def _converge_owned_root(state: Any) -> bool:
         )
         outcome = stop_recorded_server(state.root)
         if outcome is not StopOutcome.STOPPED:
-            # Each of these is a different situation for the user, and saying the
-            # wrong one is worse than saying nothing: a server still draining
-            # memory work is not a foreign process.
-            reason = {
-                StopOutcome.NOT_OURS: oc._t(
-                    "Raven did not start this process.",
-                    "这个进程不是 Raven 启动的。",
-                ),
-                StopOutcome.SIGNAL_FAILED: oc._t(
-                    "the stop signal could not be delivered.",
-                    "停止信号发送失败（权限不足？）。",
-                ),
-                StopOutcome.STILL_DRAINING: oc._t(
-                    "it is shutting down but still finishing memory work.",
-                    "它正在收尾，可能有记忆任务还在跑。",
-                ),
-            }[outcome]
-            oc.console.print(
-                oc._t(
-                    f"  [yellow]! Could not move it: {reason}[/yellow]\n"
-                    f"  [dim]Keeping {state.declared_url}. Re-run `raven onboard` "
-                    "once it has stopped.[/dim]",
-                    f"  [yellow]⚠ 无法迁移：{reason}[/yellow]\n"
-                    f"  [dim]继续使用 {state.declared_url}。等它停下后重跑 raven onboard 即可。[/dim]",
-                ),
-                highlight=False,
-            )
+            oc.console.print(_stop_failure_line(outcome, keeping=state.declared_url), highlight=False)
+            _set_base_url(state.declared_url or target)
             return True
-        _set_base_url(target)
-        return True
+        return _restart_here(state.root, target)
 
     if state.busy_elsewhere:
         oc.console.print()
@@ -1522,8 +1496,81 @@ def _converge_owned_root(state: Any) -> bool:
                 highlight=False,
             )
             return False
-        stop_recorded_server(state.root)
-        _set_base_url(target)
+        outcome = stop_recorded_server(state.root)
+        if outcome is not StopOutcome.STOPPED:
+            # The lock is still held. Walking on to spawn would put a second
+            # instance straight into it -- the failure this whole step exists to
+            # prevent -- so stop here rather than discard the outcome.
+            oc.console.print(_stop_failure_line(outcome, keeping=state.declared_url))
+            return False
+        return _restart_here(state.root, target)
+
+    # Owned, configured, and simply not running: still converge, or the legacy
+    # address survives every future run. ``ensure_everos_server`` would otherwise
+    # start a server at the old address and write it straight back into [api].
+    return _restart_here(state.root, target)
+
+
+def _stop_failure_line(outcome: Any, *, keeping: str | None) -> str:
+    """One sentence per stop outcome. Saying the wrong one sends the user
+    looking for the wrong thing -- a server draining memory work is not a
+    foreign process."""
+    from raven.plugin.memory.everos._server import StopOutcome
+
+    reason = {
+        StopOutcome.NOT_OURS: oc._t("Raven did not start this process.", "这个进程不是 Raven 启动的。"),
+        StopOutcome.SIGNAL_FAILED: oc._t("the stop signal could not be delivered.", "停止信号发送失败（权限不足？）。"),
+        StopOutcome.STILL_DRAINING: oc._t(
+            "it is shutting down but still finishing memory work.",
+            "它正在收尾，可能有记忆任务还在跑。",
+        ),
+    }[outcome]
+    tail = oc._t(f"Keeping {keeping}. ", f"继续使用 {keeping}。") if keeping else oc._t("", "")
+    return oc._t(
+        f"  [yellow]! Could not move it: {reason}[/yellow]\n"
+        f"  [dim]{tail}Re-run `raven onboard` once it has stopped.[/dim]",
+        f"  [yellow]⚠ 无法迁移：{reason}[/yellow]\n  [dim]{tail}等它停下后重跑 raven onboard 即可。[/dim]",
+    )
+
+
+def _restart_here(root: Any, target: str) -> bool:
+    """Start the service at ``target`` and record the address it now serves.
+
+    Convergence is stop -> write -> start, and the last step has to belong to
+    the same function as the first two. Leaving it to "whatever runs later"
+    meant that a user who picked ``Keep it enabled`` -- the first option, and the
+    answer an existing install gives -- left the wizard with the service stopped:
+    it had been shut down to move ports and the branch that would have restarted
+    it was never reached.
+    """
+    import asyncio
+
+    from raven.plugin.memory.everos._server import ensure_everos_server
+
+    _set_base_url(target)
+    oc.console.print(
+        oc._t(
+            f"  [dim]Starting the service at {target}...[/dim]",
+            f"  [dim]正在于 {target} 启动服务...[/dim]",
+        )
+    )
+    try:
+        asyncio.run(ensure_everos_server(target))
+    except RuntimeError as exc:
+        oc.console.print(
+            oc._t(
+                f"  [red]x Could not start it at {target}: {exc}[/red]",
+                f"  [red]✗ 无法在 {target} 启动：{exc}[/red]",
+            ),
+            highlight=False,
+        )
+        return False
+    oc.console.print(
+        oc._t(
+            f"  [green]v EverOS service is running at {target}.[/green]",
+            f"  [green]✓ EverOS 服务已在 {target} 运行。[/green]",
+        )
+    )
     return True
 
 
@@ -1594,6 +1641,7 @@ def _step4_memory(
 
     questionary = oc._require_questionary()
     from raven.cli._styles import RAVEN_STYLE
+    from raven.config.update_everos import default_everos_root
     from raven.plugin.memory.everos import _discover
 
     oc.console.print(
@@ -1607,7 +1655,14 @@ def _step4_memory(
         outcome = _reuse_unowned_root(found)
         if outcome is not _OWN_ROOT_INSTEAD:
             return outcome
-        found = None  # declined the reuse -> build raven its own root below
+        # Record the decision here rather than leaving it to the branch that
+        # builds the root. Everything downstream -- _memory_enabled(), which
+        # reads the recorded root and would still find the user's configured
+        # llm, and everos_root() itself -- has to see the new answer, and
+        # _memory_enabled() returns from this function before the building
+        # branch is ever reached.
+        _record_root(default_everos_root(), owned=True)
+        found = None
 
     if found is not None and found.owned:
         _record_root(found.root, owned=True)

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -56,7 +56,38 @@ def _memory_enabled() -> bool:
     data = oc._load_raw_config()
     if (data.get("memory") or {}).get("backend") != "everos":
         return False
+    slice_ = _recorded_memory_slice(data)
+    if slice_.get("owned") is False:
+        # A server the user runs. Its models live in a toml raven promised not
+        # to read, and no root is recorded for it, so the address is the whole
+        # of what raven can know -- liveness is the runtime's question.
+        return bool(slice_.get("base_url"))
     return _everos_role_configured("llm")
+
+
+def _recorded_memory_slice(data: dict[str, Any] | None = None) -> dict[str, Any]:
+    """``plugins.config["everos-memory"]`` as raw JSON."""
+    data = oc._load_raw_config() if data is None else data
+    plugins = data.get("plugins") or {}
+    slice_ = (plugins.get("config") or {}).get("everos-memory") if isinstance(plugins, dict) else None
+    return slice_ if isinstance(slice_, dict) else {}
+
+
+def _configured_target_url() -> str:
+    """Where a raven-managed server is meant to listen.
+
+    A recorded intent rather than a constant. Without one, "the running address
+    differs from the target" could not distinguish a port an earlier raven left
+    behind -- which should be converged -- from one the user chose, which
+    should not, and the wizard moved both while calling the second a legacy
+    port.
+    """
+    from raven.plugin.memory.everos._server import DEFAULT_EVEROS_BASE_URL
+
+    port = _recorded_memory_slice().get("port")
+    if isinstance(port, int) and port > 0:
+        return f"http://localhost:{port}"
+    return DEFAULT_EVEROS_BASE_URL
 
 
 # Providers whose main model can be reused as the EverOS memory LLM: they
@@ -1274,6 +1305,91 @@ def _config_everos_role(
         return
 
 
+_LOOPBACK_NAMES = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+
+
+def _same_address(a: str | None, b: str | None) -> bool:
+    """Whether two URLs name the same socket, allowing for spelling.
+
+    The declared address is copied out of the root's toml and the target is
+    built from a recorded port, so the same endpoint routinely arrives as
+    ``127.0.0.1`` on one side and ``localhost`` on the other. Comparing the
+    strings makes a service already on its configured port look like drift, and
+    the wizard then offers to move it onto itself.
+    """
+    from urllib.parse import urlparse
+
+    if not a or not b:
+        return False
+    pa, pb = urlparse(a), urlparse(b)
+    if pa.port != pb.port:
+        return False
+    ha, hb = (pa.hostname or "").lower(), (pb.hostname or "").lower()
+    if ha == hb:
+        return True
+    return ha in _LOOPBACK_NAMES and hb in _LOOPBACK_NAMES
+
+
+def _use_self_managed_everos() -> bool:
+    """Point raven at an EverOS the user runs. Returns False if it is unreachable.
+
+    The whole path is two prompts and one probe. Nothing is scanned: an address
+    raven guessed is an address the user did not confirm, and this is precisely
+    the setup where guessing wrong means writing to, or taking the lock on,
+    something that is not raven's.
+
+    No port default. Offering one -- and the only one raven could offer is its
+    own -- invites acceptance by reflex, which would point the self-managed path
+    at the managed path's address. Someone who runs their own EverOS knows the
+    port; someone who does not should be on the other branch.
+
+    Only the address is recorded. Without a root there is no path on disk for a
+    later change to write to by accident, which turns the read-only promise from
+    a convention into something the code cannot break.
+    """
+    from raven.config.update import set_plugin_config_fields
+    from raven.plugin.memory.everos._server import ProbeResult, probe_health
+
+    host = _prompt_text(oc._t("Host (e.g. 127.0.0.1):", "主机(如 127.0.0.1):"), default="localhost")
+    port = _prompt_text(oc._t("Port:", "端口:"))
+    if not port.isdigit():
+        oc.console.print(oc._t(f"  [red]x Not a port: {port}[/red]", f"  [red]✗ 不是合法端口：{port}[/red]"))
+        return False
+
+    base_url = f"http://{host}:{port}"
+    oc.console.print(oc._t(f"  [dim]Checking {base_url}...[/dim]", f"  [dim]正在检查 {base_url}...[/dim]"))
+    result = probe_health(base_url)
+    if result is not ProbeResult.OK:
+        oc.console.print(
+            oc._t(
+                f"  [red]x No EverOS answered at {base_url} ({result.value}).[/red]\n"
+                "  [dim]Start it, then run `raven onboard` again.[/dim]",
+                f"  [red]✗ {base_url} 上没有 EverOS 响应（{result.value}）。[/red]\n"
+                "  [dim]先启动它，然后重新运行 raven onboard。[/dim]",
+            ),
+            highlight=False,
+        )
+        return False
+
+    set_plugin_config_fields("everos-memory", {"owned": False, "base_url": base_url})
+    _set_memory_backend("everos")
+    caps = " ".join(_capability_lines(base_url))
+    oc.console.print(
+        oc._t(
+            f"  [green]v Raven will use the EverOS at {base_url}.[/green]\n"
+            f"      capability  {caps}\n"
+            "  [dim]You run it: Raven never edits its config and never starts or stops it.\n"
+            "  If it is down when a session begins, that session has no long-term memory.[/dim]",
+            f"  [green]✓ Raven 将使用 {base_url} 上的 EverOS。[/green]\n"
+            f"      能力       {caps}\n"
+            "  [dim]它由你运行：Raven 不会改它的配置，也不会启停它。\n"
+            "  会话开始时它若没在运行，这次会话就没有长期记忆。[/dim]",
+        ),
+        highlight=False,
+    )
+    return True
+
+
 def _record_root(root: Any, owned: bool) -> None:
     """Record which EverOS root is in use and whether raven may write to it.
 
@@ -1439,34 +1555,27 @@ def _converge_owned_root(state: Any) -> bool:
     what is in flight before releasing the lock -- so there is no decision for
     the user to make, only work to report.
     """
-    from raven.plugin.memory.everos import _discover
-    from raven.plugin.memory.everos._server import StopOutcome, find_recorded_server, stop_recorded_server
+    from raven.plugin.memory.everos._server import (
+        StopOutcome,
+        find_recorded_server,
+        lock_holder,
+        stop_recorded_server,
+    )
 
-    target = _discover.default_new_root_url()
+    target = _configured_target_url()
 
-    if state.serving and state.declared_url == target:
+    if state.serving and _same_address(state.declared_url, target):
         _set_base_url(target)
         return True
 
-    if state.serving and state.declared_url != target:
-        oc.console.print()
-        oc.console.print(
-            oc._t(
-                # No memory dir here: nothing on this screen is the user's to
-                # decide -- convergence is automatic -- so a path they never
-                # chose and cannot act on is noise. `raven doctor` answers
-                # "where are my memories". The address and why it is moving stay,
-                # because they are what justifies stopping a running service.
-                f"  [green]✓ Found Raven's EverOS service, running at "
-                f"{state.declared_url}[/green]\n"
-                f"  [dim]That is a port an earlier Raven version used. "
-                f"Moving it to {target}...[/dim]",
-                f"  [green]✓ 找到 Raven 管理的 EverOS 服务，正在运行于 "
-                f"{state.declared_url}[/green]\n"
-                f"  [dim]那是早期版本用过的端口，正在统一到 {target}...[/dim]",
-            ),
-            highlight=False,
-        )
+    if state.serving and not _same_address(state.declared_url, target):
+        # Stopping a healthy service is the one destructive act in this step, so
+        # it is the user's call. Adopting is the default because it is the
+        # reversible one: the address is recorded, nothing is signalled, and a
+        # later run can still move it.
+        if _adopt_or_move(state.declared_url, target) == "adopt":
+            _adopt_running_address(state.declared_url)
+            return True
         outcome = stop_recorded_server(state.root)
         if outcome is not StopOutcome.STOPPED:
             oc.console.print(_stop_failure_line(outcome, keeping=state.declared_url), highlight=False)
@@ -1488,12 +1597,42 @@ def _converge_owned_root(state: Any) -> bool:
             ),
             highlight=False,
         )
+        # Ask the OS who has the data before deciding anything. The lock names a
+        # holder whatever raven remembers, and the holder usually names a port
+        # -- which turns the one state that used to be a dead end into "it is
+        # over there", recoverable without signalling anything.
+        holder = lock_holder(state.root)
+        if holder is not None and holder.port:
+            found_at = f"http://localhost:{holder.port}"
+            oc.console.print(
+                oc._t(
+                    f"  [dim]It is answering at {found_at} (pid {holder.pid}).[/dim]",
+                    f"  [dim]它正在 {found_at} 上提供服务（pid {holder.pid}）。[/dim]",
+                ),
+                highlight=False,
+            )
+            if _adopt_or_move(found_at, target) == "adopt":
+                _adopt_running_address(found_at)
+                return True
+        elif holder is not None:
+            oc.console.print(
+                oc._t(
+                    f"  [yellow]! pid {holder.pid} holds it but is not serving HTTP:[/yellow]\n"
+                    f"  [dim]{holder.cmdline}[/dim]\n"
+                    "  [dim]Stop it and re-run `raven onboard`.[/dim]",
+                    f"  [yellow]⚠ pid {holder.pid} 占着它，但没有在提供 HTTP 服务：[/yellow]\n"
+                    f"  [dim]{holder.cmdline}[/dim]\n"
+                    "  [dim]请先停掉它，然后重跑 raven onboard。[/dim]",
+                ),
+                highlight=False,
+            )
+            return False
         if find_recorded_server(state.root) is None:
             oc.console.print(
                 oc._t(
-                    "  [red]x Cannot take over: Raven did not start that process.[/red]\n"
+                    "  [red]x Cannot take over: Raven cannot confirm it started that process.[/red]\n"
                     "  [dim]Stop it and re-run `raven onboard`.[/dim]",
-                    "  [red]✗ 无法接管：占用它的进程不是 Raven 启动的。[/red]\n"
+                    "  [red]✗ 无法接管：无法确认占用它的进程是不是 Raven 启动的。[/red]\n"
                     "  [dim]请先停掉它，然后重跑 raven onboard。[/dim]",
                 ),
                 highlight=False,
@@ -1514,6 +1653,68 @@ def _converge_owned_root(state: Any) -> bool:
     return _restart_here(state.root, target)
 
 
+def _adopt_or_move(running_at: str | None, target: str) -> str:
+    """Ask whether to keep the running address or move the service to the target.
+
+    Presented as a question rather than done silently because the two cases the
+    wizard cannot tell apart -- a port an old raven left behind, and a port the
+    user deliberately set -- want opposite answers, and only the user knows
+    which one this is.
+    """
+    questionary = oc._require_questionary()
+    from raven.cli._styles import RAVEN_STYLE
+
+    oc.console.print()
+    oc.console.print(
+        oc._t(
+            f"  [green]v Found Raven's EverOS service, running at {running_at}[/green]\n"
+            f"  [dim]The configured address is {target}.[/dim]",
+            f"  [green]✓ 找到 Raven 管理的 EverOS 服务，正在运行于 {running_at}[/green]\n"
+            f"  [dim]配置中的地址是 {target}。[/dim]",
+        ),
+        highlight=False,
+    )
+    choice = questionary.select(
+        oc._t("Which address should Raven use?", "Raven 该用哪个地址？"),
+        choices=[
+            questionary.Choice(
+                oc._t(
+                    f"Keep {running_at} (update the setting, nothing restarts)",
+                    f"就用 {running_at}（更新配置，不重启）",
+                ),
+                value="adopt",
+            ),
+            questionary.Choice(
+                oc._t(f"Move it to {target} (restarts the service)", f"迁移到 {target}（会重启服务）"),
+                value="move",
+            ),
+        ],
+        style=RAVEN_STYLE,
+        qmark=oc._QMARK,
+    ).ask()
+    if choice is None:
+        raise typer.Exit(1)
+    return str(choice)
+
+
+def _adopt_running_address(running_at: str | None) -> None:
+    """Record the address the service is already on as the intended one.
+
+    Both halves matter: ``base_url`` so this session connects, and ``port`` so
+    the next run compares against the same intent instead of asking again.
+    """
+    from urllib.parse import urlparse
+
+    from raven.config.update import set_plugin_config_fields
+
+    if not running_at:
+        return
+    _set_base_url(running_at)
+    port = urlparse(running_at).port
+    if port:
+        set_plugin_config_fields("everos-memory", {"port": int(port)})
+
+
 def _stop_failure_line(outcome: Any, *, keeping: str | None) -> str:
     """One sentence per stop outcome. Saying the wrong one sends the user
     looking for the wrong thing -- a server draining memory work is not a
@@ -1521,7 +1722,10 @@ def _stop_failure_line(outcome: Any, *, keeping: str | None) -> str:
     from raven.plugin.memory.everos._server import StopOutcome
 
     reason = {
-        StopOutcome.NOT_OURS: oc._t("Raven did not start this process.", "这个进程不是 Raven 启动的。"),
+        StopOutcome.NOT_OURS: oc._t(
+            "Raven cannot confirm it started this process.",
+            "无法确认这个进程是不是 Raven 启动的。",
+        ),
         StopOutcome.SIGNAL_FAILED: oc._t("the stop signal could not be delivered.", "停止信号发送失败（权限不足？）。"),
         StopOutcome.STILL_DRAINING: oc._t(
             "it is shutting down but still finishing memory work.",
@@ -1671,6 +1875,33 @@ def _step4_memory(
         _record_root(found.root, owned=True)
         if not _converge_owned_root(found):
             return None
+
+    if found is None and not _memory_enabled():
+        # Nothing of raven's to use, so the two ways forward are genuinely
+        # different setups rather than two spellings of one. Asked once, here,
+        # instead of inferred later from whatever happened to be on disk.
+        source = questionary.select(
+            oc._t("Where should long-term memory come from?", "长期记忆从哪来？"),
+            choices=[
+                questionary.Choice(
+                    oc._t("Let Raven run EverOS for me", "让 Raven 替我运行 EverOS"),
+                    value="managed",
+                ),
+                questionary.Choice(
+                    oc._t("I run my own EverOS -- connect to it", "我自己运行 EverOS —— 连过去"),
+                    value="self",
+                ),
+            ],
+            style=RAVEN_STYLE,
+            qmark=oc._QMARK,
+        ).ask()
+        if source is None:
+            raise typer.Exit(1)
+        if source == "self" and _use_self_managed_everos():
+            return None
+        # A refused address falls through to the managed path rather than
+        # ending the step: the user still wants memory, and this is the way
+        # that does not depend on a server they have to go and start.
 
     if _memory_enabled():
         action = questionary.select(

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -1422,55 +1422,68 @@ def _step4_memory(
             "  [dim]正在启动 EverOS 服务...[/dim]",
         )
     )
-    try:
-        asyncio.run(ensure_everos_server(base_url))
-        oc.console.print(
-            oc._t(
-                "  [green]✓ EverOS service is running.[/green]",
-                "  [green]✓ EverOS 服务已启动。[/green]",
+    # A failed start is not a decision to abandon long-term memory. The models
+    # are already on disk at this point, so "defer" keeps the whole
+    # configuration and lets the runtime start the service on the next session;
+    # only the explicit third choice turns memory off.
+    while True:
+        try:
+            asyncio.run(ensure_everos_server(base_url))
+            oc.console.print(
+                oc._t(
+                    "  [green]✓ EverOS service is running.[/green]",
+                    "  [green]✓ EverOS 服务已启动。[/green]",
+                )
             )
-        )
-    except RuntimeError as exc:
-        oc.console.print(
-            oc._t(
-                f"  [red]✗ EverOS service failed to start: {exc}[/red]\n"
-                f"  [dim]Check: everos installed? Is {base_url} free? "
-                "See ~/.raven/logs/everos-server.log[/dim]",
-                f"  [red]✗ EverOS 服务启动失败：{exc}[/red]\n"
-                f"  [dim]请检查：everos 是否安装？{base_url} 是否被占用？"
-                "查看 ~/.raven/logs/everos-server.log[/dim]",
+            break
+        except RuntimeError as exc:
+            oc.console.print(
+                oc._t(
+                    f"  [red]✗ EverOS service failed to start: {exc}[/red]",
+                    f"  [red]✗ EverOS 服务启动失败：{exc}[/red]",
+                )
             )
-        )
-        retry = questionary.select(
-            oc._t("What to do?", "怎么办？"),
-            choices=[
-                questionary.Choice(oc._t("Retry", "重试"), value="retry"),
-                questionary.Choice(oc._t("Skip (memory disabled)", "跳过（记忆禁用）"), value="skip"),
-            ],
-            style=RAVEN_STYLE,
-            qmark=oc._QMARK,
-        ).ask()
-        if retry == "retry":
-            # Recurse once — the loop in _step4_memory handles further retries
-            try:
-                asyncio.run(ensure_everos_server(base_url))
+            action = questionary.select(
+                oc._t("What to do?", "怎么办？"),
+                choices=[
+                    questionary.Choice(oc._t("Retry", "重试"), value="retry"),
+                    questionary.Choice(
+                        oc._t(
+                            "Leave it for later (settings kept, Raven retries next start)",
+                            "暂时跳过（保留配置，下次启动 Raven 时会再试）",
+                        ),
+                        value="defer",
+                    ),
+                    questionary.Choice(
+                        oc._t("Turn long-term memory off", "关闭长期记忆"),
+                        value="disable",
+                    ),
+                ],
+                style=RAVEN_STYLE,
+                qmark=oc._QMARK,
+            ).ask()
+            if action is None:
+                raise typer.Exit(1) from exc
+            if action == "retry":
+                continue
+            if action == "defer":
+                _set_memory_backend("everos")
                 oc.console.print(
                     oc._t(
-                        "  [green]✓ EverOS service is running.[/green]",
-                        "  [green]✓ EverOS 服务已启动。[/green]",
+                        "  [yellow]! Memory settings kept. Raven will try to start the "
+                        "service again on the next session.[/yellow]",
+                        "  [yellow]⚠ 已保留记忆配置。下次会话启动时 Raven 会再尝试启动服务。[/yellow]",
                     )
                 )
-            except RuntimeError:
-                oc.console.print(
-                    oc._t(
-                        "  [red]✗ Still failed. Disabling memory.[/red]",
-                        "  [red]✗ 仍然失败。禁用记忆功能。[/red]",
-                    )
-                )
-                _set_memory_backend(None)
                 return None
-        else:
             _set_memory_backend(None)
+            oc.console.print(
+                oc._t(
+                    "  [yellow]! Long-term memory turned off. Run `raven onboard` "
+                    "again whenever you want it back.[/yellow]",
+                    "  [yellow]⚠ 已关闭长期记忆。随时可以重新运行 raven onboard 开启。[/yellow]",
+                )
+            )
             return None
     _report_everos_capabilities()
     _set_memory_backend("everos")

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -1405,7 +1405,15 @@ def _step4_memory(
     # Verify EverOS server is reachable (auto-starts if needed)
     import asyncio
 
+    from raven.config.raven import load_raven_config
+    from raven.plugin.memory.everos._health import configured_base_url
     from raven.plugin.memory.everos._server import ensure_everos_server
+
+    # The configured address, not the default: the memory backend connects to
+    # whatever ``plugins.config`` names, so probing 18791 on a setup that moved
+    # everos elsewhere reports on a server nobody uses -- and then spawns a
+    # second instance that cannot hold the OME lock.
+    base_url = configured_base_url(load_raven_config())
 
     oc.console.print()
     oc.console.print(
@@ -1415,7 +1423,7 @@ def _step4_memory(
         )
     )
     try:
-        asyncio.run(ensure_everos_server())
+        asyncio.run(ensure_everos_server(base_url))
         oc.console.print(
             oc._t(
                 "  [green]✓ EverOS service is running.[/green]",
@@ -1426,10 +1434,10 @@ def _step4_memory(
         oc.console.print(
             oc._t(
                 f"  [red]✗ EverOS service failed to start: {exc}[/red]\n"
-                "  [dim]Check: everos installed? Port 18791 free? "
+                f"  [dim]Check: everos installed? Is {base_url} free? "
                 "See ~/.raven/logs/everos-server.log[/dim]",
                 f"  [red]✗ EverOS 服务启动失败：{exc}[/red]\n"
-                "  [dim]请检查：everos 是否安装？端口 18791 是否被占用？"
+                f"  [dim]请检查：everos 是否安装？{base_url} 是否被占用？"
                 "查看 ~/.raven/logs/everos-server.log[/dim]",
             )
         )
@@ -1445,7 +1453,7 @@ def _step4_memory(
         if retry == "retry":
             # Recurse once — the loop in _step4_memory handles further retries
             try:
-                asyncio.run(ensure_everos_server())
+                asyncio.run(ensure_everos_server(base_url))
                 oc.console.print(
                     oc._t(
                         "  [green]✓ EverOS service is running.[/green]",

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -1440,7 +1440,7 @@ def _converge_owned_root(state: Any) -> bool:
     the user to make, only work to report.
     """
     from raven.plugin.memory.everos import _discover
-    from raven.plugin.memory.everos._server import find_recorded_server, stop_recorded_server
+    from raven.plugin.memory.everos._server import StopOutcome, find_recorded_server, stop_recorded_server
 
     target = _discover.default_new_root_url()
     _set_base_url(state.declared_url or target)
@@ -1464,14 +1464,32 @@ def _converge_owned_root(state: Any) -> bool:
             ),
             highlight=False,
         )
-        if not stop_recorded_server(state.root):
+        outcome = stop_recorded_server(state.root)
+        if outcome is not StopOutcome.STOPPED:
+            # Each of these is a different situation for the user, and saying the
+            # wrong one is worse than saying nothing: a server still draining
+            # memory work is not a foreign process.
+            reason = {
+                StopOutcome.NOT_OURS: oc._t(
+                    "Raven did not start this process.",
+                    "这个进程不是 Raven 启动的。",
+                ),
+                StopOutcome.SIGNAL_FAILED: oc._t(
+                    "the stop signal could not be delivered.",
+                    "停止信号发送失败（权限不足？）。",
+                ),
+                StopOutcome.STILL_DRAINING: oc._t(
+                    "it is shutting down but still finishing memory work.",
+                    "它正在收尾，可能有记忆任务还在跑。",
+                ),
+            }[outcome]
             oc.console.print(
                 oc._t(
-                    f"  [yellow]! Could not stop it: Raven did not start this process.[/yellow]\n"
-                    f"  [dim]Keeping {state.declared_url}. Stop it yourself and re-run "
-                    "`raven onboard` to move it.[/dim]",
-                    f"  [yellow]⚠ 无法停止：这个进程不是 Raven 启动的。[/yellow]\n"
-                    f"  [dim]继续使用 {state.declared_url}。要统一端口，先自行停掉它再重跑 raven onboard。[/dim]",
+                    f"  [yellow]! Could not move it: {reason}[/yellow]\n"
+                    f"  [dim]Keeping {state.declared_url}. Re-run `raven onboard` "
+                    "once it has stopped.[/dim]",
+                    f"  [yellow]⚠ 无法迁移：{reason}[/yellow]\n"
+                    f"  [dim]继续使用 {state.declared_url}。等它停下后重跑 raven onboard 即可。[/dim]",
                 ),
                 highlight=False,
             )
@@ -1640,9 +1658,11 @@ def _step4_memory(
     # + ome.toml) BEFORE writing model sections — set_everos_section merges
     # into the template so default sections (memory/sqlite/lancedb/api) are
     # preserved. Also creates ome.toml which the runtime requires.
-    from raven.config.update_everos import configure_everos_env, ensure_everos_home, everos_root
+    from raven.config.update_everos import configure_everos_env, ensure_everos_home, owned_everos_root
 
-    root = everos_root()
+    # owned_everos_root, not everos_root: after a user declined to share theirs,
+    # the recorded root is still theirs, and building there would adopt it.
+    root = owned_everos_root()
     _record_root(root, owned=True)
     configure_everos_env(root)
     ensure_everos_home(root)

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -1274,6 +1274,256 @@ def _config_everos_role(
         return
 
 
+def _record_root(root: Any, owned: bool) -> None:
+    """Record which EverOS root is in use and whether raven may write to it.
+
+    Both are decisions rather than derivable facts, and every later reader --
+    the wizard, the runtime, doctor -- consults the record instead of guessing
+    again. Recording ``owned`` is what makes read-only reuse enforceable.
+    """
+    from raven.config.update import set_plugin_config_fields
+
+    set_plugin_config_fields("everos-memory", {"root": str(root), "owned": owned})
+
+
+def _capability_lines(base_url: str) -> list[str]:
+    """One line per capability the running server actually built.
+
+    "Running" stopped implying "working" in everos 1.2.1: a server whose
+    embedding provider failed to build still answers 200 and quietly degrades to
+    keyword-only recall.
+    """
+    from raven.plugin.memory.everos._health import (
+        DEGRADING_SECTIONS,
+        REQUIRED_SECTIONS,
+        capability_available,
+        probe_capabilities,
+    )
+
+    report = probe_capabilities(base_url)
+    if not report.reports_capabilities:
+        return []
+    lines = []
+    for section in (*REQUIRED_SECTIONS, *DEGRADING_SECTIONS):
+        state = capability_available(report.capabilities, section)
+        mark = "[green]✓[/green]" if state is True else "[red]✗[/red]" if state is False else "[dim]?[/dim]"
+        lines.append(f"{mark} {section}")
+    return lines
+
+
+def _reuse_unowned_root(state: Any) -> object:
+    """Screens for an EverOS the user manages: reuse it, or leave it alone.
+
+    Read-only throughout. raven records the address and reports what the server
+    can do; it does not write the config (those are the user's keys and models to
+    set) and does not start it (starting takes the OME jobstore lock
+    exclusively, which is theirs to grant).
+    """
+    questionary = oc._require_questionary()
+    from raven.cli._styles import RAVEN_STYLE
+
+    where = state.declared_url or "?"
+    oc.console.print()
+    oc.console.print(
+        oc._t(
+            "  [dim]No EverOS service managed by Raven was found.[/dim]",
+            "  [dim]未找到 Raven 管理的 EverOS 服务。[/dim]",
+        )
+    )
+
+    while True:
+        if state.serving:
+            caps = " ".join(_capability_lines(where))
+            oc.console.print(
+                oc._t(
+                    f"  [green]✓ Found another EverOS service, running[/green]\n"
+                    f"      memory dir  {state.root}   [dim]<- you manage this; "
+                    f"Raven will not modify it, nor start or stop it[/dim]\n"
+                    f"      address     {where}\n"
+                    f"      capability  {caps}",
+                    f"  [green]✓ 发现另一个 EverOS 服务，正在运行[/green]\n"
+                    f"      记忆目录   {state.root}   [dim]<- 由你管理，Raven 不会修改它，也不启停它[/dim]\n"
+                    f"      地址       {where}\n"
+                    f"      能力       {caps}",
+                ),
+                highlight=False,
+            )
+            choice = questionary.select(
+                oc._t("Reuse it for Raven's memory?", "要让 Raven 复用它吗？"),
+                choices=[
+                    questionary.Choice(
+                        oc._t(
+                            "Reuse (memory and media parsing both use this config)",
+                            "复用（记忆和多模态解析都走这一份配置）",
+                        ),
+                        value="reuse",
+                    ),
+                    questionary.Choice(
+                        oc._t("No, give Raven its own memory", "不用，让 Raven 建一份独立的记忆"),
+                        value="own",
+                    ),
+                ],
+                style=RAVEN_STYLE,
+                qmark=oc._QMARK,
+            ).ask()
+            if choice is None:
+                raise typer.Exit(1)
+            if choice == "own":
+                return _OWN_ROOT_INSTEAD
+            _record_root(state.root, owned=False)
+            _set_base_url(where)
+            _set_memory_backend("everos")
+            oc.console.print(
+                oc._t(
+                    f"  [green]✓ Recorded: Raven will store and recall memories via {where}.[/green]\n"
+                    "  [dim]You manage this EverOS. To change its models, edit its everos.toml\n"
+                    "  and restart it -- Raven follows along.[/dim]",
+                    f"  [green]✓ 已记录：Raven 将通过 {where} 存取记忆。[/green]\n"
+                    "  [dim]这份 EverOS 由你管理。要调整模型，编辑它的 everos.toml 后重启即可，\n"
+                    "  Raven 会自动跟随。[/dim]",
+                ),
+                highlight=False,
+            )
+            return None
+
+        oc.console.print(
+            oc._t(
+                f"  [yellow]! Found another EverOS config, but its service is not running[/yellow]\n"
+                f"      memory dir  {state.root}   [dim]<- you manage this; "
+                f"Raven will not start it[/dim]\n"
+                f"      address     {where} [dim](declared in its config, not answering)[/dim]",
+                f"  [yellow]⚠ 发现另一份 EverOS 配置，但服务未启动[/yellow]\n"
+                f"      记忆目录   {state.root}   [dim]<- 由你管理，Raven 不会替你启动[/dim]\n"
+                f"      地址       {where} [dim]（配置中声明，当前无响应）[/dim]",
+            ),
+            highlight=False,
+        )
+        choice = questionary.select(
+            oc._t("Reuse it?", "要复用它吗？"),
+            choices=[
+                questionary.Choice(
+                    oc._t("I will start it, then probe again", "我去启动它，然后重新探测"),
+                    value="retry",
+                ),
+                questionary.Choice(
+                    oc._t("No, give Raven its own memory", "不用，让 Raven 建一份独立的记忆"),
+                    value="own",
+                ),
+            ],
+            style=RAVEN_STYLE,
+            qmark=oc._QMARK,
+        ).ask()
+        if choice is None:
+            raise typer.Exit(1)
+        if choice == "own":
+            return _OWN_ROOT_INSTEAD
+        oc.console.print(
+            oc._t(
+                f"  [dim]Start it in another terminal, for example:[/dim]\n"
+                f"      everos server start --root {state.root}",
+                f"  [dim]请在另一个终端启动它，例如：[/dim]\n      everos server start --root {state.root}",
+            ),
+            highlight=False,
+        )
+        from raven.plugin.memory.everos import _discover
+
+        state = _discover._describe(state.root, owned=False)
+
+
+def _converge_owned_root(state: Any) -> bool:
+    """Bring a root raven owns onto the standard address.
+
+    Returns False when the step should stop (the data is held by something raven
+    cannot identify). Nothing is asked here: the process is raven's own, EverOS
+    replays interrupted strategy runs through crash recovery, and SIGTERM drains
+    what is in flight before releasing the lock -- so there is no decision for
+    the user to make, only work to report.
+    """
+    from raven.plugin.memory.everos import _discover
+    from raven.plugin.memory.everos._server import find_recorded_server, stop_recorded_server
+
+    target = _discover.default_new_root_url()
+    _set_base_url(state.declared_url or target)
+
+    if state.serving and state.declared_url == target:
+        return True
+
+    if state.serving and state.declared_url != target:
+        oc.console.print()
+        oc.console.print(
+            oc._t(
+                f"  [green]✓ Found Raven's EverOS service, running[/green]\n"
+                f"      memory dir  {state.root}\n"
+                f"      address     {state.declared_url}   [dim]<- a port an earlier "
+                f"Raven version used[/dim]\n"
+                f"  [dim]Moving it to the standard address {target}...[/dim]",
+                f"  [green]✓ 找到 Raven 管理的 EverOS 服务，正在运行[/green]\n"
+                f"      记忆目录   {state.root}\n"
+                f"      地址       {state.declared_url}   [dim]<- 早期版本用过的端口[/dim]\n"
+                f"  [dim]正在统一到标准端口 {target}...[/dim]",
+            ),
+            highlight=False,
+        )
+        if not stop_recorded_server(state.root):
+            oc.console.print(
+                oc._t(
+                    f"  [yellow]! Could not stop it: Raven did not start this process.[/yellow]\n"
+                    f"  [dim]Keeping {state.declared_url}. Stop it yourself and re-run "
+                    "`raven onboard` to move it.[/dim]",
+                    f"  [yellow]⚠ 无法停止：这个进程不是 Raven 启动的。[/yellow]\n"
+                    f"  [dim]继续使用 {state.declared_url}。要统一端口，先自行停掉它再重跑 raven onboard。[/dim]",
+                ),
+                highlight=False,
+            )
+            return True
+        _set_base_url(target)
+        return True
+
+    if state.busy_elsewhere:
+        oc.console.print()
+        oc.console.print(
+            oc._t(
+                f"  [yellow]! Something is already serving {state.root}, but not at "
+                f"{state.declared_url or 'any declared address'}.[/yellow]\n"
+                "  [dim]One memory directory admits one EverOS instance; this is not about "
+                "the port.[/dim]",
+                f"  [yellow]⚠ 已有进程在使用 {state.root}，但不在它声明的地址 "
+                f"{state.declared_url or '（未声明）'} 上。[/yellow]\n"
+                "  [dim]一份记忆数据同时只能由一个 EverOS 实例服务，这与端口无关。[/dim]",
+            ),
+            highlight=False,
+        )
+        if find_recorded_server(state.root) is None:
+            oc.console.print(
+                oc._t(
+                    "  [red]x Cannot take over: Raven did not start that process.[/red]\n"
+                    "  [dim]Stop it and re-run `raven onboard`.[/dim]",
+                    "  [red]✗ 无法接管：占用它的进程不是 Raven 启动的。[/red]\n"
+                    "  [dim]请先停掉它，然后重跑 raven onboard。[/dim]",
+                ),
+                highlight=False,
+            )
+            return False
+        stop_recorded_server(state.root)
+        _set_base_url(target)
+    return True
+
+
+def _set_base_url(base_url: str) -> None:
+    """Cache the address in raven's config.
+
+    A cache, not the truth: ``<root>/everos.toml`` is what the server reads, and
+    this follows it so the runtime does not have to scan for a root on every
+    session.
+    """
+    from raven.config.update import set_plugin_config_fields
+
+    set_plugin_config_fields("everos-memory", {"base_url": base_url})
+
+
+_OWN_ROOT_INSTEAD = object()
+
+
 def _step4_memory(
     *, skip: bool, non_interactive: bool, main_model: Optional[str], warnings: list[str], skip_test: bool = False
 ) -> object:
@@ -1326,6 +1576,25 @@ def _step4_memory(
 
     questionary = oc._require_questionary()
     from raven.cli._styles import RAVEN_STYLE
+    from raven.plugin.memory.everos import _discover
+
+    oc.console.print(
+        oc._t("  [dim]Looking for an existing memory service...[/dim]", "  [dim]正在查找已有的记忆服务...[/dim]")
+    )
+    found = _discover.pick(_discover.discover())
+
+    if found is not None and not found.owned:
+        # A root the user manages. Read-only from here: record where it is and
+        # report what it can do, never configure it and never start or stop it.
+        outcome = _reuse_unowned_root(found)
+        if outcome is not _OWN_ROOT_INSTEAD:
+            return outcome
+        found = None  # declined the reuse -> build raven its own root below
+
+    if found is not None and found.owned:
+        _record_root(found.root, owned=True)
+        if not _converge_owned_root(found):
+            return None
 
     if _memory_enabled():
         action = questionary.select(
@@ -1371,10 +1640,12 @@ def _step4_memory(
     # + ome.toml) BEFORE writing model sections — set_everos_section merges
     # into the template so default sections (memory/sqlite/lancedb/api) are
     # preserved. Also creates ome.toml which the runtime requires.
-    from raven.config.update_everos import configure_everos_env, ensure_everos_home
+    from raven.config.update_everos import configure_everos_env, ensure_everos_home, everos_root
 
-    configure_everos_env()
-    ensure_everos_home()
+    root = everos_root()
+    _record_root(root, owned=True)
+    configure_everos_env(root)
+    ensure_everos_home(root)
 
     # Configure required models FIRST, then flip the backend on — so a Ctrl+C
     # mid-configuration leaves backend at its prior (disabled) value rather

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -1361,7 +1361,7 @@ def _stop_for_reload(root: Path | str) -> bool:
     the models a moment ago, and applying them is what that means. Only a server
     raven can identify as serving this root is touched.
     """
-    from raven.plugin.memory.everos._server import StopOutcome, stop_recorded_server
+    from raven.plugin.memory.everos._server import StopOutcome, stop_pid
 
     holder = _lock_holder(root)
     if holder is None:
@@ -1372,13 +1372,21 @@ def _stop_for_reload(root: Path | str) -> bool:
             "  [dim]正在重启服务以加载新配置...[/dim]",
         )
     )
-    outcome = stop_recorded_server(root)
+    # The pid the lock named, not the one the pidfile remembers. Asking the
+    # pidfile here would report "not ours" about the very process just
+    # identified, which is the state the lock lookup exists to get out of.
+    outcome = stop_pid(holder.pid)
     if outcome is not StopOutcome.STOPPED:
+        reason = {
+            StopOutcome.SIGNAL_FAILED: oc._t("the stop signal could not be delivered", "停止信号发送失败"),
+            StopOutcome.STILL_DRAINING: oc._t("it is still finishing memory work", "它还在收尾未完成的记忆任务"),
+        }.get(outcome, oc._t("it did not stop", "它没有停下"))
         oc.console.print(
             oc._t(
-                f"  [yellow]! Could not restart it ({outcome.value}); the new models take effect "
-                "the next time it starts.[/yellow]",
-                f"  [yellow]⚠ 未能重启（{outcome.value}），新模型将在它下次启动时生效。[/yellow]",
+                f"  [yellow]! The service is still running ({reason}), so it keeps the models it "
+                "started with. The new ones take effect the next time it starts.[/yellow]",
+                f"  [yellow]⚠ 服务仍在运行（{reason}），它用的还是启动时那套模型。"
+                "新模型将在它下次启动时生效。[/yellow]",
             ),
             highlight=False,
         )

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -11,6 +11,7 @@ whichever module a caller patches through.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Optional
 from urllib.parse import urlparse
 
@@ -1340,6 +1341,51 @@ def _same_address(a: str | None, b: str | None) -> bool:
     return ha in _LOOPBACK_NAMES and hb in _LOOPBACK_NAMES
 
 
+def _lock_holder(root: Path | str):
+    """The process serving ``root``, or None. Indirected so callers can stub it."""
+    from raven.plugin.memory.everos._server import lock_holder
+
+    return lock_holder(root)
+
+
+def _stop_for_reload(root: Path | str) -> bool:
+    """Stop our own server for ``root`` so a rewritten config is actually read.
+
+    EverOS builds its LLM client in the API lifespan, at startup, so a process
+    already running keeps the models it booted with. Without this the wizard
+    wrote new models to disk and the closing ``ensure_everos_server`` found the
+    address answering and returned -- the reconfiguration was inert until some
+    unrelated restart, with nothing on screen saying so.
+
+    Not a decision to put to the user: they asked to reconfigure and filled in
+    the models a moment ago, and applying them is what that means. Only a server
+    raven can identify as serving this root is touched.
+    """
+    from raven.plugin.memory.everos._server import StopOutcome, stop_recorded_server
+
+    holder = _lock_holder(root)
+    if holder is None:
+        return False
+    oc.console.print(
+        oc._t(
+            "  [dim]Restarting the service so it picks up the new configuration...[/dim]",
+            "  [dim]正在重启服务以加载新配置...[/dim]",
+        )
+    )
+    outcome = stop_recorded_server(root)
+    if outcome is not StopOutcome.STOPPED:
+        oc.console.print(
+            oc._t(
+                f"  [yellow]! Could not restart it ({outcome.value}); the new models take effect "
+                "the next time it starts.[/yellow]",
+                f"  [yellow]⚠ 未能重启（{outcome.value}），新模型将在它下次启动时生效。[/yellow]",
+            ),
+            highlight=False,
+        )
+        return False
+    return True
+
+
 def _port_is_free(port: int) -> bool:
     """Whether a local TCP port can still be bound."""
     import socket
@@ -1353,7 +1399,7 @@ def _port_is_free(port: int) -> bool:
     return True
 
 
-def _ask_managed_port() -> int:
+def _ask_managed_port(root: Path | str) -> int:
     """Where a raven-managed server should listen.
 
     Silent while the intended port is free, which is nearly always. 18791 is a
@@ -1370,6 +1416,12 @@ def _ask_managed_port() -> int:
 
     current = urlparse(_configured_target_url()).port or urlparse(DEFAULT_EVEROS_BASE_URL).port or 18791
     if _port_is_free(current):
+        return int(current)
+    # A bind test cannot tell a stranger from our own service. When the holder
+    # of this root's lock is the thing listening there, the port is not taken --
+    # it is ours, and the step is about to restart into it.
+    holder = _lock_holder(root)
+    if holder is not None and holder.port == current:
         return int(current)
     oc.console.print(
         oc._t(
@@ -2080,7 +2132,7 @@ def _step4_memory(
     # would be a decision almost nobody has to make; the case that had no way
     # forward is the occupied one, where the start simply failed and the wizard
     # had nowhere to send the user.
-    _set_base_url(f"http://localhost:{_ask_managed_port()}")
+    _set_base_url(f"http://localhost:{_ask_managed_port(root)}")
 
     # Configure required models FIRST, then flip the backend on — so a Ctrl+C
     # mid-configuration leaves backend at its prior (disabled) value rather
@@ -2120,6 +2172,10 @@ def _step4_memory(
     # everos elsewhere reports on a server nobody uses -- and then spawns a
     # second instance that cannot hold the OME lock.
     base_url = configured_base_url(load_raven_config())
+
+    # The models were just written; a process already running booted with the
+    # old ones and will not re-read them.
+    _stop_for_reload(root)
 
     oc.console.print()
     oc.console.print(

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -732,6 +732,7 @@ async def _run_rpc_server_until_done(
         # Release the embedded index lock so the next process can start.
         if agent_loop is not None and agent_loop.backend is not None:
             try:
+                await agent_loop.drain_backend_stores()
                 await agent_loop.backend.stop()
             except Exception:
                 from loguru import logger as _logger

--- a/raven/config/loader.py
+++ b/raven/config/loader.py
@@ -322,10 +322,13 @@ def _migrate_config(data: dict, *, pop_extension_keys: bool = True) -> dict:
         if isinstance(slice_, dict):
             if slice_.pop("mode", None) is not None:
                 _log.info("Migrated: dropped plugins.config.everos-memory.mode (no reader)")
-            from raven.config.update_everos import everos_root, root_is_raven_owned
+            from raven.config.update_everos import fallback_everos_root, root_is_raven_owned
 
             if "root" not in slice_:
-                slice_["root"] = str(everos_root())
+                # Not ``everos_root()``: that re-reads whatever config path is
+                # globally current, which is not necessarily the file being
+                # migrated here.
+                slice_["root"] = str(fallback_everos_root())
                 _log.info("Migrated: recorded everos-memory.root = %s", slice_["root"])
             if "owned" not in slice_:
                 slice_["owned"] = root_is_raven_owned(slice_["root"])

--- a/raven/config/loader.py
+++ b/raven/config/loader.py
@@ -306,6 +306,30 @@ def _migrate_config(data: dict, *, pop_extension_keys: bool = True) -> dict:
                             legacy_key,
                         )
 
+    # Bring ``plugins.config["everos-memory"]`` onto the current shape: record
+    # which EverOS root is in use and whether raven owns it, and drop the dead
+    # ``mode`` key. Both new fields are decisions rather than derivable facts, so
+    # leaving them absent would mean re-deriving them at every call site --
+    # including the ones that decide whether writing to that root is allowed.
+    #
+    # Read-time normalisation only: this is a pure dict transform apart from one
+    # existence check, and it must stay that way. Reading everos.toml or probing
+    # a port here would put IO on every config load. The shape persists the next
+    # time anything writes the config.
+    plugins = data.get("plugins")
+    if isinstance(plugins, dict):
+        slice_ = (plugins.get("config") or {}).get("everos-memory")
+        if isinstance(slice_, dict):
+            if slice_.pop("mode", None) is not None:
+                _log.info("Migrated: dropped plugins.config.everos-memory.mode (no reader)")
+            from raven.config.update_everos import everos_root, root_is_raven_owned
+
+            if "root" not in slice_:
+                slice_["root"] = str(everos_root())
+                _log.info("Migrated: recorded everos-memory.root = %s", slice_["root"])
+            if "owned" not in slice_:
+                slice_["owned"] = root_is_raven_owned(slice_["root"])
+
     # ── Pop extension keys before base Config validates ──────────────
     if pop_extension_keys:
         for ek in EXTENSION_KEYS:

--- a/raven/config/update.py
+++ b/raven/config/update.py
@@ -361,6 +361,7 @@ def set_plugin_config_fields(
     plugin_id: str,
     fields: dict[str, Any],
     *,
+    remove: tuple[str, ...] | None = None,
     config_path: Path | None = None,
 ) -> None:
     """Merge ``fields`` into ``plugins.config[plugin_id]`` on the on-disk config.
@@ -369,13 +370,26 @@ def set_plugin_config_fields(
     (which EverOS root, whether raven owns it, its cached address) written at
     different moments, and a replacing write would drop whichever the caller did
     not happen to be carrying.
+
+    ``remove`` names keys that no longer apply, for the case a merge cannot
+    express. Switching to an EverOS the user runs has to retract the recorded
+    root, not merely stop updating it: left behind, it is still exported as
+    ``EVEROS_ROOT`` and still points raven at a directory it has just promised
+    to leave alone.
     """
     path = config_path or get_config_path()
     data = read_raw_or_raise(path)
     slice_ = data.setdefault("plugins", {}).setdefault("config", {}).setdefault(plugin_id, {})
     slice_.update(fields)
+    for key in remove or ():
+        slice_.pop(key, None)
     _write_atomic(path, data)
-    logger.info("config/update: plugins.config.{} updated ({})", plugin_id, ", ".join(fields))
+    logger.info(
+        "config/update: plugins.config.{} updated ({}{})",
+        plugin_id,
+        ", ".join(fields),
+        f"; removed {', '.join(remove)}" if remove else "",
+    )
 
 
 def set_memory_backend(

--- a/raven/config/update.py
+++ b/raven/config/update.py
@@ -357,6 +357,27 @@ def init_extension_block_defaults(*, config_path: Path | None = None) -> None:
     logger.info("config/update: seeded memory/plugins/skillForge extension defaults")
 
 
+def set_plugin_config_fields(
+    plugin_id: str,
+    fields: dict[str, Any],
+    *,
+    config_path: Path | None = None,
+) -> None:
+    """Merge ``fields`` into ``plugins.config[plugin_id]`` on the on-disk config.
+
+    A merge rather than a replace: the slice holds several independent decisions
+    (which EverOS root, whether raven owns it, its cached address) written at
+    different moments, and a replacing write would drop whichever the caller did
+    not happen to be carrying.
+    """
+    path = config_path or get_config_path()
+    data = read_raw_or_raise(path)
+    slice_ = data.setdefault("plugins", {}).setdefault("config", {}).setdefault(plugin_id, {})
+    slice_.update(fields)
+    _write_atomic(path, data)
+    logger.info("config/update: plugins.config.{} updated ({})", plugin_id, ", ".join(fields))
+
+
 def set_memory_backend(
     backend: str | None,
     *,

--- a/raven/config/update_everos.py
+++ b/raven/config/update_everos.py
@@ -1,27 +1,38 @@
-"""Atomic operations for EverOS memory settings (``~/.everos/raven/everos.toml``).
+"""Atomic operations for EverOS memory settings (``<root>/everos.toml``).
 
 This module is the ONLY write path for the EverOS memory-model sections
-(llm / embedding / rerank / multimodal). The onboard wizard's memory step
-writes here; EverOS reads it back through its own pydantic-settings loader
-(user-level toml, ``EVEROS_*`` env). It lives apart from raven's
-``config.json`` because EverOS owns this channel — see plan rule.
+(llm / embedding / rerank / multimodal) and for the ``[api]`` address. The
+onboard wizard's memory step writes here; EverOS reads it back through its own
+pydantic-settings loader (user-level toml, ``EVEROS_*`` env). It lives apart
+from raven's ``config.json`` because EverOS owns this channel — see plan rule.
 
-Only the four model sections are writable; other sections EverOS ships
-(memory / sqlite / lancedb / api) are preserved untouched on every write.
+Only those sections are writable; the rest EverOS ships (memory / sqlite /
+lancedb) are preserved untouched on every write.
 
-EverOS home: raven scopes EverOS under ``~/.everos/raven`` (not the bare
-``~/.everos`` EverOS defaults to) so raven's instance keeps its config + data
-in one place, isolated from any other EverOS consumer.
+**Which root.** EverOS resolves its root from ``EVEROS_ROOT`` (default: a bare
+``~/.everos``). raven does not read that variable as an input — it *writes* it
+from the root recorded in ``plugins.config["everos-memory"]["root"]``, so the
+choice of root is an explicit, recorded decision rather than something inherited
+from an ambient environment. A root picked up from the environment and never
+written down was silent data loss waiting to happen: run raven without the
+variable and the memories are still on disk while raven reports none.
+
+**Which owner.** ``plugins.config["everos-memory"]["owned"]`` says whether raven
+may write to that root at all. A root raven created is raven's to configure and
+serve; a root the user manages is read-only — raven records its address and
+nothing else.
 
 Boot sequence (called by ``make_backend`` / ``make_understand_media_tool``):
 
-1. :func:`configure_everos_env` — ``EVEROS_ROOT`` → ``~/.everos/raven``
+1. :func:`configure_everos_env` — ``EVEROS_ROOT`` → the recorded root
 2. :func:`ensure_everos_home` — create ``everos.toml`` + ``ome.toml`` from
-   shipped templates (skip if exists) + migrate legacy ``config.toml``
+   shipped templates (skip if exists) + migrate legacy ``config.toml``.
+   Owned roots only.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
@@ -33,36 +44,130 @@ import tomli_w
 
 logger = logging.getLogger(__name__)
 
-# raven's EverOS home. Both the user-level config toml and the data root
-# (sqlite / lancedb / .index / ome.db) live under here. EverOS itself defaults
-# to a bare ``~/.everos``; ``configure_everos_env`` redirects it.
-_EVEROS_BASE = Path("~/.everos/raven")
-_EVEROS_CONFIG = _EVEROS_BASE / "everos.toml"
+# Where raven's EverOS home used to live: inside the root EverOS itself
+# defaults to. That squatted on a scope slot of the user's own root --
+# ``~/.everos/raven`` is exactly the directory EverOS gives an app_id of
+# "raven" -- so new installs get ``<raven data dir>/everos`` instead. Existing
+# installs keep this one; discovery finds it and nothing is moved.
+_LEGACY_EVEROS_BASE = Path("~/.everos/raven")
 
-WRITABLE_SECTIONS = ("llm", "embedding", "rerank", "multimodal")
+WRITABLE_SECTIONS = ("llm", "embedding", "rerank", "multimodal", "api")
+
+# Sections holding a model + credentials, as opposed to the address.
+MODEL_SECTIONS = ("llm", "embedding", "rerank", "multimodal")
+
+
+def default_everos_root() -> Path:
+    """Where a fresh install puts raven's own EverOS home.
+
+    Under raven's data directory, so it follows ``--config`` and reads as
+    raven's property rather than a squatter in EverOS's default root.
+    """
+    from raven.config.paths import get_data_dir
+
+    return get_data_dir() / "everos"
+
+
+def legacy_everos_root() -> Path:
+    """raven's pre-move EverOS home, still in use by existing installs."""
+    return _LEGACY_EVEROS_BASE.expanduser()
+
+
+def raven_owned_roots() -> tuple[Path, ...]:
+    """Roots raven creates and therefore owns, newest layout first."""
+    return (default_everos_root(), legacy_everos_root())
+
+
+def root_is_raven_owned(root: Path | str) -> bool:
+    """True when ``root`` is one raven creates for itself.
+
+    Used only to infer ``owned`` for a config written before the field existed.
+    Once recorded, the field is the answer -- a root the user points raven at
+    cannot be classified by its path.
+    """
+    resolved = Path(root).expanduser()
+    return any(resolved == owned for owned in raven_owned_roots())
+
+
+def _recorded_slice() -> dict[str, Any]:
+    """raven's ``plugins.config["everos-memory"]``, read as raw JSON.
+
+    Raw rather than through the validated config so that ``raven doctor`` and
+    the runtime can ask "which root" without paying for schema validation, and
+    so an unrelated validation error elsewhere cannot make the memory path
+    unreadable. An absent or unparseable file reads as "nothing recorded".
+    """
+    from raven.config.loader import get_config_path
+
+    try:
+        with get_config_path().open(encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    plugins = data.get("plugins") or {}
+    slice_ = (plugins.get("config") or {}).get("everos-memory") if isinstance(plugins, dict) else None
+    return slice_ if isinstance(slice_, dict) else {}
+
+
+def everos_root() -> Path:
+    """The active EverOS root.
+
+    The recorded value when there is one; otherwise the legacy location if it
+    holds a config (so an install from before the move keeps its memories), else
+    the current default. ``_migrate_config`` records the outcome on the next
+    write, so this fallback only runs until then.
+    """
+    recorded = _recorded_slice().get("root")
+    if recorded:
+        return Path(str(recorded)).expanduser()
+    legacy = legacy_everos_root()
+    if (legacy / "everos.toml").is_file():
+        return legacy
+    return default_everos_root()
+
+
+def everos_owned() -> bool:
+    """Whether raven may write to and start the active root.
+
+    ``False`` means read-only reuse: record the address, never touch the config,
+    never start or stop the process. Absent from an older config, the answer is
+    inferred from the path, and anything raven did not create is treated as not
+    ours -- the conservative direction.
+    """
+    slice_ = _recorded_slice()
+    if "owned" in slice_:
+        return bool(slice_["owned"])
+    return root_is_raven_owned(everos_root())
 
 
 def get_everos_config_path() -> Path:
-    """Path of the user-level EverOS config toml (``~`` expanded)."""
-    return _EVEROS_CONFIG.expanduser()
+    """Path of the user-level EverOS config toml."""
+    return everos_root() / "everos.toml"
 
 
-def configure_everos_env() -> None:
-    """Point embedded EverOS at raven's ``~/.everos/raven`` home.
+def configure_everos_env(root: Path | str | None = None) -> None:
+    """Point EverOS at ``root`` (default: the recorded root).
 
     Sets ``EVEROS_ROOT`` so EverOS resolves both its config file
-    (``<root>/everos.toml``) and data directories (sqlite / lancedb /
-    .index / ome.toml) under raven's scoped home.
+    (``<root>/everos.toml``) and its data directories (sqlite / lancedb /
+    .index / ome.toml) under it.
 
-    Uses ``setdefault`` so an explicit operator override (a pre-set
-    ``EVEROS_ROOT``) still wins. Must run BEFORE EverOS's
-    ``load_settings()`` — which is ``@cache``-d — first executes.
+    Assigns rather than ``setdefault``: an ambient ``EVEROS_ROOT`` is not an
+    input to raven's choice of root. Following it silently pointed raven at a
+    root nothing had recorded, so the next run without the variable reported no
+    memories while they sat on disk. Operators who want a different root record
+    it in the config instead.
+
+    Must run BEFORE EverOS's ``load_settings()`` -- which is ``@cache``-d --
+    first executes, or in-process EverOS imports keep the earlier root.
     """
-    base = _EVEROS_BASE.expanduser()
-    os.environ.setdefault("EVEROS_ROOT", str(base))
+    resolved = Path(root).expanduser() if root is not None else everos_root()
+    os.environ["EVEROS_ROOT"] = str(resolved)
 
 
-def ensure_everos_home() -> None:
+def ensure_everos_home(root: Path | str | None = None) -> None:
     """Ensure the EverOS home directory has the required config files.
 
     Three steps, all idempotent:
@@ -76,8 +181,12 @@ def ensure_everos_home() -> None:
     3. **Create** ``ome.toml`` from the shipped template if absent.
        Without this file the OME engine's ``ConfigReloader`` raises
        ``FileNotFoundError`` and the memory backend silently degrades.
+
+    Callers must gate this on :func:`everos_owned`: dropping template files into
+    a root the user manages is an unrequested write, and "the files are usually
+    there already" is not a basis for a read-only promise.
     """
-    base = _EVEROS_BASE.expanduser()
+    base = Path(root).expanduser() if root is not None else everos_root()
     base.mkdir(parents=True, exist_ok=True)
 
     everos_toml = base / "everos.toml"
@@ -178,3 +287,29 @@ def clear_everos_section(section: str) -> None:
         return
     del data[section]
     _write_atomic(get_everos_config_path(), data)
+
+
+def everos_declared_address() -> str | None:
+    """The address ``<root>/everos.toml`` declares, or ``None`` when unset.
+
+    This is the authority on where a server for that root listens: EverOS reads
+    ``[api]`` at startup, and raven no longer overrides it on the command line.
+    Everything else -- raven's ``base_url``, a doctor probe -- is a copy of it.
+    """
+    api = everos_section("api")
+    host = api.get("host")
+    port = api.get("port")
+    if not host or not port:
+        return None
+    return f"http://{host}:{port}"
+
+
+def set_everos_api(*, host: str, port: int) -> None:
+    """Record the address a server for this root must listen on.
+
+    raven used to pass ``--port`` on the command line, which overrode the toml
+    and left the file describing an address nobody was using. Writing it instead
+    makes the root self-describing: anything that can read the directory knows
+    where its server lives, with no second place to drift out of sync.
+    """
+    set_everos_section("api", {"host": host, "port": int(port)})

--- a/raven/config/update_everos.py
+++ b/raven/config/update_everos.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 # ``~/.everos/raven`` is exactly the directory EverOS gives an app_id of
 # "raven" -- so new installs get ``<raven data dir>/everos`` instead. Existing
 # installs keep this one; discovery finds it and nothing is moved.
-_LEGACY_EVEROS_BASE = Path("~/.everos/raven")
+_LEGACY_EVEROS_SUFFIX = (".everos", "raven")
 
 WRITABLE_SECTIONS = ("llm", "embedding", "rerank", "multimodal", "api")
 
@@ -69,8 +69,38 @@ def default_everos_root() -> Path:
 
 
 def legacy_everos_root() -> Path:
-    """raven's pre-move EverOS home, still in use by existing installs."""
-    return _LEGACY_EVEROS_BASE.expanduser()
+    """raven's pre-move EverOS home, still in use by existing installs.
+
+    Built from :meth:`Path.home` rather than ``Path("~/...").expanduser()``:
+    expanduser reads ``$HOME`` out of the environment directly, so it walked
+    straight past the home redirection callers and tests install and reached
+    the real one.
+    """
+    return Path.home().joinpath(*_LEGACY_EVEROS_SUFFIX)
+
+
+def _is_default_installation() -> bool:
+    """Whether this process is the installation that owns ``~/.raven``."""
+    from raven.config.loader import get_config_path
+
+    return get_config_path() == Path.home() / ".raven" / "config.json"
+
+
+def applicable_legacy_root() -> Path | None:
+    """The legacy root, when this installation is the one that could have made it.
+
+    Every other root is derived from the config directory, so pointing raven at
+    another home moves them together. This one is a single machine-wide path,
+    which means an instance running from a moved config would otherwise pick up
+    the default installation's root -- and then converge it, stopping a service
+    and rewriting an ``[api]`` belonging to an installation it is meant to be
+    isolated from.
+
+    Selection only. :func:`root_is_raven_owned` still recognises the path
+    unconditionally, because a config that records it recorded a root raven
+    created, whichever installation is reading it now.
+    """
+    return legacy_everos_root() if _is_default_installation() else None
 
 
 def raven_owned_roots() -> tuple[Path, ...]:
@@ -120,8 +150,8 @@ def fallback_everos_root() -> Path:
     while holding a config dict of its own -- calling :func:`everos_root` there
     would re-read whatever path is globally current, not the file being migrated.
     """
-    legacy = legacy_everos_root()
-    if (legacy / "everos.toml").is_file():
+    legacy = applicable_legacy_root()
+    if legacy is not None and (legacy / "everos.toml").is_file():
         return legacy
     return default_everos_root()
 

--- a/raven/config/update_everos.py
+++ b/raven/config/update_everos.py
@@ -248,6 +248,18 @@ def everos_section(section: str) -> dict[str, Any]:
     return load_everos_config().get(section, {}) or {}
 
 
+def role_configured_in(data: dict[str, Any], section: str) -> bool:
+    """Whether ``section`` of an already-parsed everos.toml counts as configured.
+
+    Same criterion as :func:`everos_role_configured`, applied to a toml the caller
+    read itself. Discovery needs this: it inspects candidate roots before any of
+    them is the active one, and a second hand-rolled "does it have a key" check
+    is exactly what made two callers disagree once before.
+    """
+    sec = data.get(section) or {}
+    return bool(sec.get("model") and sec.get("api_key"))
+
+
 def everos_role_configured(section: str) -> bool:
     """True iff the user really configured this EverOS role.
 
@@ -260,8 +272,7 @@ def everos_role_configured(section: str) -> bool:
     to import it: the wizard module costs ~290ms to load, which `raven doctor`
     (a millisecond command) would otherwise pay just to answer this.
     """
-    sec = everos_section(section)
-    return bool(sec.get("model") and sec.get("api_key"))
+    return role_configured_in(load_everos_config(), section)
 
 
 def set_everos_section(section: str, fields: dict[str, Any]) -> None:

--- a/raven/config/update_everos.py
+++ b/raven/config/update_everos.py
@@ -111,20 +111,39 @@ def _recorded_slice() -> dict[str, Any]:
     return slice_ if isinstance(slice_, dict) else {}
 
 
-def everos_root() -> Path:
-    """The active EverOS root.
+def fallback_everos_root() -> Path:
+    """Which root to assume when nothing is recorded.
 
-    The recorded value when there is one; otherwise the legacy location if it
-    holds a config (so an install from before the move keeps its memories), else
-    the current default. ``_migrate_config`` records the outcome on the next
-    write, so this fallback only runs until then.
+    The legacy location when it holds a config, so an install from before the
+    move keeps its memories; otherwise the current default. Derives its answer
+    without reading raven's config, which is what lets ``_migrate_config`` use it
+    while holding a config dict of its own -- calling :func:`everos_root` there
+    would re-read whatever path is globally current, not the file being migrated.
     """
-    recorded = _recorded_slice().get("root")
-    if recorded:
-        return Path(str(recorded)).expanduser()
     legacy = legacy_everos_root()
     if (legacy / "everos.toml").is_file():
         return legacy
+    return default_everos_root()
+
+
+def everos_root() -> Path:
+    """The active EverOS root: the recorded one, else the fallback."""
+    recorded = _recorded_slice().get("root")
+    if recorded:
+        return Path(str(recorded)).expanduser()
+    return fallback_everos_root()
+
+
+def owned_everos_root() -> Path:
+    """The root raven may create in and write to.
+
+    Deliberately not the same question as :func:`everos_root`. The active root
+    can be one the user manages, and "raven needs a root of its own" must never
+    resolve to that one: a user who declines to share theirs would otherwise have
+    it adopted, seeded with templates and overwritten with raven's models.
+    """
+    if everos_owned():
+        return everos_root()
     return default_everos_root()
 
 
@@ -140,6 +159,28 @@ def everos_owned() -> bool:
     if "owned" in slice_:
         return bool(slice_["owned"])
     return root_is_raven_owned(everos_root())
+
+
+class EverosRootNotOwnedError(RuntimeError):
+    """A write was attempted against a root the user manages.
+
+    Not a ``PermissionError``: that is a filesystem condition and callers catch
+    it as one (``except OSError``), which would swallow exactly the signal this
+    is meant to raise.
+    """
+
+
+def _require_owned(action: str) -> None:
+    """Refuse a write unless raven owns the active root.
+
+    The read-only promise used to live only at the call sites that happened to
+    remember it -- the same shape as the drift this whole change is about, where
+    one rule was enforced in several places and one of them was wrong. Enforcing
+    it at the write primitives means a new caller cannot quietly opt out.
+    """
+    if everos_owned():
+        return
+    raise EverosRootNotOwnedError(f"refusing to {action}: {everos_root()} is managed by the user, not by raven")
 
 
 def get_everos_config_path() -> Path:
@@ -186,6 +227,7 @@ def ensure_everos_home(root: Path | str | None = None) -> None:
     a root the user manages is an unrequested write, and "the files are usually
     there already" is not a basis for a read-only promise.
     """
+    _require_owned("create config templates in")
     base = Path(root).expanduser() if root is not None else everos_root()
     base.mkdir(parents=True, exist_ok=True)
 
@@ -283,6 +325,7 @@ def set_everos_section(section: str, fields: dict[str, Any]) -> None:
     """
     if section not in WRITABLE_SECTIONS:
         raise KeyError(f"unknown everos section {section!r}; writable: {WRITABLE_SECTIONS}")
+    _require_owned(f"write [{section}]")
     data = load_everos_config()
     clean = {k: v for k, v in fields.items() if v is not None}
     data[section] = {**data.get(section, {}), **clean}
@@ -293,6 +336,7 @@ def clear_everos_section(section: str) -> None:
     """Drop ``[section]`` from the user-level toml (no-op if absent)."""
     if section not in WRITABLE_SECTIONS:
         raise KeyError(f"unknown everos section {section!r}; writable: {WRITABLE_SECTIONS}")
+    _require_owned(f"clear [{section}]")
     data = load_everos_config()
     if section not in data:
         return

--- a/raven/importer/orchestrator.py
+++ b/raven/importer/orchestrator.py
@@ -181,6 +181,16 @@ async def run_import(
     )
 
 
+class MemoryWriteDroppedError(RuntimeError):
+    """A batch was not written, and the backend said so rather than raising.
+
+    Raised here rather than returned so the per-source loop keeps deciding what
+    a failure means: it already marks the source failed, records the reason,
+    and moves on. Only the signal was lost when the backend stopped raising --
+    the policy around it was, and stays, correct.
+    """
+
+
 async def _feed_session(backend: MemoryBackend, session: ImportSession) -> None:
     if not session.messages:
         return
@@ -192,7 +202,11 @@ async def _feed_session(backend: MemoryBackend, session: ImportSession) -> None:
         nonlocal batch, batch_chars
         metadata: dict[str, Any] = {"is_final": is_final}
         _log_store_request(session.session_id, batch, metadata, batch_chars)
-        await backend.store(session.session_id, batch, metadata=metadata)
+        landed = await backend.store(session.session_id, batch, metadata=metadata)
+        if landed is False:
+            raise MemoryWriteDroppedError(
+                f"memory service did not accept a batch for {session.session_id}; source left unsubmitted"
+            )
         logger.debug("store completed: session_id={}", session.session_id)
         batch = []
         batch_chars = 0

--- a/raven/memory_engine/backend.py
+++ b/raven/memory_engine/backend.py
@@ -129,14 +129,13 @@ class MemoryBackend(Protocol):
         messages: list[dict[str, Any]],
         *,
         metadata: dict[str, Any] | None = None,
-    ) -> None:
-        """Persist a session slice.
+    ) -> bool:
+        """Persist a session slice. Returns whether it landed.
 
         ``messages`` follows the AgentLoop ``{"role", "content", ...}``
         shape — the existing list-of-dicts form the codebase already
         produces, so adapters don't need a conversion step. Backends
-        that want to chunk / deduplicate / extract are free to; the
-        Protocol is fire-and-forget per call.
+        that want to chunk / deduplicate / extract are free to.
 
         ``metadata`` is an optional dict for caller-supplied context
         that does not fit the message list.  Callers may pass
@@ -144,8 +143,17 @@ class MemoryBackend(Protocol):
         or ``is_final``; normal AgentLoop turns leave it ``None``.
         Backends that do not consume metadata ignore it silently.
 
-        Raises on transport / auth errors so AgentLoop can surface
-        them; the host does **not** silently swallow store failures.
+        Does not raise on transport / auth errors; it reports them.
+        The two callers want opposite things from a failed write. A
+        turn loses one turn's memory and gets a fresh chance on the
+        next, so it discards the answer and never blocks on indexing.
+        A bulk import marks a source done in its resume state, so a
+        write silently treated as landed erases the only record that
+        the source is still pending -- it must check.
+
+        Discarding the return value therefore stays valid; what is no
+        longer valid is *assuming* a write landed because nothing was
+        raised.
         """
         ...
 

--- a/raven/plugin/memory/everos/_discover.py
+++ b/raven/plugin/memory/everos/_discover.py
@@ -70,8 +70,9 @@ class RootState:
 
 
 def _describe(root: Path, *, owned: bool) -> RootState:
+    from raven.config.update_everos import role_configured_in
+
     data = _read_toml(root)
-    llm = data.get("llm") or {}
     api = data.get("api") or {}
     host, port = api.get("host"), api.get("port")
     declared = f"http://{host}:{port}" if host and port else None
@@ -79,7 +80,9 @@ def _describe(root: Path, *, owned: bool) -> RootState:
     return RootState(
         root=root,
         owned=owned,
-        configured=bool(llm.get("model") and llm.get("api_key")),
+        # Through the ops layer rather than re-reading the fields here: one
+        # definition of "configured", shared with the wizard and doctor.
+        configured=role_configured_in(data, "llm"),
         declared_url=declared,
         alive=_probe_health(declared) if declared else False,
         lock_held=ome_lock_held(root),
@@ -155,10 +158,12 @@ def pick(states: list[RootState]) -> RootState | None:
 
     Prefers a root that is already configured -- a half-built root has nothing
     to reuse -- and among those keeps discovery order, which puts the recorded
-    root first.
+    root first. ``configured`` alone is the test: it can only be true of a root
+    whose toml was read, so re-checking that the file exists adds a stat and no
+    information.
     """
     for state in states:
-        if state.exists and state.configured:
+        if state.configured:
             return state
     return None
 

--- a/raven/plugin/memory/everos/_discover.py
+++ b/raven/plugin/memory/everos/_discover.py
@@ -122,8 +122,8 @@ def discover() -> list[RootState]:
     """
     from raven.config.update_everos import (
         _recorded_slice,
-        default_everos_root,
         applicable_legacy_root,
+        default_everos_root,
         root_is_raven_owned,
     )
 

--- a/raven/plugin/memory/everos/_discover.py
+++ b/raven/plugin/memory/everos/_discover.py
@@ -1,0 +1,177 @@
+"""Find the EverOS roots on this machine and say what state each is in.
+
+raven used to assume there was exactly one root at one address and start a server
+whenever that address did not answer. Both assumptions were wrong in ways that
+cost users their memory: a root can already be served on another port, and a root
+can belong to the user rather than to raven.
+
+Discovery answers four questions per candidate root, and deliberately keeps them
+apart because they fail independently:
+
+``configured``
+    Does ``[llm]`` carry a model and a key? Without it no server can finish
+    starting, so an unconfigured root is a half-built one, not a broken one.
+``declared_url``
+    What address does ``<root>/everos.toml`` say a server for this root listens
+    on? The root is self-describing; this is the authority.
+``alive``
+    Does that address answer ``/health``?
+``lock_held``
+    Is the OME jobstore lock taken? That lock is per data directory, not per
+    port, so it is the only reliable answer to "is something already serving
+    this data". A root can be locked while its declared address is silent --
+    that is what a server started on a different port looks like.
+
+Nothing here writes, signals, or starts anything.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from raven.plugin.memory.everos._server import (
+    DEFAULT_EVEROS_BASE_URL,
+    _probe_health,
+    ome_lock_held,
+)
+
+
+@dataclass(frozen=True)
+class RootState:
+    """One candidate EverOS root and what could be observed about it."""
+
+    root: Path
+    owned: bool
+    configured: bool
+    declared_url: str | None
+    alive: bool
+    lock_held: bool
+
+    @property
+    def exists(self) -> bool:
+        return (self.root / "everos.toml").is_file()
+
+    @property
+    def serving(self) -> bool:
+        """A server for this root is up and reachable where it says it is."""
+        return self.alive
+
+    @property
+    def busy_elsewhere(self) -> bool:
+        """Something serves this data, but not at the address it declares.
+
+        A server started with a ``--port`` override, an ``EVEROS_API__PORT`` in
+        its environment, or a non-server holder of the lock (``everos demo``, an
+        embedded engine) all land here. It is the one state that cannot be fixed
+        by starting something: one data directory admits one engine.
+        """
+        return self.lock_held and not self.alive
+
+
+def _describe(root: Path, *, owned: bool) -> RootState:
+    data = _read_toml(root)
+    llm = data.get("llm") or {}
+    api = data.get("api") or {}
+    host, port = api.get("host"), api.get("port")
+    declared = f"http://{host}:{port}" if host and port else None
+
+    return RootState(
+        root=root,
+        owned=owned,
+        configured=bool(llm.get("model") and llm.get("api_key")),
+        declared_url=declared,
+        alive=_probe_health(declared) if declared else False,
+        lock_held=ome_lock_held(root),
+    )
+
+
+def _read_toml(root: Path) -> dict:
+    """Parse ``<root>/everos.toml``, or ``{}`` when absent or unreadable.
+
+    Read straight off the path instead of through ``load_everos_config``: that
+    helper follows the *active* root, and discovery is precisely the code that
+    cannot assume which root is active yet.
+    """
+    import tomllib
+
+    path = root / "everos.toml"
+    try:
+        with path.open("rb") as fh:
+            return tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+
+
+def discover() -> list[RootState]:
+    """Candidate roots, best first.
+
+    Order is the preference order, not a ranking of health: a recorded root wins
+    even when it is in a worse state than another candidate, because switching
+    roots behind the user's back would silently change which memories raven has.
+
+    The user's own ``~/.everos`` is offered only when raven has no root of its
+    own to use. Suggesting it while raven has memories of its own would invite
+    the user to abandon them, and adopting it costs them exclusive use of their
+    data.
+    """
+    from raven.config.update_everos import (
+        _recorded_slice,
+        default_everos_root,
+        legacy_everos_root,
+        root_is_raven_owned,
+    )
+
+    states: list[RootState] = []
+    seen: set[Path] = set()
+
+    def add(root: Path, *, owned: bool) -> RootState:
+        state = _describe(root, owned=owned)
+        states.append(state)
+        seen.add(root)
+        return state
+
+    slice_ = _recorded_slice()
+    recorded = slice_.get("root")
+    if recorded:
+        root = Path(str(recorded)).expanduser()
+        owned = bool(slice_["owned"]) if "owned" in slice_ else root_is_raven_owned(root)
+        add(root, owned=owned)
+
+    for root in (default_everos_root(), legacy_everos_root()):
+        if root not in seen:
+            add(root, owned=True)
+
+    if not any(s.exists and s.configured for s in states):
+        bare = legacy_everos_root().parent
+        if bare not in seen and (bare / "everos.toml").is_file():
+            add(bare, owned=False)
+
+    return states
+
+
+def pick(states: list[RootState]) -> RootState | None:
+    """The root raven should use, or ``None`` when a new one has to be created.
+
+    Prefers a root that is already configured -- a half-built root has nothing
+    to reuse -- and among those keeps discovery order, which puts the recorded
+    root first.
+    """
+    for state in states:
+        if state.exists and state.configured:
+            return state
+    return None
+
+
+def default_new_root_url() -> str:
+    """The address a freshly created root should declare.
+
+    Not the ``[api]`` default EverOS ships (8000): that port is one of the most
+    commonly occupied on a developer machine, and it only ever appeared in
+    raven's roots because raven overrode it on the command line and never wrote
+    the file.
+    """
+    return DEFAULT_EVEROS_BASE_URL
+
+
+__all__ = ["RootState", "default_new_root_url", "discover", "pick"]

--- a/raven/plugin/memory/everos/_discover.py
+++ b/raven/plugin/memory/everos/_discover.py
@@ -113,10 +113,12 @@ def discover() -> list[RootState]:
     even when it is in a worse state than another candidate, because switching
     roots behind the user's back would silently change which memories raven has.
 
-    The user's own ``~/.everos`` is offered only when raven has no root of its
-    own to use. Suggesting it while raven has memories of its own would invite
-    the user to abandon them, and adopting it costs them exclusive use of their
-    data.
+    Only roots raven creates for itself are scanned. An EverOS the user runs is
+    never discovered: finding one means offering it, offering it means asking
+    for a decision the user did not come to make, and the only answer raven can
+    honour -- read-only reuse -- is one it cannot infer from a path anyway.
+    Pointing raven at such a server is an explicit turn in the wizard where the
+    person who knows the address types it.
     """
     from raven.config.update_everos import (
         _recorded_slice,
@@ -144,11 +146,6 @@ def discover() -> list[RootState]:
     for root in (default_everos_root(), legacy_everos_root()):
         if root not in seen:
             add(root, owned=True)
-
-    if not any(s.exists and s.configured for s in states):
-        bare = legacy_everos_root().parent
-        if bare not in seen and (bare / "everos.toml").is_file():
-            add(bare, owned=False)
 
     return states
 

--- a/raven/plugin/memory/everos/_discover.py
+++ b/raven/plugin/memory/everos/_discover.py
@@ -123,7 +123,7 @@ def discover() -> list[RootState]:
     from raven.config.update_everos import (
         _recorded_slice,
         default_everos_root,
-        legacy_everos_root,
+        applicable_legacy_root,
         root_is_raven_owned,
     )
 
@@ -143,8 +143,8 @@ def discover() -> list[RootState]:
         owned = bool(slice_["owned"]) if "owned" in slice_ else root_is_raven_owned(root)
         add(root, owned=owned)
 
-    for root in (default_everos_root(), legacy_everos_root()):
-        if root not in seen:
+    for root in (default_everos_root(), applicable_legacy_root()):
+        if root is not None and root not in seen:
             add(root, owned=True)
 
     return states

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -574,10 +574,18 @@ def _start_server_if_unlocked(base_url: str) -> subprocess.Popen | None:
             # one place that decides how loopback is spelled.
             _default = urlparse(DEFAULT_EVEROS_BASE_URL)
             want_port = int(parsed.port or _default.port or 18791)
-            set_everos_api(
-                host=parsed.hostname or _default.hostname or "localhost",
-                port=want_port,
-            )
+            try:
+                set_everos_api(
+                    host=parsed.hostname or _default.hostname or "localhost",
+                    port=want_port,
+                )
+            except OSError as exc:
+                # Callers guard the start path with ``except RuntimeError``,
+                # which is what "could not start" has always meant here. An
+                # unwritable root raises OSError from the atomic write and
+                # walked past all of them, ending the wizard on a traceback for
+                # something the user can simply fix and retry.
+                raise RuntimeError(f"could not write [api] to {root}/everos.toml: {exc}") from exc
             _require_written_port(root, want_port)
             log_path = server_log_path()
             log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
+import time
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from loguru import logger
@@ -113,6 +117,97 @@ def _everos_executable() -> str:
 
 _LOG_TAIL_BYTES = 65536
 _EXCEPTION_LINE = re.compile(r"^[\w.]+(Error|Exception)\b")
+_SERVER_CMDLINE = "everos server start"
+
+
+def _pidfile_path() -> Path:
+    return get_data_dir() / "everos-server.pid"
+
+
+def _write_pidfile(pid: int, *, base_url: str, root: Path) -> None:
+    """Record the server raven just started.
+
+    Answers "is the process serving this root mine, and may I stop it?" without
+    scanning the process table or depending on ``lsof``. Best-effort: failing to
+    record must not fail the start.
+    """
+    try:
+        _pidfile_path().write_text(
+            json.dumps({"pid": pid, "base_url": base_url, "root": str(root)}),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        logger.debug("could not record everos server pidfile: {}", exc)
+
+
+def _read_pidfile() -> dict[str, Any] | None:
+    try:
+        data = json.loads(_pidfile_path().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _is_everos_server(pid: int) -> bool:
+    """Verify ``pid`` is still an everos server before signalling it.
+
+    A pidfile is stale information: the process it names may have exited and the
+    number been handed to something unrelated. Checking the command line is what
+    keeps a port-convergence restart from killing an innocent process. ``ps -p``
+    is POSIX and needs no extra dependency; the EverOS path is POSIX-only anyway.
+    """
+    ps = shutil.which("ps") or "/bin/ps"
+    try:
+        out = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            [ps, "-p", str(pid), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return _SERVER_CMDLINE in out.stdout
+
+
+def find_recorded_server(root: Path | str) -> dict[str, Any] | None:
+    """The server raven started for ``root``, if it is still that server."""
+    record = _read_pidfile()
+    if not record:
+        return None
+    if str(record.get("root")) != str(Path(root).expanduser()):
+        return None
+    pid = record.get("pid")
+    if not isinstance(pid, int) or not _is_everos_server(pid):
+        return None
+    return record
+
+
+def stop_recorded_server(root: Path | str, *, timeout: float = 35.0) -> bool:
+    """Ask the server raven started for ``root`` to shut down, and wait for it.
+
+    SIGTERM rather than SIGKILL: uvicorn's graceful shutdown runs the OME
+    engine's ``stop()``, which drains in-flight strategy runs (up to 30s) before
+    releasing the jobstore lock. Killing outright would leave that work to crash
+    recovery for no reason. Returns False when there is nothing of ours to stop.
+    """
+    record = find_recorded_server(root)
+    if record is None:
+        return False
+    pid = int(record["pid"])
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError as exc:
+        logger.debug("could not signal everos server {}: {}", pid, exc)
+        return False
+    waited = 0.0
+    while waited < timeout:
+        if not _is_everos_server(pid):
+            _pidfile_path().unlink(missing_ok=True)
+            return True
+        time.sleep(_POLL_INTERVAL)
+        waited += _POLL_INTERVAL
+    logger.warning("everos server {} did not exit within {}s", pid, timeout)
+    return False
 
 
 def _last_error_line() -> str:
@@ -138,7 +233,7 @@ def _last_error_line() -> str:
     return ""
 
 
-def _start_server_if_unlocked(port: str) -> subprocess.Popen | None:
+def _start_server_if_unlocked(base_url: str) -> subprocess.Popen | None:
     """Try to acquire the startup lock and launch the server.
 
     Returns the child process when this process launched it, or ``None`` when
@@ -148,8 +243,19 @@ def _start_server_if_unlocked(port: str) -> subprocess.Popen | None:
 
     The handle is returned rather than discarded so the caller can tell "still
     booting" apart from "already dead" -- see :func:`ensure_everos_server`.
+
+    The address is written into ``<root>/everos.toml`` rather than passed as
+    ``--port``. A command-line override left the file describing an address
+    nobody was listening on, which is how the wizard came to probe one port while
+    the backend talked to another. Writing it makes the root self-describing, and
+    both the child and any later reader agree by construction.
     """
+    from raven.config.update_everos import everos_root, set_everos_api
+
     everos = _everos_executable()
+    root = everos_root()
+    parsed = urlparse(base_url)
+    set_everos_api(host=parsed.hostname or "127.0.0.1", port=int(parsed.port or 80))
 
     try:
         with file_lock(_lock_path(), blocking=False):
@@ -157,12 +263,17 @@ def _start_server_if_unlocked(port: str) -> subprocess.Popen | None:
             log_path.parent.mkdir(parents=True, exist_ok=True)
             with open(log_path, "a") as log_file:
                 proc = subprocess.Popen(
-                    [everos, "server", "start", "--port", port],
+                    # --root on the command line rather than only inherited via
+                    # EVEROS_ROOT: a server that names its own root is one `ps`
+                    # away from being identified, which matters when a stale
+                    # instance has to be found and stopped.
+                    [everos, "server", "start", "--root", str(root)],
                     stdout=log_file,
                     stderr=subprocess.STDOUT,
                     start_new_session=True,
                 )
-            logger.info("started everos server on port {} (log: {})", port, log_path)
+            logger.info("started everos server for {} at {} (log: {})", root, base_url, log_path)
+            _write_pidfile(proc.pid, base_url=base_url, root=root)
             return proc
     except LockTimeoutError:
         logger.debug("everos server startup lock held by another process; skipping spawn")
@@ -203,8 +314,7 @@ async def ensure_everos_server(
     if on_wait is not None:
         on_wait()
 
-    port = _extract_port(base_url)
-    proc = await asyncio.to_thread(_start_server_if_unlocked, port)
+    proc = await asyncio.to_thread(_start_server_if_unlocked, base_url)
 
     elapsed = 0.0
     while elapsed < timeout:
@@ -228,8 +338,8 @@ async def ensure_everos_server(
 
     raise RuntimeError(
         f"EverOS server did not become healthy within {timeout}s at {base_url}. "
-        f"The process is still running; check that port {port} is not held by "
-        f"something else, and see {server_log_path()}"
+        f"The process is still running; check that port {_extract_port(base_url)} "
+        f"is not held by something else, and see {server_log_path()}"
     )
 
 

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -172,6 +173,7 @@ async def ensure_everos_server(
     base_url: str,
     *,
     timeout: float = 30.0,
+    on_wait: Callable[[], None] | None = None,
 ) -> None:
     """Make sure a server is answering at ``base_url``, starting one if not.
 
@@ -184,6 +186,11 @@ async def ensure_everos_server(
     reported to the user as a 30s timeout blaming a missing install. A default
     here means "forgot to read the config" is a silent runtime bug rather than a
     signature error, so there is none.
+
+    ``on_wait`` fires once, only when an actual boot is about to be waited on --
+    never when a server is already answering. That lets a caller narrate the
+    wait without adding noise to the common case where there is nothing to wait
+    for.
     """
     if await asyncio.to_thread(_probe_health, base_url):
         logger.info("everos server already running at {}", base_url)
@@ -192,6 +199,9 @@ async def ensure_everos_server(
     # Only on the spawn path: a server that answers /health has already built
     # its LLM client, so its credentials are proven by the probe above.
     _require_llm_configured()
+
+    if on_wait is not None:
+        on_wait()
 
     port = _extract_port(base_url)
     proc = await asyncio.to_thread(_start_server_if_unlocked, port)

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -52,6 +52,38 @@ def server_log_path() -> Path:
     return get_logs_dir() / "everos-server.log"
 
 
+class EverosNotConfigured(RuntimeError):
+    """The memory LLM is missing, so no server could survive startup.
+
+    A ``RuntimeError`` subclass on purpose: callers already treat that as
+    "server unavailable", and this only narrows the reason so a caller that
+    wants to say something more useful can.
+    """
+
+
+def _require_llm_configured() -> None:
+    """Refuse to spawn a server that is guaranteed to die on startup.
+
+    EverOS treats the LLM as a hard requirement: its lifespan provider builds
+    the client eagerly and raises ``LLMNotConfiguredError`` when credentials are
+    missing, which fails FastAPI startup outright. Spawning anyway costs the
+    caller a full poll timeout waiting on a process that already exited, and
+    leaves the real reason only in the server log.
+
+    This is reachable out of the box, not just after a misconfiguration:
+    ``memory.backend`` defaults to ``"everos"`` in the schema while the
+    everos.toml template ships ``[llm]`` with an empty ``api_key``.
+    """
+    from raven.config.update_everos import everos_role_configured, get_everos_config_path
+
+    if everos_role_configured("llm"):
+        return
+    raise EverosNotConfigured(
+        f"EverOS memory LLM is not configured: [llm] in {get_everos_config_path()} "
+        "needs both model and api_key."
+    )
+
+
 def _everos_executable() -> str:
     """Locate the everos CLI, preferring the one installed alongside raven.
 
@@ -127,6 +159,10 @@ async def ensure_everos_server(
         logger.info("everos server already running at {}", base_url)
         return
 
+    # Only on the spawn path: a server that answers /health has already built
+    # its LLM client, so its credentials are proven by the probe above.
+    _require_llm_configured()
+
     port = _extract_port(base_url)
     await asyncio.to_thread(_start_server_if_unlocked, port)
 
@@ -146,4 +182,4 @@ async def ensure_everos_server(
     )
 
 
-__all__ = ["DEFAULT_EVEROS_BASE_URL", "ensure_everos_server"]
+__all__ = ["DEFAULT_EVEROS_BASE_URL", "EverosNotConfigured", "ensure_everos_server"]

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -253,7 +253,21 @@ def stop_recorded_server(root: Path | str, *, timeout: float = 35.0) -> StopOutc
     record = find_recorded_server(root)
     if record is None:
         return StopOutcome.NOT_OURS
-    pid = int(record["pid"])
+    return stop_pid(int(record["pid"]), timeout=timeout)
+
+
+def stop_pid(pid: int, *, timeout: float = 35.0) -> StopOutcome:
+    """Stop a specific everos server and wait for it.
+
+    Takes the pid rather than re-deriving it, so a caller that identified the
+    process some other way -- :func:`lock_holder`, which asks the OS -- can act
+    on what it found. Going back through the pidfile there would report
+    ``NOT_OURS`` for a process the caller had just named, and losing the pidfile
+    is precisely the case the lock lookup exists to recover.
+
+    The caller is responsible for having established that this pid is an everos
+    serving the root in question; both routes in do.
+    """
     try:
         os.kill(pid, signal.SIGTERM)
     except OSError as exc:
@@ -683,4 +697,5 @@ __all__ = [
     "StopOutcome",
     "ensure_everos_server",
     "lock_holder",
+    "stop_pid",
 ]

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -107,10 +107,22 @@ def _start_server_if_unlocked(port: str) -> bool:
 
 
 async def ensure_everos_server(
-    base_url: str = DEFAULT_EVEROS_BASE_URL,
+    base_url: str,
     *,
     timeout: float = 30.0,
 ) -> None:
+    """Make sure a server is answering at ``base_url``, starting one if not.
+
+    ``base_url`` is required on purpose. It used to default to
+    ``DEFAULT_EVEROS_BASE_URL``, which let the onboard wizard probe 18791 while
+    the memory backend read ``plugins.config`` and used whatever address was
+    configured there. On a machine that had moved everos off the default port
+    the wizard then decided nothing was running, spawned a second instance, and
+    that instance died on the OME jobstore lock the first one already held --
+    reported to the user as a 30s timeout blaming a missing install. A default
+    here means "forgot to read the config" is a silent runtime bug rather than a
+    signature error, so there is none.
+    """
     if await asyncio.to_thread(_probe_health, base_url):
         logger.info("everos server already running at {}", base_url)
         return

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -329,7 +329,16 @@ def _start_server_if_unlocked(base_url: str) -> subprocess.Popen | None:
             # Inside the lock: losing the race means another process is already
             # spawning, and rewriting the declared address on the way out would
             # move the goalposts for a server that is starting or already up.
-            set_everos_api(host=parsed.hostname or "127.0.0.1", port=int(parsed.port or 80))
+            # Host and port come from the address the caller asked for, so what
+            # gets written is what will be probed -- one spelling, no resolver
+            # disagreement between the bind and the health check. The fallbacks
+            # are taken from the default URL rather than restated, so there is
+            # one place that decides how loopback is spelled.
+            _default = urlparse(DEFAULT_EVEROS_BASE_URL)
+            set_everos_api(
+                host=parsed.hostname or _default.hostname or "localhost",
+                port=int(parsed.port or _default.port or 18791),
+            )
             log_path = server_log_path()
             log_path.parent.mkdir(parents=True, exist_ok=True)
             with open(log_path, "a") as log_file:

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -235,8 +235,8 @@ def ome_lock_held(root: Path | str) -> bool:
     non-blocking exclusive ``flock`` on ``<root>/.index/sqlite/ome.db.lock``. The
     lock is the only reliable answer to "is this data already being served",
     because it is keyed on the directory rather than on a port: a second server
-    on a different port dies here, which is exactly the failure that looked like
-    a mysterious 30s startup timeout.
+    on a different port dies here, which is the failure that used to surface as a
+    silent startup timeout with no mention of a lock.
 
     Acquire-and-release, so this reports on *other* holders. Two caveats worth
     knowing: ``flock`` is held per open file description, so a raven process that
@@ -366,7 +366,7 @@ async def ensure_everos_server(
     configured there. On a machine that had moved everos off the default port
     the wizard then decided nothing was running, spawned a second instance, and
     that instance died on the OME jobstore lock the first one already held --
-    reported to the user as a 30s timeout blaming a missing install. A default
+    reported to the user as a startup timeout blaming a missing install. A default
     here means "forgot to read the config" is a silent runtime bug rather than a
     signature error, so there is none.
 

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -355,7 +355,7 @@ def _start_server_if_unlocked(base_url: str) -> subprocess.Popen | None:
 async def ensure_everos_server(
     base_url: str,
     *,
-    timeout: float = 30.0,
+    timeout: float = 10.0,
     on_wait: Callable[[], None] | None = None,
 ) -> None:
     """Make sure a server is answering at ``base_url``, starting one if not.
@@ -369,6 +369,16 @@ async def ensure_everos_server(
     reported to the user as a 30s timeout blaming a missing install. A default
     here means "forgot to read the config" is a silent runtime bug rather than a
     signature error, so there is none.
+
+    ``timeout`` is a budget for how long a caller is willing to make the user
+    wait, not a failure detector. Once the poll loop watches the child's exit
+    code, a boot that cannot succeed is reported in about a second regardless of
+    this value, so the only thing left to size is the wait itself. Overrunning it
+    is cheap: the child keeps booting, this session goes without long-term
+    memory, and the next one finds a healthy server -- so a small budget costs at
+    most one session and heals itself, while a large one blocks every first
+    session of a machine's uptime. Measured cold start on a small store is
+    around two seconds.
 
     ``on_wait`` fires once, only when an actual boot is about to be waited on --
     never when a server is already answering. That lets a caller narrate the
@@ -408,10 +418,13 @@ async def ensure_everos_server(
                 + f"Full log: {server_log_path()}"
             )
 
+    # Not phrased as a failure: the process is up and still booting, which is
+    # what the caller should tell the user and what the next session will find.
     raise RuntimeError(
-        f"EverOS server did not become healthy within {timeout}s at {base_url}. "
-        f"The process is still running; check that port {_extract_port(base_url)} "
-        f"is not held by something else, and see {server_log_path()}"
+        f"EverOS server is still starting at {base_url} after {timeout}s. "
+        f"This session runs without long-term memory; the next one should find it. "
+        f"If it never comes up, check that port {_extract_port(base_url)} is free "
+        f"and see {server_log_path()}"
     )
 
 

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -210,6 +210,38 @@ def stop_recorded_server(root: Path | str, *, timeout: float = 35.0) -> bool:
     return False
 
 
+def ome_lock_held(root: Path | str) -> bool:
+    """Is an OME engine already serving the data under ``root``?
+
+    EverOS admits one offline engine per data directory and enforces it with a
+    non-blocking exclusive ``flock`` on ``<root>/.index/sqlite/ome.db.lock``. The
+    lock is the only reliable answer to "is this data already being served",
+    because it is keyed on the directory rather than on a port: a second server
+    on a different port dies here, which is exactly the failure that looked like
+    a mysterious 30s startup timeout.
+
+    Acquire-and-release, so this reports on *other* holders. Two caveats worth
+    knowing: ``flock`` is held per open file description, so a raven process that
+    itself holds the lock would see its own -- callers run this from the wizard
+    and doctor, which do not; and a missing lock file means nobody has ever
+    started an engine here, which is not the same as "free after a crash" but
+    answers the same way.
+    """
+    lock = Path(root).expanduser() / ".index" / "sqlite" / "ome.db.lock"
+    if not lock.exists():
+        return False
+    try:
+        with file_lock(lock, blocking=False):
+            return False
+    except LockTimeoutError:
+        return True
+    except OSError as exc:
+        # Unreadable lock file: refuse to claim the data is free, since acting on
+        # that would spawn an instance that cannot start.
+        logger.debug("could not test the OME lock at {}: {}", lock, exc)
+        return True
+
+
 def _last_error_line() -> str:
     """The most recent exception line from the server log, or an empty string.
 

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -50,6 +52,33 @@ def server_log_path() -> Path:
     return get_logs_dir() / "everos-server.log"
 
 
+def _everos_executable() -> str:
+    """Locate the everos CLI, preferring the one installed alongside raven.
+
+    ``everos`` is a hard dependency of raven, so it always lives in the same
+    environment as the running interpreter -- but not necessarily on PATH:
+    ``uv tool install`` exposes only the requested package's entry points, so
+    ``~/.local/bin`` gets ``raven`` and not ``everos``. Checking the
+    interpreter's own directory first therefore fixes more than a lookup
+    failure: when PATH carries an everos from a *different* environment,
+    ``shutil.which`` would hand back a version that does not match the one
+    raven pins.
+
+    POSIX only -- the EverOS path is gated off on native Windows by both
+    callers (``onboard_everos._step4_memory`` and ``EverosBackend.start``).
+    """
+    sibling = Path(sys.executable).parent / "everos"
+    if sibling.is_file() and os.access(sibling, os.X_OK):
+        return str(sibling)
+    found = shutil.which("everos")
+    if found:
+        return found
+    raise RuntimeError(
+        f"everos not found next to {Path(sys.executable).parent} or on PATH. "
+        "Please install the everos CLI."
+    )
+
+
 def _start_server_if_unlocked(port: str) -> bool:
     """Try to acquire the startup lock and launch the server.
 
@@ -57,9 +86,7 @@ def _start_server_if_unlocked(port: str) -> bool:
     was already held (another process is spawning).  Uses the cross-
     platform ``portable_lock`` so Windows does not crash on import.
     """
-    everos = shutil.which("everos")
-    if not everos:
-        raise RuntimeError("everos not found. Please install the everos CLI.")
+    everos = _everos_executable()
 
     try:
         with file_lock(_lock_path(), blocking=False):

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import time
 from collections.abc import Callable
+from enum import Enum
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -182,32 +183,49 @@ def find_recorded_server(root: Path | str) -> dict[str, Any] | None:
     return record
 
 
-def stop_recorded_server(root: Path | str, *, timeout: float = 35.0) -> bool:
+class StopOutcome(str, Enum):
+    """Why a stop attempt ended the way it did.
+
+    A bare bool collapsed three situations a caller must tell apart: a process
+    raven never started, a signal that could not be delivered, and a server that
+    is shutting down but still draining work. Reporting them as one made the
+    wizard tell a user whose memory tasks were mid-flight that raven had not
+    started the process -- an explanation that is simply untrue.
+    """
+
+    STOPPED = "stopped"
+    NOT_OURS = "not_ours"
+    SIGNAL_FAILED = "signal_failed"
+    STILL_DRAINING = "still_draining"
+
+
+def stop_recorded_server(root: Path | str, *, timeout: float = 35.0) -> StopOutcome:
     """Ask the server raven started for ``root`` to shut down, and wait for it.
 
     SIGTERM rather than SIGKILL: uvicorn's graceful shutdown runs the OME
     engine's ``stop()``, which drains in-flight strategy runs (up to 30s) before
     releasing the jobstore lock. Killing outright would leave that work to crash
-    recovery for no reason. Returns False when there is nothing of ours to stop.
+    recovery for no reason -- which is also why ``STILL_DRAINING`` is a distinct
+    answer rather than a failure: the server is doing exactly what it should.
     """
     record = find_recorded_server(root)
     if record is None:
-        return False
+        return StopOutcome.NOT_OURS
     pid = int(record["pid"])
     try:
         os.kill(pid, signal.SIGTERM)
     except OSError as exc:
         logger.debug("could not signal everos server {}: {}", pid, exc)
-        return False
+        return StopOutcome.SIGNAL_FAILED
     waited = 0.0
     while waited < timeout:
         if not _is_everos_server(pid):
             _pidfile_path().unlink(missing_ok=True)
-            return True
+            return StopOutcome.STOPPED
         time.sleep(_POLL_INTERVAL)
         waited += _POLL_INTERVAL
     logger.warning("everos server {} did not exit within {}s", pid, timeout)
-    return False
+    return StopOutcome.STILL_DRAINING
 
 
 def ome_lock_held(root: Path | str) -> bool:
@@ -375,4 +393,9 @@ async def ensure_everos_server(
     )
 
 
-__all__ = ["DEFAULT_EVEROS_BASE_URL", "EverosNotConfiguredError", "ensure_everos_server"]
+__all__ = [
+    "DEFAULT_EVEROS_BASE_URL",
+    "EverosNotConfiguredError",
+    "StopOutcome",
+    "ensure_everos_server",
+]

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -283,6 +283,24 @@ def _last_error_line() -> str:
     return ""
 
 
+def _child_env() -> dict[str, str]:
+    """The environment the spawned server gets.
+
+    EverOS resolves settings as ``init_args > env_vars > everos.toml``, so an
+    ``EVEROS_API__PORT`` inherited from raven's own environment would outrank the
+    ``[api]`` section this module just wrote -- and the whole point of dropping
+    ``--port`` was to make that section the single authority on where a server
+    for this root listens. Anything that could re-open that gap is removed;
+    everything else is passed through, EVEROS_ROOT included, since the child
+    still needs it for the imports that do not read ``--root``.
+    """
+    env = dict(os.environ)
+    for key in list(env):
+        if key.startswith("EVEROS_API__"):
+            del env[key]
+    return env
+
+
 def _start_server_if_unlocked(base_url: str) -> subprocess.Popen | None:
     """Try to acquire the startup lock and launch the server.
 
@@ -305,10 +323,13 @@ def _start_server_if_unlocked(base_url: str) -> subprocess.Popen | None:
     everos = _everos_executable()
     root = everos_root()
     parsed = urlparse(base_url)
-    set_everos_api(host=parsed.hostname or "127.0.0.1", port=int(parsed.port or 80))
 
     try:
         with file_lock(_lock_path(), blocking=False):
+            # Inside the lock: losing the race means another process is already
+            # spawning, and rewriting the declared address on the way out would
+            # move the goalposts for a server that is starting or already up.
+            set_everos_api(host=parsed.hostname or "127.0.0.1", port=int(parsed.port or 80))
             log_path = server_log_path()
             log_path.parent.mkdir(parents=True, exist_ok=True)
             with open(log_path, "a") as log_file:
@@ -321,6 +342,7 @@ def _start_server_if_unlocked(base_url: str) -> subprocess.Popen | None:
                     stdout=log_file,
                     stderr=subprocess.STDOUT,
                     start_new_session=True,
+                    env=_child_env(),
                 )
             logger.info("started everos server for {} at {} (log: {})", root, base_url, log_path)
             _write_pidfile(proc.pid, base_url=base_url, root=root)

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -33,16 +34,48 @@ def _extract_port(base_url: str) -> str:
     return str(parsed.port or 80)
 
 
-def _probe_health(base_url: str) -> bool:
+_PROBE_TIMEOUT_S = 1.0
+
+
+class ProbeResult(Enum):
+    """Why a health probe ended the way it did.
+
+    A bare bool collapsed two answers a caller must tell apart. ``REFUSED``
+    comes back instantly and means nothing is listening, so retrying costs
+    nothing. ``TIMEOUT`` means something *is* listening but not answering, and
+    it charges the full budget every time -- a caller that retries it on every
+    turn makes the user pay for a server that will not respond.
+    """
+
+    OK = "ok"
+    REFUSED = "refused"
+    TIMEOUT = "timeout"
+    ERROR = "error"
+
+
+def probe_health(base_url: str, *, timeout: float = _PROBE_TIMEOUT_S) -> ProbeResult:
+    """Ask ``{base_url}/health`` whether a server is answering there."""
     import httpx
 
     try:
-        r = httpx.get(f"{base_url}/health", timeout=2.0)
-        return r.status_code == 200
+        r = httpx.get(f"{base_url}/health", timeout=timeout)
     except httpx.ConnectError:
-        return False
+        return ProbeResult.REFUSED
+    except httpx.TimeoutException:
+        return ProbeResult.TIMEOUT
     except Exception:
-        return False
+        return ProbeResult.ERROR
+    return ProbeResult.OK if r.status_code == 200 else ProbeResult.ERROR
+
+
+def _probe_health(base_url: str) -> bool:
+    """Liveness alone, for callers that have nothing to do with the reason.
+
+    A wrapper rather than a changed return type: every ``ProbeResult`` member is
+    truthy, so handing the enum to an existing ``if _probe_health(...)`` would
+    turn a refused connection into a pass.
+    """
+    return probe_health(base_url) is ProbeResult.OK
 
 
 def _lock_path() -> Path:
@@ -57,6 +90,15 @@ def server_log_path() -> Path:
     not exist.
     """
     return get_logs_dir() / "everos-server.log"
+
+
+class EverosBinaryMissingError(RuntimeError):
+    """The everos CLI is not installed where raven can reach it.
+
+    Distinct from a startup failure: no retry, probe, or wait resolves it, so a
+    caller that lumps it in with "server did not come up" keeps trying against
+    something that was never there.
+    """
 
 
 class EverosNotConfiguredError(RuntimeError):
@@ -111,7 +153,7 @@ def _everos_executable() -> str:
     found = shutil.which("everos")
     if found:
         return found
-    raise RuntimeError(
+    raise EverosBinaryMissingError(
         f"everos not found next to {Path(sys.executable).parent} or on PATH. Please install the everos CLI."
     )
 
@@ -260,6 +302,153 @@ def ome_lock_held(root: Path | str) -> bool:
         return True
 
 
+@dataclass(frozen=True)
+class LockHolder:
+    """The process serving a root's data, and where it can be reached.
+
+    ``port`` is ``None`` for a holder that takes the lock without serving HTTP
+    (``everos demo``, an embedded engine, a server still binding). That is a
+    real answer, not a missing one: it means the data is occupied and there is
+    nowhere to connect, which needs a different response from "it is over
+    there instead".
+    """
+
+    pid: int
+    cmdline: str
+    port: int | None
+
+
+def _lsof_lock_pid(lock: Path) -> int | None:
+    """The pid holding ``lock``, via ``lsof``. macOS ships it; Linux may not."""
+    lsof = shutil.which("lsof") or "/usr/sbin/lsof"
+    try:
+        out = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            [lsof, "-t", "--", str(lock)], capture_output=True, text=True, timeout=5
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    first = out.stdout.split()
+    return int(first[0]) if first and first[0].isdigit() else None
+
+
+def _proc_locks_pid(lock: Path) -> int | None:
+    """The pid holding ``lock``, via Linux ``/proc/locks``.
+
+    Preferred over ``lsof`` on Linux because it needs no external binary --
+    minimal container images routinely omit one. Matching is by inode, which is
+    what ``/proc/locks`` records; the path never appears there.
+    """
+    locks = Path("/proc/locks")
+    if not locks.exists():
+        return None
+    try:
+        target = lock.stat().st_ino
+        lines = locks.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    for line in lines:
+        fields = line.split()
+        # 1: FLOCK ADVISORY WRITE <pid> <major>:<minor>:<inode> 0 EOF
+        if len(fields) < 6:
+            continue
+        try:
+            pid = int(fields[4])
+            inode = int(fields[5].rsplit(":", 1)[-1])
+        except ValueError:
+            continue
+        if inode == target:
+            return pid
+    return None
+
+
+def _cmdline_of(pid: int) -> str:
+    """The full command line of ``pid``, or an empty string."""
+    ps = shutil.which("ps") or "/bin/ps"
+    try:
+        out = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            [ps, "-p", str(pid), "-o", "command="], capture_output=True, text=True, timeout=5
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return out.stdout.strip()
+
+
+def _listening_port(pid: int) -> int | None:
+    """The TCP port ``pid`` listens on, or ``None``.
+
+    ``-a`` is load-bearing: without it ``lsof`` ORs the ``-p`` and ``-i``
+    selectors and returns every file the process has open alongside every
+    socket on the machine.
+    """
+    lsof = shutil.which("lsof") or "/usr/sbin/lsof"
+    try:
+        out = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            [lsof, "-a", "-p", str(pid), "-iTCP", "-sTCP:LISTEN", "-P", "-n"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return _parse_listen_port(out.stdout)
+
+
+def _parse_listen_port(lsof_output: str) -> int | None:
+    """The port out of ``lsof -iTCP -sTCP:LISTEN`` output.
+
+    Scans each row's fields from the right for the first ``host:port``. The
+    address is not the last field -- ``(LISTEN)`` is -- and it is not at a fixed
+    index either, since the COMMAND column is padded to its widest value.
+    """
+    for line in lsof_output.splitlines()[1:]:
+        for field in reversed(line.split()):
+            _, sep, port = field.rpartition(":")
+            if sep and port.isdigit():
+                return int(port)
+    return None
+
+
+def _lock_holder_pid(lock: Path, root: Path) -> int | None:
+    """Who holds ``lock``, best source first.
+
+    The OS knows the answer regardless of what raven remembers, so it is asked
+    first; the pidfile is the fallback for when it cannot be reached. The
+    pidfile is also the only source that can be wrong about the root, so its
+    recorded root is checked before its pid is trusted.
+    """
+    pid = _lsof_lock_pid(lock) or _proc_locks_pid(lock)
+    if pid is not None:
+        return pid
+    record = _read_pidfile()
+    if not record or str(record.get("root")) != str(root):
+        return None
+    recorded = record.get("pid")
+    return recorded if isinstance(recorded, int) else None
+
+
+def lock_holder(root: Path | str) -> LockHolder | None:
+    """The process serving ``root``'s data, identified from the OS.
+
+    Answers the question ``find_recorded_server`` cannot: not "did raven start
+    this", but "who has the data". Losing the pidfile, moving the config
+    directory, or upgrading from a raven that kept no pidfile all leave the
+    lock intact, and the lock is what actually blocks a second instance.
+    """
+    resolved = Path(root).expanduser()
+    lock = resolved / ".index" / "sqlite" / "ome.db.lock"
+    if not lock.exists():
+        return None
+    pid = _lock_holder_pid(lock, resolved)
+    if pid is None:
+        return None
+    cmdline = _cmdline_of(pid)
+    # Both halves matter: the command has to be an everos server, and it has to
+    # be serving *this* root. A pid can be recycled onto anything.
+    if _SERVER_CMDLINE not in cmdline or str(resolved) not in cmdline:
+        return None
+    return LockHolder(pid=pid, cmdline=cmdline, port=_listening_port(pid))
+
+
 def _last_error_line() -> str:
     """The most recent exception line from the server log, or an empty string.
 
@@ -301,6 +490,29 @@ def _child_env() -> dict[str, str]:
     return env
 
 
+def _require_written_port(root: Path, want: int) -> None:
+    """Confirm ``[api].port`` really says ``want`` before spawning against it.
+
+    Dropping ``--port`` made the toml the single authority on where a server
+    listens, and that only holds while the file says what raven believes it
+    says. Without this check a write that did not land -- a permission error
+    swallowed upstream, a merge that dropped the section -- starts a server on
+    the template's 8000 while every reader looks for the configured port. That
+    is the exact drift the command-line override used to cause, arriving by a
+    quieter route.
+    """
+    import tomllib
+
+    path = Path(root) / "everos.toml"
+    try:
+        with path.open("rb") as fh:
+            written = (tomllib.load(fh).get("api") or {}).get("port")
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise RuntimeError(f"could not read back [api] from {path}: {exc}") from exc
+    if written != want:
+        raise RuntimeError(f"[api] write to {path} did not take effect: expected port {want}, read back {written!r}")
+
+
 def _start_server_if_unlocked(base_url: str) -> subprocess.Popen | None:
     """Try to acquire the startup lock and launch the server.
 
@@ -335,10 +547,12 @@ def _start_server_if_unlocked(base_url: str) -> subprocess.Popen | None:
             # are taken from the default URL rather than restated, so there is
             # one place that decides how loopback is spelled.
             _default = urlparse(DEFAULT_EVEROS_BASE_URL)
+            want_port = int(parsed.port or _default.port or 18791)
             set_everos_api(
                 host=parsed.hostname or _default.hostname or "localhost",
-                port=int(parsed.port or _default.port or 18791),
+                port=want_port,
             )
+            _require_written_port(root, want_port)
             log_path = server_log_path()
             log_path.parent.mkdir(parents=True, exist_ok=True)
             with open(log_path, "a") as log_file:
@@ -366,7 +580,7 @@ async def ensure_everos_server(
     *,
     timeout: float = 10.0,
     on_wait: Callable[[], None] | None = None,
-) -> None:
+) -> subprocess.Popen | None:
     """Make sure a server is answering at ``base_url``, starting one if not.
 
     ``base_url`` is required on purpose. It used to default to
@@ -396,7 +610,7 @@ async def ensure_everos_server(
     """
     if await asyncio.to_thread(_probe_health, base_url):
         logger.info("everos server already running at {}", base_url)
-        return
+        return None
 
     # Only on the spawn path: a server that answers /health has already built
     # its LLM client, so its credentials are proven by the probe above.
@@ -413,7 +627,7 @@ async def ensure_everos_server(
         elapsed += _POLL_INTERVAL
         if await asyncio.to_thread(_probe_health, base_url):
             logger.info("everos server ready at {}", base_url)
-            return
+            return proc
         # A dead child will never answer, so stop waiting on it. Without this
         # the caller paid the full timeout for a process that exited in under a
         # second -- once per session, silently. ``proc`` is None only when
@@ -439,7 +653,12 @@ async def ensure_everos_server(
 
 __all__ = [
     "DEFAULT_EVEROS_BASE_URL",
+    "ProbeResult",
+    "probe_health",
+    "EverosBinaryMissingError",
     "EverosNotConfiguredError",
+    "LockHolder",
     "StopOutcome",
     "ensure_everos_server",
+    "lock_holder",
 ]

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -348,7 +348,19 @@ def _proc_locks_pid(lock: Path) -> int | None:
         return None
     for line in lines:
         fields = line.split()
-        # 1: FLOCK ADVISORY WRITE <pid> <major>:<minor>:<inode> 0 EOF
+        # 3: FLOCK  ADVISORY  WRITE 1550263 fc:00:4980767 0 EOF
+        #                          ^pid     ^maj:min:inode
+        #
+        # A process blocked waiting on the same lock gets a row of its own,
+        # prefixed with "->", which shifts every field right by one:
+        #
+        # 2: -> FLOCK  ADVISORY  WRITE 1550264 fc:00:4980768 0 EOF
+        #
+        # Reading position 4 there yields the lock type rather than a pid, so
+        # int() rejects it and the waiter is skipped. That is the intended
+        # outcome and not a lucky accident to preserve by hand: the holder is
+        # who may be signalled, and handing back a waiter's pid would have the
+        # caller stop the wrong process.
         if len(fields) < 6:
             continue
         try:

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -52,7 +53,7 @@ def server_log_path() -> Path:
     return get_logs_dir() / "everos-server.log"
 
 
-class EverosNotConfigured(RuntimeError):
+class EverosNotConfiguredError(RuntimeError):
     """The memory LLM is missing, so no server could survive startup.
 
     A ``RuntimeError`` subclass on purpose: callers already treat that as
@@ -78,9 +79,8 @@ def _require_llm_configured() -> None:
 
     if everos_role_configured("llm"):
         return
-    raise EverosNotConfigured(
-        f"EverOS memory LLM is not configured: [llm] in {get_everos_config_path()} "
-        "needs both model and api_key."
+    raise EverosNotConfiguredError(
+        f"EverOS memory LLM is not configured: [llm] in {get_everos_config_path()} needs both model and api_key."
     )
 
 
@@ -106,17 +106,47 @@ def _everos_executable() -> str:
     if found:
         return found
     raise RuntimeError(
-        f"everos not found next to {Path(sys.executable).parent} or on PATH. "
-        "Please install the everos CLI."
+        f"everos not found next to {Path(sys.executable).parent} or on PATH. Please install the everos CLI."
     )
 
 
-def _start_server_if_unlocked(port: str) -> bool:
+_LOG_TAIL_BYTES = 65536
+_EXCEPTION_LINE = re.compile(r"^[\w.]+(Error|Exception)\b")
+
+
+def _last_error_line() -> str:
+    """The most recent exception line from the server log, or an empty string.
+
+    The poll loop knows *that* the child died; the reason only exists in the
+    log. Surfacing it beats telling the user to go read a file that is often
+    hundreds of kilobytes of tracebacks. Only the tail is read, and any failure
+    to read degrades to "no detail" rather than masking the original error.
+    """
+    try:
+        path = server_log_path()
+        with path.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            fh.seek(max(0, fh.tell() - _LOG_TAIL_BYTES))
+            tail = fh.read().decode("utf-8", "replace")
+    except OSError:
+        return ""
+    for line in reversed(tail.splitlines()):
+        stripped = line.strip()
+        if _EXCEPTION_LINE.match(stripped):
+            return stripped
+    return ""
+
+
+def _start_server_if_unlocked(port: str) -> subprocess.Popen | None:
     """Try to acquire the startup lock and launch the server.
 
-    Returns True if this process launched the server, False if the lock
-    was already held (another process is spawning).  Uses the cross-
-    platform ``portable_lock`` so Windows does not crash on import.
+    Returns the child process when this process launched it, or ``None`` when
+    the lock was already held (another process is spawning, so there is no child
+    of ours to watch). Uses the cross-platform ``portable_lock`` so Windows does
+    not crash on import.
+
+    The handle is returned rather than discarded so the caller can tell "still
+    booting" apart from "already dead" -- see :func:`ensure_everos_server`.
     """
     everos = _everos_executable()
 
@@ -125,17 +155,17 @@ def _start_server_if_unlocked(port: str) -> bool:
             log_path = server_log_path()
             log_path.parent.mkdir(parents=True, exist_ok=True)
             with open(log_path, "a") as log_file:
-                subprocess.Popen(
+                proc = subprocess.Popen(
                     [everos, "server", "start", "--port", port],
                     stdout=log_file,
                     stderr=subprocess.STDOUT,
                     start_new_session=True,
                 )
             logger.info("started everos server on port {} (log: {})", port, log_path)
-            return True
+            return proc
     except LockTimeoutError:
         logger.debug("everos server startup lock held by another process; skipping spawn")
-        return False
+        return None
 
 
 async def ensure_everos_server(
@@ -164,7 +194,7 @@ async def ensure_everos_server(
     _require_llm_configured()
 
     port = _extract_port(base_url)
-    await asyncio.to_thread(_start_server_if_unlocked, port)
+    proc = await asyncio.to_thread(_start_server_if_unlocked, port)
 
     elapsed = 0.0
     while elapsed < timeout:
@@ -173,13 +203,24 @@ async def ensure_everos_server(
         if await asyncio.to_thread(_probe_health, base_url):
             logger.info("everos server ready at {}", base_url)
             return
+        # A dead child will never answer, so stop waiting on it. Without this
+        # the caller paid the full timeout for a process that exited in under a
+        # second -- once per session, silently. ``proc`` is None only when
+        # another process holds the startup lock, in which case there is no
+        # child of ours to inspect and polling health is all we can do.
+        if proc is not None and proc.poll() is not None:
+            detail = await asyncio.to_thread(_last_error_line)
+            raise RuntimeError(
+                f"EverOS server exited with code {proc.returncode} while starting at {base_url}. "
+                + (f"{detail} " if detail else "")
+                + f"Full log: {server_log_path()}"
+            )
 
     raise RuntimeError(
-        f"EverOS server failed to start within {timeout}s at {base_url}. "
-        f"Check: (1) everos is installed (`uv run everos --help`), "
-        f"(2) port {port} is not occupied, "
-        f"(3) logs at {server_log_path()}"
+        f"EverOS server did not become healthy within {timeout}s at {base_url}. "
+        f"The process is still running; check that port {port} is not held by "
+        f"something else, and see {server_log_path()}"
     )
 
 
-__all__ = ["DEFAULT_EVEROS_BASE_URL", "EverosNotConfigured", "ensure_everos_server"]
+__all__ = ["DEFAULT_EVEROS_BASE_URL", "EverosNotConfiguredError", "ensure_everos_server"]

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -580,6 +580,7 @@ async def ensure_everos_server(
     *,
     timeout: float = 10.0,
     on_wait: Callable[[], None] | None = None,
+    on_proc: Callable[[subprocess.Popen], None] | None = None,
 ) -> subprocess.Popen | None:
     """Make sure a server is answering at ``base_url``, starting one if not.
 
@@ -603,6 +604,9 @@ async def ensure_everos_server(
     session of a machine's uptime. Measured cold start on a small store is
     around two seconds.
 
+    ``on_proc`` receives the spawned child the moment it exists, so a caller
+    still holds it when this function goes on to raise.
+
     ``on_wait`` fires once, only when an actual boot is about to be waited on --
     never when a server is already answering. That lets a caller narrate the
     wait without adding noise to the common case where there is nothing to wait
@@ -620,6 +624,12 @@ async def ensure_everos_server(
         on_wait()
 
     proc = await asyncio.to_thread(_start_server_if_unlocked, base_url)
+    # Handed over as soon as it exists, not only on the success return: a child
+    # that dies during boot makes this function raise, and a caller that learns
+    # of the handle only from the return value cannot then tell "already dead"
+    # from "still starting" -- which is the distinction it needs most.
+    if proc is not None and on_proc is not None:
+        on_proc(proc)
 
     elapsed = 0.0
     while elapsed < timeout:

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -660,6 +660,26 @@ class EverosBackend:
             await asyncio.to_thread(self._warn_if_recall_cannot_work, base_url)
 
     @staticmethod
+    def _warn_unowned_recall(base_url: str, report: Any) -> None:
+        """Say what a server the user runs cannot do, on its own authority.
+
+        No log path in the message: the log raven knows about is the one it
+        writes for servers it starts, and this is not one of those. Silence
+        from a server too old to report capabilities stays silence rather than
+        becoming a verdict.
+        """
+        if not report.reports_capabilities or report.available("embedding") is not False:
+            return
+        from rich.console import Console
+
+        Console(stderr=True).print(
+            "[yellow]The EverOS you run is up but embedding is unavailable: recall falls back "
+            "to keyword matching.[/yellow]\n"
+            "[dim]Memories are still stored. Fix the embedding provider in that server's own\n"
+            "config and restart it -- Raven follows along.[/dim]"
+        )
+
+    @staticmethod
     def _warn_if_recall_cannot_work(base_url: str) -> None:
         """Say out loud when the server is up but recall is not what it should be.
 
@@ -674,9 +694,18 @@ class EverosBackend:
         the user never configured is a choice they already know about, and
         repeating it every start would be noise.
         """
+        from raven.config.update_everos import everos_owned
         from raven.plugin.memory.everos._health import probe_capabilities
 
         report = probe_capabilities(base_url)
+        if not everos_owned():
+            # Their server, so the local toml is not evidence about it: no root
+            # is recorded, and everos_role_configured would read the fallback
+            # one -- the fabricated root doctor was fixed to stop trusting. It
+            # usually does not exist, so the gate read False and this warning,
+            # the only move raven has left on this path, never fired at all.
+            EverosBackend._warn_unowned_recall(base_url, report)
+            return
         from raven.config.update_everos import everos_role_configured
 
         if not (everos_role_configured("embedding") and report.available("embedding") is False):

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -398,15 +398,43 @@ class EverosBackend:
                 self._adapter = _NoOpAdapter()
                 return
 
-            from raven.plugin.memory.everos._server import ensure_everos_server
+            from rich.console import Console
 
+            from raven.plugin.memory.everos._server import (
+                EverosNotConfiguredError,
+                ensure_everos_server,
+            )
+
+            stderr = Console(stderr=True)
             base_url = self._config.get("base_url") or DEFAULT_EVEROS_BASE_URL
             try:
-                await ensure_everos_server(base_url)
+                # Narrate only a real wait. ``on_wait`` does not fire when a
+                # server is already answering, which is the common case -- a line
+                # there would be noise on every single session, and a healthy
+                # start is meant to be silent.
+                await ensure_everos_server(
+                    base_url,
+                    on_wait=lambda: stderr.print("[dim]Starting memory service...[/dim]"),
+                )
+            except EverosNotConfiguredError:
+                # Reachable out of the box: memory.backend defaults to "everos"
+                # while the shipped everos.toml has an empty [llm] api_key. The
+                # user can act on this, so say it here rather than only in the
+                # log the caller writes.
+                stderr.print(
+                    "[yellow]Long-term memory is off: its LLM is not configured.[/yellow]\n"
+                    "[dim]Run `raven onboard` to set it up.[/dim]"
+                )
+                self._adapter = _NoOpAdapter()
+                return
             except Exception as e:
                 self._logger.error(
                     "EverosBackend: failed to start EverOS server (%s)",
                     e,
+                )
+                stderr.print(
+                    f"[yellow]Memory service unavailable: {e}[/yellow]\n"
+                    "[dim]This session runs without long-term memory.[/dim]"
                 )
                 raise
             # Off-thread: the probe and the config read below are both blocking

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -30,6 +30,7 @@ import asyncio
 import logging
 import re
 import time
+from enum import Enum
 from types import SimpleNamespace
 from typing import Any, Literal, Protocol
 
@@ -121,6 +122,49 @@ def _jsonify(obj: Any) -> Any:
 
 _DEFAULT_HTTP_TIMEOUT_S: float = 60.0
 _MEMORIZE_TIMEOUT_S: float = 360.0
+
+# Per-operation budgets. One flat 60s covered both reads and writes, which made
+# every turn hostage to a service that answers slowly or not at all. These are
+# sized by what the caller loses when they run out: a read that overruns costs
+# the turn its recalled memory, a write that overruns costs that turn's memory
+# permanently, and neither is worth a minute of the user's time.
+_RECALL_TIMEOUT_S: float = 8.0
+_STORE_TIMEOUT_S: float = 10.0
+
+
+class ServiceState(Enum):
+    """Whether the memory service is usable, and what would change that.
+
+    Two axes are folded into one enum because callers only ever act on the
+    combination: may I send a request, and is it worth probing again. The
+    states that answer "no" to both -- ``UNCONFIGURED`` and ``NO_BINARY`` --
+    describe the installation rather than the process, so no amount of probing
+    resolves them and a stray success must not clear them.
+    """
+
+    UNKNOWN = "unknown"
+    READY = "ready"
+    STARTING = "starting"
+    FAILED = "failed"
+    UNRESPONSIVE = "unresponsive"
+    UNCONFIGURED = "unconfigured"
+    NO_BINARY = "no_binary"
+    FOREIGN = "foreign"
+
+
+# Probing cannot change these: they are facts about the install, not the
+# process. Letting a probe promote out of them would hide a missing binary
+# behind somebody else's server answering on the same port.
+_TERMINAL_STATES = frozenset({ServiceState.UNCONFIGURED, ServiceState.NO_BINARY})
+
+# Only the opening state may spawn. Every other non-ready state has already
+# either spawned once (STARTING / FAILED), found the data occupied
+# (UNRESPONSIVE), been told not to (FOREIGN), or knows a spawn cannot succeed.
+_SPAWNABLE_STATES = frozenset({ServiceState.UNKNOWN})
+
+# Minimum gap between out-of-band probes. Coarse on purpose: this exists to
+# stop a task per turn from piling up, not to schedule anything.
+_PROBE_MIN_INTERVAL_S: float = 2.0
 
 
 class _HttpEverosAdapter:
@@ -320,6 +364,21 @@ class EverosBackend:
         )
         self._turn_counts: dict[str, int] = {}
         self._feedback_noop_logged = False
+        # An injected adapter comes from a caller supplying its own transport,
+        # which is also a caller that owns whatever is on the other end: there
+        # is no server for this backend to probe or spawn. Production never
+        # takes this branch (``make_backend`` passes no adapter), so the state
+        # machine still governs every real session.
+        self._state: ServiceState = ServiceState.READY if adapter is not None else ServiceState.UNKNOWN
+        # The child raven spawned, when it spawned one. Kept past the start
+        # window so a later failure can ask "is it still booting or did it
+        # die" instead of guessing from how long it has been.
+        self._proc: Any | None = None
+        self._reported: set[ServiceState] = set()
+        self._probe_task: asyncio.Task | None = None
+        self._last_probe_at: float = 0.0
+        self._store_inflight: set[asyncio.Task] = set()
+        self._dropped_writes = 0
 
         if adapter is not None:
             self._adapter: _Adapter | None = adapter
@@ -342,6 +401,107 @@ class EverosBackend:
             api_key=api_key,
             timeout_s=timeout_s,
         )
+
+    # ── Service state ───────────────────────────────────────────────
+
+    def _apply_probe(self, result: Any) -> None:
+        """Move the state to whatever the probe just proved.
+
+        ``REFUSED`` is the only result that needs a second question. Nothing is
+        listening, but that is true both of a child still binding its port and
+        of one that exited a second ago, and the two want opposite responses --
+        wait, or stop and report. The child's exit code separates them; there is
+        no timing heuristic that does.
+        """
+        from raven.plugin.memory.everos._server import ProbeResult
+
+        if self._state in _TERMINAL_STATES:
+            return
+        if result is ProbeResult.OK:
+            self._state = ServiceState.READY
+            return
+        if result is ProbeResult.TIMEOUT:
+            self._state = ServiceState.UNRESPONSIVE
+            return
+        if result is ProbeResult.REFUSED:
+            self._state = self._state_from_child()
+            return
+        self._state = ServiceState.UNRESPONSIVE
+
+    def _state_from_child(self) -> ServiceState:
+        """``STARTING`` or ``FAILED``, per the spawned child's exit code.
+
+        ``None`` means no child of ours: either nothing was spawned yet, or
+        another process holds the spawn lock and is starting one. Neither is a
+        failure of ours to report, so both read as still starting.
+        """
+        if self._proc is None or self._proc.poll() is None:
+            return ServiceState.STARTING
+        return ServiceState.FAILED
+
+    def _may_spawn(self) -> bool:
+        """Whether starting a server could still help.
+
+        Guards against the loop where a child that dies on startup is spawned
+        again on the next turn, and again, filling the log with identical
+        tracebacks while the user waits.
+        """
+        return self._state in _SPAWNABLE_STATES
+
+    def _should_report(self) -> bool:
+        """True once per state per session, so a warning stays a warning."""
+        if self._state in self._reported:
+            return False
+        self._reported.add(self._state)
+        return True
+
+    def _kick_probe(self) -> None:
+        """Start an out-of-band probe, if one is not already due or running.
+
+        Fire-and-forget on purpose: the caller has already decided this turn
+        has no memory, and making it wait for confirmation would reintroduce
+        the stall the state machine exists to remove. The result lands in
+        ``_state`` and the next call benefits.
+        """
+        import time as _time
+
+        if self._state in _TERMINAL_STATES:
+            return
+        if self._probe_task is not None and not self._probe_task.done():
+            return
+        now = _time.monotonic()
+        if now - self._last_probe_at < _PROBE_MIN_INTERVAL_S:
+            return
+        self._last_probe_at = now
+        try:
+            self._probe_task = asyncio.get_running_loop().create_task(self._probe_once())
+        except RuntimeError:  # no running loop (sync context / teardown)
+            self._probe_task = None
+
+    async def _probe_once(self) -> None:
+        from raven.plugin.memory.everos._server import probe_health
+
+        base_url = self._config.get("base_url") or DEFAULT_EVEROS_BASE_URL
+        result = await asyncio.to_thread(probe_health, base_url)
+        self._apply_probe(result)
+
+    def _demote_from_exception(self, exc: BaseException) -> None:
+        """Classify a request failure the same way a probe would.
+
+        A read that fails and a probe that fails are the same observation
+        arriving through different doors, so they must not disagree about what
+        state the service is in.
+        """
+        import httpx
+
+        from raven.plugin.memory.everos._server import ProbeResult
+
+        if isinstance(exc, (httpx.TimeoutException, asyncio.TimeoutError)):
+            self._apply_probe(ProbeResult.TIMEOUT)
+        elif isinstance(exc, httpx.ConnectError):
+            self._apply_probe(ProbeResult.REFUSED)
+        else:
+            self._apply_probe(ProbeResult.ERROR)
 
     def _warn_stale_identity_keys(self) -> None:
         """Surface a config left over from before identity moved to the host.
@@ -400,8 +560,9 @@ class EverosBackend:
 
             from rich.console import Console
 
-            from raven.config.update_everos import everos_declared_address, everos_owned
+            from raven.config.update_everos import everos_owned
             from raven.plugin.memory.everos._server import (
+                EverosBinaryMissingError,
                 EverosNotConfiguredError,
                 ensure_everos_server,
             )
@@ -413,22 +574,24 @@ class EverosBackend:
                 # A root the user manages: connect if a server is up, never start
                 # one. Starting it would take the OME jobstore lock exclusively,
                 # which is theirs to grant, not raven's to assume.
-                from raven.plugin.memory.everos._server import _probe_health
+                from raven.plugin.memory.everos._server import ProbeResult, probe_health
 
-                if await asyncio.to_thread(_probe_health, base_url):
+                if await asyncio.to_thread(probe_health, base_url) is ProbeResult.OK:
+                    self._state = ServiceState.READY
                     # Say what it can actually do, exactly as the owned path
                     # does. The argument for the warning is stronger here, not
                     # weaker: raven cannot repair someone else's embedding
                     # config, so telling them is the only move it has.
                     await asyncio.to_thread(self._warn_if_recall_cannot_work, base_url)
                     return
-                declared = await asyncio.to_thread(everos_declared_address)
-                where = declared or base_url
+                # FOREIGN, not NoOp: raven still must not start this server, but
+                # the user may start it themselves mid-session, and the probe
+                # that notices needs an adapter left to use.
+                self._state = ServiceState.FOREIGN
                 stderr.print(
-                    f"[yellow]Long-term memory is off: the EverOS you manage is not running at {where}.[/yellow]\n"
+                    f"[yellow]Long-term memory is off: the EverOS you manage is not running at {base_url}.[/yellow]\n"
                     "[dim]Start it yourself and Raven will use it; Raven does not start or stop it.[/dim]"
                 )
-                self._adapter = _NoOpAdapter()
                 return
 
             try:
@@ -436,31 +599,48 @@ class EverosBackend:
                 # server is already answering, which is the common case -- a line
                 # there would be noise on every single session, and a healthy
                 # start is meant to be silent.
-                await ensure_everos_server(
+                self._proc = await ensure_everos_server(
                     base_url,
                     on_wait=lambda: stderr.print("[dim]Starting memory service...[/dim]"),
                 )
+                self._state = ServiceState.READY
             except EverosNotConfiguredError:
                 # Reachable out of the box: memory.backend defaults to "everos"
                 # while the shipped everos.toml has an empty [llm] api_key. The
                 # user can act on this, so say it here rather than only in the
                 # log the caller writes.
+                self._state = ServiceState.UNCONFIGURED
                 stderr.print(
                     "[yellow]Long-term memory is off: its LLM is not configured.[/yellow]\n"
                     "[dim]Run `raven onboard` to set it up.[/dim]"
                 )
-                self._adapter = _NoOpAdapter()
+                return
+            except EverosBinaryMissingError as e:
+                # An install problem, not a startup problem: no probe and no
+                # retry can resolve it, so it must not be filed with the states
+                # that keep trying.
+                self._state = ServiceState.NO_BINARY
+                stderr.print(
+                    f"[yellow]Long-term memory is off: {e}[/yellow]\n"
+                    "[dim]Install the everos CLI, then start a new session.[/dim]"
+                )
                 return
             except Exception as e:
+                # Not raised on: the session continues without memory, and the
+                # state machine keeps probing in case the server comes up. The
+                # old ``raise`` cost the caller a traceback for a degradation it
+                # already handles.
+                self._state = self._state_from_child()
                 self._logger.error(
-                    "EverosBackend: failed to start EverOS server (%s)",
+                    "EverosBackend: failed to start EverOS server (%s); state=%s",
                     e,
+                    self._state.value,
                 )
                 stderr.print(
                     f"[yellow]Memory service unavailable: {e}[/yellow]\n"
-                    "[dim]This session runs without long-term memory.[/dim]"
+                    "[dim]This session starts without long-term memory; Raven retries in the background.[/dim]"
                 )
-                raise
+                return
             # Off-thread: the probe and the config read below are both blocking
             # IO, and start() runs on the loop every session begins on.
             await asyncio.to_thread(self._warn_if_recall_cannot_work, base_url)
@@ -500,6 +680,19 @@ class EverosBackend:
 
     async def stop(self) -> None:
         self._logger.info("EverosBackend.stop")
+        if self._probe_task is not None and not self._probe_task.done():
+            self._probe_task.cancel()
+        if self._dropped_writes:
+            # Said out loud, once, at the only moment it is still actionable.
+            # A dropped write is a conversation the user will never be able to
+            # recall, and until now that fact lived only in a log file the TUI
+            # does not even print to the terminal.
+            from rich.console import Console
+
+            Console(stderr=True).print(
+                f"[yellow]{self._dropped_writes} turn(s) were not written to long-term memory "
+                "because the memory service was unavailable.[/yellow]"
+            )
         aclose = getattr(self._adapter, "aclose", None)
         if aclose is not None:
             try:
@@ -540,17 +733,29 @@ class EverosBackend:
         owner_type: _OwnerType = "user" if user_id is not None else "agent"
         if self._adapter is None:
             return []  # adapter still building (start() not finished); degrade to no hits
+        if self._state is not ServiceState.READY:
+            # Nothing to wait for and nothing to pay: the turn gets no memory,
+            # and a probe goes out of band so the next turn might. This is what
+            # replaces swapping in a no-op adapter, which ended the session's
+            # chance of recovering the moment one start failed.
+            self._kick_probe()
+            return []
         try:
-            data = await self._adapter.search(
-                user_id=user_id,
-                agent_id=agent_id,
-                query=query,
-                top_k=top_k,
+            data = await asyncio.wait_for(
+                self._adapter.search(
+                    user_id=user_id,
+                    agent_id=agent_id,
+                    query=query,
+                    top_k=top_k,
+                ),
+                timeout=_RECALL_TIMEOUT_S,
             )
-        except Exception as e:
+        except (Exception, asyncio.TimeoutError) as e:
+            self._demote_from_exception(e)
             self._logger.warning(
-                "EverosBackend.recall failed (%s); returning empty",
+                "EverosBackend.recall failed (%s); state=%s; returning empty",
                 e,
+                self._state.value,
             )
             return []
         if data is None:
@@ -588,6 +793,13 @@ class EverosBackend:
             return
         if self._adapter is None:
             return
+        if self._state is not ServiceState.READY:
+            # Counted rather than logged and forgotten: a dropped write is a
+            # turn the user will never be able to recall, and the only place
+            # that fact can still be told to them is the end of the session.
+            self._dropped_writes += 1
+            self._kick_probe()
+            return
         if metadata and "is_final" in metadata:
             is_final = bool(metadata["is_final"])
         else:
@@ -595,13 +807,25 @@ class EverosBackend:
             self._turn_counts[session_id] = n
             is_final = self._flush_every_turns > 0 and n % self._flush_every_turns == 0
 
-        await self._adapter.memorize(
-            session_id,
-            payload,
-            is_final=is_final,
-            app_id=metadata.get("app_id") if metadata else None,
-            project_id=metadata.get("project_id") if metadata else None,
-        )
+        try:
+            await asyncio.wait_for(
+                self._adapter.memorize(
+                    session_id,
+                    payload,
+                    is_final=is_final,
+                    app_id=metadata.get("app_id") if metadata else None,
+                    project_id=metadata.get("project_id") if metadata else None,
+                ),
+                timeout=_STORE_TIMEOUT_S,
+            )
+        except (Exception, asyncio.TimeoutError) as e:
+            self._demote_from_exception(e)
+            self._dropped_writes += 1
+            self._logger.warning(
+                "EverosBackend.store failed (%s); state=%s; this turn was not indexed",
+                e,
+                self._state.value,
+            )
 
     async def feedback(self, signals: dict[str, Any]) -> None:
         """Deliberate no-op pending an upstream everos feedback sink.

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -416,6 +416,11 @@ class EverosBackend:
                 from raven.plugin.memory.everos._server import _probe_health
 
                 if await asyncio.to_thread(_probe_health, base_url):
+                    # Say what it can actually do, exactly as the owned path
+                    # does. The argument for the warning is stronger here, not
+                    # weaker: raven cannot repair someone else's embedding
+                    # config, so telling them is the only move it has.
+                    await asyncio.to_thread(self._warn_if_recall_cannot_work, base_url)
                     return
                 declared = await asyncio.to_thread(everos_declared_address)
                 where = declared or base_url

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -768,8 +768,13 @@ class EverosBackend:
         messages: list[dict[str, Any]],
         *,
         metadata: dict[str, Any] | None = None,
-    ) -> None:
+    ) -> bool:
         """Forward a turn's messages to EverOS for indexing.
+
+        Returns whether the slice landed. A caller that cannot act on the answer
+        is free to discard it -- the protocol is still fire-and-forget per call
+        -- but one whose resume state marks a source done needs to know, or a
+        dropped write erases the only record that the source is still pending.
 
         EverOS partitions internally by message sender (user-track vs
         agent-track); we don't need to specify ``owner_type`` here. We
@@ -783,23 +788,26 @@ class EverosBackend:
         skip the adapter call entirely.
         """
         if not messages:
-            return
+            return True
         payload = self._convert_messages(
             messages,
             agent_id=self._agent_id,
             user_id=self._user_id,
         )
         if not payload:
-            return
+            # Nothing to write is not a failed write: the conversion drops
+            # system messages, and a slice that is empty afterwards must not
+            # be reported as a source that needs retrying.
+            return True
         if self._adapter is None:
-            return
+            return False
         if self._state is not ServiceState.READY:
             # Counted rather than logged and forgotten: a dropped write is a
             # turn the user will never be able to recall, and the only place
             # that fact can still be told to them is the end of the session.
             self._dropped_writes += 1
             self._kick_probe()
-            return
+            return False
         if metadata and "is_final" in metadata:
             is_final = bool(metadata["is_final"])
         else:
@@ -826,6 +834,8 @@ class EverosBackend:
                 e,
                 self._state.value,
             )
+            return False
+        return True
 
     async def feedback(self, signals: dict[str, Any]) -> None:
         """Deliberate no-op pending an upstream everos feedback sink.

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -400,6 +400,7 @@ class EverosBackend:
 
             from rich.console import Console
 
+            from raven.config.update_everos import everos_declared_address, everos_owned
             from raven.plugin.memory.everos._server import (
                 EverosNotConfiguredError,
                 ensure_everos_server,
@@ -407,6 +408,24 @@ class EverosBackend:
 
             stderr = Console(stderr=True)
             base_url = self._config.get("base_url") or DEFAULT_EVEROS_BASE_URL
+
+            if not everos_owned():
+                # A root the user manages: connect if a server is up, never start
+                # one. Starting it would take the OME jobstore lock exclusively,
+                # which is theirs to grant, not raven's to assume.
+                from raven.plugin.memory.everos._server import _probe_health
+
+                if await asyncio.to_thread(_probe_health, base_url):
+                    return
+                declared = await asyncio.to_thread(everos_declared_address)
+                where = declared or base_url
+                stderr.print(
+                    f"[yellow]Long-term memory is off: the EverOS you manage is not running at {where}.[/yellow]\n"
+                    "[dim]Start it yourself and Raven will use it; Raven does not start or stop it.[/dim]"
+                )
+                self._adapter = _NoOpAdapter()
+                return
+
             try:
                 # Narrate only a real wait. ``on_wait`` does not fire when a
                 # server is already answering, which is the common case -- a line
@@ -828,10 +847,19 @@ def make_backend(ctx: PluginContext) -> EverosBackend:
     """Plugin entry-point factory. Called by :class:`PluginRegistry`
     after manifest activation. Sync construction only — async setup
     happens in ``EverosBackend.start()``."""
-    from raven.config.update_everos import configure_everos_env, ensure_everos_home
+    from raven.config.update_everos import (
+        configure_everos_env,
+        ensure_everos_home,
+        everos_owned,
+        everos_root,
+    )
 
-    configure_everos_env()
-    ensure_everos_home()
+    root = everos_root()
+    configure_everos_env(root)
+    # See tools.py: a root the user manages is read-only, template files
+    # included.
+    if everos_owned():
+        ensure_everos_home(root)
     return EverosBackend(ctx)
 
 

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -166,6 +166,11 @@ _SPAWNABLE_STATES = frozenset({ServiceState.UNKNOWN})
 # stop a task per turn from piling up, not to schedule anything.
 _PROBE_MIN_INTERVAL_S: float = 2.0
 
+# States where no write was ever going to land, so nothing was lost. Reporting
+# a loss here would tell an install that never configured a memory LLM that it
+# dropped turns of memory it never had.
+_NEVER_HAD_MEMORY = frozenset({ServiceState.UNCONFIGURED, ServiceState.NO_BINARY})
+
 
 class _HttpEverosAdapter:
     """Adapter that talks to a remote EverOS service over HTTP.
@@ -439,6 +444,10 @@ class EverosBackend:
             return ServiceState.STARTING
         return ServiceState.FAILED
 
+    def _remember_child(self, proc: Any) -> None:
+        """Hold the spawned child, even if the start it belongs to then fails."""
+        self._proc = proc
+
     def _may_spawn(self) -> bool:
         """Whether starting a server could still help.
 
@@ -599,9 +608,14 @@ class EverosBackend:
                 # server is already answering, which is the common case -- a line
                 # there would be noise on every single session, and a healthy
                 # start is meant to be silent.
+                # on_proc rather than the return value: when the child dies on
+                # startup the call raises, and an assignment from its result
+                # never happens -- leaving the handler unable to tell a dead
+                # child from one still booting.
                 self._proc = await ensure_everos_server(
                     base_url,
                     on_wait=lambda: stderr.print("[dim]Starting memory service...[/dim]"),
+                    on_proc=self._remember_child,
                 )
                 self._state = ServiceState.READY
             except EverosNotConfiguredError:
@@ -805,7 +819,11 @@ class EverosBackend:
             # Counted rather than logged and forgotten: a dropped write is a
             # turn the user will never be able to recall, and the only place
             # that fact can still be told to them is the end of the session.
-            self._dropped_writes += 1
+            # Not counted when the service was never configured or installed --
+            # there was no memory to lose, and saying otherwise tells a fresh
+            # install it lost something it never had.
+            if self._state not in _NEVER_HAD_MEMORY:
+                self._dropped_writes += 1
             self._kick_probe()
             return False
         if metadata and "is_final" in metadata:
@@ -815,6 +833,10 @@ class EverosBackend:
             self._turn_counts[session_id] = n
             is_final = self._flush_every_turns > 0 and n % self._flush_every_turns == 0
 
+        # A per-turn append must not hold a turn open; a final flush is the call
+        # that makes EverOS extract, which is what the six-minute budget was
+        # sized for. One number for both silently overrode the other.
+        budget = _MEMORIZE_TIMEOUT_S if is_final else _STORE_TIMEOUT_S
         try:
             await asyncio.wait_for(
                 self._adapter.memorize(
@@ -824,9 +846,19 @@ class EverosBackend:
                     app_id=metadata.get("app_id") if metadata else None,
                     project_id=metadata.get("project_id") if metadata else None,
                 ),
-                timeout=_STORE_TIMEOUT_S,
+                timeout=budget,
             )
-        except (Exception, asyncio.TimeoutError) as e:
+        except asyncio.TimeoutError:
+            # Deliberately not a demotion: an extraction that outran its budget
+            # is slow, not absent, and demoting would drop the next write too --
+            # turning one slow batch into the loss of the batch behind it.
+            self._dropped_writes += 1
+            self._logger.warning(
+                "EverosBackend.store timed out after %ss; this turn was not indexed",
+                budget,
+            )
+            return False
+        except Exception as e:
             self._demote_from_exception(e)
             self._dropped_writes += 1
             self._logger.warning(

--- a/raven/plugin/memory/everos/tools.py
+++ b/raven/plugin/memory/everos/tools.py
@@ -125,10 +125,21 @@ def make_understand_media_tool(ctx: Any) -> Tool | None:
     del ctx
     # Point EverOS at raven's ~/.everos/raven home before any everos import
     # resolves settings (the multimodal parser/LLM read EVEROS_* at call time).
-    from raven.config.update_everos import configure_everos_env, ensure_everos_home
+    from raven.config.update_everos import (
+        configure_everos_env,
+        ensure_everos_home,
+        everos_owned,
+        everos_root,
+    )
 
-    configure_everos_env()
-    ensure_everos_home()
+    root = everos_root()
+    configure_everos_env(root)
+    # Templates only into a root raven owns. Multimodal parsing reads the same
+    # EverOS config the memory does -- one machine, one user, one set of keys --
+    # but reusing a root the user manages must not write to it, and "the files
+    # are usually already there" is not a basis for that promise.
+    if everos_owned():
+        ensure_everos_home(root)
     if not _multimodal_available():
         return None
     return UnderstandMediaTool()

--- a/tests/test_agent_loop_backend_dispatch.py
+++ b/tests/test_agent_loop_backend_dispatch.py
@@ -171,3 +171,78 @@ class TestLegacyCompat:
         assert isinstance(agent.memory_consolidator, MemoryConsolidator)
         assert agent.context.skills is not None
         assert agent.backend is None
+
+
+class TestTheTurnDoesNotWaitOnIndexing:
+    """Indexing a turn must not hold the turn open.
+
+    ``backend.store`` was awaited inline in the after-turn pipeline with a 60s
+    HTTP budget, so a memory service that hung stalled the end of every turn --
+    and on the no-model delivery path the await sat *before* ``emit``, so it
+    stalled the user seeing the reply at all. The write still gets its own
+    budget; what changed is that the turn stops paying for it.
+    """
+
+    async def test_a_slow_write_releases_the_turn(self, tmp_path: Path, monkeypatch) -> None:
+        import asyncio
+
+        from raven.agent.loop import main as loop_main
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        class _SlowBackend:
+            def __init__(self) -> None:
+                self.finished = False
+
+            async def store(self, session_id, messages, **kw):
+                started.set()
+                await release.wait()
+                self.finished = True
+
+        b = _SlowBackend()
+        agent = _make_loop(tmp_path, backend=b)
+        monkeypatch.setattr(loop_main, "_STORE_TURN_BUDGET_S", 0.05)
+
+        await agent._dispatch_backend_store("s", [{"role": "user", "content": "hi"}])
+
+        assert started.is_set(), "the write should have been launched"
+        assert not b.finished, "the turn returned before the write finished"
+
+        release.set()
+        await asyncio.gather(*agent._store_inflight)
+        assert b.finished
+
+    async def test_a_fast_write_still_completes_within_the_turn(self, tmp_path: Path) -> None:
+        """The budget is an upper bound, not a delay: a healthy write finishes
+        inside the turn exactly as it did before."""
+        b = _FakeBackend()
+        agent = _make_loop(tmp_path, backend=b)
+        await agent._dispatch_backend_store("s", [{"role": "user", "content": "hi"}])
+        assert len(b.store_calls) == 1
+
+    async def test_outstanding_writes_are_drained_on_teardown(self, tmp_path: Path, monkeypatch) -> None:
+        """A detached write that outlives the turn must not outlive the process:
+        without a drain, exiting right after a slow turn silently loses it."""
+        import asyncio
+
+        from raven.agent.loop import main as loop_main
+
+        release = asyncio.Event()
+
+        class _SlowBackend:
+            def __init__(self) -> None:
+                self.finished = False
+
+            async def store(self, session_id, messages, **kw):
+                await release.wait()
+                self.finished = True
+
+        b = _SlowBackend()
+        agent = _make_loop(tmp_path, backend=b)
+        monkeypatch.setattr(loop_main, "_STORE_TURN_BUDGET_S", 0.05)
+        await agent._dispatch_backend_store("s", [{"role": "user", "content": "hi"}])
+
+        release.set()
+        await agent.drain_backend_stores()
+        assert b.finished

--- a/tests/test_agent_loop_backend_dispatch.py
+++ b/tests/test_agent_loop_backend_dispatch.py
@@ -246,3 +246,40 @@ class TestTheTurnDoesNotWaitOnIndexing:
         release.set()
         await agent.drain_backend_stores()
         assert b.finished
+
+
+class TestBackpressureCannotStallATurn:
+    """The queue may stop growing; the turn may not stop.
+
+    The backpressure wait had no timeout, so its real bound was the slowest
+    outstanding write's own budget. With ``flush_every_turns`` defaulting to 1
+    every interactive turn is a final flush, which carries the six-minute
+    extraction budget -- so once the in-flight cap was reached, a turn waited
+    minutes on a wedged extraction. That is the stall this whole change exists
+    to remove, reintroduced one layer down.
+    """
+
+    async def test_no_dispatch_exceeds_the_turn_budget(self, tmp_path: Path, monkeypatch) -> None:
+        import asyncio
+        import time
+
+        from raven.agent.loop import main as loop_main
+
+        class _Slow:
+            async def store(self, session_id, messages, **kw):
+                await asyncio.sleep(30)
+
+        agent = _make_loop(tmp_path, backend=_Slow())
+        monkeypatch.setattr(loop_main, "_STORE_TURN_BUDGET_S", 0.2)
+
+        elapsed = []
+        for _ in range(loop_main._STORE_MAX_INFLIGHT + 2):
+            t0 = time.monotonic()
+            await agent._dispatch_backend_store("s", [{"role": "user", "content": "hi"}])
+            elapsed.append(time.monotonic() - t0)
+
+        for task in agent._store_inflight:
+            task.cancel()
+
+        worst = max(elapsed)
+        assert worst < 2.0, f"a turn waited {worst:.1f}s on indexing; per-dispatch: {[round(e, 2) for e in elapsed]}"

--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -596,3 +596,71 @@ class TestDoctorDoesNotInventASelfManagedRoot:
 
         assert info.root is None
         assert info.retrieval is None
+
+
+class TestASelfManagedServerCanStillBeBroken:
+    """ "What the server knows about" and "what it built" must not be one list.
+
+    For a not-owned install ``configured`` was the sections the server reports
+    as available, and ``unbuilt`` the subset of those it reports as
+    unavailable. Over one capability map those conditions are mutually
+    exclusive, so ``unbuilt`` -- and with it ``broken`` and the exit code --
+    was structurally always empty. A self-managed server whose LLM failed to
+    build reported healthy, and any CI gating on ``raven doctor`` saw green.
+
+    Raven cannot read their toml to learn what they configured. It does not
+    have to: a server that reports a section as unavailable tried to build it
+    and failed, and that is the same evidence.
+    """
+
+    @staticmethod
+    def _info(monkeypatch, caps: dict):
+        from raven.cli import doctor_commands as dc
+        from raven.plugin.memory.everos import _health
+
+        monkeypatch.setattr("raven.config.update_everos.everos_owned", lambda: False)
+        monkeypatch.setattr(
+            _health,
+            "probe_capabilities",
+            lambda *_a, **_kw: _health.CapabilityReport(reachable=True, capabilities=caps),
+        )
+        return dc._probe_memory(SimpleNamespace(memory=SimpleNamespace(backend="everos")))
+
+    def test_a_failed_required_role_is_reported_as_broken(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        info = self._info(monkeypatch, {"llm": False, "embed": True})
+
+        assert "llm" in info.unbuilt
+        assert info.broken == ["llm"], "a server that cannot build its LLM reported healthy"
+
+    def test_it_reaches_the_exit_code(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from raven.cli import doctor_commands as dc
+
+        info = self._info(monkeypatch, {"llm": False, "embed": True})
+        report = dc.DoctorReport()
+        # The earlier gates return first; this case is about the memory one.
+        report.paths = SimpleNamespace(config_exists=True, config_valid=True)
+        report.config_loaded = True
+        report.routing = SimpleNamespace(provider="openai")
+        report.memory = info
+
+        assert report.exit_code() == 2, "doctor exited 0 with a memory service that cannot work"
+
+    def test_a_failed_optional_role_costs_quality_not_function(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        info = self._info(monkeypatch, {"llm": True, "embed": False})
+
+        assert "embedding" in info.unbuilt
+        assert info.broken == [], "a missing embedding is a worse memory, not a broken one"
+
+    def test_a_working_server_is_not_accused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        info = self._info(monkeypatch, {"llm": True, "embed": True})
+
+        assert info.unbuilt == []
+
+    def test_a_role_the_server_says_nothing_about_is_not_claimed_either_way(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``rerank`` absent from the map is silence, not a failure."""
+        info = self._info(monkeypatch, {"llm": True, "embed": True})
+
+        assert "rerank" not in info.configured
+        assert "rerank" not in info.unbuilt

--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -284,6 +284,49 @@ def test_doctor_reports_a_reachable_memory_server(healthy_config: Path, no_memor
     assert "running" in r.stdout
 
 
+def test_doctor_answers_where_the_memories_are(healthy_config: Path, no_memory_server, tmp_path) -> None:
+    """Nothing used to answer this. The wizard printed the root once while
+    converging and no command showed it again, so a user asking "where are my
+    memories" had to read config.json by hand. Doctor is where that question
+    gets asked."""
+    from raven.config import update_everos as ue
+
+    _configured(no_memory_server, "llm")
+    _capabilities(no_memory_server, llm=True)
+    no_memory_server.setattr(ue, "everos_root", lambda: tmp_path / "mem-root")
+    no_memory_server.setattr(ue, "everos_owned", lambda: True)
+
+    r = runner.invoke(app, ["doctor"])
+
+    assert r.exit_code == 0, r.stdout
+    # Asserting the tail segment, not the whole path: rich wraps long paths and
+    # the full string is not contiguous in stdout.
+    assert "Memories:" in r.stdout
+    assert "mem-root" in r.stdout
+    assert "Address:" in r.stdout
+    assert "Managed by you" not in r.stdout
+
+
+def test_doctor_says_when_the_memories_are_not_ravens_to_touch(
+    healthy_config: Path, no_memory_server, tmp_path
+) -> None:
+    """A user-managed root is read-only, and doctor is the one place a user is
+    asking about state rather than being walked through a decision -- so it has to
+    say which of the two situations they are in."""
+    from raven.config import update_everos as ue
+
+    _configured(no_memory_server, "llm")
+    _capabilities(no_memory_server, llm=True)
+    no_memory_server.setattr(ue, "everos_root", lambda: tmp_path / "theirs")
+    no_memory_server.setattr(ue, "everos_owned", lambda: False)
+
+    r = runner.invoke(app, ["doctor"])
+
+    out = " ".join(r.stdout.split())
+    assert "Managed by you" in out
+    assert "never writes or restarts it" in out
+
+
 def test_an_unbuilt_optional_role_is_reported_without_failing(healthy_config: Path, no_memory_server) -> None:
     """Without embedding the adapter searches lexically instead of semantically:
     weaker memory, not broken memory. Worth saying, not worth an exit code."""

--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from typer.testing import CliRunner
@@ -324,7 +325,9 @@ def test_doctor_says_when_the_memories_are_not_ravens_to_touch(
 
     out = " ".join(r.stdout.split())
     assert "Managed by you" in out
-    assert "never writes or restarts it" in out
+    assert "never writes, starts or stops it" in out
+    # And it must not name a directory: nothing records where their memories live.
+    assert str(tmp_path / "theirs") not in out
 
 
 def test_an_unbuilt_optional_role_is_reported_without_failing(healthy_config: Path, no_memory_server) -> None:
@@ -530,3 +533,66 @@ def test_memory_retrieval_reaches_the_json_output(tmp_path: Path) -> None:
     )
     payload = json.loads(r.stdout[r.stdout.index("{") :])
     assert payload["memory"]["retrieval"] == "keyword-only"
+
+
+class TestDoctorDoesNotInventASelfManagedRoot:
+    """A self-managed install records no root, so doctor must not name one.
+
+    ``everos_root()`` answers with a fallback when nothing is recorded, which
+    is right for the code that needs somewhere to write and wrong for the code
+    that reports where the memories are. Printing it labelled "Managed by you"
+    points the user at a directory that is not theirs and has nothing in it.
+
+    The roles are worse than cosmetic. They were read out of that same
+    fabricated root's toml, so an install whose server has embedding
+    configured was told its recall was keyword-only. Doctor cannot read the
+    user's toml -- that is the whole read-only promise -- so what the server
+    reports about itself is the only honest source.
+    """
+
+    @staticmethod
+    def _collect(monkeypatch, *, caps: dict, reachable: bool = True):
+        from raven.cli import doctor_commands as dc
+
+        monkeypatch.setattr("raven.config.update_everos.everos_owned", lambda: False)
+        monkeypatch.setattr("raven.config.update_everos.everos_root", lambda: Path("/fallback/everos"))
+        monkeypatch.setattr(
+            "raven.config.update_everos.everos_role_configured",
+            lambda _s: pytest.fail("read the local toml for a root raven does not own"),
+        )
+        from raven.plugin.memory.everos import _health
+
+        monkeypatch.setattr(
+            _health,
+            "probe_capabilities",
+            # reports_capabilities is derived from capabilities, not a field.
+            lambda *_a, **_kw: _health.CapabilityReport(reachable=reachable, capabilities=caps),
+        )
+        return dc
+
+    def test_no_root_is_claimed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dc = self._collect(monkeypatch, caps={"llm": True, "embed": True})
+        info = dc._probe_memory(SimpleNamespace(memory=SimpleNamespace(backend="everos")))
+
+        assert info.root is None, "named a directory for an install that records none"
+
+    def test_retrieval_follows_what_the_server_reports(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dc = self._collect(monkeypatch, caps={"llm": True, "embed": True})
+        info = dc._probe_memory(SimpleNamespace(memory=SimpleNamespace(backend="everos")))
+
+        assert info.retrieval == "semantic", "told the user recall was keyword-only while the server has embedding"
+
+    def test_no_embedding_on_the_server_reads_as_keyword_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dc = self._collect(monkeypatch, caps={"llm": True, "embed": False})
+        info = dc._probe_memory(SimpleNamespace(memory=SimpleNamespace(backend="everos")))
+
+        assert info.retrieval == "keyword-only"
+
+    def test_an_unreachable_server_claims_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Down is not the same as misconfigured. With nothing to ask, doctor
+        has no basis for either answer and must not pick one."""
+        dc = self._collect(monkeypatch, caps={}, reachable=False)
+        info = dc._probe_memory(SimpleNamespace(memory=SimpleNamespace(backend="everos")))
+
+        assert info.root is None
+        assert info.retrieval is None

--- a/tests/test_cli_import_commands.py
+++ b/tests/test_cli_import_commands.py
@@ -974,3 +974,51 @@ class TestStatusCancelled:
             result = runner.invoke(import_app, ["status"])
         assert result.exit_code == 0
         assert "Cancelled" in result.output or "cancelled" in result.output
+
+
+class TestImportRefusesToRunWithoutMemory:
+    """An import against an unavailable memory service must not start.
+
+    The guard here caught an exception from ``backend.start()``. Once start
+    stopped raising -- it degrades and keeps probing, which is right for a
+    session -- the guard became unreachable, and an import would walk the whole
+    source list writing into nothing. An import is not a session: it is one
+    deliberate batch whose entire value is that the writes land.
+    """
+
+    def test_a_backend_that_is_not_ready_stops_the_run(self) -> None:
+        import typer
+
+        from raven.cli.import_commands import _require_memory_service_ready
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        class _NotReady:
+            _state = ServiceState.FAILED
+
+        with pytest.raises(typer.Exit):
+            _require_memory_service_ready(_NotReady())
+
+    def test_a_ready_backend_passes(self) -> None:
+        from raven.cli.import_commands import _require_memory_service_ready
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        class _Ready:
+            _state = ServiceState.READY
+
+        _require_memory_service_ready(_Ready())
+
+    def test_a_backend_with_no_state_is_allowed(self) -> None:
+        """Only the everos backend reports a state. A third-party backend that
+        does not must not be locked out of importing."""
+        from raven.cli.import_commands import _require_memory_service_ready
+
+        _require_memory_service_ready(object())
+
+    def test_the_run_path_consults_the_guard(self) -> None:
+        """Pins the wiring: the guard is worthless if _build_and_run never
+        calls it, and that is exactly how the previous check died."""
+        import inspect
+
+        from raven.cli import import_commands
+
+        assert "_require_memory_service_ready" in inspect.getsource(import_commands._build_and_run)

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -5307,10 +5307,10 @@ class TestPointingRavenAtAnEverosYouRun:
     def test_an_unreachable_address_is_refused(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Recording an address that never answered would defer the failure to
         every future session, with nothing left to say why."""
+        import questionary
+
         from raven.cli import onboard_everos
         from raven.plugin.memory.everos._server import ProbeResult
-
-        import questionary
 
         tmp_env.write_text(json.dumps({}), encoding="utf-8")
         self._stub_prompts(monkeypatch, host="127.0.0.1", port="8000")

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1859,9 +1859,7 @@ class TestConvergingRavensOwnPort:
         _stubs.setattr(_server, "ensure_everos_server", _ensure)
         _stubs.setattr(questionary, "select", lambda *a, **kw: _Answer("keep"))
 
-        onboard_everos._step4_memory(
-            skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[]
-        )
+        onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
 
         assert touched == [], "restarted a service that was already where it belongs"
         slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
@@ -1887,9 +1885,7 @@ class TestConvergingRavensOwnPort:
         _stubs.setattr(_server, "ensure_everos_server", _ensure)
         _stubs.setattr(questionary, "select", lambda *a, **kw: _Answer("keep"))
 
-        onboard_everos._step4_memory(
-            skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[]
-        )
+        onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
 
         assert started == ["http://localhost:18791"]
         slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
@@ -1915,9 +1911,7 @@ class TestConvergingRavensOwnPort:
         reached: list[int] = []
         _stubs.setattr(onboard_everos, "_config_everos_role", lambda **_kw: reached.append(1))
 
-        onboard_everos._step4_memory(
-            skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[]
-        )
+        onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
 
         assert started == [], "spawned into a jobstore lock that is still held"
         assert reached == []
@@ -1939,9 +1933,7 @@ class TestConvergingRavensOwnPort:
         reached: list[int] = []
         _stubs.setattr(onboard_everos, "_config_everos_role", lambda **_kw: reached.append(1))
 
-        onboard_everos._step4_memory(
-            skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[]
-        )
+        onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
 
         out = " ".join(capsys.readouterr().out.split())
         assert "port 18791 is occupied" in out, "swallowed the reason the restart failed"

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -5506,16 +5506,17 @@ class TestTheManagedPortIsOfferedNotImposed:
         assert "_ask_managed_port" in inspect.getsource(onboard_everos._step4_memory)
 
 
-class TestAnUpgradeDoesNotRelocateAnExistingService:
-    """A config written before `port` existed still states where it runs.
+class TestAnUpgradeIsAskedBeforeItIsMoved:
+    """A pre-upgrade install is protected by the question, not by the target.
 
-    Falling straight through to the constant would read every pre-upgrade
-    install as sitting on a legacy port and move it -- silently, on the very
-    first run after the upgrade, and with no question asked. The recorded
-    address is the intent until the user says otherwise.
+    An earlier attempt read the recorded address as the intent so that nothing
+    would be relocated. That over-corrected: with no intent stored the two
+    addresses always matched, the "keep it or move it" screen never appeared,
+    and the upgrade ended parked on the old port with the standard one never
+    mentioned. Silence in the other direction is still silence.
     """
 
-    def test_a_recorded_address_is_the_intent_when_no_port_is_stored(self, tmp_env: Path) -> None:
+    def test_the_old_address_and_the_target_disagree_so_the_user_is_asked(self, tmp_env: Path) -> None:
         from raven.cli import onboard_everos
 
         tmp_env.write_text(
@@ -5523,28 +5524,21 @@ class TestAnUpgradeDoesNotRelocateAnExistingService:
             encoding="utf-8",
         )
 
-        assert onboard_everos._configured_target_url() == "http://localhost:1995"
-
-    def test_an_explicit_port_still_wins_over_the_cached_address(self, tmp_env: Path) -> None:
-        """base_url follows the service; port is the decision. When they
-        disagree the decision is what convergence aims at."""
-        from raven.cli import onboard_everos
-
-        tmp_env.write_text(
-            json.dumps(
-                {"plugins": {"config": {"everos-memory": {"base_url": "http://localhost:1995", "port": 18791}}}}
-            ),
-            encoding="utf-8",
+        target = onboard_everos._configured_target_url()
+        assert target == "http://localhost:18791"
+        assert not onboard_everos._same_address("http://127.0.0.1:1995", target), (
+            "a pre-upgrade address must not read as already-at-target, or the question never fires"
         )
 
-        assert onboard_everos._configured_target_url() == "http://localhost:18791"
-
-    def test_nothing_recorded_falls_back_to_the_shipped_default(self, tmp_env: Path) -> None:
+    def test_answering_keep_records_the_intent_so_it_is_asked_only_once(self, tmp_env: Path) -> None:
         from raven.cli import onboard_everos
 
         tmp_env.write_text(json.dumps({}), encoding="utf-8")
+        onboard_everos._adopt_running_address("http://127.0.0.1:1995")
 
-        assert onboard_everos._configured_target_url() == "http://localhost:18791"
+        target = onboard_everos._configured_target_url()
+        assert target == "http://localhost:1995"
+        assert onboard_everos._same_address("http://127.0.0.1:1995", target)
 
 
 class TestARefusedSelfManagedAddressEndsTheStep:
@@ -5759,3 +5753,55 @@ class TestReconfiguringRestartsOurOwnService:
 
         monkeypatch.setattr(onboard_everos, "_lock_holder", lambda _root: None)
         assert onboard_everos._stop_for_reload(Path("/r")) is False
+
+
+class TestIntentAndAddressAreDifferentQuestions:
+    """Where it should be, and where it is, are answered from different fields.
+
+    Convergence compares them, so it must not read the current address as the
+    intent -- doing that makes every pre-upgrade install look like it is already
+    where it belongs, and the "keep it or move it" question never fires. The
+    upgrade path then quietly ends at the old port forever, which is the
+    outcome the question exists to put in front of the user.
+
+    Creating a root is the other question, and there a recorded address is the
+    best answer available: ignoring it was the original defect behind
+    "start the everos server at its configured address, not the default".
+    """
+
+    def test_no_recorded_intent_targets_the_default(self, tmp_env: Path) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(
+            json.dumps({"plugins": {"config": {"everos-memory": {"base_url": "http://localhost:1995"}}}}),
+            encoding="utf-8",
+        )
+
+        assert onboard_everos._configured_target_url() == "http://localhost:18791"
+
+    def test_recorded_intent_wins(self, tmp_env: Path) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(
+            json.dumps(
+                {"plugins": {"config": {"everos-memory": {"base_url": "http://localhost:1995", "port": 20000}}}}
+            ),
+            encoding="utf-8",
+        )
+
+        assert onboard_everos._configured_target_url() == "http://localhost:20000"
+
+    def test_creating_a_root_still_honours_a_recorded_address(
+        self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The build path is where "do not ignore the configured address"
+        belongs; convergence is not."""
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(
+            json.dumps({"plugins": {"config": {"everos-memory": {"base_url": "http://localhost:1995"}}}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(onboard_everos, "_port_is_free", lambda _p: True)
+
+        assert onboard_everos._ask_managed_port(Path("/r")) == 1995

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -5171,6 +5171,8 @@ def test_everos_role_optionality_matches_design():
     assert "skip_note" not in _EVEROS_ROLES["llm"]
     for role in DEGRADING_SECTIONS:
         assert "skip_note" in _EVEROS_ROLES[role]
+
+
 class TestMemoryEnabledRespectsOwnership:
     """ "Configured" means something different for a root raven does not own.
 

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -959,12 +959,17 @@ def test_minimax_catalog_models_keep_public_provider_prefix(provider: str, model
 
 @pytest.fixture
 def everos_isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Redirect EverOS writes to a throwaway toml (never touches ~/.everos)."""
+    """Redirect EverOS writes to a throwaway root raven owns.
+
+    Owned is pinned rather than inferred: these tests exercise the wizard's
+    write paths, and a root the user manages is read-only by design.
+    """
     import raven.config.update_everos as ue
 
-    cfg = tmp_path / ".everos" / "everos.toml"
-    monkeypatch.setattr(ue, "_EVEROS_CONFIG", cfg)
-    return cfg
+    root = tmp_path / ".everos"
+    monkeypatch.setattr(ue, "everos_root", lambda: root)
+    monkeypatch.setattr(ue, "everos_owned", lambda: True)
+    return root / "everos.toml"
 
 
 def _seed_provider(provider: str = "openai", key: str = "sk-seed", model: str = "openai/gpt-4o-mini") -> None:
@@ -1288,7 +1293,12 @@ def test_memory_giving_up_sets_backend_null(
     onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
     data = json.loads(tmp_env.read_text())
     assert data["memory"]["backend"] is None
-    assert not everos_isolated.exists()
+    # The step lays down EverOS's config templates before asking anything, so
+    # what matters is that no role ended up configured -- not that the file is
+    # absent. A template [llm] carries an empty api_key and reads as unconfigured.
+    from raven.config.update_everos import everos_role_configured
+
+    assert not everos_role_configured("llm")
     # Effective config (schema default is "everos") must resolve to disabled.
     from raven.config.raven import load_raven_config
 
@@ -1444,8 +1454,13 @@ def test_memory_enable_writes_everos_sections(
     assert everos["embedding"]["model"] == "mem-embed"
     assert everos["embedding"]["api_key"] == "k-embed"
     assert everos["embedding"]["base_url"] == "https://llm/v1"
-    assert "rerank" not in everos
-    assert "multimodal" not in everos
+    # Skipped roles keep whatever the shipped template holds, which is a model
+    # name with no credentials -- so they must read as unconfigured rather than
+    # be absent outright.
+    from raven.config.update_everos import everos_role_configured
+
+    assert not everos_role_configured("rerank")
+    assert not everos_role_configured("multimodal")
 
 
 def test_the_memory_step_reaches_the_capability_report(

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -5670,3 +5670,33 @@ class TestARefusedAddressCanBeRetyped:
         monkeypatch.setattr("raven.plugin.memory.everos._server.probe_health", lambda _u, **_kw: ProbeResult.OK)
 
         assert onboard_everos._use_self_managed_everos() is True
+
+
+class TestSkippingIsQuiet:
+    """The step is leaving; saying so again is noise.
+
+    "Skip" was followed by a line restating what skip means, on a screen the
+    wizard is already walking off. The user chose the option one line earlier.
+    """
+
+    def test_nothing_is_printed_after_the_choice(
+        self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        import questionary
+
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(json.dumps({"memory": {"backend": "everos"}}), encoding="utf-8")
+        monkeypatch.setattr(onboard_everos, "_use_self_managed_everos", lambda: False)
+        monkeypatch.setattr(onboard_everos, "_memory_enabled", lambda: False)
+        monkeypatch.setattr(_discover_mod, "pick", lambda _s: None)
+        monkeypatch.setattr(_discover_mod, "discover", list)
+        monkeypatch.setattr(questionary, "select", lambda *a, **kw: _Answer("self"))
+        capsys.readouterr()
+
+        onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
+
+        after = capsys.readouterr().out
+        assert "长期记忆保持关闭" not in after
+        assert "stays off until" not in after
+        assert json.loads(tmp_env.read_text())["memory"]["backend"] is None

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1687,11 +1687,28 @@ class TestReusingAnEverosTheUserManages:
         assert self.writes == [], "wrote into a root the user manages"
         assert self.signals == [], "signalled a process raven does not own"
 
-    def test_declining_falls_through_to_ravens_own_root(self, tmp_env: Path, everos_isolated: Path, _no_writes) -> None:
-        """Saying no must leave raven building its own memory, not with none."""
+    def test_declining_falls_through_to_ravens_own_root(self, tmp_env: Path, _no_writes) -> None:
+        """Saying no must leave raven building its OWN memory, not adopting theirs.
+
+        Deliberately without the ``everos_isolated`` fixture: that pins ownership
+        to true, which is the condition under test. Ownership has to resolve for
+        real from the recorded config here, or the root assertion below cannot
+        fail -- which is how the first version of this test passed while raven was
+        taking over the user's root.
+        """
         import questionary
 
+        from raven.config import update_everos as ue
+
         theirs = tmp_env.parent / "theirs"
+        mine = tmp_env.parent / "mine"
+        _no_writes.setattr(ue, "default_everos_root", lambda: mine)
+        _no_writes.setattr(ue, "legacy_everos_root", lambda: tmp_env.parent / "legacy")
+        # The state a previous session's reuse leaves behind.
+        tmp_env.write_text(
+            json.dumps({"plugins": {"config": {"everos-memory": {"root": str(theirs), "owned": False}}}}),
+            encoding="utf-8",
+        )
         _found(_no_writes, _root_state(theirs, owned=False))
         _no_writes.setattr(questionary, "select", lambda *a, **kw: _Answer("own"))
         reached: list[int] = []
@@ -1706,7 +1723,13 @@ class TestReusingAnEverosTheUserManages:
         onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
 
         assert len(reached) == 4, "did not reach the four role screens"
-        assert json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]["owned"] is True
+        slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
+        assert slice_["owned"] is True
+        # The point of declining: raven builds its OWN root. Asserting only that
+        # ownership flipped to true was the hole -- it passes just as well when
+        # raven has adopted the user's root and is about to overwrite it.
+        assert Path(slice_["root"]) != theirs, "adopted the root the user declined to share"
+        assert Path(slice_["root"]) == mine
 
     def test_a_stopped_one_is_probed_again_rather_than_started(
         self, tmp_env: Path, everos_isolated: Path, _no_writes, capsys: pytest.CaptureFixture
@@ -1750,7 +1773,11 @@ class TestConvergingRavensOwnPort:
         root = tmp_env.parent / "everos"
         _found(_stubs, _root_state(root, declared_url="http://localhost:1995"))
         stopped: list[Path] = []
-        _stubs.setattr(_server, "stop_recorded_server", lambda r, **_kw: stopped.append(r) or True)
+        _stubs.setattr(
+            _server,
+            "stop_recorded_server",
+            lambda r, **_kw: (stopped.append(r), _server.StopOutcome.STOPPED)[1],
+        )
         _stubs.setattr(questionary, "select", lambda *a, **kw: _Answer("keep"))
 
         onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
@@ -1769,13 +1796,13 @@ class TestConvergingRavensOwnPort:
 
         root = tmp_env.parent / "everos"
         _found(_stubs, _root_state(root, declared_url="http://localhost:1995"))
-        _stubs.setattr(_server, "stop_recorded_server", lambda _r, **_kw: False)
+        _stubs.setattr(_server, "stop_recorded_server", lambda _r, **_kw: _server.StopOutcome.NOT_OURS)
         _stubs.setattr(questionary, "select", lambda *a, **kw: _Answer("keep"))
 
         onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
 
         out = " ".join(capsys.readouterr().out.split())
-        assert "not start this process" in out or "不是 Raven 启动的" in out
+        assert "did not start this process" in out or "不是 Raven 启动的" in out
         slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
         assert slice_["base_url"] == "http://localhost:1995"
 

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -5310,8 +5310,13 @@ class TestPointingRavenAtAnEverosYouRun:
         from raven.cli import onboard_everos
         from raven.plugin.memory.everos._server import ProbeResult
 
+        import questionary
+
         tmp_env.write_text(json.dumps({}), encoding="utf-8")
         self._stub_prompts(monkeypatch, host="127.0.0.1", port="8000")
+        # A refusal now offers a retype before giving up; this case is the
+        # giving-up branch, so answer it that way.
+        monkeypatch.setattr(questionary, "select", lambda *a, **kw: _Answer("skip"))
         monkeypatch.setattr("raven.plugin.memory.everos._server.probe_health", lambda _u, **_kw: ProbeResult.REFUSED)
 
         assert onboard_everos._use_self_managed_everos() is False
@@ -5592,3 +5597,76 @@ class TestARefusedSelfManagedAddressEndsTheStep:
         onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
 
         assert json.loads(tmp_env.read_text())["memory"]["backend"] is None
+
+
+class TestARefusedAddressCanBeRetyped:
+    """A mistyped port should cost a retype, not a whole onboard run.
+
+    Ending the step outright was right about not falling through to the managed
+    path, but wrong about the most likely cause: the address was refused because
+    the server is not up yet or the port has a digit wrong. Both are fixed in
+    one line, and neither is a reason to send the user back to the start.
+    """
+
+    @staticmethod
+    def _prompts(monkeypatch, answers):
+        from raven.cli import onboard_everos
+
+        it = iter(answers)
+        monkeypatch.setattr(onboard_everos, "_prompt_text", lambda *a, **kw: next(it))
+
+    @staticmethod
+    def _choices(monkeypatch, answers):
+        import questionary
+
+        from raven.cli import onboard_everos
+
+        it = iter(answers)
+        monkeypatch.setattr(questionary, "select", lambda *a, **kw: _Answer(next(it)))
+        monkeypatch.setattr(onboard_everos.oc, "_require_questionary", lambda: questionary)
+
+    def test_a_second_address_is_accepted(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from raven.cli import onboard_everos
+        from raven.plugin.memory.everos._server import ProbeResult
+
+        tmp_env.write_text(json.dumps({}), encoding="utf-8")
+        self._prompts(monkeypatch, ["127.0.0.1", "8000", "127.0.0.1", "8100"])
+        self._choices(monkeypatch, ["retry"])
+        seen: list[str] = []
+
+        def _probe(url, **_kw):
+            seen.append(url)
+            return ProbeResult.OK if url.endswith(":8100") else ProbeResult.REFUSED
+
+        monkeypatch.setattr("raven.plugin.memory.everos._server.probe_health", _probe)
+
+        assert onboard_everos._use_self_managed_everos() is True
+        assert seen == ["http://127.0.0.1:8000", "http://127.0.0.1:8100"]
+        slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
+        assert slice_["base_url"] == "http://127.0.0.1:8100"
+
+    def test_skipping_gives_up_without_recording_anything(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from raven.cli import onboard_everos
+        from raven.plugin.memory.everos._server import ProbeResult
+
+        tmp_env.write_text(json.dumps({}), encoding="utf-8")
+        self._prompts(monkeypatch, ["127.0.0.1", "8000"])
+        self._choices(monkeypatch, ["skip"])
+        monkeypatch.setattr("raven.plugin.memory.everos._server.probe_health", lambda _u, **_kw: ProbeResult.REFUSED)
+
+        assert onboard_everos._use_self_managed_everos() is False
+        slice_ = (json.loads(tmp_env.read_text()).get("plugins") or {}).get("config", {}).get("everos-memory", {})
+        assert not slice_.get("base_url")
+
+    def test_a_nonsense_port_offers_the_same_choice(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A typo in the port is the same mistake as a typo in the host; it
+        should not be the one that ends the step without asking."""
+        from raven.cli import onboard_everos
+        from raven.plugin.memory.everos._server import ProbeResult
+
+        tmp_env.write_text(json.dumps({}), encoding="utf-8")
+        self._prompts(monkeypatch, ["127.0.0.1", "80o0", "127.0.0.1", "8000"])
+        self._choices(monkeypatch, ["retry"])
+        monkeypatch.setattr("raven.plugin.memory.everos._server.probe_health", lambda _u, **_kw: ProbeResult.OK)
+
+        assert onboard_everos._use_self_managed_everos() is True

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1540,6 +1540,11 @@ def test_memory_step_starts_the_configured_address_not_the_default(
     import raven.plugin.memory.everos._server as everos_server
 
     monkeypatch.setattr(everos_server, "ensure_everos_server", _fake_ensure)
+    # The port question is asked only when the intended port is taken, and this
+    # case is about which address is used, not about occupancy. Left to a real
+    # bind test it would depend on whether 1995 happens to be free on the
+    # machine running the suite.
+    monkeypatch.setattr(onboard_everos, "_port_is_free", lambda _p: True)
     monkeypatch.setattr(onboard_everos, "_report_everos_capabilities", lambda: None)
     monkeypatch.setattr(onboard_everos, "_config_everos_role", lambda **_: None)
     monkeypatch.setattr(onboard_everos, "_memory_enabled", lambda: False)

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -5452,25 +5452,27 @@ class TestTheManagedPortIsOfferedNotImposed:
             onboard_everos, "_prompt_text", lambda *a, **kw: pytest.fail("asked about a port that was free")
         )
 
-        assert onboard_everos._ask_managed_port() == 18791
+        assert onboard_everos._ask_managed_port(Path("/r")) == 18791
 
     def test_a_typed_port_is_recorded_as_the_target(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from raven.cli import onboard_everos
 
         tmp_env.write_text(json.dumps({}), encoding="utf-8")
         monkeypatch.setattr(onboard_everos, "_port_is_free", lambda _p: False)
+        monkeypatch.setattr(onboard_everos, "_lock_holder", lambda _root: None)
         monkeypatch.setattr(onboard_everos, "_prompt_text", lambda *a, **kw: "20000")
 
-        assert onboard_everos._ask_managed_port() == 20000
+        assert onboard_everos._ask_managed_port(Path("/r")) == 20000
 
     def test_nonsense_falls_back_to_the_default(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from raven.cli import onboard_everos
 
         tmp_env.write_text(json.dumps({}), encoding="utf-8")
         monkeypatch.setattr(onboard_everos, "_port_is_free", lambda _p: False)
+        monkeypatch.setattr(onboard_everos, "_lock_holder", lambda _root: None)
         monkeypatch.setattr(onboard_everos, "_prompt_text", lambda *a, **kw: "not-a-port")
 
-        assert onboard_everos._ask_managed_port() == 18791
+        assert onboard_everos._ask_managed_port(Path("/r")) == 18791
 
     def test_an_already_recorded_port_is_the_offered_default(
         self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch
@@ -5484,6 +5486,7 @@ class TestTheManagedPortIsOfferedNotImposed:
             encoding="utf-8",
         )
         monkeypatch.setattr(onboard_everos, "_port_is_free", lambda _p: False)
+        monkeypatch.setattr(onboard_everos, "_lock_holder", lambda _root: None)
         seen: list[str] = []
 
         def _spy(_label, **kw):
@@ -5492,7 +5495,7 @@ class TestTheManagedPortIsOfferedNotImposed:
 
         monkeypatch.setattr(onboard_everos, "_prompt_text", _spy)
 
-        assert onboard_everos._ask_managed_port() == 20000
+        assert onboard_everos._ask_managed_port(Path("/r")) == 20000
         assert seen == ["20000"]
 
     def test_the_build_path_asks(self) -> None:
@@ -5700,3 +5703,59 @@ class TestSkippingIsQuiet:
         assert "长期记忆保持关闭" not in after
         assert "stays off until" not in after
         assert json.loads(tmp_env.read_text())["memory"]["backend"] is None
+
+
+class TestReconfiguringRestartsOurOwnService:
+    """Rewriting the models has to reach the process that reads them.
+
+    EverOS builds its LLM client in the API lifespan, at startup, so a server
+    already running keeps the models it booted with. Reconfiguring therefore
+    wrote new models to disk and left them inert: the wizard's closing
+    `ensure_everos_server` finds the address answering and returns, and the
+    user's change silently takes effect at some unrelated restart.
+    """
+
+    def test_our_own_port_is_not_reported_as_taken(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The occupancy check is a bind test, so a service we started and are
+        about to restart into looks exactly like a stranger squatting."""
+        from raven.cli import onboard_everos
+        from raven.plugin.memory.everos._server import LockHolder
+
+        tmp_env.write_text(
+            json.dumps({"plugins": {"config": {"everos-memory": {"port": 31995, "root": "/r"}}}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(onboard_everos, "_port_is_free", lambda _p: False)
+        monkeypatch.setattr(
+            onboard_everos,
+            "_lock_holder",
+            lambda _root: LockHolder(pid=1, cmdline="everos server start --root /r", port=31995),
+        )
+        monkeypatch.setattr(
+            onboard_everos, "_prompt_text", lambda *a, **kw: pytest.fail("asked about a port that is ours")
+        )
+
+        assert onboard_everos._ask_managed_port(Path("/r")) == 31995
+
+    def test_a_stranger_on_the_port_still_asks(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(json.dumps({}), encoding="utf-8")
+        monkeypatch.setattr(onboard_everos, "_port_is_free", lambda _p: False)
+        monkeypatch.setattr(onboard_everos, "_lock_holder", lambda _root: None)
+        monkeypatch.setattr(onboard_everos, "_prompt_text", lambda *a, **kw: "19999")
+
+        assert onboard_everos._ask_managed_port(Path("/r")) == 19999
+
+    def test_the_running_service_is_stopped_before_the_restart(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from raven.cli import onboard_everos
+
+        stopped: list[str] = []
+        monkeypatch.setattr(onboard_everos, "_stop_for_reload", lambda root: stopped.append(str(root)) or True)
+        assert "_stop_for_reload" in __import__("inspect").getsource(onboard_everos._step4_memory)
+
+    def test_stop_for_reload_is_a_noop_when_nothing_runs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from raven.cli import onboard_everos
+
+        monkeypatch.setattr(onboard_everos, "_lock_holder", lambda _root: None)
+        assert onboard_everos._stop_for_reload(Path("/r")) is False

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -29,6 +29,7 @@ from typer.testing import CliRunner
 from raven.cli import onboard_channels, onboard_commands, onboard_everos
 from raven.cli.commands import app
 from raven.config.loader import set_config_path
+from raven.plugin.memory.everos import _discover as _discover_mod
 
 runner = CliRunner()
 
@@ -5536,3 +5537,58 @@ class TestAnUpgradeDoesNotRelocateAnExistingService:
         tmp_env.write_text(json.dumps({}), encoding="utf-8")
 
         assert onboard_everos._configured_target_url() == "http://localhost:18791"
+
+
+class TestARefusedSelfManagedAddressEndsTheStep:
+    """Choosing self-managed and mistyping the port is not a change of mind.
+
+    The step used to fall through to the managed path, so a user who had just
+    said "I run my own EverOS" was walked through configuring four model roles
+    and an API key for a setup they had not asked for -- and left with a root
+    built on disk that they would not use. The message printed one line earlier
+    already says what to do: start it and re-run. Doing the opposite of that in
+    the same breath is the contradiction worth removing.
+    """
+
+    @staticmethod
+    def _seed(tmp_env: Path) -> None:
+        tmp_env.write_text(json.dumps({"memory": {"backend": "everos"}}), encoding="utf-8")
+
+    def test_the_wizard_does_not_go_on_to_configure_models(
+        self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import questionary
+
+        from raven.cli import onboard_everos
+
+        self._seed(tmp_env)
+        monkeypatch.setattr(onboard_everos, "_use_self_managed_everos", lambda: False)
+        monkeypatch.setattr(onboard_everos, "_memory_enabled", lambda: False)
+        monkeypatch.setattr(
+            onboard_everos,
+            "_config_everos_role",
+            lambda **_kw: pytest.fail("configured a managed model after the user chose self-managed"),
+        )
+        monkeypatch.setattr(_discover_mod, "pick", lambda _s: None)
+        monkeypatch.setattr(_discover_mod, "discover", list)
+        monkeypatch.setattr(questionary, "select", lambda *a, **kw: _Answer("self"))
+
+        onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
+
+    def test_memory_is_left_off_rather_than_half_built(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Leaving the backend on would have the runtime spawn a managed server
+        against a root the user never agreed to."""
+        import questionary
+
+        from raven.cli import onboard_everos
+
+        self._seed(tmp_env)
+        monkeypatch.setattr(onboard_everos, "_use_self_managed_everos", lambda: False)
+        monkeypatch.setattr(onboard_everos, "_memory_enabled", lambda: False)
+        monkeypatch.setattr(_discover_mod, "pick", lambda _s: None)
+        monkeypatch.setattr(_discover_mod, "discover", list)
+        monkeypatch.setattr(questionary, "select", lambda *a, **kw: _Answer("self"))
+
+        onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
+
+        assert json.loads(tmp_env.read_text())["memory"]["backend"] is None

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1538,6 +1538,78 @@ def test_memory_step_starts_the_configured_address_not_the_default(
     assert seen == ["http://localhost:1995", "http://localhost:1995"]
 
 
+@pytest.mark.parametrize(
+    ("action", "expected_backend"),
+    [("defer", "everos"), ("disable", None)],
+)
+def test_a_failed_start_does_not_decide_to_abandon_memory(
+    tmp_env: Path,
+    everos_isolated: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    action: str,
+    expected_backend: object,
+) -> None:
+    """Failing to start the service and giving up on memory are separate choices.
+
+    The models are already on disk by this point, so deferring has to keep the
+    whole configuration -- the runtime starts the service on demand anyway. Only
+    the explicit third choice turns memory off.
+    """
+    import questionary
+
+    async def _always_fails(*_a: object, **_kw: object) -> None:
+        raise RuntimeError("boom")
+
+    import raven.plugin.memory.everos._server as everos_server
+
+    monkeypatch.setattr(everos_server, "ensure_everos_server", _always_fails)
+    monkeypatch.setattr(onboard_everos, "_config_everos_role", lambda **_: None)
+    monkeypatch.setattr(onboard_everos, "_memory_enabled", lambda: False)
+    monkeypatch.setattr(onboard_everos, "_report_everos_capabilities", lambda: None)
+
+    class _FQ:
+        def ask(self):
+            return action
+
+    monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ())
+
+    onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
+
+    assert json.loads(tmp_env.read_text())["memory"]["backend"] == expected_backend
+
+
+def test_a_failed_start_can_be_retried_until_it_works(
+    tmp_env: Path, everos_isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Retry loops rather than disabling memory on the second failure."""
+    import questionary
+
+    attempts = []
+
+    async def _fails_twice(*_a: object, **_kw: object) -> None:
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise RuntimeError("boom")
+
+    import raven.plugin.memory.everos._server as everos_server
+
+    monkeypatch.setattr(everos_server, "ensure_everos_server", _fails_twice)
+    monkeypatch.setattr(onboard_everos, "_config_everos_role", lambda **_: None)
+    monkeypatch.setattr(onboard_everos, "_memory_enabled", lambda: False)
+    monkeypatch.setattr(onboard_everos, "_report_everos_capabilities", lambda: None)
+
+    class _FQ:
+        def ask(self):
+            return "retry"
+
+    monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ())
+
+    onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
+
+    assert len(attempts) == 3
+    assert json.loads(tmp_env.read_text())["memory"]["backend"] == "everos"
+
+
 def test_memory_llm_reuse_pulls_provider_creds(
     tmp_env: Path, everos_isolated: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1705,12 +1705,34 @@ class TestReusingAnEverosTheUserManages:
         _no_writes.setattr(ue, "default_everos_root", lambda: mine)
         _no_writes.setattr(ue, "legacy_everos_root", lambda: tmp_env.parent / "legacy")
         # The state a previous session's reuse leaves behind.
+        # Their root has to hold a real configured llm, and memory.backend has to
+        # be on: _memory_enabled() reads both, and if either is missing it is
+        # false, the keep/reconfigure branch is skipped, and the branch that used
+        # to discard the decision -- the one this test exists for -- is never
+        # entered. The first two attempts at this test passed for exactly that
+        # reason.
+        theirs.mkdir(parents=True, exist_ok=True)
+        (theirs / "everos.toml").write_text('[llm]\nmodel = "m"\napi_key = "k"\n', encoding="utf-8")
         tmp_env.write_text(
-            json.dumps({"plugins": {"config": {"everos-memory": {"root": str(theirs), "owned": False}}}}),
+            json.dumps(
+                {
+                    "memory": {"backend": "everos"},
+                    "plugins": {"config": {"everos-memory": {"root": str(theirs), "owned": False}}},
+                }
+            ),
             encoding="utf-8",
         )
-        _found(_no_writes, _root_state(theirs, owned=False))
-        _no_writes.setattr(questionary, "select", lambda *a, **kw: _Answer("own"))
+        # Assert the branch is reachable before asserting what it does. Without
+        # this the test can pass because it never got there -- which is how two
+        # earlier versions of it passed while the decision was being discarded.
+        assert onboard_everos._memory_enabled() is True
+
+        _found(_no_writes, _root_state(theirs, owned=False, declared_url="http://localhost:8000"))
+        # Two screens: decline the reuse, then answer the keep/reconfigure menu
+        # the way an existing install would. A single stubbed answer let "own"
+        # stand in for both and slipped past the branch under test.
+        answers = iter(["own", "keep"])
+        _no_writes.setattr(questionary, "select", lambda *a, **kw: _Answer(next(answers)))
         reached: list[int] = []
         _no_writes.setattr(onboard_everos, "_config_everos_role", lambda **_kw: reached.append(1))
         _no_writes.setattr(onboard_everos, "_report_everos_capabilities", lambda: None)
@@ -1773,16 +1795,28 @@ class TestConvergingRavensOwnPort:
         root = tmp_env.parent / "everos"
         _found(_stubs, _root_state(root, declared_url="http://localhost:1995"))
         stopped: list[Path] = []
+        started: list[str] = []
         _stubs.setattr(
             _server,
             "stop_recorded_server",
             lambda r, **_kw: (stopped.append(r), _server.StopOutcome.STOPPED)[1],
         )
+
+        async def _ensure(url: str, **_kw: object) -> None:
+            started.append(url)
+
+        _stubs.setattr(_server, "ensure_everos_server", _ensure)
+        # "Keep it enabled" is the first option, and the answer an existing
+        # install gives -- the path that used to exit with the service stopped.
         _stubs.setattr(questionary, "select", lambda *a, **kw: _Answer("keep"))
 
         onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
 
         assert stopped == [root]
+        # Asserting only "it stopped" and "the config moved" is what let the
+        # service stay down: convergence is stop -> write -> start, and the last
+        # step has to be part of the same claim.
+        assert started == ["http://localhost:18791"], "stopped the service and never started it again"
         slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
         assert slice_["base_url"] == "http://localhost:18791"
 

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -5426,3 +5426,113 @@ class TestSwitchingToSelfManagedClearsTheOldRoot:
         slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
         assert slice_["owned"] is False
         assert "root" not in slice_, "kept a path into a root raven promised not to touch"
+
+
+class TestTheManagedPortIsOfferedNotImposed:
+    """18791 is a recommendation, not a fixed address.
+
+    A managed setup could only ever reach a different port by having a server
+    already running on one and the user electing to keep it. Nobody could say
+    up front "use this port instead", which is the case that matters when 18791
+    is already taken -- there the managed path had no way forward at all.
+    """
+
+    def test_a_free_port_is_not_worth_a_screen(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(json.dumps({}), encoding="utf-8")
+        monkeypatch.setattr(onboard_everos, "_port_is_free", lambda _p: True)
+        monkeypatch.setattr(
+            onboard_everos, "_prompt_text", lambda *a, **kw: pytest.fail("asked about a port that was free")
+        )
+
+        assert onboard_everos._ask_managed_port() == 18791
+
+    def test_a_typed_port_is_recorded_as_the_target(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(json.dumps({}), encoding="utf-8")
+        monkeypatch.setattr(onboard_everos, "_port_is_free", lambda _p: False)
+        monkeypatch.setattr(onboard_everos, "_prompt_text", lambda *a, **kw: "20000")
+
+        assert onboard_everos._ask_managed_port() == 20000
+
+    def test_nonsense_falls_back_to_the_default(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(json.dumps({}), encoding="utf-8")
+        monkeypatch.setattr(onboard_everos, "_port_is_free", lambda _p: False)
+        monkeypatch.setattr(onboard_everos, "_prompt_text", lambda *a, **kw: "not-a-port")
+
+        assert onboard_everos._ask_managed_port() == 18791
+
+    def test_an_already_recorded_port_is_the_offered_default(
+        self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A second run must not offer 18791 to someone who already moved off
+        it -- accepting the offer would silently undo their choice."""
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(
+            json.dumps({"plugins": {"config": {"everos-memory": {"port": 20000}}}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(onboard_everos, "_port_is_free", lambda _p: False)
+        seen: list[str] = []
+
+        def _spy(_label, **kw):
+            seen.append(kw.get("default", ""))
+            return kw.get("default", "")
+
+        monkeypatch.setattr(onboard_everos, "_prompt_text", _spy)
+
+        assert onboard_everos._ask_managed_port() == 20000
+        assert seen == ["20000"]
+
+    def test_the_build_path_asks(self) -> None:
+        import inspect
+
+        from raven.cli import onboard_everos
+
+        assert "_ask_managed_port" in inspect.getsource(onboard_everos._step4_memory)
+
+
+class TestAnUpgradeDoesNotRelocateAnExistingService:
+    """A config written before `port` existed still states where it runs.
+
+    Falling straight through to the constant would read every pre-upgrade
+    install as sitting on a legacy port and move it -- silently, on the very
+    first run after the upgrade, and with no question asked. The recorded
+    address is the intent until the user says otherwise.
+    """
+
+    def test_a_recorded_address_is_the_intent_when_no_port_is_stored(self, tmp_env: Path) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(
+            json.dumps({"plugins": {"config": {"everos-memory": {"base_url": "http://localhost:1995"}}}}),
+            encoding="utf-8",
+        )
+
+        assert onboard_everos._configured_target_url() == "http://localhost:1995"
+
+    def test_an_explicit_port_still_wins_over_the_cached_address(self, tmp_env: Path) -> None:
+        """base_url follows the service; port is the decision. When they
+        disagree the decision is what convergence aims at."""
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(
+            json.dumps(
+                {"plugins": {"config": {"everos-memory": {"base_url": "http://localhost:1995", "port": 18791}}}}
+            ),
+            encoding="utf-8",
+        )
+
+        assert onboard_everos._configured_target_url() == "http://localhost:18791"
+
+    def test_nothing_recorded_falls_back_to_the_shipped_default(self, tmp_env: Path) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(json.dumps({}), encoding="utf-8")
+
+        assert onboard_everos._configured_target_url() == "http://localhost:18791"

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -1623,6 +1624,186 @@ def test_a_failed_start_can_be_retried_until_it_works(
 
     assert len(attempts) == 3
     assert json.loads(tmp_env.read_text())["memory"]["backend"] == "everos"
+
+
+def _root_state(root: Path, **kw: Any) -> Any:
+    from raven.plugin.memory.everos._discover import RootState
+
+    defaults = {
+        "root": root,
+        "owned": True,
+        "configured": True,
+        "declared_url": "http://127.0.0.1:18791",
+        "alive": True,
+        "lock_held": True,
+    }
+    defaults.update(kw)
+    return RootState(**defaults)
+
+
+def _found(monkeypatch: pytest.MonkeyPatch, state: Any) -> None:
+    from raven.plugin.memory.everos import _discover
+
+    monkeypatch.setattr(_discover, "discover", lambda: [state])
+
+
+class TestReusingAnEverosTheUserManages:
+    """Read-only reuse: record the address, touch nothing else.
+
+    Writing its config would overwrite the user's own models and keys; starting it
+    would take the OME jobstore lock exclusively, which is theirs to grant.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_writes(self, monkeypatch: pytest.MonkeyPatch):
+        from raven.config import update_everos as ue
+
+        self.writes: list[str] = []
+        self.signals: list[int] = []
+        monkeypatch.setattr(ue, "set_everos_section", lambda s, _f: self.writes.append(s))
+        monkeypatch.setattr(ue, "clear_everos_section", lambda s: self.writes.append(s))
+        monkeypatch.setattr(ue, "ensure_everos_home", lambda *_a, **_kw: self.writes.append("template"))
+        monkeypatch.setattr(os, "kill", lambda *_a: self.signals.append(1))
+        monkeypatch.setattr(onboard_everos, "_capability_lines", lambda _u: ["ok"])
+        return monkeypatch
+
+    def test_reuse_records_the_address_and_writes_nothing(
+        self, tmp_env: Path, everos_isolated: Path, _no_writes
+    ) -> None:
+        import questionary
+
+        theirs = tmp_env.parent / "theirs"
+        _found(_no_writes, _root_state(theirs, owned=False, declared_url="http://localhost:8000"))
+        _no_writes.setattr(questionary, "select", lambda *a, **kw: _Answer("reuse"))
+
+        onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
+
+        data = json.loads(tmp_env.read_text())
+        slice_ = data["plugins"]["config"]["everos-memory"]
+        assert slice_["root"] == str(theirs)
+        assert slice_["owned"] is False
+        assert slice_["base_url"] == "http://localhost:8000"
+        assert data["memory"]["backend"] == "everos"
+        assert self.writes == [], "wrote into a root the user manages"
+        assert self.signals == [], "signalled a process raven does not own"
+
+    def test_declining_falls_through_to_ravens_own_root(self, tmp_env: Path, everos_isolated: Path, _no_writes) -> None:
+        """Saying no must leave raven building its own memory, not with none."""
+        import questionary
+
+        theirs = tmp_env.parent / "theirs"
+        _found(_no_writes, _root_state(theirs, owned=False))
+        _no_writes.setattr(questionary, "select", lambda *a, **kw: _Answer("own"))
+        reached: list[int] = []
+        _no_writes.setattr(onboard_everos, "_config_everos_role", lambda **_kw: reached.append(1))
+        _no_writes.setattr(onboard_everos, "_report_everos_capabilities", lambda: None)
+
+        async def _ok(*_a: object, **_kw: object) -> None:
+            return None
+
+        _no_writes.setattr("raven.plugin.memory.everos._server.ensure_everos_server", _ok)
+
+        onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
+
+        assert len(reached) == 4, "did not reach the four role screens"
+        assert json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]["owned"] is True
+
+    def test_a_stopped_one_is_probed_again_rather_than_started(
+        self, tmp_env: Path, everos_isolated: Path, _no_writes, capsys: pytest.CaptureFixture
+    ) -> None:
+        import questionary
+
+        from raven.plugin.memory.everos import _discover
+
+        theirs = tmp_env.parent / "theirs"
+        _found(_no_writes, _root_state(theirs, owned=False, alive=False, declared_url="http://localhost:8000"))
+        _no_writes.setattr(questionary, "select", lambda *a, **kw: _Answer("retry"))
+        # The user starts it; the re-probe then sees it up.
+        _no_writes.setattr(
+            _discover,
+            "_describe",
+            lambda root, owned: _root_state(root, owned=owned, alive=True, declared_url="http://localhost:8000"),
+        )
+
+        onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "everos server start --root" in out, "did not tell the user how to start it"
+        assert self.writes == []
+        assert self.signals == []
+        assert json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]["owned"] is False
+
+
+class TestConvergingRavensOwnPort:
+    @pytest.fixture(autouse=True)
+    def _stubs(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(onboard_everos, "_report_everos_capabilities", lambda: None)
+        monkeypatch.setattr(onboard_everos, "_memory_enabled", lambda: True)
+        return monkeypatch
+
+    def test_a_legacy_port_is_moved_to_the_standard_one(self, tmp_env: Path, everos_isolated: Path, _stubs) -> None:
+        """An install seeded with an older default keeps working, on one address."""
+        import questionary
+
+        from raven.plugin.memory.everos import _server
+
+        root = tmp_env.parent / "everos"
+        _found(_stubs, _root_state(root, declared_url="http://localhost:1995"))
+        stopped: list[Path] = []
+        _stubs.setattr(_server, "stop_recorded_server", lambda r, **_kw: stopped.append(r) or True)
+        _stubs.setattr(questionary, "select", lambda *a, **kw: _Answer("keep"))
+
+        onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
+
+        assert stopped == [root]
+        slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
+        assert slice_["base_url"] == "http://localhost:18791"
+
+    def test_a_process_raven_did_not_start_is_left_alone(
+        self, tmp_env: Path, everos_isolated: Path, _stubs, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Its address stays in use rather than being taken over blindly."""
+        import questionary
+
+        from raven.plugin.memory.everos import _server
+
+        root = tmp_env.parent / "everos"
+        _found(_stubs, _root_state(root, declared_url="http://localhost:1995"))
+        _stubs.setattr(_server, "stop_recorded_server", lambda _r, **_kw: False)
+        _stubs.setattr(questionary, "select", lambda *a, **kw: _Answer("keep"))
+
+        onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "not start this process" in out or "不是 Raven 启动的" in out
+        slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
+        assert slice_["base_url"] == "http://localhost:1995"
+
+    def test_data_held_by_an_unidentifiable_process_stops_the_step(
+        self, tmp_env: Path, everos_isolated: Path, _stubs, capsys: pytest.CaptureFixture
+    ) -> None:
+        """One memory directory admits one instance, so there is nothing to start."""
+        from raven.plugin.memory.everos import _server
+
+        root = tmp_env.parent / "everos"
+        _found(_stubs, _root_state(root, alive=False, lock_held=True))
+        _stubs.setattr(_server, "find_recorded_server", lambda _r: None)
+        reached: list[int] = []
+        _stubs.setattr(onboard_everos, "_config_everos_role", lambda **_kw: reached.append(1))
+
+        onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "Cannot take over" in out or "无法接管" in out
+        assert reached == [], "walked into role configuration on data it cannot serve"
+
+
+class _Answer:
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    def ask(self) -> object:
+        return self._value
 
 
 def test_memory_llm_reuse_pulls_provider_creds(

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -1292,6 +1293,31 @@ def test_memory_giving_up_sets_backend_null(
     from raven.config.raven import load_raven_config
 
     assert load_raven_config().memory.backend is None
+
+
+def test_memory_step_is_skipped_on_native_windows(
+    tmp_env: Path, everos_isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Native Windows leaves the step untouched and the backend disabled.
+
+    This guard is what lets the rest of the EverOS path stay POSIX-only --
+    ``_everos_executable`` looks for a bare ``everos`` with no ``.exe`` variant
+    precisely because it can never run here. Remove the guard and that lookup
+    starts failing on Windows instead of being unreachable.
+    """
+    import questionary
+
+    def _explode(*_a, **_kw):
+        raise AssertionError("step 4 must not prompt on native Windows")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(questionary, "select", _explode)
+    monkeypatch.setattr(questionary, "text", _explode)
+
+    onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
+
+    assert json.loads(tmp_env.read_text())["memory"]["backend"] is None
+    assert not everos_isolated.exists()
 
 
 def test_giving_up_says_what_is_lost(

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -5360,3 +5360,69 @@ class TestAddressComparisonIsNotStringComparison:
         from raven.cli.onboard_everos import _same_address
 
         assert not _same_address(None, "http://localhost:18791")
+
+
+class TestTheIntendedPortIsAlwaysRecorded:
+    """The target address is only a setting if something writes it.
+
+    _configured_target_url reads `port` to tell a port an old raven left behind
+    from one the user chose. Only the adopt branch ever wrote it, so on every
+    ordinary converge the field stayed absent and the target fell back to the
+    shipped constant -- which is exactly the behaviour the field exists to
+    prevent, arriving one branch further along.
+    """
+
+    def test_setting_the_address_records_the_port_with_it(self, tmp_env: Path) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(json.dumps({}), encoding="utf-8")
+        onboard_everos._set_base_url("http://localhost:20000")
+
+        slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
+        assert slice_["base_url"] == "http://localhost:20000"
+        assert slice_["port"] == 20000, "address recorded without the intent behind it"
+
+    def test_the_target_then_survives_a_second_run(self, tmp_env: Path) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(json.dumps({}), encoding="utf-8")
+        onboard_everos._set_base_url("http://localhost:20000")
+
+        assert onboard_everos._configured_target_url() == "http://localhost:20000"
+
+
+class TestSwitchingToSelfManagedClearsTheOldRoot:
+    """`owned: False` next to a stale `root` is a contradiction with teeth.
+
+    The slice is written by merge, so recording a self-managed address left any
+    previously recorded root in place. configure_everos_env exports that root
+    as EVEROS_ROOT, so raven would still be pointed at a directory it had just
+    promised to stop touching -- and the promise was documented as structural
+    precisely because no path is recorded.
+    """
+
+    def test_the_previous_root_does_not_survive(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from raven.cli import onboard_everos
+        from raven.plugin.memory.everos._server import ProbeResult
+
+        tmp_env.write_text(
+            json.dumps(
+                {
+                    "memory": {"backend": "everos"},
+                    "plugins": {"config": {"everos-memory": {"root": "/previous/root", "owned": True}}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        import questionary
+
+        answers = iter(["127.0.0.1", "8000"])
+        monkeypatch.setattr(questionary, "text", lambda *a, **kw: _Answer(next(answers)))
+        monkeypatch.setattr(onboard_everos.oc, "_require_questionary", lambda: questionary)
+        monkeypatch.setattr("raven.plugin.memory.everos._server.probe_health", lambda _u, **_kw: ProbeResult.OK)
+
+        assert onboard_everos._use_self_managed_everos() is True
+
+        slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
+        assert slice_["owned"] is False
+        assert "root" not in slice_, "kept a path into a root raven promised not to touch"

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1495,6 +1495,49 @@ def test_the_memory_step_reaches_the_capability_report(
     assert reported == [1], "the memory step never reported what EverOS can do"
 
 
+def test_memory_step_starts_the_configured_address_not_the_default(
+    tmp_env: Path, everos_isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The wizard must probe the address the memory backend will actually use.
+
+    Probing the 18791 default while ``plugins.config`` names another port made
+    the wizard conclude nothing was running and spawn a second instance, which
+    then died on the OME jobstore lock the first one held -- surfaced to the user
+    as a 30s timeout that blamed a missing install. Both the first attempt and
+    the retry have to carry the configured address.
+    """
+    import questionary
+
+    tmp_env.write_text(
+        json.dumps({"plugins": {"config": {"everos-memory": {"base_url": "http://localhost:1995"}}}}),
+        encoding="utf-8",
+    )
+
+    seen: list[str] = []
+
+    async def _fake_ensure(base_url: str, **_kw: object) -> None:
+        seen.append(base_url)
+        if len(seen) == 1:
+            raise RuntimeError("boom")
+
+    import raven.plugin.memory.everos._server as everos_server
+
+    monkeypatch.setattr(everos_server, "ensure_everos_server", _fake_ensure)
+    monkeypatch.setattr(onboard_everos, "_report_everos_capabilities", lambda: None)
+    monkeypatch.setattr(onboard_everos, "_config_everos_role", lambda **_: None)
+    monkeypatch.setattr(onboard_everos, "_memory_enabled", lambda: False)
+
+    class _FQ:
+        def ask(self):
+            return "retry"
+
+    monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ())
+
+    onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
+
+    assert seen == ["http://localhost:1995", "http://localhost:1995"]
+
+
 def test_memory_llm_reuse_pulls_provider_creds(
     tmp_env: Path, everos_isolated: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1840,6 +1840,113 @@ class TestConvergingRavensOwnPort:
         slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
         assert slice_["base_url"] == "http://localhost:1995"
 
+    def test_a_root_already_on_the_standard_address_is_left_alone(
+        self, tmp_env: Path, everos_isolated: Path, _stubs
+    ) -> None:
+        """The steady state after a convergence: nothing to stop, nothing to start."""
+        import questionary
+
+        from raven.plugin.memory.everos import _server
+
+        root = tmp_env.parent / "everos"
+        _found(_stubs, _root_state(root, declared_url="http://localhost:18791"))
+        touched: list[str] = []
+        _stubs.setattr(_server, "stop_recorded_server", lambda *_a, **_kw: touched.append("stop"))
+
+        async def _ensure(url: str, **_kw: object) -> None:
+            touched.append(url)
+
+        _stubs.setattr(_server, "ensure_everos_server", _ensure)
+        _stubs.setattr(questionary, "select", lambda *a, **kw: _Answer("keep"))
+
+        onboard_everos._step4_memory(
+            skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[]
+        )
+
+        assert touched == [], "restarted a service that was already where it belongs"
+        slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
+        assert slice_["base_url"] == "http://localhost:18791"
+
+    def test_an_owned_root_that_is_simply_down_still_converges(
+        self, tmp_env: Path, everos_isolated: Path, _stubs
+    ) -> None:
+        """Otherwise the legacy address survives every future run: the service
+        would be started at the old port and set_everos_api would write it
+        straight back into the toml."""
+        import questionary
+
+        from raven.plugin.memory.everos import _server
+
+        root = tmp_env.parent / "everos"
+        _found(_stubs, _root_state(root, alive=False, lock_held=False, declared_url="http://localhost:1995"))
+        started: list[str] = []
+
+        async def _ensure(url: str, **_kw: object) -> None:
+            started.append(url)
+
+        _stubs.setattr(_server, "ensure_everos_server", _ensure)
+        _stubs.setattr(questionary, "select", lambda *a, **kw: _Answer("keep"))
+
+        onboard_everos._step4_memory(
+            skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[]
+        )
+
+        assert started == ["http://localhost:18791"]
+        slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
+        assert slice_["base_url"] == "http://localhost:18791"
+
+    def test_a_lock_that_could_not_be_freed_stops_the_step(
+        self, tmp_env: Path, everos_isolated: Path, _stubs, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Spawning into a lock that is still held is the failure this whole step
+        exists to prevent, so a stop that did not stop must not fall through."""
+        from raven.plugin.memory.everos import _server
+
+        root = tmp_env.parent / "everos"
+        _found(_stubs, _root_state(root, alive=False, lock_held=True))
+        _stubs.setattr(_server, "find_recorded_server", lambda _r: {"pid": 1, "root": str(root)})
+        _stubs.setattr(_server, "stop_recorded_server", lambda *_a, **_kw: _server.StopOutcome.STILL_DRAINING)
+        started: list[str] = []
+
+        async def _ensure(url: str, **_kw: object) -> None:
+            started.append(url)
+
+        _stubs.setattr(_server, "ensure_everos_server", _ensure)
+        reached: list[int] = []
+        _stubs.setattr(onboard_everos, "_config_everos_role", lambda **_kw: reached.append(1))
+
+        onboard_everos._step4_memory(
+            skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[]
+        )
+
+        assert started == [], "spawned into a jobstore lock that is still held"
+        assert reached == []
+        out = " ".join(capsys.readouterr().out.split())
+        assert "still finishing memory work" in out or "还在跑" in out
+
+    def test_a_restart_that_fails_is_reported_and_stops_the_step(
+        self, tmp_env: Path, everos_isolated: Path, _stubs, capsys: pytest.CaptureFixture
+    ) -> None:
+        from raven.plugin.memory.everos import _server
+
+        root = tmp_env.parent / "everos"
+        _found(_stubs, _root_state(root, alive=False, lock_held=False, declared_url="http://localhost:1995"))
+
+        async def _boom(_url: str, **_kw: object) -> None:
+            raise RuntimeError("port 18791 is occupied")
+
+        _stubs.setattr(_server, "ensure_everos_server", _boom)
+        reached: list[int] = []
+        _stubs.setattr(onboard_everos, "_config_everos_role", lambda **_kw: reached.append(1))
+
+        onboard_everos._step4_memory(
+            skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[]
+        )
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "port 18791 is occupied" in out, "swallowed the reason the restart failed"
+        assert reached == []
+
     def test_data_held_by_an_unidentifiable_process_stops_the_step(
         self, tmp_env: Path, everos_isolated: Path, _stubs, capsys: pytest.CaptureFixture
     ) -> None:

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1284,7 +1284,7 @@ def test_memory_giving_up_sets_backend_null(
     """
     import questionary
 
-    answers = iter([onboard_commands._BACK, "abort"])
+    answers = iter(["managed", onboard_commands._BACK, "abort"])
 
     class _FQ:
         def ask(self):
@@ -1339,7 +1339,7 @@ def test_giving_up_says_what_is_lost(
     everything."""
     import questionary
 
-    answers = iter([onboard_commands._BACK, "abort"])
+    answers = iter(["managed", onboard_commands._BACK, "abort"])
 
     class _FQ:
         def ask(self):
@@ -1374,7 +1374,7 @@ def test_giving_up_says_what_is_lost_in_both_languages(
     import questionary
 
     monkeypatch.setattr(onboard_commands, "_LANG", lang)
-    answers = iter([onboard_commands._BACK, "abort"])
+    answers = iter(["managed", onboard_commands._BACK, "abort"])
 
     class _FQ:
         def ask(self):
@@ -1406,7 +1406,7 @@ def test_memory_enable_writes_everos_sections(
     #   3. embedding source picker      -> ("custom",)
     #   4. rerank "Configure it?"       -> "skip"
     #   5. multimodal "Configure it?"   -> "skip"
-    select_answers = iter([("custom",), "redo", ("custom",), "skip", "skip"])
+    select_answers = iter(["managed", ("custom",), "redo", ("custom",), "skip", "skip"])
     # text(): LLM base_url, LLM model, embed base_url, embed model.
     text_answers = iter(["https://llm/v1", "mem-llm", "https://llm/v1", "mem-embed"])
     # password(): LLM api key, embed api key.
@@ -1473,7 +1473,7 @@ def test_the_memory_step_reaches_the_capability_report(
     import questionary
 
     _seed_provider("openrouter", "sk-or", "openrouter/anthropic/claude-sonnet-4-5")
-    select_answers = iter([("custom",), "redo", ("custom",), "skip", "skip"])
+    select_answers = iter(["managed", ("custom",), "redo", ("custom",), "skip", "skip"])
     text_answers = iter(["https://llm/v1", "mem-llm", "https://llm/v1", "mem-embed"])
     password_answers = iter(["k-llm", "k-embed"])
 
@@ -1717,7 +1717,20 @@ class TestReusingAnEverosTheUserManages:
             json.dumps(
                 {
                     "memory": {"backend": "everos"},
-                    "plugins": {"config": {"everos-memory": {"root": str(theirs), "owned": False}}},
+                    # base_url alongside root: an unowned slice is "configured"
+                    # by its address, since raven never reads their toml. A
+                    # recorded unowned *root* only reaches this code from a
+                    # config written before self-managed setups stopped
+                    # recording one.
+                    "plugins": {
+                        "config": {
+                            "everos-memory": {
+                                "root": str(theirs),
+                                "owned": False,
+                                "base_url": "http://localhost:8000",
+                            }
+                        }
+                    },
                 }
             ),
             encoding="utf-8",
@@ -1836,7 +1849,10 @@ class TestConvergingRavensOwnPort:
         onboard_everos._step4_memory(skip=False, non_interactive=False, main_model="openai/gpt-4o-mini", warnings=[])
 
         out = " ".join(capsys.readouterr().out.split())
-        assert "did not start this process" in out or "不是 Raven 启动的" in out
+        # Worded as an inability to confirm rather than a claim of fact: a lost
+        # pidfile looks exactly like a foreign process, and asserting the latter
+        # sends the user hunting for something that does not exist.
+        assert "cannot confirm it started this process" in out or "无法确认这个进程是不是 Raven 启动的" in out
         slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
         assert slice_["base_url"] == "http://localhost:1995"
 
@@ -4359,7 +4375,7 @@ def test_the_memory_step_states_the_capability_tiers(
     import questionary
 
     monkeypatch.setattr(onboard_commands, "_LANG", lang)
-    answers = iter([onboard_commands._BACK, "abort"])
+    answers = iter(["managed", onboard_commands._BACK, "abort"])
 
     class _FQ:
         def ask(self):
@@ -5155,3 +5171,190 @@ def test_everos_role_optionality_matches_design():
     assert "skip_note" not in _EVEROS_ROLES["llm"]
     for role in DEGRADING_SECTIONS:
         assert "skip_note" in _EVEROS_ROLES[role]
+class TestMemoryEnabledRespectsOwnership:
+    """ "Configured" means something different for a root raven does not own.
+
+    The check reads ``[llm]`` out of the active root's toml, which for a
+    user-managed EverOS is a file raven has promised never to touch -- and
+    since a user-managed root is no longer recorded at all, there is no path to
+    read. What raven knows about such a server is its address and that a health
+    probe once answered there; that is the whole of what "configured" can mean.
+    """
+
+    def test_an_unowned_slice_is_enabled_on_its_address_alone(
+        self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(
+            json.dumps(
+                {
+                    "memory": {"backend": "everos"},
+                    "plugins": {"config": {"everos-memory": {"owned": False, "base_url": "http://localhost:8000"}}},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        def _must_not_read_their_toml(_section: str) -> bool:
+            raise AssertionError("read the user's everos.toml for an unowned root")
+
+        monkeypatch.setattr(onboard_everos, "_everos_role_configured", _must_not_read_their_toml)
+
+        assert onboard_everos._memory_enabled() is True
+
+    def test_an_unowned_slice_without_an_address_is_not_enabled(self, tmp_env: Path) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(
+            json.dumps(
+                {
+                    "memory": {"backend": "everos"},
+                    "plugins": {"config": {"everos-memory": {"owned": False}}},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert onboard_everos._memory_enabled() is False
+
+    def test_an_owned_slice_still_reads_the_llm_role(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(
+            json.dumps(
+                {
+                    "memory": {"backend": "everos"},
+                    "plugins": {"config": {"everos-memory": {"owned": True, "base_url": "http://localhost:18791"}}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(onboard_everos, "_everos_role_configured", lambda _s: False)
+
+        assert onboard_everos._memory_enabled() is False
+
+
+class TestTheConvergenceTargetIsConfigured:
+    """Where a raven-managed server should listen is a setting, not a constant.
+
+    Comparing the running address against a hardcoded 18791 cannot tell a port
+    an old raven left behind from a port the user picked on purpose, so it
+    treated both as drift and moved them back -- announcing the user's own
+    choice as "a port an earlier Raven version used".
+    """
+
+    def test_defaults_to_the_shipped_port(self, tmp_env: Path) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(json.dumps({}), encoding="utf-8")
+
+        assert onboard_everos._configured_target_url() == "http://localhost:18791"
+
+    def test_a_recorded_port_wins(self, tmp_env: Path) -> None:
+        from raven.cli import onboard_everos
+
+        tmp_env.write_text(
+            json.dumps({"plugins": {"config": {"everos-memory": {"port": 20000}}}}),
+            encoding="utf-8",
+        )
+
+        assert onboard_everos._configured_target_url() == "http://localhost:20000"
+
+
+class TestPointingRavenAtAnEverosYouRun:
+    """Self-managed setup is a turn the user takes, not one raven proposes.
+
+    Discovery no longer looks for anyone else's EverOS, so this path starts
+    with a person who knows they run one and types its address. Nothing about
+    that server is inspected beyond a single health probe, and nothing about it
+    is recorded beyond where it answers -- not even its root, so there is no
+    path on disk raven could write to even by mistake.
+    """
+
+    @staticmethod
+    def _stub_prompts(monkeypatch, *, host: str, port: str) -> None:
+        import questionary
+
+        from raven.cli import onboard_everos
+
+        answers = iter([host, port])
+        # _prompt_text reaches questionary through the shared wizard module, so
+        # that is where the stub has to land.
+        monkeypatch.setattr(questionary, "text", lambda *a, **kw: _Answer(next(answers)))
+        monkeypatch.setattr(onboard_everos.oc, "_require_questionary", lambda: questionary)
+
+    def test_a_reachable_address_is_recorded_without_a_root(
+        self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from raven.cli import onboard_everos
+        from raven.plugin.memory.everos._server import ProbeResult
+
+        tmp_env.write_text(json.dumps({}), encoding="utf-8")
+        self._stub_prompts(monkeypatch, host="127.0.0.1", port="8000")
+        monkeypatch.setattr("raven.plugin.memory.everos._server.probe_health", lambda _u, **_kw: ProbeResult.OK)
+
+        assert onboard_everos._use_self_managed_everos() is True
+
+        slice_ = json.loads(tmp_env.read_text())["plugins"]["config"]["everos-memory"]
+        assert slice_["base_url"] == "http://127.0.0.1:8000"
+        assert slice_["owned"] is False
+        assert "root" not in slice_, "recorded a path into a root raven promised not to touch"
+
+    def test_an_unreachable_address_is_refused(self, tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Recording an address that never answered would defer the failure to
+        every future session, with nothing left to say why."""
+        from raven.cli import onboard_everos
+        from raven.plugin.memory.everos._server import ProbeResult
+
+        tmp_env.write_text(json.dumps({}), encoding="utf-8")
+        self._stub_prompts(monkeypatch, host="127.0.0.1", port="8000")
+        monkeypatch.setattr("raven.plugin.memory.everos._server.probe_health", lambda _u, **_kw: ProbeResult.REFUSED)
+
+        assert onboard_everos._use_self_managed_everos() is False
+
+        slice_ = (json.loads(tmp_env.read_text()).get("plugins") or {}).get("config", {}).get("everos-memory", {})
+        assert not slice_.get("base_url")
+
+    def test_no_port_default_is_offered(self) -> None:
+        """The port is the user's to state. Pre-filling raven's own 18791 is an
+        invitation to accept it by reflex, and accepting it points this path at
+        the managed setup's address."""
+        import inspect
+
+        from raven.cli import onboard_everos
+
+        src = inspect.getsource(onboard_everos._use_self_managed_everos)
+        assert "18791" not in src
+
+
+class TestAddressComparisonIsNotStringComparison:
+    """``127.0.0.1`` and ``localhost`` are one endpoint spelled two ways.
+
+    The declared address is whatever is in the root's toml and the target is
+    built from a recorded port, so the two arrive spelled differently even when
+    they name the same socket. Comparing the strings made a service already on
+    its configured port look like drift, and offered to move it onto itself.
+    """
+
+    def test_loopback_spellings_are_the_same_address(self) -> None:
+        from raven.cli.onboard_everos import _same_address
+
+        assert _same_address("http://127.0.0.1:20000", "http://localhost:20000")
+        assert _same_address("http://localhost:20000", "http://127.0.0.1:20000")
+        assert _same_address("http://[::1]:20000", "http://localhost:20000")
+
+    def test_a_different_port_is_a_different_address(self) -> None:
+        from raven.cli.onboard_everos import _same_address
+
+        assert not _same_address("http://127.0.0.1:20000", "http://localhost:18791")
+
+    def test_a_non_loopback_host_is_not_loopback(self) -> None:
+        from raven.cli.onboard_everos import _same_address
+
+        assert not _same_address("http://10.0.0.5:20000", "http://localhost:20000")
+
+    def test_a_missing_address_never_matches(self) -> None:
+        from raven.cli.onboard_everos import _same_address
+
+        assert not _same_address(None, "http://localhost:18791")

--- a/tests/test_cli_tui_commands.py
+++ b/tests/test_cli_tui_commands.py
@@ -246,6 +246,9 @@ def rpc_server_deps(monkeypatch: pytest.MonkeyPatch):
 
     fake_agent_loop = MagicMock()
     fake_agent_loop.backend = spy_backend
+    # Awaited during teardown before backend.stop(); a bare MagicMock is not
+    # awaitable and would swallow the stop it is supposed to precede.
+    fake_agent_loop.drain_backend_stores = AsyncMock()
     fake_agent_loop.cron_service = None
     fake_agent_loop.tools.get.return_value = None
     fake_agent_loop.subagents.set_submit = MagicMock()

--- a/tests/test_config_raven_sections.py
+++ b/tests/test_config_raven_sections.py
@@ -194,7 +194,13 @@ class TestLoaderIntegration:
         )
         cfg = load_raven_config(path)
         assert cfg.plugins.disabled == ["mem0-memory"]
-        assert cfg.plugins.config["everos-memory"]["mode"] == "embedded"
+        # ``mode`` never had a reader and is dropped on load; ``root`` / ``owned``
+        # are recorded in its place so every caller reads one recorded decision
+        # instead of re-deriving it.
+        everos_slice = cfg.plugins.config["everos-memory"]
+        assert "mode" not in everos_slice
+        assert everos_slice["root"]
+        assert isinstance(everos_slice["owned"], bool)
         assert cfg.memory.backend == "everos"
         assert cfg.memory.user_id == "alice"
         assert cfg.memory.memory_top_k == 10

--- a/tests/test_config_update_everos.py
+++ b/tests/test_config_update_everos.py
@@ -260,3 +260,85 @@ def test_clear_absent_section_with_existing_file_preserves_it(everos_home: Path)
 def test_clear_unknown_section_rejected(everos_home: Path) -> None:
     with pytest.raises(KeyError):
         ue.clear_everos_section("sqlite")
+
+
+# ---------------------------------------------------------------------------
+# ownership as a write gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _unowned(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """An active root the user manages."""
+    monkeypatch.setattr(ue, "everos_root", lambda: tmp_path / "theirs")
+    monkeypatch.setattr(ue, "everos_owned", lambda: False)
+    return tmp_path / "theirs"
+
+
+def test_writing_a_section_of_an_unowned_root_is_refused(_unowned: Path) -> None:
+    """The read-only promise is enforced at the write, not only at the callers
+    that remember to check -- one rule kept in several places is the drift this
+    whole change is about."""
+    with pytest.raises(ue.EverosRootNotOwnedError, match="managed by the user"):
+        ue.set_everos_section("llm", {"model": "m", "api_key": "k"})
+    assert not (_unowned / "everos.toml").exists()
+
+
+def test_clearing_a_section_of_an_unowned_root_is_refused(_unowned: Path) -> None:
+    with pytest.raises(ue.EverosRootNotOwnedError):
+        ue.clear_everos_section("rerank")
+
+
+def test_seeding_templates_into_an_unowned_root_is_refused(_unowned: Path) -> None:
+    with pytest.raises(ue.EverosRootNotOwnedError):
+        ue.ensure_everos_home()
+    assert not _unowned.exists(), "created a directory inside a root the user manages"
+
+
+def test_the_address_write_is_refused_too(_unowned: Path) -> None:
+    """[api] goes through the same gate: the address is raven's to manage only on
+    a root raven owns."""
+    with pytest.raises(ue.EverosRootNotOwnedError):
+        ue.set_everos_api(host="127.0.0.1", port=18791)
+
+
+def test_a_root_raven_owns_may_be_written(everos_home: Path) -> None:
+    ue.set_everos_section("llm", {"model": "m", "api_key": "k"})
+    assert everos_home.exists()
+
+
+# ---------------------------------------------------------------------------
+# owned_everos_root
+# ---------------------------------------------------------------------------
+
+
+def test_own_root_falls_back_when_the_active_one_is_the_users(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """ "raven needs a root of its own" must never resolve to a root the user
+    manages, or declining to share theirs would hand it over anyway."""
+    monkeypatch.setattr(ue, "everos_root", lambda: tmp_path / "theirs")
+    monkeypatch.setattr(ue, "everos_owned", lambda: False)
+    monkeypatch.setattr(ue, "default_everos_root", lambda: tmp_path / "mine")
+
+    assert ue.owned_everos_root() == tmp_path / "mine"
+
+
+def test_own_root_keeps_the_active_one_when_raven_owns_it(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(ue, "everos_root", lambda: tmp_path / "recorded")
+    monkeypatch.setattr(ue, "everos_owned", lambda: True)
+    monkeypatch.setattr(ue, "default_everos_root", lambda: tmp_path / "mine")
+
+    assert ue.owned_everos_root() == tmp_path / "recorded"
+
+
+def test_fallback_root_reads_no_raven_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The migration calls this while holding a config dict of its own; reading
+    the globally-current config there would stamp one file with another's root."""
+    monkeypatch.setattr(ue, "legacy_everos_root", lambda: tmp_path / "absent")
+    monkeypatch.setattr(ue, "default_everos_root", lambda: tmp_path / "mine")
+
+    def _boom() -> dict:
+        raise AssertionError("fallback_everos_root read raven's config")
+
+    monkeypatch.setattr(ue, "_recorded_slice", _boom)
+
+    assert ue.fallback_everos_root() == tmp_path / "mine"

--- a/tests/test_config_update_everos.py
+++ b/tests/test_config_update_everos.py
@@ -68,6 +68,10 @@ def test_legacy_root_is_kept_when_it_holds_a_config(monkeypatch: pytest.MonkeyPa
     (legacy / "everos.toml").write_text("[llm]\n", encoding="utf-8")
     monkeypatch.setattr(ue, "_recorded_slice", dict)
     monkeypatch.setattr(ue, "legacy_everos_root", lambda: legacy)
+    # State the premise: the legacy root is only a candidate for the
+    # installation that could have created it, and set_config_path is a
+    # process global another test may have moved.
+    monkeypatch.setattr(ue, "_is_default_installation", lambda: True)
 
     assert ue.everos_root() == legacy
 
@@ -342,3 +346,66 @@ def test_fallback_root_reads_no_raven_config(monkeypatch: pytest.MonkeyPatch, tm
     monkeypatch.setattr(ue, "_recorded_slice", _boom)
 
     assert ue.fallback_everos_root() == tmp_path / "mine"
+
+
+class TestTheLegacyRootBelongsToTheDefaultInstall:
+    """``~/.everos/raven`` is one machine-wide path, not a per-instance one.
+
+    Every other root raven uses is derived from its config directory, so moving
+    the installation moves them. This one is a literal, which made it leak in
+    two directions: it ignored the home the process was told to use, and an
+    instance running from a moved config would adopt -- and converge, and
+    rewrite the ``[api]`` of -- the default installation's root.
+    """
+
+    def test_it_follows_the_home_in_use(self, tmp_path, monkeypatch) -> None:
+        """``Path("~/...").expanduser()`` reads $HOME directly, so it slipped
+        past the ``Path.home`` redirection the test fixtures isolate with and
+        reached the developer's own machine."""
+        from raven.config import update_everos as ue
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        assert ue.legacy_everos_root() == tmp_path / ".everos" / "raven"
+
+    def test_the_default_install_still_considers_it(self, tmp_path, monkeypatch) -> None:
+        from raven.config import update_everos as ue
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr("raven.config.loader.get_config_path", lambda: tmp_path / ".raven" / "config.json")
+
+        assert ue.applicable_legacy_root() == tmp_path / ".everos" / "raven"
+
+    def test_a_moved_install_does_not(self, tmp_path, monkeypatch) -> None:
+        """The isolated instance never created this root, so treating it as a
+        candidate would have one installation converge another's service."""
+        from raven.config import update_everos as ue
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr("raven.config.loader.get_config_path", lambda: tmp_path / "elsewhere" / "config.json")
+
+        assert ue.applicable_legacy_root() is None
+
+    def test_classification_is_unconditional(self, tmp_path, monkeypatch) -> None:
+        """Selecting the root and recognising it are different questions. A
+        config that already records it recorded a root raven created, whichever
+        installation is reading now."""
+        from raven.config import update_everos as ue
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr("raven.config.loader.get_config_path", lambda: tmp_path / "elsewhere" / "config.json")
+
+        assert ue.root_is_raven_owned(tmp_path / ".everos" / "raven") is True
+
+    def test_the_fallback_skips_it_when_moved(self, tmp_path, monkeypatch) -> None:
+        from raven.config import update_everos as ue
+
+        legacy = tmp_path / ".everos" / "raven"
+        legacy.mkdir(parents=True)
+        (legacy / "everos.toml").write_text("", encoding="utf-8")
+        mine = tmp_path / "elsewhere" / "everos"
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr("raven.config.loader.get_config_path", lambda: tmp_path / "elsewhere" / "config.json")
+        monkeypatch.setattr(ue, "default_everos_root", lambda: mine)
+
+        assert ue.fallback_everos_root() == mine

--- a/tests/test_config_update_everos.py
+++ b/tests/test_config_update_everos.py
@@ -9,6 +9,7 @@ coverage here.
 
 from __future__ import annotations
 
+import os
 import tomllib
 from pathlib import Path
 
@@ -19,10 +20,11 @@ import raven.config.update_everos as ue
 
 @pytest.fixture
 def everos_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Point the ops library at a throwaway config path."""
-    cfg = tmp_path / ".everos" / "everos.toml"
-    monkeypatch.setattr(ue, "_EVEROS_CONFIG", cfg)
-    return cfg
+    """Point the ops library at a throwaway root that raven owns."""
+    root = tmp_path / ".everos"
+    monkeypatch.setattr(ue, "everos_root", lambda: root)
+    monkeypatch.setattr(ue, "everos_owned", lambda: True)
+    return root / "everos.toml"
 
 
 def _read(path: Path) -> dict:
@@ -35,10 +37,9 @@ def _read(path: Path) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def test_config_path_expands_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setattr(ue, "_EVEROS_CONFIG", Path("~/.everos/everos.toml"))
-    monkeypatch.setenv("HOME", str(tmp_path))
-    assert ue.get_everos_config_path() == tmp_path / ".everos" / "everos.toml"
+def test_config_path_follows_the_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(ue, "everos_root", lambda: tmp_path / "somewhere")
+    assert ue.get_everos_config_path() == tmp_path / "somewhere" / "everos.toml"
 
 
 def test_load_absent_returns_empty(everos_home: Path) -> None:
@@ -46,37 +47,96 @@ def test_load_absent_returns_empty(everos_home: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# root resolution + ownership
+# ---------------------------------------------------------------------------
+
+
+def test_recorded_root_wins(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        ue,
+        "_recorded_slice",
+        lambda: {"root": str(tmp_path / "recorded"), "owned": True},
+    )
+    assert ue.everos_root() == tmp_path / "recorded"
+    assert ue.everos_owned() is True
+
+
+def test_legacy_root_is_kept_when_it_holds_a_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """An install from before the move must not be pointed at an empty dir."""
+    legacy = tmp_path / ".everos" / "raven"
+    legacy.mkdir(parents=True)
+    (legacy / "everos.toml").write_text("[llm]\n", encoding="utf-8")
+    monkeypatch.setattr(ue, "_recorded_slice", dict)
+    monkeypatch.setattr(ue, "legacy_everos_root", lambda: legacy)
+
+    assert ue.everos_root() == legacy
+
+
+def test_fresh_install_uses_the_raven_data_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(ue, "_recorded_slice", dict)
+    monkeypatch.setattr(ue, "legacy_everos_root", lambda: tmp_path / "absent")
+    monkeypatch.setattr(ue, "default_everos_root", lambda: tmp_path / "data" / "everos")
+
+    assert ue.everos_root() == tmp_path / "data" / "everos"
+
+
+def test_ownership_of_an_unrecorded_foreign_root_is_denied(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Absent the field, anything raven did not create is treated as not ours."""
+    monkeypatch.setattr(ue, "_recorded_slice", lambda: {"root": str(tmp_path / "theirs")})
+    monkeypatch.setattr(ue, "default_everos_root", lambda: tmp_path / "ours")
+    monkeypatch.setattr(ue, "legacy_everos_root", lambda: tmp_path / "legacy")
+
+    assert ue.everos_owned() is False
+
+
+def test_recorded_ownership_overrides_the_path_guess(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A user-managed root cannot be classified by its path, so the record wins."""
+    monkeypatch.setattr(
+        ue,
+        "_recorded_slice",
+        lambda: {"root": str(tmp_path / "ours"), "owned": False},
+    )
+    monkeypatch.setattr(ue, "default_everos_root", lambda: tmp_path / "ours")
+
+    assert ue.everos_owned() is False
+
+
+# ---------------------------------------------------------------------------
 # configure_everos_env
 # ---------------------------------------------------------------------------
 
 
-def test_configure_everos_env_points_at_raven_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setattr(ue, "_EVEROS_BASE", tmp_path / ".everos" / "raven")
+def test_configure_everos_env_points_at_the_recorded_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(ue, "everos_root", lambda: tmp_path / "recorded")
     monkeypatch.delenv("EVEROS_ROOT", raising=False)
 
     ue.configure_everos_env()
 
-    base = tmp_path / ".everos" / "raven"
-    import os
-
-    assert os.environ["EVEROS_ROOT"] == str(base)
+    assert os.environ["EVEROS_ROOT"] == str(tmp_path / "recorded")
 
 
-def test_configure_everos_env_respects_explicit_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    # An operator-set EVEROS_ROOT must win (setdefault, not overwrite).
-    monkeypatch.setattr(ue, "_EVEROS_BASE", tmp_path / ".everos" / "raven")
+def test_configure_everos_env_overrides_an_ambient_value(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The recorded root wins over the environment, not the other way round.
+
+    This reverses the old contract deliberately. Following an ambient
+    EVEROS_ROOT pointed raven at a root nothing had recorded, so the next run
+    without the variable reported no memories while they sat on disk. Operators
+    who want another root record it in the config.
+    """
+    monkeypatch.setattr(ue, "everos_root", lambda: tmp_path / "recorded")
     monkeypatch.setenv("EVEROS_ROOT", "/custom/root")
 
     ue.configure_everos_env()
 
-    import os
-
-    assert os.environ["EVEROS_ROOT"] == "/custom/root"
+    assert os.environ["EVEROS_ROOT"] == str(tmp_path / "recorded")
 
 
-def test_default_config_path_under_raven_home() -> None:
-    # The production default lives under ~/.everos/raven, not bare ~/.everos.
-    assert ue.get_everos_config_path() == (Path("~/.everos/raven/everos.toml").expanduser())
+def test_configure_everos_env_accepts_an_explicit_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(ue, "everos_root", lambda: tmp_path / "recorded")
+
+    ue.configure_everos_env(tmp_path / "explicit")
+
+    assert os.environ["EVEROS_ROOT"] == str(tmp_path / "explicit")
 
 
 def test_load_round_trips_written_content(everos_home: Path) -> None:
@@ -157,7 +217,9 @@ def test_set_preserves_mixed_value_types(everos_home: Path) -> None:
 
 
 def test_set_unknown_section_rejected(everos_home: Path) -> None:
-    for bad in ("sqlite", "memory", "api", "lancedb", ""):
+    # ``api`` is writable now (the address lives there); the data-layout
+    # sections EverOS owns still are not.
+    for bad in ("sqlite", "memory", "lancedb", ""):
         with pytest.raises(KeyError):
             ue.set_everos_section(bad, {"x": 1})
 

--- a/tests/test_everos_backend.py
+++ b/tests/test_everos_backend.py
@@ -1572,3 +1572,73 @@ class TestASessionPicksUpAServiceThatArrivesLate:
         assert await b.recall("q", user_id="u", top_k=5) == []
         assert b._probe_task is None, "probed a state no probe can resolve"
         assert b._state is ServiceState.UNCONFIGURED
+
+
+@pytest.mark.asyncio
+class TestTheDegradationWarningOnASelfManagedServer:
+    """The one place raven can only talk, it was silent.
+
+    The warning gated on the local toml's embedding role. A self-managed
+    install records no root, so that read lands on the fallback root -- the
+    fabricated one doctor was fixed to stop trusting. It usually does not
+    exist, the gate reads False, and the warning never fires on exactly the
+    path whose comment argues the case for it is strongest: raven cannot repair
+    somebody else's embedding config, so saying so is the only move it has.
+
+    When a stale raven-managed root does exist the gate passes instead, and the
+    advice points at a log raven never wrote for that server.
+    """
+
+    @staticmethod
+    def _ctx():
+        ctx = MagicMock()
+        ctx.config = {"base_url": "http://localhost:18791"}
+        ctx.services.agent_id = "default"
+        ctx.services.user_id = "default"
+        ctx.logger = MagicMock()
+        return ctx
+
+    async def _start_unowned(self, monkeypatch, *, caps: dict):
+        from raven.plugin.memory.everos import _health
+        from raven.plugin.memory.everos._server import ProbeResult
+        from raven.plugin.memory.everos.backend import EverosBackend
+
+        monkeypatch.setattr("raven.config.update_everos.everos_owned", lambda: False)
+        monkeypatch.setattr(
+            "raven.config.update_everos.everos_role_configured",
+            lambda _s: pytest.fail("read the local toml for a root raven does not own"),
+        )
+        monkeypatch.setattr("raven.plugin.memory.everos._server.probe_health", lambda _u, **_kw: ProbeResult.OK)
+        monkeypatch.setattr(
+            _health,
+            "probe_capabilities",
+            lambda *_a, **_kw: _health.CapabilityReport(reachable=True, capabilities=caps),
+        )
+        b = EverosBackend(self._ctx())
+        await b.start()
+        return b
+
+    async def test_it_speaks_when_the_server_says_embedding_is_down(
+        self, monkeypatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        await self._start_unowned(monkeypatch, caps={"llm": True, "embed": False})
+
+        err = " ".join(capsys.readouterr().err.split())
+        assert "embedding is unavailable" in err
+        # Their server, their log. Pointing at raven's is a dead end.
+        assert "everos-server.log" not in err
+
+    async def test_it_stays_quiet_when_the_server_says_embedding_is_fine(
+        self, monkeypatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        await self._start_unowned(monkeypatch, caps={"llm": True, "embed": True})
+
+        assert "embedding is unavailable" not in capsys.readouterr().err
+
+    async def test_a_server_too_old_to_report_is_not_condemned(
+        self, monkeypatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """An empty capability map is silence, not a negative."""
+        await self._start_unowned(monkeypatch, caps={})
+
+        assert "embedding is unavailable" not in capsys.readouterr().err

--- a/tests/test_everos_backend.py
+++ b/tests/test_everos_backend.py
@@ -150,6 +150,70 @@ class TestLifecycle:
         mock_ensure.assert_called_once()
 
 
+class TestColdStartSpeaksUp:
+    """The memory service starts on demand every session, and it can fail.
+
+    Both the wait and the failure used to be invisible: the wait was silent and
+    the reason went only to the log file, so a broken backend looked like an
+    agent that had simply gone quiet.
+    """
+
+    async def test_a_real_wait_says_so(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        async def _waits(_base_url: str, *, on_wait=None, **_kw: object) -> None:
+            if on_wait is not None:
+                on_wait()
+
+        with patch("raven.plugin.memory.everos._server.ensure_everos_server", new=_waits):
+            b = EverosBackend(_ctx(tmp_path))
+            await b.start()
+
+        assert "Starting memory service" in capsys.readouterr().err
+
+    async def test_an_already_running_server_stays_silent(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """``on_wait`` must not fire when there is nothing to wait for: this path
+        runs on every session, and a line here would be pure noise."""
+
+        async def _already_up(_base_url: str, *, on_wait=None, **_kw: object) -> None:
+            return None
+
+        with patch("raven.plugin.memory.everos._server.ensure_everos_server", new=_already_up):
+            b = EverosBackend(_ctx(tmp_path))
+            await b.start()
+
+        assert "Starting memory service" not in capsys.readouterr().err
+
+    async def test_unconfigured_llm_degrades_with_an_actionable_line(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """This is the out-of-the-box state: backend defaults to everos while the
+        shipped everos.toml has an empty [llm] api_key."""
+        from raven.plugin.memory.everos._server import EverosNotConfiguredError
+
+        async def _unconfigured(*_a: object, **_kw: object) -> None:
+            raise EverosNotConfiguredError("no llm")
+
+        with patch("raven.plugin.memory.everos._server.ensure_everos_server", new=_unconfigured):
+            b = EverosBackend(_ctx(tmp_path))
+            await b.start()
+
+        err = " ".join(capsys.readouterr().err.split())
+        assert "its LLM is not configured" in err
+        assert "raven onboard" in err
+
+    async def test_other_failures_name_the_reason(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        async def _boom(*_a: object, **_kw: object) -> None:
+            raise RuntimeError("EverOS server exited with code 1")
+
+        with patch("raven.plugin.memory.everos._server.ensure_everos_server", new=_boom):
+            b = EverosBackend(_ctx(tmp_path))
+            with pytest.raises(RuntimeError):
+                await b.start()
+
+        err = " ".join(capsys.readouterr().err.split())
+        assert "exited with code 1" in err
+        assert "without long-term memory" in err
+
+
 class TestStartWarnsWhenRecallCannotWork:
     """A running server stopped implying a working one in everos 1.2.1."""
 

--- a/tests/test_everos_backend.py
+++ b/tests/test_everos_backend.py
@@ -12,15 +12,17 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from raven.memory_engine import MemoryBackend
 from raven.plugin import PluginContext, ServiceLocator
+from raven.plugin.memory.everos._server import ProbeResult
 from raven.plugin.memory.everos.backend import (
     _PROFILE_MAX_CHARS,
     EverosBackend,
+    ServiceState,
     _flatten_profile,
     _HttpEverosAdapter,
     make_backend,
@@ -206,9 +208,12 @@ class TestColdStartSpeaksUp:
 
         with patch("raven.plugin.memory.everos._server.ensure_everos_server", new=_boom):
             b = EverosBackend(_ctx(tmp_path))
-            with pytest.raises(RuntimeError):
-                await b.start()
+            # Degrades rather than raising: the caller already treats a missing
+            # memory service as a degradation, and the state machine keeps
+            # probing in case the server turns up later in the session.
+            await b.start()
 
+        assert b._state is not ServiceState.READY
         err = " ".join(capsys.readouterr().err.split())
         assert "exited with code 1" in err
         assert "without long-term memory" in err
@@ -237,12 +242,16 @@ class TestAUserManagedRootIsReadOnly:
             started.append(1)
 
         monkeypatch.setattr("raven.plugin.memory.everos._server.ensure_everos_server", _ensure)
-        monkeypatch.setattr("raven.plugin.memory.everos._server._probe_health", lambda _u: False)
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server.probe_health",
+            lambda _u, **_kw: ProbeResult.REFUSED,
+        )
 
         b = EverosBackend(_ctx(tmp_path))
         await b.start()
 
         assert started == [], "started a server on a root raven does not own"
+        assert b._state is ServiceState.FOREIGN
         err = " ".join(capsys.readouterr().err.split())
         assert "you manage is not running" in err
         assert "does not start or stop it" in err
@@ -257,12 +266,16 @@ class TestAUserManagedRootIsReadOnly:
             started.append(1)
 
         monkeypatch.setattr("raven.plugin.memory.everos._server.ensure_everos_server", _ensure)
-        monkeypatch.setattr("raven.plugin.memory.everos._server._probe_health", lambda _u: True)
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server.probe_health",
+            lambda _u, **_kw: ProbeResult.OK,
+        )
 
         b = EverosBackend(_ctx(tmp_path))
         await b.start()
 
         assert started == []
+        assert b._state is ServiceState.READY
         assert capsys.readouterr().err == ""
 
     def test_the_factory_drops_no_templates_into_it(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -903,12 +916,25 @@ class TestStoreConversion:
         )
         assert adapter.memorize_calls[0]["payload_messages"][0]["sender_id"] == "alice-123"
 
-    async def test_memorize_exception_propagates(self, tmp_path: Path) -> None:
+    async def test_memorize_failure_is_absorbed_and_accounted(self, tmp_path: Path) -> None:
+        """A failed write is recorded here, not raised.
+
+        store runs as a detached task now, so there is no caller left to catch
+        anything it throws -- an exception would surface only as asyncio's
+        "Task exception was never retrieved". The backend is the last place that
+        can both classify the failure (demoting the service state) and remember
+        that a turn went unindexed, so it does both instead.
+        """
+        from raven.plugin.memory.everos.backend import ServiceState
+
         adapter = _FakeAdapter()
         adapter.memorize_raises = RuntimeError("everos down")
         b = _backend(tmp_path, adapter=adapter)
-        with pytest.raises(RuntimeError, match="everos down"):
-            await b.store("s", [{"role": "user", "content": "x"}])
+
+        await b.store("s", [{"role": "user", "content": "x"}])
+
+        assert b._dropped_writes == 1
+        assert b._state is not ServiceState.READY
 
 
 # ---------------------------------------------------------------------------
@@ -1020,3 +1046,237 @@ class TestIdentityFromServices:
         # for it in config.json.
         with pytest.raises(ValueError, match="memory.userId"):
             await backend.start()
+
+
+class TestServiceStateMachine:
+    """The session's view of whether memory is usable, and what to do next.
+
+    Before this the backend answered the question once, at start(), and a
+    failure swapped in a no-op adapter for the rest of the session -- a server
+    that came up two seconds later was never noticed. The state machine
+    replaces that one-shot verdict with a fact that can change, and separates
+    the two things a failure has to say: is this worth retrying, and is it
+    worth waiting for.
+    """
+
+    @staticmethod
+    def _backend(**cfg):
+        from raven.plugin.memory.everos.backend import EverosBackend
+
+        ctx = MagicMock()
+        ctx.config = {"base_url": "http://localhost:18791", **cfg}
+        ctx.services.agent_id = "default"
+        ctx.services.user_id = "default"
+        ctx.logger = MagicMock()
+        return EverosBackend(ctx, adapter=MagicMock())
+
+    def test_a_real_backend_starts_unknown(self) -> None:
+        """Production builds its own HTTP adapter, so the lifecycle is this
+        backend's to establish and nothing is known until the first probe."""
+        from raven.plugin.memory.everos.backend import EverosBackend, ServiceState
+
+        ctx = MagicMock()
+        ctx.config = {"base_url": "http://localhost:18791"}
+        ctx.services.agent_id = "default"
+        ctx.services.user_id = "default"
+        ctx.logger = MagicMock()
+        assert EverosBackend(ctx)._state is ServiceState.UNKNOWN
+
+    def test_an_injected_adapter_is_assumed_ready(self) -> None:
+        """The caller supplied the transport, so it owns what is behind it --
+        there is no server here to probe or spawn."""
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        assert self._backend()._state is ServiceState.READY
+
+    def test_probe_ok_reaches_ready(self) -> None:
+        from raven.plugin.memory.everos._server import ProbeResult
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        b = self._backend()
+        b._apply_probe(ProbeResult.OK)
+        assert b._state is ServiceState.READY
+
+    def test_timeout_is_unresponsive_not_failed(self) -> None:
+        """A hung server is listening, so re-probing it charges the full budget
+        every time. Filing it as FAILED would be wrong in the other direction:
+        FAILED means the child is gone."""
+        from raven.plugin.memory.everos._server import ProbeResult
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        b = self._backend()
+        b._state = ServiceState.READY
+        b._apply_probe(ProbeResult.TIMEOUT)
+        assert b._state is ServiceState.UNRESPONSIVE
+
+    def test_refused_with_a_live_child_is_starting(self) -> None:
+        from raven.plugin.memory.everos._server import ProbeResult
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        b = self._backend()
+        b._proc = MagicMock(**{"poll.return_value": None})
+        b._apply_probe(ProbeResult.REFUSED)
+        assert b._state is ServiceState.STARTING
+
+    def test_refused_with_a_dead_child_is_failed(self) -> None:
+        from raven.plugin.memory.everos._server import ProbeResult
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        b = self._backend()
+        b._proc = MagicMock(**{"poll.return_value": 1, "returncode": 1})
+        b._apply_probe(ProbeResult.REFUSED)
+        assert b._state is ServiceState.FAILED
+
+    def test_refused_with_no_child_of_ours_is_starting(self) -> None:
+        """``None`` means another process holds the spawn lock, so there is no
+        exit code to read. Calling that FAILED would stop a start that is
+        someone else's and going fine."""
+        from raven.plugin.memory.everos._server import ProbeResult
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        b = self._backend()
+        b._proc = None
+        b._apply_probe(ProbeResult.REFUSED)
+        assert b._state is ServiceState.STARTING
+
+    def test_any_state_recovers_to_ready_on_a_later_probe(self) -> None:
+        """FAILED is not terminal. The user can start the server by hand in
+        another terminal, and the next probe has to see it."""
+        from raven.plugin.memory.everos._server import ProbeResult
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        for start in (
+            ServiceState.FAILED,
+            ServiceState.STARTING,
+            ServiceState.UNRESPONSIVE,
+            ServiceState.FOREIGN,
+        ):
+            b = self._backend()
+            b._state = start
+            b._apply_probe(ProbeResult.OK)
+            assert b._state is ServiceState.READY, start
+
+    def test_terminal_states_ignore_probes(self) -> None:
+        """UNCONFIGURED and NO_BINARY describe the install, not the process.
+        Probing cannot fix either, so a stray OK must not paper over them."""
+        from raven.plugin.memory.everos._server import ProbeResult
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        for terminal in (ServiceState.UNCONFIGURED, ServiceState.NO_BINARY):
+            b = self._backend()
+            b._state = terminal
+            b._apply_probe(ProbeResult.OK)
+            assert b._state is terminal
+
+    def test_may_spawn_only_from_states_that_can_be_fixed_by_spawning(self) -> None:
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        b = self._backend()
+        can = {ServiceState.UNKNOWN}
+        for state in ServiceState:
+            b._state = state
+            assert b._may_spawn() is (state in can), state
+
+    def test_reports_each_state_once(self) -> None:
+        """One line per problem per session. Re-reporting on every turn is how
+        a warning becomes something users filter out."""
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        b = self._backend()
+        b._state = ServiceState.FAILED
+        assert b._should_report() is True
+        assert b._should_report() is False
+        b._state = ServiceState.UNRESPONSIVE
+        assert b._should_report() is True
+
+
+@pytest.mark.asyncio
+class TestRecallNeverBlocks:
+    """A turn must not pay for a memory service that is not there.
+
+    recall used to run through an adapter with a 60s timeout, and a failure at
+    start() replaced the adapter outright so the session could never recover.
+    Both directions are wrong: the healthy path should be able to come back,
+    and the unhealthy path should cost nothing.
+    """
+
+    @staticmethod
+    def _backend(state, adapter=None):
+        from raven.plugin.memory.everos.backend import EverosBackend
+
+        ctx = MagicMock()
+        ctx.config = {"base_url": "http://localhost:18791"}
+        ctx.services.agent_id = "default"
+        ctx.services.user_id = "default"
+        ctx.logger = MagicMock()
+        b = EverosBackend(ctx, adapter=adapter or MagicMock())
+        b._state = state
+        return b
+
+    async def test_non_ready_returns_immediately_without_touching_the_adapter(self) -> None:
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        adapter = MagicMock()
+        adapter.search = AsyncMock(side_effect=AssertionError("must not be called"))
+        b = self._backend(ServiceState.UNRESPONSIVE, adapter)
+        with patch.object(b, "_kick_probe") as kick:
+            assert await b.recall("q", user_id="u", top_k=5) == []
+        kick.assert_called_once()
+
+    async def test_non_ready_kicks_an_out_of_band_probe(self) -> None:
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        b = self._backend(ServiceState.FAILED)
+        with patch.object(b, "_kick_probe") as kick:
+            await b.recall("q", user_id="u", top_k=5)
+        kick.assert_called_once()
+
+    async def test_a_timeout_demotes_so_the_next_turn_is_free(self) -> None:
+        import httpx
+
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        adapter = MagicMock()
+        adapter.search = AsyncMock(side_effect=httpx.ReadTimeout("hung"))
+        b = self._backend(ServiceState.READY, adapter)
+        assert await b.recall("q", user_id="u", top_k=5) == []
+        assert b._state is ServiceState.UNRESPONSIVE
+
+    async def test_a_refusal_consults_the_child_process(self) -> None:
+        import httpx
+
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        adapter = MagicMock()
+        adapter.search = AsyncMock(side_effect=httpx.ConnectError("gone"))
+        b = self._backend(ServiceState.READY, adapter)
+        b._proc = MagicMock(**{"poll.return_value": 2, "returncode": 2})
+        assert await b.recall("q", user_id="u", top_k=5) == []
+        assert b._state is ServiceState.FAILED
+
+
+@pytest.mark.asyncio
+class TestStoreIsDiscardedWhenTheServiceIsNotReady:
+    """A write to a service that is not there is not worth a task."""
+
+    @staticmethod
+    def _backend(state):
+        from raven.plugin.memory.everos.backend import EverosBackend
+
+        ctx = MagicMock()
+        ctx.config = {"base_url": "http://localhost:18791"}
+        ctx.services.agent_id = "default"
+        ctx.services.user_id = "default"
+        ctx.logger = MagicMock()
+        adapter = MagicMock()
+        adapter.memorize = AsyncMock(side_effect=AssertionError("must not be called"))
+        b = EverosBackend(ctx, adapter=adapter)
+        b._state = state
+        return b
+
+    async def test_dropped_and_counted(self) -> None:
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        b = self._backend(ServiceState.FAILED)
+        await b.store("s1", [{"role": "user", "content": "hi"}])
+        assert b._dropped_writes == 1

--- a/tests/test_everos_backend.py
+++ b/tests/test_everos_backend.py
@@ -1495,3 +1495,80 @@ class TestADeadChildIsReportedAsFailed:
             await b.start()
 
         assert b._state is ServiceState.FAILED
+
+
+@pytest.mark.asyncio
+class TestASessionPicksUpAServiceThatArrivesLate:
+    """The two halves compose: a turn with no memory leaves one that has it.
+
+    The state transition and the out-of-band kick are each covered on their
+    own, which is not the same as the property they exist for -- a session that
+    began without a memory service must start using one that comes up while it
+    is still running, with no restart. Before the state machine that was
+    impossible by construction: the first failure swapped in a no-op adapter
+    and the session was done.
+    """
+
+    @staticmethod
+    def _backend(adapter):
+        from raven.plugin.memory.everos.backend import EverosBackend, ServiceState
+
+        ctx = MagicMock()
+        ctx.config = {"base_url": "http://localhost:18791"}
+        ctx.services.agent_id = "default"
+        ctx.services.user_id = "default"
+        ctx.logger = MagicMock()
+        b = EverosBackend(ctx, adapter=adapter)
+        b._state = ServiceState.STARTING
+        return b
+
+    async def test_a_later_turn_recalls_once_the_server_answers(self, monkeypatch) -> None:
+        from raven.plugin.memory.everos import backend as mod
+        from raven.plugin.memory.everos._server import ProbeResult
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        adapter = MagicMock()
+        adapter.search = AsyncMock(return_value=None)
+        b = self._backend(adapter)
+        # No rate limit in the way: the point is the composition, not the
+        # throttle, which has its own coverage.
+        monkeypatch.setattr(mod, "_PROBE_MIN_INTERVAL_S", 0.0)
+
+        answers = iter([ProbeResult.REFUSED, ProbeResult.OK])
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server.probe_health",
+            lambda _u, **_kw: next(answers, ProbeResult.OK),
+        )
+
+        # Turn one: nothing there. Returns empty without touching the adapter,
+        # and leaves a probe behind.
+        assert await b.recall("q", user_id="u", top_k=5) == []
+        adapter.search.assert_not_awaited()
+        await b._probe_task
+
+        # The server came up between the turns.
+        assert await b.recall("q", user_id="u", top_k=5) == []
+        await b._probe_task
+        assert b._state is ServiceState.READY
+
+        # Turn three actually reaches it -- no restart, same backend object.
+        await b.recall("q", user_id="u", top_k=5)
+        adapter.search.assert_awaited()
+
+    async def test_a_terminal_state_never_recovers_this_way(self, monkeypatch) -> None:
+        """UNCONFIGURED describes the install. A server answering on that port
+        is somebody else's, and adopting it would hide a missing memory LLM."""
+        from raven.plugin.memory.everos import backend as mod
+        from raven.plugin.memory.everos._server import ProbeResult
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        adapter = MagicMock()
+        adapter.search = AsyncMock(return_value=None)
+        b = self._backend(adapter)
+        b._state = ServiceState.UNCONFIGURED
+        monkeypatch.setattr(mod, "_PROBE_MIN_INTERVAL_S", 0.0)
+        monkeypatch.setattr("raven.plugin.memory.everos._server.probe_health", lambda _u, **_kw: ProbeResult.OK)
+
+        assert await b.recall("q", user_id="u", top_k=5) == []
+        assert b._probe_task is None, "probed a state no probe can resolve"
+        assert b._state is ServiceState.UNCONFIGURED

--- a/tests/test_everos_backend.py
+++ b/tests/test_everos_backend.py
@@ -1280,3 +1280,68 @@ class TestStoreIsDiscardedWhenTheServiceIsNotReady:
         b = self._backend(ServiceState.FAILED)
         await b.store("s1", [{"role": "user", "content": "hi"}])
         assert b._dropped_writes == 1
+
+
+@pytest.mark.asyncio
+class TestStoreReportsWhetherItLanded:
+    """A caller that can retry needs to know; a caller that cannot may ignore it.
+
+    The MemoryBackend protocol calls store fire-and-forget, and a turn really
+    is: one turn's memory lost, next turn a fresh chance. A bulk import is the
+    opposite -- its resume state marks a source done, so a write silently
+    treated as landed removes the only record that it has not been. A return
+    value serves both: ignoring it stays valid, checking it becomes possible.
+    """
+
+    @staticmethod
+    def _backend(state, adapter):
+        from raven.plugin.memory.everos.backend import EverosBackend
+
+        ctx = MagicMock()
+        ctx.config = {"base_url": "http://localhost:18791"}
+        ctx.services.agent_id = "default"
+        ctx.services.user_id = "default"
+        ctx.logger = MagicMock()
+        b = EverosBackend(ctx, adapter=adapter)
+        b._state = state
+        return b
+
+    async def test_true_when_the_write_lands(self) -> None:
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        adapter = MagicMock()
+        adapter.memorize = AsyncMock(return_value=None)
+        b = self._backend(ServiceState.READY, adapter)
+
+        assert await b.store("s", [{"role": "user", "content": "x"}]) is True
+
+    async def test_false_when_the_service_is_not_ready(self) -> None:
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        adapter = MagicMock()
+        adapter.memorize = AsyncMock(side_effect=AssertionError("must not be called"))
+        b = self._backend(ServiceState.FAILED, adapter)
+
+        assert await b.store("s", [{"role": "user", "content": "x"}]) is False
+
+    async def test_false_when_the_write_raises(self) -> None:
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        adapter = MagicMock()
+        adapter.memorize = AsyncMock(side_effect=RuntimeError("everos down"))
+        b = self._backend(ServiceState.READY, adapter)
+
+        assert await b.store("s", [{"role": "user", "content": "x"}]) is False
+
+    async def test_nothing_to_write_is_not_a_failure(self) -> None:
+        """An empty slice and a dropped slice must not look the same: the
+        importer would mark a real source failed over a message list that was
+        legitimately empty after filtering."""
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        adapter = MagicMock()
+        adapter.memorize = AsyncMock(return_value=None)
+        b = self._backend(ServiceState.READY, adapter)
+
+        assert await b.store("s", []) is True
+        assert await b.store("s", [{"role": "system", "content": "dropped by conversion"}]) is True

--- a/tests/test_everos_backend.py
+++ b/tests/test_everos_backend.py
@@ -9,6 +9,7 @@ embedding services that the test environment doesn't have).
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -1345,3 +1346,152 @@ class TestStoreReportsWhetherItLanded:
 
         assert await b.store("s", []) is True
         assert await b.store("s", [{"role": "system", "content": "dropped by conversion"}]) is True
+
+
+@pytest.mark.asyncio
+class TestWriteBudgetFollowsTheCaller:
+    """Ten seconds is a turn's patience, not an extraction's runtime.
+
+    A per-turn append should not hold a turn open, so it gets a short budget.
+    A final flush and an importer batch are the calls that actually make EverOS
+    extract, which is why _MEMORIZE_TIMEOUT_S was set to six minutes in the
+    first place. Capping every write at the turn's budget silently overrode
+    that, and the overrun then filed a slow extraction as a dead service.
+    """
+
+    @staticmethod
+    def _backend(adapter):
+        from raven.plugin.memory.everos.backend import EverosBackend, ServiceState
+
+        ctx = MagicMock()
+        ctx.config = {"base_url": "http://localhost:18791"}
+        ctx.services.agent_id = "default"
+        ctx.services.user_id = "default"
+        ctx.logger = MagicMock()
+        b = EverosBackend(ctx, adapter=adapter)
+        b._state = ServiceState.READY
+        return b
+
+    async def test_an_incremental_append_gets_the_short_budget(self, monkeypatch) -> None:
+        from raven.plugin.memory.everos import backend as mod
+
+        seen: list[float] = []
+
+        async def _spy(coro, timeout=None):
+            seen.append(timeout)
+            return await coro
+
+        monkeypatch.setattr(mod.asyncio, "wait_for", _spy)
+        adapter = MagicMock()
+        adapter.memorize = AsyncMock(return_value=None)
+        b = self._backend(adapter)
+
+        await b.store("s", [{"role": "user", "content": "x"}], metadata={"is_final": False})
+
+        assert seen == [mod._STORE_TIMEOUT_S]
+
+    async def test_a_final_flush_gets_the_extraction_budget(self, monkeypatch) -> None:
+        from raven.plugin.memory.everos import backend as mod
+
+        seen: list[float] = []
+
+        async def _spy(coro, timeout=None):
+            seen.append(timeout)
+            return await coro
+
+        monkeypatch.setattr(mod.asyncio, "wait_for", _spy)
+        adapter = MagicMock()
+        adapter.memorize = AsyncMock(return_value=None)
+        b = self._backend(adapter)
+
+        await b.store("s", [{"role": "user", "content": "x"}], metadata={"is_final": True})
+
+        assert seen == [mod._MEMORIZE_TIMEOUT_S]
+
+    async def test_a_slow_extraction_is_not_a_dead_service(self) -> None:
+        """Demoting on a write timeout would drop the *next* write too, so one
+        slow extraction would cascade into losing the batch behind it."""
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        adapter = MagicMock()
+        adapter.memorize = AsyncMock(side_effect=asyncio.TimeoutError())
+        b = self._backend(adapter)
+
+        assert await b.store("s", [{"role": "user", "content": "x"}]) is False
+        assert b._state is ServiceState.READY
+
+
+class TestDroppedWritesCountOnlyRealLosses:
+    """A fresh install has nothing to lose, and should not be told it lost it.
+
+    The counter fires on any not-ready state, so an install that has never
+    configured a memory LLM ends every session with "N turns were not written
+    to long-term memory" -- about memory it never had.
+    """
+
+    @staticmethod
+    def _backend(state):
+        from raven.plugin.memory.everos.backend import EverosBackend
+
+        ctx = MagicMock()
+        ctx.config = {"base_url": "http://localhost:18791"}
+        ctx.services.agent_id = "default"
+        ctx.services.user_id = "default"
+        ctx.logger = MagicMock()
+        b = EverosBackend(ctx, adapter=MagicMock())
+        b._state = state
+        return b
+
+    @pytest.mark.asyncio
+    async def test_never_configured_is_not_a_loss(self) -> None:
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        for state in (ServiceState.UNCONFIGURED, ServiceState.NO_BINARY):
+            b = self._backend(state)
+            await b.store("s", [{"role": "user", "content": "x"}])
+            assert b._dropped_writes == 0, state
+
+    @pytest.mark.asyncio
+    async def test_a_service_that_should_have_been_there_is(self) -> None:
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        for state in (ServiceState.FAILED, ServiceState.UNRESPONSIVE, ServiceState.STARTING):
+            b = self._backend(state)
+            await b.store("s", [{"role": "user", "content": "x"}])
+            assert b._dropped_writes == 1, state
+
+
+@pytest.mark.asyncio
+class TestADeadChildIsReportedAsFailed:
+    """FAILED was unreachable from start().
+
+    ``self._proc = await ensure_everos_server(...)`` only assigns when the call
+    returns, so the handler for the call raising saw ``_proc`` still None and
+    read a child that had already exited as one still booting -- which is the
+    one state that keeps probing instead of reporting.
+    """
+
+    async def test_a_child_that_exited_reaches_failed(self, tmp_path) -> None:
+        from raven.plugin.memory.everos.backend import EverosBackend, ServiceState
+
+        dead = MagicMock(**{"poll.return_value": 1, "returncode": 1})
+
+        async def _boom(*_a, **kw):
+            # The real function spawns, then raises when the child dies; the
+            # handle exists by then and has to survive the exception.
+            report = kw.get("on_proc")
+            if report is not None:
+                report(dead)
+            raise RuntimeError("EverOS server exited with code 1")
+
+        ctx = MagicMock()
+        ctx.config = {"base_url": "http://localhost:18791"}
+        ctx.services.agent_id = "default"
+        ctx.services.user_id = "default"
+        ctx.logger = MagicMock()
+        b = EverosBackend(ctx)
+
+        with patch("raven.plugin.memory.everos._server.ensure_everos_server", new=_boom):
+            await b.start()
+
+        assert b._state is ServiceState.FAILED

--- a/tests/test_everos_backend.py
+++ b/tests/test_everos_backend.py
@@ -214,6 +214,80 @@ class TestColdStartSpeaksUp:
         assert "without long-term memory" in err
 
 
+class TestAUserManagedRootIsReadOnly:
+    """Reusing an EverOS the user manages means recording its address, nothing more.
+
+    Writing to it or starting it would take the OME jobstore lock exclusively --
+    theirs to grant, not raven's to assume.
+    """
+
+    @staticmethod
+    def _not_owned(monkeypatch: pytest.MonkeyPatch) -> None:
+        from raven.config import update_everos
+
+        monkeypatch.setattr(update_everos, "everos_owned", lambda: False)
+
+    async def test_an_unreachable_server_is_not_started_for_us(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        self._not_owned(monkeypatch)
+        started: list[int] = []
+
+        async def _ensure(*_a: object, **_kw: object) -> None:
+            started.append(1)
+
+        monkeypatch.setattr("raven.plugin.memory.everos._server.ensure_everos_server", _ensure)
+        monkeypatch.setattr("raven.plugin.memory.everos._server._probe_health", lambda _u: False)
+
+        b = EverosBackend(_ctx(tmp_path))
+        await b.start()
+
+        assert started == [], "started a server on a root raven does not own"
+        err = " ".join(capsys.readouterr().err.split())
+        assert "you manage is not running" in err
+        assert "does not start or stop it" in err
+
+    async def test_a_reachable_server_is_simply_used(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        self._not_owned(monkeypatch)
+        started: list[int] = []
+
+        async def _ensure(*_a: object, **_kw: object) -> None:
+            started.append(1)
+
+        monkeypatch.setattr("raven.plugin.memory.everos._server.ensure_everos_server", _ensure)
+        monkeypatch.setattr("raven.plugin.memory.everos._server._probe_health", lambda _u: True)
+
+        b = EverosBackend(_ctx(tmp_path))
+        await b.start()
+
+        assert started == []
+        assert capsys.readouterr().err == ""
+
+    def test_the_factory_drops_no_templates_into_it(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._not_owned(monkeypatch)
+        from raven.config import update_everos
+
+        seeded: list[int] = []
+        monkeypatch.setattr(update_everos, "ensure_everos_home", lambda *_a, **_kw: seeded.append(1))
+
+        make_backend(_ctx(tmp_path))
+
+        assert seeded == [], "wrote template files into a root the user manages"
+
+    def test_an_owned_root_still_gets_its_templates(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from raven.config import update_everos
+
+        monkeypatch.setattr(update_everos, "everos_owned", lambda: True)
+        seeded: list[int] = []
+        monkeypatch.setattr(update_everos, "ensure_everos_home", lambda *_a, **_kw: seeded.append(1))
+
+        make_backend(_ctx(tmp_path))
+
+        assert seeded == [1]
+
+
 class TestStartWarnsWhenRecallCannotWork:
     """A running server stopped implying a working one in everos 1.2.1."""
 

--- a/tests/test_everos_discover.py
+++ b/tests/test_everos_discover.py
@@ -1,0 +1,183 @@
+"""Discovery of EverOS roots: what exists, who owns it, and what is serving it.
+
+The states are kept apart on purpose because they fail independently, and the one
+that used to be invisible -- data already served, but not at the address it
+declares -- is the state that produced a 30s startup timeout blaming a missing
+install.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from raven.plugin.memory.everos import _discover
+
+
+def _write_root(root: Path, *, api: tuple[str, int] | None = ("127.0.0.1", 18791), key: str = "k") -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    body = f'[llm]\nmodel = "m"\napi_key = "{key}"\n'
+    if api is not None:
+        body += f'[api]\nhost = "{api[0]}"\nport = {api[1]}\n'
+    (root / "everos.toml").write_text(body, encoding="utf-8")
+
+
+@pytest.fixture
+def _quiet_probes(monkeypatch: pytest.MonkeyPatch):
+    """Default every observation to "nothing there"; tests opt into each fact."""
+    monkeypatch.setattr(_discover, "_probe_health", lambda _u: False)
+    monkeypatch.setattr(_discover, "ome_lock_held", lambda _r: False)
+    return monkeypatch
+
+
+class TestDescribeOneRoot:
+    def test_the_address_is_read_from_the_root(self, tmp_path: Path, _quiet_probes) -> None:
+        root = tmp_path / "everos"
+        _write_root(root)
+
+        state = _discover._describe(root, owned=True)
+
+        assert state.declared_url == "http://127.0.0.1:18791"
+        assert state.configured is True
+        assert state.exists is True
+
+    def test_a_root_without_an_api_section_declares_nothing(self, tmp_path: Path, _quiet_probes) -> None:
+        """No declared address means there is nothing to probe -- not that a
+        server is down."""
+        root = tmp_path / "everos"
+        _write_root(root, api=None)
+
+        state = _discover._describe(root, owned=True)
+
+        assert state.declared_url is None
+        assert state.alive is False
+
+    def test_an_empty_api_key_reads_as_unconfigured(self, tmp_path: Path, _quiet_probes) -> None:
+        """The shipped template carries a model with no key; that is half-built,
+        and no server started from it can finish starting."""
+        root = tmp_path / "everos"
+        _write_root(root, key="")
+
+        assert _discover._describe(root, owned=True).configured is False
+
+    def test_an_absent_root_is_described_without_raising(self, tmp_path: Path, _quiet_probes) -> None:
+        state = _discover._describe(tmp_path / "nope", owned=True)
+
+        assert state.exists is False
+        assert state.configured is False
+        assert state.declared_url is None
+
+    def test_unparseable_toml_is_treated_as_empty(self, tmp_path: Path, _quiet_probes) -> None:
+        root = tmp_path / "everos"
+        root.mkdir()
+        (root / "everos.toml").write_text("this is not toml {{{", encoding="utf-8")
+
+        assert _discover._describe(root, owned=True).configured is False
+
+    def test_locked_but_silent_is_its_own_state(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Data served somewhere other than where it says -- the state that
+        cannot be fixed by starting anything, since one directory admits one
+        engine."""
+        root = tmp_path / "everos"
+        _write_root(root)
+        monkeypatch.setattr(_discover, "_probe_health", lambda _u: False)
+        monkeypatch.setattr(_discover, "ome_lock_held", lambda _r: True)
+
+        state = _discover._describe(root, owned=True)
+
+        assert state.busy_elsewhere is True
+        assert state.serving is False
+
+    def test_serving_means_reachable_where_it_declares(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        root = tmp_path / "everos"
+        _write_root(root)
+        monkeypatch.setattr(_discover, "_probe_health", lambda _u: True)
+        monkeypatch.setattr(_discover, "ome_lock_held", lambda _r: True)
+
+        state = _discover._describe(root, owned=True)
+
+        assert state.serving is True
+        assert state.busy_elsewhere is False
+
+
+class TestDiscoveryOrder:
+    @pytest.fixture(autouse=True)
+    def _isolate(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from raven.config import update_everos as ue
+
+        self.default = tmp_path / "data" / "everos"
+        self.legacy = tmp_path / "home" / ".everos" / "raven"
+        monkeypatch.setattr(ue, "default_everos_root", lambda: self.default)
+        monkeypatch.setattr(ue, "legacy_everos_root", lambda: self.legacy)
+        monkeypatch.setattr(ue, "_recorded_slice", dict)
+        monkeypatch.setattr(_discover, "_probe_health", lambda _u: False)
+        monkeypatch.setattr(_discover, "ome_lock_held", lambda _r: False)
+        return monkeypatch
+
+    def test_the_recorded_root_comes_first(self, tmp_path: Path, _isolate) -> None:
+        """Switching roots behind the user's back would change which memories
+        raven has, so a recorded root wins even over a healthier candidate."""
+        from raven.config import update_everos as ue
+
+        recorded = tmp_path / "recorded"
+        _write_root(recorded)
+        _write_root(self.default)
+        _isolate.setattr(ue, "_recorded_slice", lambda: {"root": str(recorded), "owned": True})
+
+        assert _discover.discover()[0].root == recorded
+        assert _discover.pick(_discover.discover()).root == recorded
+
+    def test_the_legacy_root_is_found_when_the_new_default_is_empty(self, _isolate) -> None:
+        _write_root(self.legacy)
+
+        picked = _discover.pick(_discover.discover())
+
+        assert picked is not None
+        assert picked.root == self.legacy
+        assert picked.owned is True
+
+    def test_nothing_configured_picks_nothing(self, _isolate) -> None:
+        assert _discover.pick(_discover.discover()) is None
+
+    def test_a_half_built_root_is_not_picked(self, _isolate) -> None:
+        _write_root(self.default, key="")
+
+        assert _discover.pick(_discover.discover()) is None
+
+    def test_the_users_own_root_is_offered_only_as_a_last_resort(self, _isolate) -> None:
+        """Suggesting it while raven has memories of its own would invite the
+        user to abandon them."""
+        bare = self.legacy.parent
+        _write_root(bare)
+
+        offered = [s for s in _discover.discover() if s.root == bare]
+        assert offered and offered[0].owned is False
+
+        _write_root(self.default)
+        assert not [s for s in _discover.discover() if s.root == bare]
+
+    def test_a_recorded_unowned_root_keeps_its_ownership(self, tmp_path: Path, _isolate) -> None:
+        from raven.config import update_everos as ue
+
+        theirs = tmp_path / "theirs"
+        _write_root(theirs)
+        _isolate.setattr(ue, "_recorded_slice", lambda: {"root": str(theirs), "owned": False})
+
+        assert _discover.discover()[0].owned is False
+
+    def test_no_duplicate_candidates(self, _isolate) -> None:
+        from raven.config import update_everos as ue
+
+        _write_root(self.default)
+        _isolate.setattr(ue, "_recorded_slice", lambda: {"root": str(self.default), "owned": True})
+
+        roots = [s.root for s in _discover.discover()]
+        assert len(roots) == len(set(roots))
+
+
+def test_a_new_root_does_not_declare_the_everos_default_port() -> None:
+    """8000 is among the most commonly occupied ports on a developer machine; it
+    only ever appeared in raven's roots because raven overrode it on the command
+    line and never wrote the file."""
+    assert "8000" not in _discover.default_new_root_url()

--- a/tests/test_everos_discover.py
+++ b/tests/test_everos_discover.py
@@ -145,17 +145,30 @@ class TestDiscoveryOrder:
 
         assert _discover.pick(_discover.discover()) is None
 
-    def test_the_users_own_root_is_offered_only_as_a_last_resort(self, _isolate) -> None:
-        """Suggesting it while raven has memories of its own would invite the
-        user to abandon them."""
+    def test_the_users_own_root_is_never_offered(self, _isolate) -> None:
+        """Discovery scans raven's own roots and nothing else.
+
+        Offering the user's ``~/.everos`` made the wizard propose a decision the
+        user had not come to make, and the answer it invited -- "reuse it" --
+        was one raven could only honour by never touching the thing it had just
+        adopted. Choosing to point raven at an EverOS of one's own is now an
+        explicit turn in the wizard, with an address typed by the person who
+        knows it.
+        """
         bare = self.legacy.parent
         _write_root(bare)
 
-        offered = [s for s in _discover.discover() if s.root == bare]
-        assert offered and offered[0].owned is False
+        assert not [s for s in _discover.discover() if s.root == bare]
 
         _write_root(self.default)
         assert not [s for s in _discover.discover() if s.root == bare]
+
+    def test_every_discovered_root_is_ravens_own(self, _isolate) -> None:
+        _write_root(self.default)
+        _write_root(self.legacy)
+
+        roots = {s.root for s in _discover.discover()}
+        assert roots <= {self.default, self.legacy}
 
     def test_a_recorded_unowned_root_keeps_its_ownership(self, tmp_path: Path, _isolate) -> None:
         from raven.config import update_everos as ue

--- a/tests/test_everos_discover.py
+++ b/tests/test_everos_discover.py
@@ -110,6 +110,9 @@ class TestDiscoveryOrder:
         self.legacy = tmp_path / "home" / ".everos" / "raven"
         monkeypatch.setattr(ue, "default_everos_root", lambda: self.default)
         monkeypatch.setattr(ue, "legacy_everos_root", lambda: self.legacy)
+        # Discovery only offers the legacy root to the installation that could
+        # have created it; these cases are about ordering, so say which we are.
+        monkeypatch.setattr(ue, "_is_default_installation", lambda: True)
         monkeypatch.setattr(ue, "_recorded_slice", dict)
         monkeypatch.setattr(_discover, "_probe_health", lambda _u: False)
         monkeypatch.setattr(_discover, "ome_lock_held", lambda _r: False)

--- a/tests/test_everos_plugin_discovery.py
+++ b/tests/test_everos_plugin_discovery.py
@@ -145,7 +145,7 @@ class TestActivationAndFactory:
 
 @pytest.fixture
 def backend(tmp_path: Path):
-    from raven.plugin.memory.everos.backend import _NoOpAdapter
+    from raven.plugin.memory.everos.backend import ServiceState, _NoOpAdapter
 
     reg = assemble_plugin_registry(bundled_dir=_BUNDLED)
     be = reg.build_memory_backend(
@@ -154,6 +154,11 @@ def backend(tmp_path: Path):
         services=ServiceLocator(workspace=tmp_path, user_id="default", agent_id="default"),
     )
     be._adapter = _NoOpAdapter()
+    # Swapping the adapter after construction is a test-only move; the
+    # constructor's adapter= argument is what tells a backend its transport is
+    # someone else's problem. Say the same thing here, or the backend keeps
+    # treating the service as unproven and refuses to write through the stub.
+    be._state = ServiceState.READY
     return be
 
 
@@ -170,12 +175,15 @@ class TestStubBehavior:
         assert isinstance(hits, list)
         assert all(isinstance(h, Memory) for h in hits)
 
-    async def test_store_returns_none(self, backend) -> None:
+    async def test_store_reports_that_it_landed(self, backend) -> None:
+        """store answers whether the slice was written. The stub accepts
+        everything, so it answers True -- a caller that checks the result must
+        not read the stub as a permanent failure."""
         result = await backend.store(
             "session-1",
             [{"role": "user", "content": "hi"}],
         )
-        assert result is None
+        assert result is True
 
     async def test_feedback_accepts_any_dict(self, backend) -> None:
         await backend.feedback({})

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -303,6 +304,114 @@ class TestStoppingWhatWeStarted:
         assert stop_recorded_server(_data_dir) is True
         assert sent == [_signal.SIGTERM]
         assert not (_data_dir / "everos-server.pid").exists()
+
+
+class TestThePrimitivesAgainstTheRealOS:
+    """The four OS-touching helpers, unmocked.
+
+    Everything above stubs these out to stay deterministic, which leaves the
+    layer where a wrong assumption about flock or ``ps`` would not be caught by
+    anything. These run them for real.
+    """
+
+    def test_an_untouched_root_reads_as_free(self, tmp_path) -> None:
+        from raven.plugin.memory.everos._server import ome_lock_held
+
+        assert ome_lock_held(tmp_path / "never-started") is False
+
+    def test_a_held_ome_lock_is_detected(self, tmp_path) -> None:
+        """The signal the whole "served elsewhere" state rests on.
+
+        Also pins the documented flock caveat: the lock lives on the open file
+        description, so a holder in *this* process collides with itself. That is
+        why only the wizard and doctor -- which hold no engine -- may ask.
+        """
+        from raven.plugin.memory.everos._server import ome_lock_held
+        from raven.utils.portable_lock import file_lock
+
+        lock = tmp_path / "root" / ".index" / "sqlite" / "ome.db.lock"
+        lock.parent.mkdir(parents=True)
+        lock.touch()
+
+        with file_lock(lock, blocking=False):
+            assert ome_lock_held(tmp_path / "root") is True
+
+        assert ome_lock_held(tmp_path / "root") is False, "the lock outlived its holder"
+
+    def test_ps_does_not_mistake_this_process_for_a_server(self) -> None:
+        """The pid-reuse guard, run against a real ``ps``.
+
+        A pidfile names a number, not a process; without this check a recycled
+        pid would take a SIGTERM meant for an everos server.
+        """
+        from raven.plugin.memory.everos._server import _is_everos_server
+
+        assert _is_everos_server(os.getpid()) is False
+
+    def test_ps_recognises_a_process_whose_command_line_says_everos(self) -> None:
+        import subprocess
+        import sys
+
+        from raven.plugin.memory.everos._server import _is_everos_server
+
+        # A stand-in whose command line carries the marker `ps` looks for; the
+        # point is that the parsing works against real `ps` output, not that this
+        # is an everos build.
+        #
+        # Deliberately not `sh -c "sleep 5 # marker"`: a shell handed a single
+        # simple command execs it directly, replacing its own command line and
+        # dropping the marker -- which made this pass alone and fail in a full
+        # run. A python interpreter never rewrites its argv, so the marker stays.
+        proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(5)  # everos server start --root /x"])
+        try:
+            assert _is_everos_server(proc.pid) is True
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+    def test_a_dead_pid_is_not_a_server(self) -> None:
+        import subprocess
+
+        from raven.plugin.memory.everos._server import _is_everos_server
+
+        proc = subprocess.Popen(["sh", "-c", "exit 0"])
+        proc.wait(timeout=5)
+
+        assert _is_everos_server(proc.pid) is False
+
+    def test_health_probe_reads_a_real_response(self, tmp_path) -> None:
+        """``_probe_health`` against a real socket: 200 is up, 500 is not, and a
+        closed port is not an exception the caller has to handle."""
+        import http.server
+        import threading
+
+        from raven.plugin.memory.everos._server import _probe_health
+
+        class _Handler(http.server.BaseHTTPRequestHandler):
+            status = 200
+
+            def do_GET(self):  # noqa: N802 - stdlib callback name
+                self.send_response(self.status)
+                self.end_headers()
+
+            def log_message(self, *_a):
+                return
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            assert _probe_health(f"http://127.0.0.1:{port}") is True
+            _Handler.status = 503
+            assert _probe_health(f"http://127.0.0.1:{port}") is False
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+        # Nothing listening any more: a refused connection is False, not a raise.
+        assert _probe_health(f"http://127.0.0.1:{port}") is False
 
 
 class TestDeadChildDetection:

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -6,7 +6,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from raven.plugin.memory.everos._server import _everos_executable, ensure_everos_server
+from raven.plugin.memory.everos._server import (
+    EverosNotConfigured,
+    _everos_executable,
+    ensure_everos_server,
+)
 
 
 def _make_executable(path):
@@ -79,6 +83,88 @@ class TestEverosExecutable:
             _everos_executable()
 
 
+@pytest.fixture
+def everos_toml(tmp_path, monkeypatch):
+    """Redirect the EverOS config read to a throwaway toml."""
+    import raven.config.update_everos as ue
+
+    cfg = tmp_path / ".everos" / "everos.toml"
+    monkeypatch.setattr(ue, "_EVEROS_CONFIG", cfg)
+    return cfg
+
+
+def _write_llm_section(cfg, *, model="mem-llm", api_key="k"):
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    body = "[llm]\n"
+    if model is not None:
+        body += f'model = "{model}"\n'
+    if api_key is not None:
+        body += f'api_key = "{api_key}"\n'
+    cfg.write_text(body, encoding="utf-8")
+
+
+class TestSpawnPreflight:
+    """A server with no LLM credentials cannot survive startup, so do not spawn.
+
+    EverOS builds its LLM client eagerly during startup and fails outright when
+    credentials are missing. Spawning regardless burned a full poll timeout on a
+    process that had already exited and buried the reason in the server log.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_does_not_spawn(self, everos_toml, monkeypatch) -> None:
+        _write_llm_section(everos_toml, api_key="")
+        spawned = []
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._start_server_if_unlocked",
+            lambda *a, **kw: spawned.append(1),
+        )
+        with patch("raven.plugin.memory.everos._server._probe_health", return_value=False):
+            with pytest.raises(EverosNotConfigured, match="memory LLM is not configured"):
+                await ensure_everos_server("http://localhost:18791", timeout=1.0)
+
+        assert spawned == [], "spawned a server that could never finish starting"
+
+    @pytest.mark.asyncio
+    async def test_missing_section_entirely_does_not_spawn(self, everos_toml, monkeypatch) -> None:
+        everos_toml.parent.mkdir(parents=True, exist_ok=True)
+        everos_toml.write_text("[memory]\ntimezone = \"UTC\"\n", encoding="utf-8")
+        spawned = []
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._start_server_if_unlocked",
+            lambda *a, **kw: spawned.append(1),
+        )
+        with patch("raven.plugin.memory.everos._server._probe_health", return_value=False):
+            with pytest.raises(EverosNotConfigured):
+                await ensure_everos_server("http://localhost:18791", timeout=1.0)
+
+        assert spawned == []
+
+    @pytest.mark.asyncio
+    async def test_a_running_server_needs_no_credential_check(self, everos_toml) -> None:
+        """A /health 200 proves the LLM client was built, so do not second-guess it."""
+        _write_llm_section(everos_toml, api_key="")
+        with patch("raven.plugin.memory.everos._server._probe_health", return_value=True):
+            await ensure_everos_server("http://localhost:18791")
+
+    @pytest.mark.asyncio
+    async def test_configured_llm_reaches_the_spawn(self, everos_toml, tmp_path, monkeypatch) -> None:
+        _write_llm_section(everos_toml)
+        spawned = []
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._start_server_if_unlocked",
+            lambda *a, **kw: spawned.append(1),
+        )
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server.get_logs_dir",
+            lambda: tmp_path,
+        )
+        with patch("raven.plugin.memory.everos._server._probe_health", side_effect=[False, True]):
+            await ensure_everos_server("http://localhost:18791", timeout=5.0)
+
+        assert spawned == [1]
+
+
 class TestEnsureEverosServer:
     @pytest.mark.asyncio
     async def test_server_already_running(self) -> None:
@@ -92,7 +178,8 @@ class TestEnsureEverosServer:
             await ensure_everos_server("http://localhost:18791")
 
     @pytest.mark.asyncio
-    async def test_auto_start_on_connection_error(self, tmp_path) -> None:
+    async def test_auto_start_on_connection_error(self, tmp_path, everos_toml) -> None:
+        _write_llm_section(everos_toml)
         call_count = 0
 
         def probe_side_effect(*_args, **_kwargs):
@@ -118,7 +205,13 @@ class TestEnsureEverosServer:
         mock_start.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_timeout_raises(self, tmp_path) -> None:
+    async def test_timeout_raises(self, tmp_path, everos_toml) -> None:
+        """A live-but-unhealthy start still gets the full poll budget.
+
+        The credential gate must not shorten this: a slow first boot is exactly
+        what the timeout exists for.
+        """
+        _write_llm_section(everos_toml)
         with (
             patch(
                 "raven.plugin.memory.everos._server._probe_health",

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -151,8 +151,11 @@ class TestSpawnPreflight:
     async def test_a_running_server_needs_no_credential_check(self, everos_toml) -> None:
         """A /health 200 proves the LLM client was built, so do not second-guess it."""
         _write_llm_section(everos_toml, api_key="")
+        waits: list[int] = []
         with patch("raven.plugin.memory.everos._server._probe_health", return_value=True):
-            await ensure_everos_server("http://localhost:18791")
+            await ensure_everos_server("http://localhost:18791", on_wait=lambda: waits.append(1))
+
+        assert waits == [], "narrated a wait that never happened"
 
     @pytest.mark.asyncio
     async def test_configured_llm_reaches_the_spawn(self, everos_toml, tmp_path, monkeypatch) -> None:

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -9,6 +9,7 @@ import pytest
 
 from raven.plugin.memory.everos._server import (
     EverosNotConfiguredError,
+    StopOutcome,
     _everos_executable,
     ensure_everos_server,
 )
@@ -264,7 +265,7 @@ class TestStoppingWhatWeStarted:
         signalled: list[int] = []
         monkeypatch.setattr(_os, "kill", lambda *a: signalled.append(1))
 
-        assert stop_recorded_server(_data_dir) is False
+        assert stop_recorded_server(_data_dir) is StopOutcome.NOT_OURS
         assert signalled == [], "signalled a pid that is no longer an everos server"
 
     def test_a_record_for_another_root_is_ignored(self, _data_dir, monkeypatch) -> None:
@@ -280,8 +281,48 @@ class TestStoppingWhatWeStarted:
         signalled: list[int] = []
         monkeypatch.setattr(_os, "kill", lambda *a: signalled.append(1))
 
-        assert stop_recorded_server(_data_dir) is False
+        assert stop_recorded_server(_data_dir) is StopOutcome.NOT_OURS
         assert signalled == []
+
+    def test_a_server_that_will_not_exit_reports_draining_not_ownership(self, _data_dir, monkeypatch) -> None:
+        """A shutdown that is still draining memory work is not a foreign process.
+
+        Collapsed into one False, the wizard told users whose OME jobs were
+        mid-flight that raven had not started the server -- an explanation that is
+        simply untrue, and one that sends them looking for the wrong thing.
+        """
+        import json
+        import os as _os
+
+        from raven.plugin.memory.everos._server import stop_recorded_server
+
+        (_data_dir / "everos-server.pid").write_text(
+            json.dumps({"pid": 4242, "base_url": "http://localhost:18791", "root": str(_data_dir)})
+        )
+        monkeypatch.setattr("raven.plugin.memory.everos._server._is_everos_server", lambda _p: True)
+        monkeypatch.setattr(_os, "kill", lambda *_a: None)
+        monkeypatch.setattr("raven.plugin.memory.everos._server.time.sleep", lambda _s: None)
+
+        assert stop_recorded_server(_data_dir, timeout=1.0) is StopOutcome.STILL_DRAINING
+        assert (_data_dir / "everos-server.pid").exists(), "forgot a server that is still up"
+
+    def test_an_undeliverable_signal_is_its_own_answer(self, _data_dir, monkeypatch) -> None:
+        import json
+        import os as _os
+
+        from raven.plugin.memory.everos._server import stop_recorded_server
+
+        (_data_dir / "everos-server.pid").write_text(
+            json.dumps({"pid": 4242, "base_url": "http://localhost:18791", "root": str(_data_dir)})
+        )
+        monkeypatch.setattr("raven.plugin.memory.everos._server._is_everos_server", lambda _p: True)
+
+        def _denied(*_a):
+            raise PermissionError("nope")
+
+        monkeypatch.setattr(_os, "kill", _denied)
+
+        assert stop_recorded_server(_data_dir) is StopOutcome.SIGNAL_FAILED
 
     def test_a_verified_server_gets_sigterm_not_sigkill(self, _data_dir, monkeypatch) -> None:
         import json
@@ -301,7 +342,7 @@ class TestStoppingWhatWeStarted:
         sent: list[int] = []
         monkeypatch.setattr(_os, "kill", lambda _pid, sig: sent.append(sig))
 
-        assert stop_recorded_server(_data_dir) is True
+        assert stop_recorded_server(_data_dir) is StopOutcome.STOPPED
         assert sent == [_signal.SIGTERM]
         assert not (_data_dir / "everos-server.pid").exists()
 

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -455,6 +455,21 @@ class TestThePrimitivesAgainstTheRealOS:
         assert _probe_health(f"http://127.0.0.1:{port}") is False
 
 
+def test_the_wait_budget_stays_small() -> None:
+    """The timeout is a budget for how long a user waits, not a failure detector.
+
+    Once the poll loop watches the child's exit code, a boot that cannot succeed
+    is caught in about a second whatever this value is -- so the only thing left
+    to size is the wait, and overrunning it is cheap: the child keeps booting and
+    the next session finds it. Pinned because the number reads like a safety
+    margin and invites being raised back.
+    """
+    import inspect
+
+    default = inspect.signature(ensure_everos_server).parameters["timeout"].default
+    assert default == 10.0
+
+
 class TestDeadChildDetection:
     """ "Still booting" and "already dead" are different states.
 
@@ -532,7 +547,7 @@ class TestDeadChildDetection:
             return False
 
         with patch("raven.plugin.memory.everos._server._probe_health", side_effect=_probe):
-            with pytest.raises(RuntimeError, match="did not become healthy"):
+            with pytest.raises(RuntimeError, match="is still starting"):
                 await ensure_everos_server("http://localhost:18791", timeout=1.0)
 
         # One pre-loop probe plus one per 0.5s poll interval across a 1s budget.
@@ -623,7 +638,7 @@ class TestEnsureEverosServer:
                 "raven.plugin.memory.everos._server.get_logs_dir",
                 return_value=tmp_path,
             ),
-            pytest.raises(RuntimeError, match="did not become healthy"),
+            pytest.raises(RuntimeError, match="is still starting"),
         ):
             await ensure_everos_server("http://localhost:18791", timeout=1.0)
 

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -648,3 +648,245 @@ class TestEnsureEverosServer:
         assert _extract_port("http://localhost:18791") == "18791"
         assert _extract_port("http://127.0.0.1:9999") == "9999"
         assert _extract_port("http://localhost") == "80"
+
+
+class TestProbeClassification:
+    """A probe answers *why* it failed, not just that it did.
+
+    Collapsing every failure into ``False`` hid the one distinction the caller
+    has to act on: a refused connection is instant and means nobody is
+    listening, while a timeout costs the full budget and means something *is*
+    listening but not answering. Retrying the first is free; retrying the second
+    charges the user again every turn.
+    """
+
+    def test_ok_on_200(self) -> None:
+        from raven.plugin.memory.everos._server import ProbeResult, probe_health
+
+        resp = MagicMock(status_code=200)
+        with patch("httpx.get", return_value=resp):
+            assert probe_health("http://localhost:18791") is ProbeResult.OK
+
+    def test_refused_is_distinct_from_timeout(self) -> None:
+        import httpx
+
+        from raven.plugin.memory.everos._server import ProbeResult, probe_health
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("refused")):
+            assert probe_health("http://localhost:18791") is ProbeResult.REFUSED
+
+        with patch("httpx.get", side_effect=httpx.ConnectTimeout("slow")):
+            assert probe_health("http://localhost:18791") is ProbeResult.TIMEOUT
+
+        with patch("httpx.get", side_effect=httpx.ReadTimeout("hung")):
+            assert probe_health("http://localhost:18791") is ProbeResult.TIMEOUT
+
+    def test_non_200_is_error_not_refused(self) -> None:
+        from raven.plugin.memory.everos._server import ProbeResult, probe_health
+
+        resp = MagicMock(status_code=503)
+        with patch("httpx.get", return_value=resp):
+            assert probe_health("http://localhost:18791") is ProbeResult.ERROR
+
+    def test_unexpected_exception_is_error(self) -> None:
+        from raven.plugin.memory.everos._server import ProbeResult, probe_health
+
+        with patch("httpx.get", side_effect=ValueError("garbage")):
+            assert probe_health("http://localhost:18791") is ProbeResult.ERROR
+
+    def test_bool_wrapper_stays_truthful(self) -> None:
+        """``_probe_health`` keeps its bool contract for the callers that only
+        need liveness. Returning the enum from it directly would be a silent
+        bug: every enum member is truthy, so ``if _probe_health(...)`` would
+        pass on a refused connection."""
+        import httpx
+
+        from raven.plugin.memory.everos._server import _probe_health
+
+        resp = MagicMock(status_code=200)
+        with patch("httpx.get", return_value=resp):
+            assert _probe_health("http://localhost:18791") is True
+        with patch("httpx.get", side_effect=httpx.ConnectError("refused")):
+            assert _probe_health("http://localhost:18791") is False
+        with patch("httpx.get", side_effect=httpx.ReadTimeout("hung")):
+            assert _probe_health("http://localhost:18791") is False
+
+    def test_probe_budget_is_one_second(self) -> None:
+        """Loopback: if it does not answer in a second it is not answering.
+
+        The probe runs out of band now, but it still has to finish quickly --
+        a probe that outlives the turn it was kicked from is a leak, not a
+        check.
+        """
+        from raven.plugin.memory.everos._server import _PROBE_TIMEOUT_S
+
+        assert _PROBE_TIMEOUT_S == 1.0
+
+
+class TestLockHolderLookup:
+    """Who holds this root's data, and where is it actually listening?
+
+    The pidfile answers "did raven start it", which is a record raven keeps
+    about itself -- lose the file and a server raven did start reads as
+    foreign. The lock answers "who is serving this data" from the OS, which is
+    the question that actually blocks a start, and it stays true across a lost
+    pidfile, a moved config dir, and a rename.
+
+    Finding the holder's listening port turns the one unrecoverable state --
+    the lock is taken and the declared address is silent -- into a recoverable
+    one: connect to where it really is instead of killing it.
+    """
+
+    def test_returns_none_when_lock_file_absent(self, tmp_path) -> None:
+        from raven.plugin.memory.everos._server import lock_holder
+
+        assert lock_holder(tmp_path) is None
+
+    def test_lsof_pid_is_verified_against_the_cmdline(self, tmp_path) -> None:
+        """A pid alone is not enough: the number may have been recycled onto an
+        unrelated process, and signalling that is the accident this guards."""
+        from raven.plugin.memory.everos import _server
+
+        lock = tmp_path / ".index" / "sqlite" / "ome.db.lock"
+        lock.parent.mkdir(parents=True)
+        lock.touch()
+
+        with (
+            patch.object(_server, "_lock_holder_pid", return_value=4242),
+            patch.object(_server, "_cmdline_of", return_value="/usr/bin/vim notes.txt"),
+        ):
+            assert _server.lock_holder(tmp_path) is None
+
+    def test_reports_the_port_the_holder_actually_listens_on(self, tmp_path) -> None:
+        from raven.plugin.memory.everos import _server
+
+        lock = tmp_path / ".index" / "sqlite" / "ome.db.lock"
+        lock.parent.mkdir(parents=True)
+        lock.touch()
+        cmdline = f"/venv/bin/python /venv/bin/everos server start --root {tmp_path}"
+
+        with (
+            patch.object(_server, "_lock_holder_pid", return_value=4242),
+            patch.object(_server, "_cmdline_of", return_value=cmdline),
+            patch.object(_server, "_listening_port", return_value=39999),
+        ):
+            holder = _server.lock_holder(tmp_path)
+
+        assert holder is not None
+        assert holder.pid == 4242
+        assert holder.port == 39999
+
+    def test_a_holder_with_no_listening_port_is_still_reported(self, tmp_path) -> None:
+        """``everos demo`` and an embedded engine hold the lock without serving
+        HTTP. Reporting them with ``port=None`` is what lets the wizard say
+        "something has your data but there is nowhere to connect" instead of
+        silently deciding nobody is there."""
+        from raven.plugin.memory.everos import _server
+
+        lock = tmp_path / ".index" / "sqlite" / "ome.db.lock"
+        lock.parent.mkdir(parents=True)
+        lock.touch()
+        cmdline = f"/venv/bin/python /venv/bin/everos server start --root {tmp_path}"
+
+        with (
+            patch.object(_server, "_lock_holder_pid", return_value=4242),
+            patch.object(_server, "_cmdline_of", return_value=cmdline),
+            patch.object(_server, "_listening_port", return_value=None),
+        ):
+            holder = _server.lock_holder(tmp_path)
+
+        assert holder is not None
+        assert holder.port is None
+
+    def test_falls_back_to_the_pidfile_when_the_os_cannot_answer(self, tmp_path) -> None:
+        from raven.plugin.memory.everos import _server
+
+        lock = tmp_path / ".index" / "sqlite" / "ome.db.lock"
+        lock.parent.mkdir(parents=True)
+        lock.touch()
+        cmdline = f"/venv/bin/python /venv/bin/everos server start --root {tmp_path}"
+
+        with (
+            patch.object(_server, "_lsof_lock_pid", return_value=None),
+            patch.object(_server, "_proc_locks_pid", return_value=None),
+            patch.object(_server, "_read_pidfile", return_value={"pid": 77, "root": str(tmp_path)}),
+            patch.object(_server, "_cmdline_of", return_value=cmdline),
+            patch.object(_server, "_listening_port", return_value=18791),
+        ):
+            holder = _server.lock_holder(tmp_path)
+
+        assert holder is not None
+        assert holder.pid == 77
+
+
+class TestTheWrittenAddressIsVerified:
+    """Writing ``[api]`` and then spawning assumes the write landed.
+
+    Dropping ``--port`` made the toml the single authority on where a server
+    listens; that only holds if the file really says what raven thinks it
+    says. An unverified write turns a failed edit into a server on the wrong
+    port -- exactly the drift the change was meant to end.
+    """
+
+    def test_readback_mismatch_refuses_to_spawn(self, tmp_path, monkeypatch) -> None:
+        from raven.plugin.memory.everos import _server
+
+        root = tmp_path / "everos"
+        root.mkdir()
+        (root / "everos.toml").write_text('[api]\nhost = "127.0.0.1"\nport = 8000\n')
+
+        monkeypatch.setattr(_server, "_everos_executable", lambda: "/bin/true")
+        monkeypatch.setattr("raven.config.update_everos.everos_root", lambda: root)
+        # A write that silently does not take: the readback is the only thing
+        # standing between this and a server bound to 8000 while raven probes 18791.
+        monkeypatch.setattr("raven.config.update_everos.set_everos_api", lambda **kw: None)
+
+        with pytest.raises(RuntimeError, match="did not take effect"):
+            _server._start_server_if_unlocked("http://localhost:18791")
+
+
+class TestParsingLsofListenOutput:
+    """Real ``lsof`` rows, because the shape is what the parser got wrong.
+
+    The address is neither the last field -- ``(LISTEN)`` is -- nor at a fixed
+    index, since COMMAND is padded to the widest value in the output. Taking
+    the last field silently found no port at all, so a server that was plainly
+    listening looked like a lock holder serving nothing.
+    """
+
+    def test_ipv4_row(self) -> None:
+        from raven.plugin.memory.everos._server import _parse_listen_port
+
+        out = (
+            "COMMAND     PID  USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME\n"
+            "python3.1 94107 admin   32u  IPv4 0x88b36e3af566b544      0t0  TCP 127.0.0.1:31995 (LISTEN)\n"
+        )
+        assert _parse_listen_port(out) == 31995
+
+    def test_ipv6_row(self) -> None:
+        from raven.plugin.memory.everos._server import _parse_listen_port
+
+        out = (
+            "COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\n"
+            "everos   4242 admin   11u  IPv6  0x1e2      0t0  TCP [::1]:18791 (LISTEN)\n"
+        )
+        assert _parse_listen_port(out) == 18791
+
+    def test_wildcard_row(self) -> None:
+        from raven.plugin.memory.everos._server import _parse_listen_port
+
+        out = (
+            "COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\n"
+            "everos   4242 admin   11u  IPv4  0x1e2      0t0  TCP *:8000 (LISTEN)\n"
+        )
+        assert _parse_listen_port(out) == 8000
+
+    def test_header_only_is_no_port(self) -> None:
+        from raven.plugin.memory.everos._server import _parse_listen_port
+
+        assert _parse_listen_port("COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\n") is None
+
+    def test_empty_output_is_no_port(self) -> None:
+        from raven.plugin.memory.everos._server import _parse_listen_port
+
+        assert _parse_listen_port("") is None

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -930,3 +930,45 @@ class TestParsingProcLocks:
     def test_an_unrelated_inode_is_not_matched(self, tmp_path, monkeypatch) -> None:
         rows = "3: FLOCK  ADVISORY  WRITE 1550263 fc:00:4980767 0 EOF\n"
         assert self._parse(rows, 999999, tmp_path, monkeypatch) is None
+
+
+class TestStoppingWhatTheLockNamed:
+    """The pidfile finds the target for a stop; the lock finds it for a lookup.
+
+    Letting those disagree defeats the reason the lock lookup exists. A server
+    raven started and then lost the pidfile for is exactly the case the lock was
+    added to recover, and a caller that identifies the holder that way and then
+    stops "the recorded server" gets NOT_OURS for a process it just named.
+    """
+
+    def test_a_pid_from_the_lock_can_be_stopped(self, monkeypatch) -> None:
+        from raven.plugin.memory.everos import _server
+
+        signalled: list[int] = []
+        monkeypatch.setattr(_server.os, "kill", lambda pid, sig: signalled.append(pid))
+        # First poll says still alive, second says gone.
+        alive = iter([True, False])
+        monkeypatch.setattr(_server, "_is_everos_server", lambda _p: next(alive, False))
+        monkeypatch.setattr(_server.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(_server, "_pidfile_path", lambda: Path("/nonexistent/everos-server.pid"))
+
+        assert _server.stop_pid(4242) is _server.StopOutcome.STOPPED
+        assert signalled == [4242]
+
+    def test_an_undeliverable_signal_is_reported(self, monkeypatch) -> None:
+        from raven.plugin.memory.everos import _server
+
+        def _boom(_pid, _sig):
+            raise PermissionError("not yours")
+
+        monkeypatch.setattr(_server.os, "kill", _boom)
+        assert _server.stop_pid(4242) is _server.StopOutcome.SIGNAL_FAILED
+
+    def test_a_process_that_will_not_go_is_reported_as_draining(self, monkeypatch) -> None:
+        from raven.plugin.memory.everos import _server
+
+        monkeypatch.setattr(_server.os, "kill", lambda _p, _s: None)
+        monkeypatch.setattr(_server, "_is_everos_server", lambda _p: True)
+        monkeypatch.setattr(_server.time, "sleep", lambda _s: None)
+
+        assert _server.stop_pid(4242, timeout=1.0) is _server.StopOutcome.STILL_DRAINING

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -6,7 +6,77 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from raven.plugin.memory.everos._server import ensure_everos_server
+from raven.plugin.memory.everos._server import _everos_executable, ensure_everos_server
+
+
+def _make_executable(path):
+    path.write_text("#!/bin/sh\n")
+    path.chmod(0o755)
+    return path
+
+
+class TestEverosExecutable:
+    """The interpreter's own directory wins over PATH.
+
+    ``uv tool install`` exposes only the requested package's entry points, so a
+    released install has ``raven`` on PATH and ``everos`` only inside the tool
+    venv. Preferring the sibling also avoids picking up an everos from an
+    unrelated environment whose version does not match raven's pin.
+    """
+
+    def test_prefers_interpreter_sibling(self, tmp_path, monkeypatch) -> None:
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        _make_executable(venv_bin / "everos")
+        monkeypatch.setattr("sys.executable", str(venv_bin / "python3"))
+        monkeypatch.setenv("PATH", "")
+
+        assert _everos_executable() == str(venv_bin / "everos")
+
+    def test_falls_back_to_path(self, tmp_path, monkeypatch) -> None:
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        path_dir = tmp_path / "elsewhere"
+        path_dir.mkdir()
+        _make_executable(path_dir / "everos")
+        monkeypatch.setattr("sys.executable", str(venv_bin / "python3"))
+        monkeypatch.setenv("PATH", str(path_dir))
+
+        assert _everos_executable() == str(path_dir / "everos")
+
+    def test_sibling_beats_path_when_both_exist(self, tmp_path, monkeypatch) -> None:
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        _make_executable(venv_bin / "everos")
+        path_dir = tmp_path / "elsewhere"
+        path_dir.mkdir()
+        _make_executable(path_dir / "everos")
+        monkeypatch.setattr("sys.executable", str(venv_bin / "python3"))
+        monkeypatch.setenv("PATH", str(path_dir))
+
+        assert _everos_executable() == str(venv_bin / "everos")
+
+    def test_sibling_without_exec_bit_is_skipped(self, tmp_path, monkeypatch) -> None:
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "everos").write_text("not executable\n")
+        (venv_bin / "everos").chmod(0o644)
+        path_dir = tmp_path / "elsewhere"
+        path_dir.mkdir()
+        _make_executable(path_dir / "everos")
+        monkeypatch.setattr("sys.executable", str(venv_bin / "python3"))
+        monkeypatch.setenv("PATH", str(path_dir))
+
+        assert _everos_executable() == str(path_dir / "everos")
+
+    def test_missing_everywhere_names_the_interpreter_dir(self, tmp_path, monkeypatch) -> None:
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        monkeypatch.setattr("sys.executable", str(venv_bin / "python3"))
+        monkeypatch.setenv("PATH", "")
+
+        with pytest.raises(RuntimeError, match=str(venv_bin)):
+            _everos_executable()
 
 
 class TestEnsureEverosServer:

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -85,12 +85,13 @@ class TestEverosExecutable:
 
 @pytest.fixture
 def everos_toml(tmp_path, monkeypatch):
-    """Redirect the EverOS config read to a throwaway toml."""
+    """Redirect the EverOS config read/write to a throwaway root raven owns."""
     import raven.config.update_everos as ue
 
-    cfg = tmp_path / ".everos" / "everos.toml"
-    monkeypatch.setattr(ue, "_EVEROS_CONFIG", cfg)
-    return cfg
+    root = tmp_path / ".everos"
+    monkeypatch.setattr(ue, "everos_root", lambda: root)
+    monkeypatch.setattr(ue, "everos_owned", lambda: True)
+    return root / "everos.toml"
 
 
 def _live_child():
@@ -173,6 +174,135 @@ class TestSpawnPreflight:
             await ensure_everos_server("http://localhost:18791", timeout=5.0)
 
         assert spawned == [1]
+
+
+class TestTheRootDescribesItsOwnAddress:
+    """The address goes into ``<root>/everos.toml``, not onto the command line.
+
+    A ``--port`` override left the file describing an address nobody listened on,
+    which is how the wizard came to probe one port while the backend talked to
+    another.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_real_spawn(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("raven.plugin.memory.everos._server.get_logs_dir", lambda: tmp_path)
+        monkeypatch.setattr("raven.plugin.memory.everos._server.get_data_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._everos_executable",
+            lambda: "/bin/true",
+        )
+        self.spawned: list[list[str]] = []
+
+        class _Proc:
+            pid = 4242
+
+            def poll(self):
+                return None
+
+        def _popen(argv, **_kw):
+            self.spawned.append(argv)
+            return _Proc()
+
+        monkeypatch.setattr("subprocess.Popen", _popen)
+
+    def test_the_declared_address_is_written_before_the_child_starts(self, everos_toml) -> None:
+        import tomllib
+
+        from raven.plugin.memory.everos._server import _start_server_if_unlocked
+
+        _write_llm_section(everos_toml)
+        _start_server_if_unlocked("http://localhost:18791")
+
+        with everos_toml.open("rb") as fh:
+            api = tomllib.load(fh)["api"]
+        assert api == {"host": "localhost", "port": 18791}
+
+    def test_the_child_gets_root_and_no_port(self, everos_toml) -> None:
+        from raven.plugin.memory.everos._server import _start_server_if_unlocked
+
+        _write_llm_section(everos_toml)
+        _start_server_if_unlocked("http://localhost:18791")
+
+        argv = self.spawned[0]
+        assert "--port" not in argv, "a command-line port would override the toml again"
+        assert "--root" in argv
+        assert argv[argv.index("--root") + 1] == str(everos_toml.parent)
+
+    def test_the_started_server_is_recorded(self, everos_toml, tmp_path) -> None:
+        import json
+
+        from raven.plugin.memory.everos._server import _start_server_if_unlocked
+
+        _write_llm_section(everos_toml)
+        _start_server_if_unlocked("http://localhost:18791")
+
+        record = json.loads((tmp_path / "everos-server.pid").read_text())
+        assert record["pid"] == 4242
+        assert record["root"] == str(everos_toml.parent)
+
+
+class TestStoppingWhatWeStarted:
+    """A pidfile is stale information, so verify before signalling."""
+
+    @pytest.fixture
+    def _data_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("raven.plugin.memory.everos._server.get_data_dir", lambda: tmp_path)
+        return tmp_path
+
+    def test_a_pid_reused_by_another_program_is_not_signalled(self, _data_dir, monkeypatch) -> None:
+        import json
+        import os as _os
+
+        from raven.plugin.memory.everos._server import stop_recorded_server
+
+        (_data_dir / "everos-server.pid").write_text(
+            json.dumps({"pid": 4242, "base_url": "http://localhost:18791", "root": str(_data_dir)})
+        )
+        monkeypatch.setattr("raven.plugin.memory.everos._server._is_everos_server", lambda _p: False)
+        signalled: list[int] = []
+        monkeypatch.setattr(_os, "kill", lambda *a: signalled.append(1))
+
+        assert stop_recorded_server(_data_dir) is False
+        assert signalled == [], "signalled a pid that is no longer an everos server"
+
+    def test_a_record_for_another_root_is_ignored(self, _data_dir, monkeypatch) -> None:
+        import json
+        import os as _os
+
+        from raven.plugin.memory.everos._server import stop_recorded_server
+
+        (_data_dir / "everos-server.pid").write_text(
+            json.dumps({"pid": 4242, "base_url": "http://localhost:18791", "root": "/somewhere/else"})
+        )
+        monkeypatch.setattr("raven.plugin.memory.everos._server._is_everos_server", lambda _p: True)
+        signalled: list[int] = []
+        monkeypatch.setattr(_os, "kill", lambda *a: signalled.append(1))
+
+        assert stop_recorded_server(_data_dir) is False
+        assert signalled == []
+
+    def test_a_verified_server_gets_sigterm_not_sigkill(self, _data_dir, monkeypatch) -> None:
+        import json
+        import os as _os
+        import signal as _signal
+
+        from raven.plugin.memory.everos._server import stop_recorded_server
+
+        (_data_dir / "everos-server.pid").write_text(
+            json.dumps({"pid": 4242, "base_url": "http://localhost:18791", "root": str(_data_dir)})
+        )
+        alive = [True, False]
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._is_everos_server",
+            lambda _p: alive.pop(0) if alive else False,
+        )
+        sent: list[int] = []
+        monkeypatch.setattr(_os, "kill", lambda _pid, sig: sent.append(sig))
+
+        assert stop_recorded_server(_data_dir) is True
+        assert sent == [_signal.SIGTERM]
+        assert not (_data_dir / "everos-server.pid").exists()
 
 
 class TestDeadChildDetection:

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from raven.plugin.memory.everos._server import (
-    EverosNotConfigured,
+    EverosNotConfiguredError,
     _everos_executable,
     ensure_everos_server,
 )
@@ -93,6 +93,13 @@ def everos_toml(tmp_path, monkeypatch):
     return cfg
 
 
+def _live_child():
+    """A Popen stand-in that is still running (``poll()`` returns None)."""
+    proc = MagicMock()
+    proc.poll.return_value = None
+    return proc
+
+
 def _write_llm_section(cfg, *, model="mem-llm", api_key="k"):
     cfg.parent.mkdir(parents=True, exist_ok=True)
     body = "[llm]\n"
@@ -120,7 +127,7 @@ class TestSpawnPreflight:
             lambda *a, **kw: spawned.append(1),
         )
         with patch("raven.plugin.memory.everos._server._probe_health", return_value=False):
-            with pytest.raises(EverosNotConfigured, match="memory LLM is not configured"):
+            with pytest.raises(EverosNotConfiguredError, match="memory LLM is not configured"):
                 await ensure_everos_server("http://localhost:18791", timeout=1.0)
 
         assert spawned == [], "spawned a server that could never finish starting"
@@ -128,14 +135,14 @@ class TestSpawnPreflight:
     @pytest.mark.asyncio
     async def test_missing_section_entirely_does_not_spawn(self, everos_toml, monkeypatch) -> None:
         everos_toml.parent.mkdir(parents=True, exist_ok=True)
-        everos_toml.write_text("[memory]\ntimezone = \"UTC\"\n", encoding="utf-8")
+        everos_toml.write_text('[memory]\ntimezone = "UTC"\n', encoding="utf-8")
         spawned = []
         monkeypatch.setattr(
             "raven.plugin.memory.everos._server._start_server_if_unlocked",
             lambda *a, **kw: spawned.append(1),
         )
         with patch("raven.plugin.memory.everos._server._probe_health", return_value=False):
-            with pytest.raises(EverosNotConfigured):
+            with pytest.raises(EverosNotConfiguredError):
                 await ensure_everos_server("http://localhost:18791", timeout=1.0)
 
         assert spawned == []
@@ -163,6 +170,115 @@ class TestSpawnPreflight:
             await ensure_everos_server("http://localhost:18791", timeout=5.0)
 
         assert spawned == [1]
+
+
+class TestDeadChildDetection:
+    """ "Still booting" and "already dead" are different states.
+
+    The Popen handle used to be discarded, so a child that exited in under a
+    second still cost the caller the full poll timeout -- 30s per session, with
+    the reason buried in the server log.
+    """
+
+    @pytest.fixture
+    def _logs(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("raven.plugin.memory.everos._server.get_logs_dir", lambda: tmp_path)
+        return tmp_path / "everos-server.log"
+
+    @pytest.mark.asyncio
+    async def test_exited_child_fails_immediately(self, everos_toml, _logs, monkeypatch) -> None:
+        _write_llm_section(everos_toml)
+        probes = []
+
+        def _probe(*_a, **_kw):
+            probes.append(1)
+            return False
+
+        dead = MagicMock()
+        dead.poll.return_value = 1
+        dead.returncode = 1
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._start_server_if_unlocked",
+            lambda *a, **kw: dead,
+        )
+        with patch("raven.plugin.memory.everos._server._probe_health", side_effect=_probe):
+            with pytest.raises(RuntimeError, match="exited with code 1"):
+                await ensure_everos_server("http://localhost:18791", timeout=30.0)
+
+        # Asserting on the probe count rather than wall-clock keeps this
+        # deterministic: one pre-loop probe plus one inside the loop, versus the
+        # 61 a full 30s budget would have cost.
+        assert len(probes) == 2
+
+    @pytest.mark.asyncio
+    async def test_failure_carries_the_reason_from_the_log(self, everos_toml, _logs, monkeypatch) -> None:
+        _write_llm_section(everos_toml)
+        _logs.parent.mkdir(parents=True, exist_ok=True)
+        _logs.write_text(
+            "some uvicorn noise\n"
+            "Traceback (most recent call last):\n"
+            '  File "engine.py", line 554, in _acquire_lock\n'
+            "everos.infra.ome.exceptions.EngineLockHeldError: another OfflineEngine "
+            "instance already holds /tmp/ome.db.lock\n"
+            "Application startup failed. Exiting.\n",
+            encoding="utf-8",
+        )
+        dead = MagicMock()
+        dead.poll.return_value = 3
+        dead.returncode = 3
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._start_server_if_unlocked",
+            lambda *a, **kw: dead,
+        )
+        with patch("raven.plugin.memory.everos._server._probe_health", return_value=False):
+            with pytest.raises(RuntimeError, match="EngineLockHeldError"):
+                await ensure_everos_server("http://localhost:18791", timeout=5.0)
+
+    @pytest.mark.asyncio
+    async def test_live_child_still_gets_the_full_budget(self, everos_toml, _logs, monkeypatch) -> None:
+        """A slow first boot is what the timeout exists for; do not cut it short."""
+        _write_llm_section(everos_toml)
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._start_server_if_unlocked",
+            lambda *a, **kw: _live_child(),
+        )
+        probes = []
+
+        def _probe(*_a, **_kw):
+            probes.append(1)
+            return False
+
+        with patch("raven.plugin.memory.everos._server._probe_health", side_effect=_probe):
+            with pytest.raises(RuntimeError, match="did not become healthy"):
+                await ensure_everos_server("http://localhost:18791", timeout=1.0)
+
+        # One pre-loop probe plus one per 0.5s poll interval across a 1s budget.
+        assert len(probes) == 3, "timeout budget was not spent polling"
+
+    @pytest.mark.asyncio
+    async def test_another_process_spawning_is_not_treated_as_dead(self, everos_toml, _logs, monkeypatch) -> None:
+        """No handle means someone else holds the startup lock, not a dead child."""
+        _write_llm_section(everos_toml)
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._start_server_if_unlocked",
+            lambda *a, **kw: None,
+        )
+        with patch("raven.plugin.memory.everos._server._probe_health", side_effect=[False, True]):
+            await ensure_everos_server("http://localhost:18791", timeout=5.0)
+
+    @pytest.mark.asyncio
+    async def test_missing_log_degrades_to_no_detail(self, everos_toml, _logs, monkeypatch) -> None:
+        _write_llm_section(everos_toml)
+        dead = MagicMock()
+        dead.poll.return_value = 2
+        dead.returncode = 2
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._start_server_if_unlocked",
+            lambda *a, **kw: dead,
+        )
+        with patch("raven.plugin.memory.everos._server._probe_health", return_value=False):
+            with pytest.raises(RuntimeError, match="exited with code 2"):
+                await ensure_everos_server("http://localhost:18791", timeout=5.0)
 
 
 class TestEnsureEverosServer:
@@ -194,6 +310,7 @@ class TestEnsureEverosServer:
             ),
             patch(
                 "raven.plugin.memory.everos._server._start_server_if_unlocked",
+                return_value=_live_child(),
             ) as mock_start,
             patch(
                 "raven.plugin.memory.everos._server.get_logs_dir",
@@ -206,11 +323,9 @@ class TestEnsureEverosServer:
 
     @pytest.mark.asyncio
     async def test_timeout_raises(self, tmp_path, everos_toml) -> None:
-        """A live-but-unhealthy start still gets the full poll budget.
-
-        The credential gate must not shorten this: a slow first boot is exactly
-        what the timeout exists for.
-        """
+        """No child of ours to watch (another process holds the startup lock),
+        and the address never turns healthy, so the budget is spent and the
+        message says the process is still up."""
         _write_llm_section(everos_toml)
         with (
             patch(
@@ -219,12 +334,13 @@ class TestEnsureEverosServer:
             ),
             patch(
                 "raven.plugin.memory.everos._server._start_server_if_unlocked",
+                return_value=None,
             ),
             patch(
                 "raven.plugin.memory.everos._server.get_logs_dir",
                 return_value=tmp_path,
             ),
-            pytest.raises(RuntimeError, match="EverOS server failed to start"),
+            pytest.raises(RuntimeError, match="did not become healthy"),
         ):
             await ensure_everos_server("http://localhost:18791", timeout=1.0)
 

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -972,3 +972,33 @@ class TestStoppingWhatTheLockNamed:
         monkeypatch.setattr(_server.time, "sleep", lambda _s: None)
 
         assert _server.stop_pid(4242, timeout=1.0) is _server.StopOutcome.STILL_DRAINING
+
+
+class TestAnUnwritableRootFailsAsAStartFailure:
+    """A root raven cannot write to must read as "the server did not start".
+
+    The address is written into the root before the child is spawned, so a
+    directory that refuses the write raises OSError from deep inside the start
+    path. Every caller guards with ``except RuntimeError`` -- the wizard, the
+    backend -- because that is what "could not start" has always been. An
+    OSError walked past all of them and ended the wizard on a traceback, in a
+    situation the user can act on: fix the permissions and run it again.
+    """
+
+    def test_it_surfaces_as_runtime_error(self, tmp_path, monkeypatch) -> None:
+        from raven.plugin.memory.everos import _server
+
+        root = tmp_path / "everos"
+        root.mkdir()
+        (root / "everos.toml").write_text('[api]\nhost = "127.0.0.1"\nport = 8000\n')
+        root.chmod(0o555)
+        monkeypatch.setattr(_server, "_everos_executable", lambda: "/bin/true")
+        monkeypatch.setattr("raven.config.update_everos.everos_root", lambda: root)
+        monkeypatch.setattr("raven.config.update_everos.everos_owned", lambda: True)
+        try:
+            with pytest.raises(RuntimeError) as caught:
+                _server._start_server_if_unlocked("http://localhost:18791")
+        finally:
+            root.chmod(0o755)
+
+        assert "everos.toml" in str(caught.value) or "write" in str(caught.value).lower()

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -890,3 +892,41 @@ class TestParsingLsofListenOutput:
         from raven.plugin.memory.everos._server import _parse_listen_port
 
         assert _parse_listen_port("") is None
+
+
+class TestParsingProcLocks:
+    """Rows captured from a real Linux /proc/locks (kernel 6.8, Ubuntu).
+
+    This branch cannot run on the development machine, so the format is pinned
+    from a live capture rather than from the documentation. The waiter row is
+    the reason: a process blocked on the same lock is listed with a "->" prefix
+    that shifts every field right by one, and a parser that read the pid
+    positionally without noticing would hand back the waiter. The caller of
+    ``lock_holder`` goes on to signal what it is told.
+    """
+
+    @staticmethod
+    def _parse(rows: str, inode: int, tmp_path, monkeypatch) -> int | None:
+        from raven.plugin.memory.everos import _server
+
+        lock = tmp_path / "ome.db.lock"
+        lock.touch()
+        monkeypatch.setattr(Path, "read_text", lambda self, **kw: rows)
+        monkeypatch.setattr(Path, "exists", lambda self: True)
+        monkeypatch.setattr(_server.Path, "stat", lambda self, **kw: SimpleNamespace(st_ino=inode))
+        return _server._proc_locks_pid(lock)
+
+    def test_a_holder_row(self, tmp_path, monkeypatch) -> None:
+        rows = "3: FLOCK  ADVISORY  WRITE 1550263 fc:00:4980767 0 EOF\n"
+        assert self._parse(rows, 4980767, tmp_path, monkeypatch) == 1550263
+
+    def test_a_waiter_never_wins_whatever_the_order(self, tmp_path, monkeypatch) -> None:
+        holder = "2: FLOCK  ADVISORY  WRITE 1550263 fc:00:4980768 0 EOF"
+        waiter = "2: -> FLOCK  ADVISORY  WRITE 1550264 fc:00:4980768 0 EOF"
+
+        for rows in (f"{holder}\n{waiter}\n", f"{waiter}\n{holder}\n"):
+            assert self._parse(rows, 4980768, tmp_path, monkeypatch) == 1550263
+
+    def test_an_unrelated_inode_is_not_matched(self, tmp_path, monkeypatch) -> None:
+        rows = "3: FLOCK  ADVISORY  WRITE 1550263 fc:00:4980767 0 EOF\n"
+        assert self._parse(rows, 999999, tmp_path, monkeypatch) is None

--- a/tests/test_importer_orchestrator.py
+++ b/tests/test_importer_orchestrator.py
@@ -25,19 +25,25 @@ from raven.importer.types import (
 class FakeBackend:
     """Records store() calls for assertion."""
 
-    def __init__(self, *, fail_on: set[str] | None = None) -> None:
+    def __init__(self, *, fail_on: set[str] | None = None, drop_on: set[str] | None = None) -> None:
         self.calls: list[dict[str, Any]] = []
         self._fail_on = fail_on or set()
+        # A backend that reports a dropped write instead of raising: the shape
+        # a real EverosBackend takes when the memory service is unavailable.
+        self._drop_on = drop_on or set()
 
     async def recall(self, query: str, *, user_id: str | None = None, agent_id: str | None = None, top_k: int) -> list:
         return []
 
     async def store(
         self, session_id: str, messages: list[dict[str, Any]], *, metadata: dict[str, Any] | None = None
-    ) -> None:
+    ) -> bool:
         if session_id in self._fail_on:
             raise RuntimeError(f"store failed for {session_id}")
+        if session_id in self._drop_on:
+            return False
         self.calls.append({"session_id": session_id, "messages": messages, "metadata": metadata})
+        return True
 
     async def feedback(self, signals: dict[str, Any]) -> None:
         pass
@@ -199,6 +205,32 @@ class TestErrorIsolation:
     async def test_store_failure_continues(self, tmp_path: Path) -> None:
         state = ImportState(path=tmp_path / "state.json")
         backend = FakeBackend(fail_on={"import-a"})
+        scanner = FakeScanner(
+            {
+                "a": _session(n_msgs=1, session_id="import-a"),
+                "b": _session(n_msgs=1, session_id="import-b"),
+            }
+        )
+        items = [(scanner, _scan_result("a")), (scanner, _scan_result("b"))]
+
+        summary = await run_import(items, backend, state)
+
+        assert summary.failed == 1
+        assert summary.submitted == 1
+        assert not state.is_submitted("claude_code", "a")
+        assert state.is_submitted("claude_code", "b")
+
+    @pytest.mark.asyncio
+    async def test_a_dropped_write_is_treated_exactly_like_a_raised_one(self, tmp_path: Path) -> None:
+        """The policy does not change, only the signal that triggers it.
+
+        A backend that reports a dropped write rather than raising must still
+        leave the source unsubmitted. Without this the resume state marks the
+        source done, and a rerun skips the very history that was never stored
+        -- silent, permanent, and invisible in the summary.
+        """
+        state = ImportState(path=tmp_path / "state.json")
+        backend = FakeBackend(drop_on={"import-a"})
         scanner = FakeScanner(
             {
                 "a": _session(n_msgs=1, session_id="import-a"),


### PR DESCRIPTION
## Summary

EverOS memory used to fail in ways that were hard to attribute: a session
would stall for up to a minute, or quietly come up with no memory at all, and
the reason lived in a log file. Underneath, raven could not answer two
questions it kept acting on -- which EverOS root the memories are in, and
whether it is allowed to touch that root's process.

**Ownership becomes a recorded decision.** The root and whether raven may write
to it are stored in `plugins.config["everos-memory"]` instead of being
re-derived at each call site from a path. A root the user runs is read-only:
raven records the address, never edits the config, never starts or stops it.
Enforcement sits on the write primitives, so a new caller cannot opt out.

**Nothing claims to know what it cannot.** A self-managed install records no
root, which is what makes the read-only promise structural. Everything that
reports on memory had to stop asking the filesystem about it: `raven doctor`
names no directory for such an install and takes the retrieval mode from what
the server says about itself, because the fallback root it used to print was
one the user had never chosen, and the roles read out of that root's toml
described an install nobody was using.

**Two ways to get memory, chosen rather than inferred.** Step 4 asks. The
managed path is unchanged in spirit: raven creates a root, configures the
models, runs the server. The self-managed path is two prompts and one health
probe, with no scan and no port default -- the only port raven could suggest is
its own, and accepting it by reflex would point this path at the other path's
address. Only the address is recorded, not a root, so there is no path on disk
a later change could write to by accident.

**The port is a setting, not a constant.** 18791 is a recommendation. When it
is already taken the wizard asks for another instead of failing with nowhere to
go, and stays silent otherwise -- a port screen on every fresh install asks for
a decision almost nobody has to make. A port already held by raven's own
service does not count as taken: a bind test cannot tell a stranger from the
process the step is about to restart into.

**Reconfiguring reaches the process that reads the models.** EverOS builds its
LLM client in the API lifespan, at startup, so a server already running keeps
what it booted with. Writing new models and leaving it running made the whole
reconfigure inert until some later, unrelated restart, with nothing on screen
saying so. Raven's own server for that root is stopped first -- identified from
the lock rather than the pidfile, so a root whose pidfile was lost is not
reported as somebody else's.

**Convergence asks before it acts.** The target address comes from a recorded
port rather than a constant, because comparing against a hardcoded 18791 cannot
tell a port an old raven left behind from one the user set deliberately -- and
the wizard moved both, describing the user's own choice as a legacy port. When
the running address does differ, the user chooses: keep it (reversible, and the
default) or move it (restarts the service). Addresses are compared by socket
rather than by spelling, since `127.0.0.1` and `localhost` name one endpoint.

**The lock, not the pidfile, answers "who has this data".** A pidfile records
what raven remembers about itself, so losing it made a server raven did start
read as foreign. `lock_holder` asks the OS (lsof, then `/proc/locks` on Linux,
then the pidfile), verifies the command line names this root, and reports the
port the holder is listening on. That turns the one dead-end state -- lock
taken, declared address silent -- into a recoverable one: connect where it
really is instead of stopping it. A holder that serves no HTTP is described,
with its command line, and left alone.

**A session survives a memory service that comes and goes.** `start()` used to
answer "is memory available" once, and a failure swapped in a no-op adapter for
the rest of the session, so a server that came up two seconds later was never
noticed. That verdict is now a seven-state machine. `STARTING` and `FAILED` are
told apart by the spawned child's exit code rather than by elapsed time.
`UNRESPONSIVE` exists so a hung server is charged for once and short-circuited
after. `UNCONFIGURED` and `NO_BINARY` describe the installation, so probing
cannot clear them. Recovery is automatic: recall returns empty immediately and
kicks a rate-limited out-of-band probe, and the next call picks up the result.

**Nothing waits a minute any more.** One flat 60s HTTP budget covered reads and
writes. It becomes 1s for a health probe, 8s for a recall, and a write budget
that follows what the write is doing -- and the turn itself waits at most 5s on
indexing before letting the write finish in the background. On the no-model
delivery path that await sat before `emit`, so it was stalling the user seeing
the reply. Outstanding writes are bounded and drained at teardown, and any that
were dropped are reported once at the end of the session rather than only to a
log file the TUI does not print.

Also fixed along the way: the everos binary is located next to the interpreter
before PATH (`uv tool install` exposes only raven's entry points); a spawn is
refused when `[llm]` has no credentials rather than timing out against a
process that cannot start; the written `[api]` port is read back before
spawning against it; and a failed start no longer counts as a decision to
abandon long-term memory.

### Second review pass

A second adversarial review raised eight findings against the branch. All eight
are fixed here, and every fix landed test-first, so each assertion was observed
failing against the code it covers before the code changed. Seven were
implementation gaps; one was a gap in the design's coverage.

Three of them share a root cause worth naming, because it explains why they
arrived together: this change moves "the memory service is not there" from an
exception path to a normal one, and the first pass migrated only the caller it
was designed around.

- **A bulk import read an unavailable service as a clean run.** The turn loop
  wants a failed write dropped and counted; an import marks its source done in
  resume state, so the same policy erased the only record that the source was
  still pending. `store` now reports whether the slice landed. The importer's
  own policy is untouched -- it already marked the source failed and continued;
  only the signal had gone missing.
- **`raven import run` guarded a start that no longer raises.** The guard is
  asked instead of caught, and refuses to import against a service that is not
  READY.
- **Write budgets ignored what the write was doing.** A per-turn append and a
  final flush shared one number, silently overriding the six-minute extraction
  budget. A write that overruns no longer demotes the service either: a slow
  extraction is not an absent one, and demoting dropped the batch behind it.

Two more were fields added without wiring every writer:

- **The intended port was recorded by one branch only.** Only the adopt branch
  wrote it, so an ordinary converge left it absent and the target fell back to
  the constant -- doing the thing the field exists to prevent.
- **Switching to a self-managed EverOS left the previous root in the config**,
  and it was still exported as `EVEROS_ROOT`. Recording no root is what makes
  the read-only promise structural, so the write now retracts it.

The remaining three: the legacy root ignored both the home in use and which
installation was asking (below); dropped writes were counted for installs that
never had memory to lose; and `FAILED` was unreachable from `start()` because
the child handle came from the return value of a call that raises.

### Third review pass

One blocking finding, now fixed: `raven doctor` reported a fabricated memory
root, and a fabricated capability set, for the self-managed install this PR
introduces. It is the same root cause as three of the second-pass findings --
a contract changed here (self-managed records no root) without every reader
being enumerated, and doctor is a reader. The retrieval mode was the worst of
it: derived from a toml in a directory the user had never chosen, so an install
whose server has embedding configured was told its recall was keyword-only.

Also from hand-running the wizard rather than reading it: the occupancy check
announced raven's own service as "something else" on the port; the
restart-on-reconfigure path identified the server by lock and then stopped it
by pidfile, so a lost pidfile reported "not ours" about a process just named;
an unwritable root ended the wizard on a traceback instead of a start failure;
and skipping printed a line restating what skip means.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

Full suite, on an ordinary developer HOME rather than a throwaway one:

```
uv run pytest tests/ -q
6504 passed, 33 skipped, 13 deselected, 1 failed
```

The environment matters here. An earlier revision of this branch was verified
under `HOME=$(mktemp -d)`, which made the suite green by hiding a defect this
branch had introduced: twelve wizard tests were reading the developer's real
`~/.everos/raven`. Isolation was standing in for a diagnosis. The acceptance
criterion for that fix is therefore the unmodified HOME, and it now passes
there.

The one remaining failure is `tests/test_cli_theme.py::test_bold_accent_renders_styled_not_bare`.
It reproduces on a clean checkout of `main` with a clean HOME, passes in CI on
Linux, and this branch touches nothing it exercises -- it is a macOS-local,
pre-existing failure.

```
uv run ruff check raven/ tests/           # All checks passed
uv run ruff format --check raven/ tests/  # 820 files already formatted
make check-large-files                    # pass
make check-commits                        # pass
```

Roughly 100 new tests, each written before the code it covers and observed
failing first. The state machine is exercised transition by transition with an
injected child process and injected httpx errors, so no real server is needed.
Two sandbox findings are pinned as tests: address comparison across
`127.0.0.1` / `localhost` / `[::1]`, and parsing real `lsof` LISTEN rows, where
the address is neither the last field nor at a fixed column.

Hand-run against real everos processes (1.2.1 and 1.2.2) in a throwaway HOME:
the lock holder is identified after the pidfile is deleted, and its real port
is recovered when the declared address is silent.

The Linux branch of the lock-holder lookup has now been run on Linux (Ubuntu,
kernel 6.8) rather than inferred from the documented format, using the shipped
function against a real flock. It finds the holder, reports nothing for an
unlocked file, and stops reporting once the holder exits. A second process
blocked on the same lock turned out to matter: its row is prefixed with `->`,
shifting every field right by one, so a positional read of the pid would have
returned the waiter -- and `lock_holder`'s caller signals what it is told. The
existing parser already skipped that row, but incidentally rather than by
intent, so the captured rows are now pinned as a test.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

Docs are not updated: the wizard screens are described in the working notes for
this change, and there is no user-facing document that documents them yet.

## Risk

Not yet verified, and worth knowing before merge:

- The write-budget change assumes a final flush can outrun ten seconds. That is
  reasoned from the importer's batch size rather than measured against a real
  EverOS extraction, so the six-minute budget may be more headroom than the
  call needs.
- The interactive screens have been driven by hand against real everos
  processes, and that pass is what surfaced the third-round findings above. The
  written script it follows lives with the working notes rather than in the
  repo, so it is not re-runnable from a clean checkout.
- Switching an already-configured managed setup to a self-managed one is not
  possible in the wizard: the source question only appears when there is no
  configured root, so a working install sees keep/reconfigure and no third way.
  Reaching a self-managed setup from there means editing the config by hand.
- Worse in the other direction, and known-unfixed here: a self-managed install
  reaches the same keep/reconfigure menu, and Reconfigure is the only plausible
  button for "change the address of my own server". It walks the four model
  roles and ends with raven's own root recorded, `owned` flipped to true and the
  user's address overwritten, without confirming any of it -- and backing out of
  all four roles turns memory off after the config has already been rewritten.
  Discovery does the same silently for anyone who reached self-managed by hand.
  A third menu entry and a confirmation before the managed path rewrites
  ownership are the fix; neither is in this PR.
- When the memory LLM provider is DeepSeek, the embedding screen has no
  same-source option -- DeepSeek serves no embeddings, so it is correctly
  filtered out, and the user is left finding a second key with no explanation
  of why.

User-visible behaviour changes:

- Step 4 opens with a new question about where memory should come from.
- A managed setup asks for a port when the intended one is occupied, and is
  silent otherwise.
- Reconfiguring restarts raven's own memory service so the new models load.
  Previously the models were written and the running server kept the old ones.
- `raven doctor` no longer prints a memory directory for a self-managed install,
  and reports its retrieval mode as unknown while that server is unreachable.
- A raven-managed server on a non-standard port is no longer moved silently;
  the user is asked, and the default answer leaves the service alone.
- An EverOS the user runs is no longer discovered or offered. Pointing raven at
  one is now explicit. A config that already recorded such a root keeps working.
- A session no longer blocks on the memory service. A turn that cannot be
  indexed is counted and reported at exit instead of holding the turn open.
- `backend.start()` no longer raises and `backend.store()` returns whether the
  write landed instead of raising. Discarding that return value stays valid;
  assuming a write landed because nothing was raised does not.
- `raven import run` exits non-zero rather than importing into a memory service
  that is not available.

Rollback: revert the branch, then move the memories back.

The config this PR writes (`owned`, `root`, `port` under
`plugins.config["everos-memory"]`) is additive and ignored by the previous code,
which falls back to `base_url` and a path-based ownership guess as before. The
directory is not additive. A new install onboarded on this branch puts its
EverOS root under `<raven data dir>/everos`, while the reverted code hardcodes
`~/.everos/raven` -- so reverting on such an install leaves raven looking at an
empty path and reporting no memories at all, with the data still on disk. Move
`<raven data dir>/everos` to `~/.everos/raven` as part of the revert, or point
`plugins.config["everos-memory"].root` at it before rolling back.

Installs that existed before this branch are unaffected: their root already is
`~/.everos/raven`, and nothing moves it.

## Related Issues

N/A