### PR TITLE
ci: add claude code pr review workflows

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -1,0 +1,36 @@
+name: Claude Mention
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Runs only when someone with write access mentions @claude. The action's built-in
+    # actor check blocks external PR authors, so external PRs are reviewed only when a
+    # maintainer explicitly triggers this.
+    if: >
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read        # review/comment only; set to write to let @claude push fixes
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-5

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,73 @@
+name: Claude Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened, labeled]
+    paths-ignore:
+      - '**/*.md'
+      - 'uv.lock'
+      - 'package-lock.json'
+      - '**/package-lock.json'
+      - 'docs/**'
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Same-repo (internal), non-draft PRs only; skip dependabot's own PRs. On a
+    # public repo GitHub withholds secrets from fork PRs, so external PRs are
+    # skipped here by design. A `labeled` event only re-runs when the added
+    # label is `deep-review` (which escalates the model to Opus, see below).
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      (github.event.action != 'labeled' || github.event.label.name == 'deep-review')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read        # read code only; never writes or pushes
+      pull-requests: write  # post inline + summary comments
+      id-token: write       # required for the GitHub App auth
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          use_sticky_comment: true
+          # Sonnet by default; a `deep-review` label escalates to Opus for that PR.
+          claude_args: |
+            --model ${{ contains(github.event.pull_request.labels.*.name, 'deep-review') && 'claude-opus-5' || 'claude-sonnet-5' }}
+            --max-turns 40
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR: ${{ github.event.pull_request.number }} -> ${{ github.event.pull_request.base.ref }}
+
+            FIRST read the review comments already on this PR, including your own from
+            earlier runs - this workflow re-runs on every push and keeps no memory between
+            runs. Do NOT repeat a finding that has already been raised; only add what is new
+            or newly broken, and you may note briefly if an earlier issue now looks fixed.
+
+            Then read the diff plus the surrounding code, callers and tests you need. Before
+            reporting a finding, try to REFUTE it - drop it unless you can name the concrete
+            failure it causes. Out of scope: pre-existing issues on untouched lines, anything
+            a linter catches, and undocumented style.
+
+            Focus, in order:
+            1. Correctness - bugs, edge cases, error handling, broken callers, back-compat.
+            2. Repo conventions in AGENTS.md / CLAUDE.md - Conventional-Commit and branch
+               naming, uv-only dependency changes (never a hand-edited pyproject/lockfile),
+               test file naming (tests/test_cli_<module>_commands.py etc.), canonical
+               domain terms from CONTEXT-MAP.md, and no report/asset/large files.
+            3. Tests - was any test weakened, skipped, or made green without exercising it?
+
+            Post only to GitHub: inline comments on the exact lines, plus one top-level
+            summary. Do NOT narrate your review into the workflow log. Open the summary with
+            your stance in one sentence - "No blockers; this can merge." or "Blocking: <one
+            line>." Be willing to approve.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -80,12 +80,15 @@ jobs:
             files; (3) tests - was any test weakened, skipped, or made green without
             exercising the change?
 
-            VERIFY, do not just reason. For each candidate finding, try to DISPROVE it: check
-            callers and invariants, and where a quick check settles it, RUN it - `uv run
-            python -c '...'` for a runtime-behavior claim, or `uv run --all-extras pytest
-            <path> -q` for a specific test (you may `git stash` / `git checkout` a file to
-            revert a fix and confirm a test actually catches it, then restore it). For whether
-            the whole suite passes, read the CI result via the actions tool - do not re-run it.
+            Settle each candidate finding by READING first - the diff, callers, invariants,
+            the tests. Static reading is the default and is enough for almost everything, so
+            do NOT run tests routinely. ONLY when a claim genuinely cannot be settled by
+            reading - a subtle runtime-behavior question you are truly unsure about - verify
+            by running, smallest check first: a one-line `uv run python -c '...'` repro. Run
+            `uv run --all-extras pytest <path> -q` (slow) only for one specific test you must
+            confirm, never the whole suite; for whole-suite pass/fail read the CI result via
+            the actions tool. You may `git stash`/`git checkout` a file to revert a fix and
+            confirm a test truly catches it, then restore it.
 
             Report only findings you are highly confident are real AND introduced by this PR.
             Every behavior claim needs a file:line citation, not an inference from naming. When

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -54,13 +54,14 @@ jobs:
           additional_permissions: |
             actions: read
           # Sonnet by default; a `deep-review` label escalates to Opus for that PR.
-          # Bash is scoped to read + targeted test execution (uv run) + git revert
-          # helpers so the reviewer can VERIFY by running, not just reason. No Write/Edit:
-          # a throwaway repro is a heredoc inside a Bash call; tracked files stay untouched.
+          # Read + targeted execution (uv run) + Write/Edit, so it can write a throwaway
+          # repro script and run it, or revert a fix locally, to VERIFY rather than reason.
+          # contents:read means nothing written/edited here can be pushed; the runner is
+          # ephemeral, and CLAUDE_CODE_SUBPROCESS_ENV_SCRUB keeps the token out of subprocesses.
           claude_args: |
             --model ${{ contains(github.event.pull_request.labels.*.name, 'deep-review') && 'claude-opus-5' || 'claude-sonnet-5' }}
             --max-turns 40
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(uv run:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(git stash:*),Bash(git checkout:*),Read,Grep,Glob"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(uv run:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(git stash:*),Bash(git checkout:*),Read,Grep,Glob,Write,Edit"
           prompt: |
             REPO: ${{ github.repository }}
             PR: ${{ github.event.pull_request.number }} -> ${{ github.event.pull_request.base.ref }}
@@ -84,11 +85,13 @@ jobs:
             the tests. Static reading is the default and is enough for almost everything, so
             do NOT run tests routinely. ONLY when a claim genuinely cannot be settled by
             reading - a subtle runtime-behavior question you are truly unsure about - verify
-            by running, smallest check first: a one-line `uv run python -c '...'` repro. Run
-            `uv run --all-extras pytest <path> -q` (slow) only for one specific test you must
-            confirm, never the whole suite; for whole-suite pass/fail read the CI result via
-            the actions tool. You may `git stash`/`git checkout` a file to revert a fix and
-            confirm a test truly catches it, then restore it.
+            by running, smallest check first: a one-line `uv run python -c '...'`, or write a
+            throwaway script (e.g. /tmp/repro.py) and run it with `uv run python /tmp/repro.py`
+            for anything longer. Run `uv run --all-extras pytest <path> -q` (slow) only for
+            one specific test you must confirm, never the whole suite; for whole-suite
+            pass/fail read the CI result via the actions tool. Anything you write or edit is a
+            throwaway experiment on the ephemeral runner - restore tracked files with
+            `git checkout` and never push.
 
             Report only findings you are highly confident are real AND introduced by this PR.
             Every behavior claim needs a file:line citation, not an inference from naming. When

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -47,6 +47,7 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
       - uses: anthropics/claude-code-action@v1
+        id: review
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
@@ -54,14 +55,14 @@ jobs:
           additional_permissions: |
             actions: read
           # Sonnet by default; a `deep-review` label escalates to Opus for that PR.
-          # Read + targeted execution (uv run) + Write/Edit, so it can write a throwaway
-          # repro script and run it, or revert a fix locally, to VERIFY rather than reason.
-          # contents:read means nothing written/edited here can be pushed; the runner is
-          # ephemeral, and CLAUDE_CODE_SUBPROCESS_ENV_SCRUB keeps the token out of subprocesses.
+          # Read + targeted execution (uv run) + Write/Edit so it can write a throwaway repro
+          # and run it, plus Task/Agent so it can spawn an independent verifier subagent that
+          # tries to disprove each finding before posting. contents:read means nothing written
+          # here can be pushed; the runner is ephemeral and the token is scrubbed from subprocesses.
           claude_args: |
             --model ${{ contains(github.event.pull_request.labels.*.name, 'deep-review') && 'claude-opus-5' || 'claude-sonnet-5' }}
-            --max-turns 40
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(uv run:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(git stash:*),Bash(git checkout:*),Read,Grep,Glob,Write,Edit"
+            --max-turns 50
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(uv run:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(git stash:*),Bash(git checkout:*),Read,Grep,Glob,Write,Edit,Task,Agent"
           prompt: |
             REPO: ${{ github.repository }}
             PR: ${{ github.event.pull_request.number }} -> ${{ github.event.pull_request.base.ref }}
@@ -93,6 +94,13 @@ jobs:
             throwaway experiment on the ephemeral runner - restore tracked files with
             `git checkout` and never push.
 
+            Before posting, run an independent verification pass. If you have candidate
+            findings, spawn ONE fresh subagent (Task) that receives them and, assuming none is
+            correct, tries to DISPROVE each - re-reading callers and invariants, running a
+            targeted check where cheap - and keep only the findings it confirms. If a subagent
+            is unavailable, do the same disprove pass yourself with deliberate skepticism. Skip
+            this entirely when you have no candidate findings.
+
             Report only findings you are highly confident are real AND introduced by this PR;
             when unsure, drop it. Every behavior claim needs a file:line citation, not an
             inference from naming. Label each finding [blocker] (must fix before merge), [nit]
@@ -103,3 +111,14 @@ jobs:
             lines, anything a linter catches, undocumented style. Open the summary with your
             stance in one sentence - "No blockers; this can merge." or "Blocking: <one line>."
             Be willing to approve.
+      # The action reports success even when the model errored (expired auth, usage limit,
+      # etc.). Parse its execution transcript and fail loudly so a green check never hides a
+      # review that did not actually run.
+      - name: Fail loudly on a silent review error
+        if: always()
+        run: |
+          FILE='${{ steps.review.outputs.execution_file }}'
+          [ -f "$FILE" ] || { echo "::warning::no execution file; cannot confirm the review ran"; exit 0; }
+          jq -e 'last(.[] | select(.type == "result")) | .is_error == true' "$FILE" >/dev/null || exit 0
+          echo "::error::Claude review errored (a green status would mislead): $(jq -r 'last(.[] | select(.type == "result")) | .result // "no error text"' "$FILE" | tr '\n' ' ' | head -c 500)"
+          exit 1

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,56 +18,78 @@ jobs:
   review:
     # Same-repo (internal), non-draft PRs only; skip dependabot's own PRs. On a
     # public repo GitHub withholds secrets from fork PRs, so external PRs are
-    # skipped here by design. A `labeled` event only re-runs when the added
-    # label is `deep-review` (which escalates the model to Opus, see below).
+    # skipped by design. A `labeled` event only re-runs for the `deep-review` label.
     if: >
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       (github.event.action != 'labeled' || github.event.label.name == 'deep-review')
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read        # read code only; never writes or pushes
       pull-requests: write  # post inline + summary comments
       id-token: write       # required for the GitHub App auth
+      actions: read         # read the real CI result instead of re-running the suite
+    env:
+      # The reviewer may run this PR's own tests (conftest.py, deps come from the PR
+      # head). Scrub Anthropic/cloud secrets from its Bash subprocesses so a malicious
+      # test file cannot read the token. NOT auto-on without allowed_non_write_users.
+      CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+      # Make `uv` available so the reviewer can run targeted tests to verify a finding.
+      # The heavy env sync happens lazily, only if Claude actually runs `uv run`.
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           use_sticky_comment: true
+          additional_permissions: |
+            actions: read
           # Sonnet by default; a `deep-review` label escalates to Opus for that PR.
+          # Bash is scoped to read + targeted test execution (uv run) + git revert
+          # helpers so the reviewer can VERIFY by running, not just reason. No Write/Edit:
+          # a throwaway repro is a heredoc inside a Bash call; tracked files stay untouched.
           claude_args: |
             --model ${{ contains(github.event.pull_request.labels.*.name, 'deep-review') && 'claude-opus-5' || 'claude-sonnet-5' }}
             --max-turns 40
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(uv run:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(git stash:*),Bash(git checkout:*),Read,Grep,Glob"
           prompt: |
             REPO: ${{ github.repository }}
             PR: ${{ github.event.pull_request.number }} -> ${{ github.event.pull_request.base.ref }}
 
-            FIRST read the review comments already on this PR, including your own from
-            earlier runs - this workflow re-runs on every push and keeps no memory between
-            runs. Do NOT repeat a finding that has already been raised; only add what is new
-            or newly broken, and you may note briefly if an earlier issue now looks fixed.
+            Review this pull request. Post only to GitHub: inline comments on the exact
+            lines plus one short top-level summary. Do not narrate into the workflow log.
 
-            Then read the diff plus the surrounding code, callers and tests you need. Before
-            reporting a finding, try to REFUTE it - drop it unless you can name the concrete
-            failure it causes. Out of scope: pre-existing issues on untouched lines, anything
-            a linter catches, and undocumented style.
+            First read the comments already on this PR, including your own from earlier runs
+            (this re-runs on every push with no memory between runs). Do not repeat a finding
+            already raised; add only what is new or newly broken.
 
-            Focus, in order:
-            1. Correctness - bugs, edge cases, error handling, broken callers, back-compat.
-            2. Repo conventions in AGENTS.md / CLAUDE.md - Conventional-Commit and branch
-               naming, uv-only dependency changes (never a hand-edited pyproject/lockfile),
-               test file naming (tests/test_cli_<module>_commands.py etc.), canonical
-               domain terms from CONTEXT-MAP.md, and no report/asset/large files.
-            3. Tests - was any test weakened, skipped, or made green without exercising it?
+            Then review the diff, the surrounding code and callers, the tests, and this
+            repo's AGENTS.md / CLAUDE.md rules. Cover, in order: (1) correctness - bugs, edge
+            cases, error handling, broken callers, back-compat; (2) repo conventions -
+            Conventional-Commit and branch naming, uv-only dependency changes, test naming
+            (tests/test_cli_<module>_commands.py etc.), CONTEXT-MAP.md terms, no asset/large
+            files; (3) tests - was any test weakened, skipped, or made green without
+            exercising the change?
 
-            Post only to GitHub: inline comments on the exact lines, plus one top-level
-            summary. Do NOT narrate your review into the workflow log. Open the summary with
-            your stance in one sentence - "No blockers; this can merge." or "Blocking: <one
-            line>." Be willing to approve.
+            VERIFY, do not just reason. For each candidate finding, try to DISPROVE it: check
+            callers and invariants, and where a quick check settles it, RUN it - `uv run
+            python -c '...'` for a runtime-behavior claim, or `uv run --all-extras pytest
+            <path> -q` for a specific test (you may `git stash` / `git checkout` a file to
+            revert a fix and confirm a test actually catches it, then restore it). For whether
+            the whole suite passes, read the CI result via the actions tool - do not re-run it.
+
+            Report only findings you are highly confident are real AND introduced by this PR.
+            Every behavior claim needs a file:line citation, not an inference from naming. When
+            unsure, drop it - false positives waste the author's time. Out of scope:
+            pre-existing issues on untouched lines, anything a linter catches, undocumented
+            style. Open the summary with your stance in one sentence - "No blockers; this can
+            merge." or "Blocking: <one line>." Be willing to approve.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -93,9 +93,13 @@ jobs:
             throwaway experiment on the ephemeral runner - restore tracked files with
             `git checkout` and never push.
 
-            Report only findings you are highly confident are real AND introduced by this PR.
-            Every behavior claim needs a file:line citation, not an inference from naming. When
-            unsure, drop it - false positives waste the author's time. Out of scope:
-            pre-existing issues on untouched lines, anything a linter catches, undocumented
-            style. Open the summary with your stance in one sentence - "No blockers; this can
-            merge." or "Blocking: <one line>." Be willing to approve.
+            Report only findings you are highly confident are real AND introduced by this PR;
+            when unsure, drop it. Every behavior claim needs a file:line citation, not an
+            inference from naming. Label each finding [blocker] (must fix before merge), [nit]
+            (minor, non-blocking), or [pre-existing] (not introduced here). Post at most 5
+            nits; if there are more, give the count in the summary rather than a comment each.
+            On a re-run of an already-reviewed change, post only NEW blockers - do not re-raise
+            nits or re-nag settled points. Out of scope: pre-existing issues on untouched
+            lines, anything a linter catches, undocumented style. Open the summary with your
+            stance in one sentence - "No blockers; this can merge." or "Blocking: <one line>."
+            Be willing to approve.


### PR DESCRIPTION
## Summary

Add AI-assisted PR review via the official Claude Code GitHub Action
(anthropics/claude-code-action@v1), authenticated with the
CLAUDE_CODE_OAUTH_TOKEN subscription secret. The Claude GitHub App is already
installed on this repo.

Two workflows:

- claude-review.yml auto-reviews internal (same-repo, non-draft) PRs on
  open/synchronize. Default model is claude-sonnet-5; a `deep-review` label
  escalates that PR to claude-opus-5. It skips fork PRs (a public repo withholds
  secrets from forks anyway), dependabot PRs, and docs/lock-only diffs. Posts
  inline comments plus one sticky summary as claude[bot]; `contents: read`, so
  it never writes code.
- claude-mention.yml responds to @claude mentions in comments/reviews. The
  action's built-in write-access check means only maintainers can trigger it,
  which is how external fork PRs get reviewed on demand. Also read-only.

Cost and noise controls: use_sticky_comment plus a "read existing comments, do
not repeat" prompt to avoid duplicate comments across re-runs; --max-turns and
timeout-minutes caps; paths-ignore and a dependabot filter; shallow checkout.
The review prompt asks Claude to honor this repo's AGENTS.md / CLAUDE.md
conventions.

## Type

- [x] CI / tooling

## Verification

Workflow YAML only; no application code touched.

- actionlint on both workflows: no issues
- yaml.safe_load on both files: parse OK
- ASCII-only check on both files: pass

- [ ] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

Adds automation that runs on PR events and posts under claude[bot]. No runtime
or library behavior changes. Both workflows are `contents: read`, so Claude
cannot push or modify code. Rollback: delete the two workflow files.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A