### PR TITLE
test(context_engine): skip the chmod attachment case when the runner is root

### DIFF
--- a/tests/test_read_file_image.py
+++ b/tests/test_read_file_image.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import os
 import threading
 import time
 from pathlib import Path
@@ -1615,14 +1616,13 @@ def test_an_attachment_that_cannot_be_prepared_is_named_not_dropped(tmp_path: Pa
     assert "could not be prepared" in out
 
 
+@pytest.mark.skipif(os.geteuid() == 0, reason="chmod 000 does not block root")
 def test_an_attachment_that_cannot_be_read_costs_a_note_not_the_turn(tmp_path: Path) -> None:
     """Resolution only proved the path pointed at a file. Permissions can change
     between then and the read, and the file can be gone -- and this renderer runs
     deep inside turn assembly, where an ``OSError`` reaches the caller as a failed
     turn rather than as a message about one attachment.
     """
-    import os
-
     from raven.context_engine.segments import render
 
     locked = _write_image(tmp_path / "locked.png", (60, 40))


### PR DESCRIPTION
## Summary

`test_an_attachment_that_cannot_be_read_costs_a_note_not_the_turn` makes a file
unreadable with `chmod 000` and asserts the renderer notes the failed attachment
instead of failing the whole turn. `chmod 000` does not block a root user, so
the file stays readable, the error path is never entered, and the case fails for
anyone running the suite as root. It passes in CI, which does not run as root,
so the failure is invisible there and shows up only on a developer's machine.

Skipped for root rather than reworked: the behaviour under test is what happens
when a read raises, and making that happen without permissions means faking the
error, which would test the mock. The case is worth keeping for the runs that
can exercise it honestly.

The commit is `0xKT`'s, cherry-picked from the GitLab trunk where it already
landed. Authorship is preserved.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

Test-only.

## Verification

```
uv run pytest tests/test_read_file_image.py    105 passed, 1 skipped
```

Before this, the same command as root gave `1 failed, 105 passed`, with the
failure on this case. The skip reason names the cause, so a reader is not left
guessing why it is absent.

- [x] Relevant tests pass locally
- [ ] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

None to the product: no source file is touched. Non-root runs, CI included,
execute the case exactly as before.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A