### PR TITLE
fix(tracing): reject a dashboard viewer whose ui files are gone

### DIFF
--- a/raven/cli/tracing_commands.py
+++ b/raven/cli/tracing_commands.py
@@ -37,6 +37,12 @@ def _viewer_dir() -> Path:
     return Path(__file__).resolve().parent.parent / "tracing" / "viewer"
 
 
+# Asset the viewer must still be able to read off disk for the page to work.
+# Served by ``serveStatic``, unlike the health payload and HTML shell, which the
+# process answers from memory and therefore survive their files being deleted.
+_VIEWER_UI_PROBE = "/app.js"
+
+
 def _port_live(port: int) -> bool:
     """True if something is already listening on 127.0.0.1:port."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
@@ -45,12 +51,20 @@ def _port_live(port: int) -> bool:
 
 
 def _viewer_health(port: int) -> bool:
-    """True only if *our* tracing viewer is serving on ``port``.
+    """True only if *our* tracing viewer is serving on ``port`` and can still
+    serve its UI.
 
-    A live port is not enough: a stale viewer from an older layout, or an
-    unrelated server (e.g. another observability tool), can hold it and 404
-    every request. The viewer answers ``/api/health`` with ``{"ok": true}``;
-    a foreign server does not, so this distinguishes reuse from a clash.
+    Two probes, because either one alone accepts a viewer that cannot render:
+
+    * ``/api/health`` separates our viewer from an unrelated server (e.g.
+      another observability tool) holding the port -- a foreign server does not
+      answer ``{"ok": true}``.
+    * ``_VIEWER_UI_PROBE`` separates a working viewer from one whose files were
+      deleted from under it. The health payload and the HTML shell are both
+      answered from memory, so a viewer whose install directory was replaced
+      (a version upgrade, a switch to an editable install) keeps passing the
+      first probe indefinitely while every asset read 404s -- the page then
+      renders unstyled and never connects.
     """
     try:
         with urllib.request.urlopen(f"http://127.0.0.1:{port}/api/health", timeout=0.5) as resp:
@@ -59,7 +73,13 @@ def _viewer_health(port: int) -> bool:
             data = json.loads(resp.read().decode("utf-8"))
     except Exception:  # noqa: BLE001 — any failure means "not our viewer"
         return False
-    return isinstance(data, dict) and data.get("ok") is True
+    if not (isinstance(data, dict) and data.get("ok") is True):
+        return False
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}{_VIEWER_UI_PROBE}", timeout=0.5) as resp:
+            return resp.status == 200
+    except Exception:  # noqa: BLE001 — a 404 raises here; either way the UI is gone
+        return False
 
 
 def _find_free_port(start: int, span: int = 20) -> int | None:

--- a/raven/tracing/viewer/server.js
+++ b/raven/tracing/viewer/server.js
@@ -981,7 +981,17 @@ const server = http.createServer((req, res) => {
   const url = new URL(req.url, `http://${req.headers.host || '127.0.0.1'}`);
 
   if (url.pathname === '/api/health') {
-    sendJson(res, 200, { ok: true, port: PORT, stateDir: STATE_DIR });
+    // Report the UI as part of health, not just the process. STATIC_DIR is read
+    // per request, so an upgrade that replaces the install directory leaves this
+    // process able to answer from memory while every asset 404s; a bare
+    // ok:true would then invite the launcher to reuse a viewer that cannot render.
+    const uiOk = fs.existsSync(path.join(STATIC_DIR, 'app.js'));
+    sendJson(res, uiOk ? 200 : 503, {
+      ok: uiOk,
+      port: PORT,
+      stateDir: STATE_DIR,
+      ui: uiOk ? 'ok' : 'missing'
+    });
     return;
   }
 

--- a/tests/test_cli_tracing_commands.py
+++ b/tests/test_cli_tracing_commands.py
@@ -31,6 +31,11 @@ class _Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", "application/json")
             self.end_headers()
             self.wfile.write(body)
+        elif self.path == tc._VIEWER_UI_PROBE and getattr(self.server, "ui_ok", False):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/javascript")
+            self.end_headers()
+            self.wfile.write(b"// app\n")
         else:
             self.send_response(404)
             self.end_headers()
@@ -40,9 +45,10 @@ class _Handler(BaseHTTPRequestHandler):
         pass
 
 
-def _serve(port: int, health_ok: bool) -> HTTPServer:
+def _serve(port: int, health_ok: bool, ui_ok: bool = True) -> HTTPServer:
     srv = HTTPServer(("127.0.0.1", port), _Handler)
     srv.health_ok = health_ok  # type: ignore[attr-defined]
+    srv.ui_ok = ui_ok  # type: ignore[attr-defined]
     threading.Thread(target=srv.serve_forever, daemon=True).start()
     return srv
 
@@ -65,6 +71,21 @@ def test_viewer_health_true_for_our_viewer():
     srv = _serve(port, health_ok=True)
     try:
         assert tc._viewer_health(port) is True
+    finally:
+        srv.shutdown()
+
+
+def test_viewer_health_false_when_ui_assets_are_gone():
+    """The observed failure: a viewer whose install directory was replaced.
+
+    Health and the HTML shell come from memory, so the process keeps reporting
+    itself healthy while every asset read 404s -- reusing it hands the user an
+    unstyled page that never connects. Both probes must pass, not just health.
+    """
+    port = _free_port()
+    srv = _serve(port, health_ok=True, ui_ok=False)
+    try:
+        assert tc._viewer_health(port) is False
     finally:
         srv.shutdown()
 


### PR DESCRIPTION
## Summary

The dashboard opened as unstyled HTML that never connected: `/` and `/api/health` answered 200 while `/app.css` and `/app.js` both 404'd.

The port-reuse guard added in #141 asks the viewer whether it is alive, not whether it can still serve a page. Both the health payload and the HTML shell are produced from memory, while `STATIC_DIR` is read per request -- so a viewer whose install directory was **removed** rather than overwritten keeps reporting itself healthy for as long as the process stays up, and the launcher happily reuses it. Observed after the local install changed form (a switch to an editable install rebuilt the environment on a different Python version, deleting the directory the running viewer had been started from); a plain in-place upgrade overwrites the same path and does not trigger it.

Two changes, because either probe alone accepts a viewer that cannot render:

- `_viewer_health` now also fetches an asset the page cannot work without, and requires 200. This catches any stale viewer regardless of the code it is running -- including one started before this change.
- `/api/health` now reports the UI as part of health, answering `503 {"ok": false, "ui": "missing"}` when its static directory no longer holds `app.js`, so a fresh process is honest about the same condition to any other consumer.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

```
uv run pytest tests/test_cli_tracing_commands.py tests/test_tracing_api.py -q
  -> 27 passed

uv run ruff check raven tests            -> All checks passed!
uv run ruff format --check raven tests   -> 814 files already formatted
node --check raven/tracing/viewer/server.js -> ok
```

The new test is not vacuous -- against the same fake viewer (health 200, assets 404) the previous implementation of `_viewer_health` returns `True` and the new one returns `False`.

End-to-end against a real viewer started with `app.js` absent from its static directory:

```
GET /api/health -> 503 {"ok":false,"port":4399,"stateDir":"...","ui":"missing"}
_viewer_health(4399) -> False
```

And against a healthy viewer, `/`, `/app.css`, `/app.js` and `/api/health` all return 200 with `"ui":"ok"`.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

The health endpoint gains a field and can now return 503. The only in-tree consumer is `_viewer_health`, which is updated here; an external consumer that treated any 200 as healthy would newly see a 503, which is the intended signal. No change to what the dashboard renders when it is working.

`_VIEWER_UI_PROBE` adds one localhost request per launch, on the path already taken only when a port is found occupied.

Rollback is reverting the commit: the guard returns to health-only and the endpoint to a bare `ok: true`.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A -- follow-up to #141, which introduced the guard this hardens.