### PR TITLE
fix(cli): first-run onboarding hints and host-run confirmation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -266,7 +266,8 @@ main() {
 
   printf '\n'
   ok "All set! Open a new terminal (or source your shell profile), then run:"
-  printf '\n    \033[1mraven\033[0m            # enter the TUI\n'
+  printf '\n    \033[1mraven onboard\033[0m    # first-time setup\n'
+  printf '    \033[1mraven\033[0m            # enter the TUI\n'
   printf '    \033[1mraven agent\033[0m -m "hello"\n\n'
   if ! printf '%s' "$PATH" | grep -q "$HOME/.local/bin"; then
     warn "Your current PATH does not include ~/.local/bin yet -- open a new terminal, or run: export PATH=\"\$HOME/.local/bin:\$PATH\""

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -2019,6 +2019,33 @@ def _probe_boxlite() -> tuple[bool, str]:
     return True, "ok"
 
 
+def _warn_host_risk() -> None:
+    console.print(
+        _t(
+            "  [yellow]⚠ Third-party messages (channels, imports) can inject instructions.[/yellow]\n"
+            "  [yellow]⚠ On the host, injected commands execute with full host privileges.[/yellow]",
+            "  [yellow]⚠ 第三方消息(渠道、导入内容)可能向智能体注入指令。[/yellow]\n"
+            "  [yellow]⚠ 本机模式下,注入的命令将以宿主机全部权限执行。[/yellow]",
+        )
+    )
+
+
+def _confirm_host_run(questionary: Any) -> bool:
+    """Warn about host-mode risk and ask for explicit confirmation (default No)."""
+    from raven.cli._styles import RAVEN_STYLE
+
+    _warn_host_risk()
+    confirmed = questionary.confirm(
+        _t("Run directly on the host anyway?", "仍要在本机直接运行吗?"),
+        default=False,
+        style=RAVEN_STYLE,
+        qmark=_QMARK,
+    ).ask()
+    if confirmed is None:
+        raise typer.Exit(1)
+    return bool(confirmed)
+
+
 def _step2_sandbox(*, skip: bool, non_interactive: bool) -> object:
     """Step 2 — choose run location (host / boxlite sandbox)."""
     _step_header(2, _t("Choose where Raven runs code / commands", "选择 Raven 运行代码 / 命令的位置"))
@@ -2030,6 +2057,8 @@ def _step2_sandbox(*, skip: bool, non_interactive: bool) -> object:
                 "  [dim]保持运行位置:本机直接运行。[/dim]",
             )
         )
+        if _current_sandbox_backend() == "none":
+            _warn_host_risk()
         return None
 
     questionary = _require_questionary()
@@ -2061,16 +2090,20 @@ def _step2_sandbox(*, skip: bool, non_interactive: bool) -> object:
         ]
     )
 
-    picked = questionary.select(
-        _t("Run location:", "运行位置:"), choices=choices, style=RAVEN_STYLE, qmark=_QMARK
-    ).ask()
-    if picked is None:
-        raise typer.Exit(1)
-    if picked is _BACK:
-        return _BACK
-    if picked == "keep":
-        return None
-    if picked == "none":
+    while True:
+        picked = questionary.select(
+            _t("Run location:", "运行位置:"), choices=choices, style=RAVEN_STYLE, qmark=_QMARK
+        ).ask()
+        if picked is None:
+            raise typer.Exit(1)
+        if picked is _BACK:
+            return _BACK
+        if picked == "keep":
+            return None
+        if picked != "none":
+            break
+        if not _confirm_host_run(questionary):
+            continue
         _persist_sandbox_backend("none")
         console.print(
             _t(
@@ -2126,6 +2159,8 @@ def _step2_sandbox(*, skip: bool, non_interactive: bool) -> object:
         if choice == "retry":
             continue
         if choice == "host":
+            if not _confirm_host_run(questionary):
+                continue
             _persist_sandbox_backend("none")
             console.print(
                 _t(

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -2148,27 +2148,30 @@ def _step2_sandbox(*, skip: bool, non_interactive: bool) -> object:
                     "  [dim]可能本机缺少所需的虚拟化支持。可退回本机运行,或查阅 boxlite 安装文档。[/dim]",
                 )
             )
-        choice = _failure_choice(
-            [
-                (_t("Fall back to host", "退回本机运行"), "host"),
-                (_t("Retry after install", "安装后重试"), "retry"),
-                (_t("Skip", "跳过"), "skip"),
-            ],
-            non_interactive=non_interactive,
-        )
-        if choice == "retry":
-            continue
-        if choice == "host":
-            if not _confirm_host_run(questionary):
-                continue
-            _persist_sandbox_backend("none")
-            console.print(
-                _t(
-                    "  [green]✓ Running directly on the host.[/green]",
-                    "  [green]✓ 将在本机直接运行。[/green]",
-                )
+        while True:
+            choice = _failure_choice(
+                [
+                    (_t("Fall back to host", "退回本机运行"), "host"),
+                    (_t("Retry after install", "安装后重试"), "retry"),
+                    (_t("Skip", "跳过"), "skip"),
+                ],
+                non_interactive=non_interactive,
             )
-        return None
+            if choice == "retry":
+                break
+            if choice == "host":
+                # A declined confirm re-asks this submenu; only "retry" may
+                # re-probe (and reprint the failure banner).
+                if not _confirm_host_run(questionary):
+                    continue
+                _persist_sandbox_backend("none")
+                console.print(
+                    _t(
+                        "  [green]✓ Running directly on the host.[/green]",
+                        "  [green]✓ 将在本机直接运行。[/green]",
+                    )
+                )
+            return None
 
 
 # ---------------------------------------------------------------------------

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -1044,6 +1044,14 @@ def _pick_model(
             )
             model_ids = known
 
+    if default_value and default_value == spec.default_model:
+        console.print(
+            _t(
+                f"  [dim]Default: {default_value} — recommended balance of quality/cost for daily use.[/dim]",
+                f"  [dim]默认:{default_value} — 质量/成本均衡,适合日常使用。[/dim]",
+            )
+        )
+
     if model_ids:
         choices = [_format_model_for_provider(provider, spec, mid) for mid in model_ids]
         # Dedupe: the chain above already prefixes its ids, and _format_ leaves a

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -1319,8 +1319,7 @@ def _step4_memory(
             oc._t(
                 "  [dim]Long-term memory stays off.[/dim]\n"
                 "  [dim]Run `raven onboard` again whenever you want to configure it.[/dim]",
-                "  [dim]长期记忆保持关闭。[/dim]\n"
-                "  [dim]随时可以重新运行 raven onboard 配置。[/dim]",
+                "  [dim]长期记忆保持关闭。[/dim]\n  [dim]随时可以重新运行 raven onboard 配置。[/dim]",
             )
         )
         return None

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -1317,8 +1317,10 @@ def _step4_memory(
             _set_memory_backend(None)
         oc.console.print(
             oc._t(
-                "  [dim]Long-term memory stays off.[/dim]",
-                "  [dim]长期记忆保持关闭。[/dim]",
+                "  [dim]Long-term memory stays off.[/dim]\n"
+                "  [dim]Run `raven onboard` again whenever you want to configure it.[/dim]",
+                "  [dim]长期记忆保持关闭。[/dim]\n"
+                "  [dim]随时可以重新运行 raven onboard 配置。[/dim]",
             )
         )
         return None

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -4570,3 +4570,19 @@ def test_pick_model_shows_default_positioning_line(
     captured_out = capsys.readouterr().out
     assert re.search(r"Default: .*—", captured_out)
     assert chosen == "openai/m1"
+
+
+def test_memory_skip_hints_configure_later(
+    tmp_env: Path,
+    everos_isolated: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """The Step 4 skip/non-interactive exit must name the remediation command,
+    matching the give-up exit's 'run raven onboard again' hint."""
+    import re
+
+    monkeypatch.setattr(onboard_commands.console, "_width", 200)
+    onboard_everos._step4_memory(skip=True, non_interactive=False, main_model=None, warnings=[])
+    out = " ".join(capsys.readouterr().out.split())
+    assert re.search(r"raven onboard.*again", out)

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -4519,3 +4519,14 @@ def test_each_provider_sits_in_the_group_its_credentials_put_it_in() -> None:
             if group["kind"] != want:
                 misfiled.append(f"{entry['name']}: filed under {group['kind']!r}, credentials say {want!r}")
     assert not misfiled, "; ".join(misfiled)
+
+
+# --------------------------------------------------------------------------- first-run hints
+
+
+def test_install_sh_all_set_mentions_onboard() -> None:
+    """The install.sh closing hints must point first-time users at ``raven onboard``
+    (README already does; the installer's "All set" block must match)."""
+    text = (Path(__file__).resolve().parents[1] / "install.sh").read_text()
+    tail = text[text.index("All set") :]
+    assert "raven onboard" in tail

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1253,6 +1253,42 @@ def test_sandbox_boxlite_probe_failure_falls_back(tmp_env: Path, monkeypatch: py
     assert data["tools"]["sandbox"]["backend"] == "none"
 
 
+def test_sandbox_host_decline_reasks_submenu_without_reprobe(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Declining the host confirm inside the failure submenu returns to the
+    submenu directly: no second boxlite probe, no reprinted failure banner."""
+    import questionary
+
+    class _FQ:
+        def __init__(self, a):
+            self._a = a
+
+        def ask(self):
+            return self._a
+
+    probes: list[bool] = []
+
+    def probe():
+        probes.append(True)
+        return (False, "missing")
+
+    fc_answers = iter(["host", "skip"])
+    fc_calls: list[bool] = []
+
+    def fake_failure_choice(options, *, non_interactive):
+        fc_calls.append(True)
+        return next(fc_answers)
+
+    monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ("boxlite"))
+    monkeypatch.setattr(questionary, "confirm", lambda *a, **kw: _FQ(False))
+    monkeypatch.setattr(onboard_commands, "_probe_boxlite", probe)
+    monkeypatch.setattr(onboard_commands, "_failure_choice", fake_failure_choice)
+
+    onboard_commands._step2_sandbox(skip=False, non_interactive=False)
+
+    assert len(probes) == 1
+    assert len(fc_calls) == 2
+
+
 def test_sandbox_keep_current_first_option(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """An already-configured sandbox offers a 'keep current' first choice."""
     from raven.config.update import set_sandbox_backend
@@ -4623,9 +4659,7 @@ def test_sandbox_host_choice_warns_and_confirms(
     assert json.loads(tmp_env.read_text())["tools"]["sandbox"]["backend"] == "none"
 
 
-def test_sandbox_host_decline_returns_to_menu(
-    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_sandbox_host_decline_returns_to_menu(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Declining the host confirmation re-shows the run-location menu instead
     of persisting; the next pick (boxlite) wins."""
     import questionary

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -4530,3 +4530,43 @@ def test_install_sh_all_set_mentions_onboard() -> None:
     text = (Path(__file__).resolve().parents[1] / "install.sh").read_text()
     tail = text[text.index("All set") :]
     assert "raven onboard" in tail
+
+
+def test_pick_model_shows_default_positioning_line(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Before prompting, ``_pick_model`` explains why the prefilled default
+    model is recommended (not just its name)."""
+    import re
+    from types import SimpleNamespace
+
+    import questionary
+
+    class _FQ:
+        def __init__(self, a):
+            self._a = a
+
+        def ask(self):
+            return self._a
+
+    monkeypatch.setattr(onboard_commands.console, "_width", 200)
+    monkeypatch.setattr(questionary, "autocomplete", lambda *a, **kw: _FQ("m1"))
+    spec = SimpleNamespace(
+        name="openai",
+        default_model="m1",
+        litellm_prefix="",
+        skip_prefixes=(),
+        keywords=("openai",),
+    )
+    chosen = onboard_commands._pick_model(
+        "openai",
+        spec,
+        current_model=None,
+        model_ids=["m1", "m2"],
+        probe_status="ok",
+        user_provided_model=None,
+        non_interactive=False,
+    )
+    captured_out = capsys.readouterr().out
+    assert re.search(r"Default: .*—", captured_out)
+    assert chosen == "openai/m1"

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1224,6 +1224,7 @@ def test_sandbox_backend_persisted_via_ops(tmp_env: Path, monkeypatch: pytest.Mo
             return self._a
 
     monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ("none"))
+    monkeypatch.setattr(questionary, "confirm", lambda *a, **kw: _FQ(True))
     onboard_commands._step2_sandbox(skip=False, non_interactive=False)
     data = json.loads(tmp_env.read_text())
     assert data["tools"]["sandbox"]["backend"] == "none"
@@ -1243,6 +1244,7 @@ def test_sandbox_boxlite_probe_failure_falls_back(tmp_env: Path, monkeypatch: py
             return self._a
 
     monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ(next(answers)))
+    monkeypatch.setattr(questionary, "confirm", lambda *a, **kw: _FQ(True))
     monkeypatch.setattr(onboard_commands, "_probe_boxlite", lambda: (False, "missing"))
     # Failure submenu picks "fall back to host".
     monkeypatch.setattr(onboard_commands, "_failure_choice", lambda options, *, non_interactive: "host")
@@ -4586,3 +4588,71 @@ def test_memory_skip_hints_configure_later(
     onboard_everos._step4_memory(skip=True, non_interactive=False, main_model=None, warnings=[])
     out = " ".join(capsys.readouterr().out.split())
     assert re.search(r"raven onboard.*again", out)
+
+
+def test_sandbox_host_choice_warns_and_confirms(
+    tmp_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Interactively picking host must show the prompt-injection risk warning
+    and pass through an explicit confirmation before persisting."""
+    import re
+
+    import questionary
+
+    class _FQ:
+        def __init__(self, a):
+            self._a = a
+
+        def ask(self):
+            return self._a
+
+    confirm_calls: list = []
+
+    def _confirm(*a, **kw):
+        confirm_calls.append((a, kw))
+        return _FQ(True)
+
+    monkeypatch.setattr(onboard_commands.console, "_width", 200)
+    monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ("none"))
+    monkeypatch.setattr(questionary, "confirm", _confirm)
+    onboard_commands._step2_sandbox(skip=False, non_interactive=False)
+    out = capsys.readouterr().out
+    confirm_called = bool(confirm_calls)
+    assert confirm_called
+    assert re.search(r"full host privileges|host access", out, re.I)
+    assert json.loads(tmp_env.read_text())["tools"]["sandbox"]["backend"] == "none"
+
+
+def test_sandbox_host_decline_returns_to_menu(
+    tmp_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Declining the host confirmation re-shows the run-location menu instead
+    of persisting; the next pick (boxlite) wins."""
+    import questionary
+
+    class _FQ:
+        def __init__(self, a):
+            self._a = a
+
+        def ask(self):
+            return self._a
+
+    answers = iter(["none", "boxlite"])
+    monkeypatch.setattr(questionary, "select", lambda *a, **kw: _FQ(next(answers)))
+    monkeypatch.setattr(questionary, "confirm", lambda *a, **kw: _FQ(False))
+    monkeypatch.setattr(onboard_commands, "_probe_boxlite", lambda: (True, "ok"))
+    onboard_commands._step2_sandbox(skip=False, non_interactive=False)
+    assert json.loads(tmp_env.read_text())["tools"]["sandbox"]["backend"] == "boxlite"
+
+
+def test_sandbox_non_interactive_host_warns(
+    tmp_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Non-interactive runs landing on host still surface the risk warning
+    (without blocking, keeping headless usable)."""
+    import re
+
+    monkeypatch.setattr(onboard_commands.console, "_width", 200)
+    onboard_commands._step2_sandbox(skip=False, non_interactive=True)
+    out = capsys.readouterr().out
+    assert re.search(r"full host privileges|host access", out, re.I)

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -4656,3 +4656,17 @@ def test_sandbox_non_interactive_host_warns(
     onboard_commands._step2_sandbox(skip=False, non_interactive=True)
     out = capsys.readouterr().out
     assert re.search(r"full host privileges|host access", out, re.I)
+
+
+def test_everos_role_optionality_matches_design():
+    """Design guard: the memory llm role is mandatory (no skip affordance in
+    the wizard) while embedding/rerank/multimodal degrade gracefully and stay
+    skippable. Keeps the wizard metadata aligned with the health contract."""
+    from raven.cli.onboard_everos import _EVEROS_ROLES
+    from raven.plugin.memory.everos._health import DEGRADING_SECTIONS, REQUIRED_SECTIONS
+
+    assert REQUIRED_SECTIONS == ("llm",)
+    assert set(DEGRADING_SECTIONS) == {"embedding", "rerank", "multimodal"}
+    assert "skip_note" not in _EVEROS_ROLES["llm"]
+    for role in DEGRADING_SECTIONS:
+        assert "skip_note" in _EVEROS_ROLES[role]


### PR DESCRIPTION
## Summary

First-run experience fixes found in an internal usability review of v0.1.11. install.sh closing hints
now point to `raven onboard` first, matching the README. The model picker
prints a one-line positioning note for the recommended default. The
memory step's skip/non-interactive exits now print the same
configure-later hint the interactive give-up path already has ("Run
raven onboard again whenever you want to configure it"), re-anchored
into onboard_everos.py after the upstream onboarding split. Choosing the
host run location now shows a prompt-injection risk warning with an
explicit confirm (default No); non-interactive host runs print the
warning without blocking.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_cli_onboard_commands.py -x`: 200 passed.
- Full suite `uv run pytest -q`: 1 failed / 6151 passed; the single failure is the pre-existing test_read_file_image failure already present on main.
- Sandbox-HOME real runs: install.sh closing block greps for raven onboard; non-TTY onboard guard unchanged (exit 2 with the re-run hint); the skip-branch hint prints in a real wizard run; host selection was exercised on a real pseudo-TTY (warning + confirm, refuse returns to the menu without writing config).
- All changes were written red-first against frozen acceptance assertions; two assertions were amended with documented reasons after the upstream onboarding restructure (details in the branch worktree NOTES).

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

The host-run confirm adds one interactive gate on a security-sensitive
default; non-interactive flows are warned but not blocked, so headless
setups keep working. Rollback = revert the branch.

## Related Issues

N/A - found in an internal usability review of v0.1.11; no tracked GitHub issues.

