### PR TITLE
fix(cli): doctor config tri-state, retrieval line, and one config warning

### DIFF
--- a/raven/cli/doctor_commands.py
+++ b/raven/cli/doctor_commands.py
@@ -33,6 +33,7 @@ console = Console()
 class PathsInfo:
     config_path: str
     config_exists: bool
+    config_valid: bool = False
     workspace_path: str = ""
     workspace_exists: bool = False
 
@@ -119,6 +120,8 @@ class DoctorReport:
     def exit_code(self) -> int:
         if self.paths is None or not self.paths.config_exists:
             return 1
+        if not self.paths.config_valid:
+            return 1
         if not self.config_loaded:
             return 1
         if self.routing is None or self.routing.provider is None:
@@ -134,7 +137,12 @@ class DoctorReport:
 
 def _gather_static_checks() -> DoctorReport:
     """Inspect config / routing / features. Strictly zero-network."""
-    from raven.config.loader import get_config_path, load_config
+    from raven.config.loader import (
+        ConfigReadError,
+        get_config_path,
+        load_config,
+        read_raw_or_raise,
+    )
 
     config_path = get_config_path()
     paths = PathsInfo(
@@ -145,6 +153,15 @@ def _gather_static_checks() -> DoctorReport:
 
     if not paths.config_exists:
         return report
+
+    # Classify JSON validity directly: load_config swallows syntax errors
+    # and returns defaults, so it cannot distinguish valid from invalid.
+    try:
+        read_raw_or_raise(config_path)
+    except ConfigReadError:
+        paths.config_valid = False
+    else:
+        paths.config_valid = True
 
     try:
         config = load_config()
@@ -303,10 +320,12 @@ def _render_human_output(report: DoctorReport) -> None:
     paths = report.paths
     assert paths is not None  # _gather_static_checks always populates this
     console.print("[bold]Paths[/bold]")
-    if paths.config_exists:
-        console.print(f"  Config:    {paths.config_path}  [green]✓[/green]")
-    else:
+    if not paths.config_exists:
         console.print(f"  Config:    {paths.config_path}  [red]✗  (not found)[/red]")
+    elif not paths.config_valid:
+        console.print(f"  Config:    {paths.config_path}  [yellow]⚠  invalid JSON (running on defaults)[/yellow]")
+    else:
+        console.print(f"  Config:    {paths.config_path}  [green]✓[/green]")
     if paths.config_exists:
         mark = "[green]✓[/green]" if paths.workspace_exists else "[red]✗[/red]"
         console.print(f"  Workspace: {paths.workspace_path}  {mark}")
@@ -383,6 +402,9 @@ def _render_human_output(report: DoctorReport) -> None:
             console.print("Run [cyan]doctor --probe[/cyan] to send a test message and verify the LLM responds.")
         else:
             console.print("[green]✓ All checks passed.[/green]")
+    elif not paths.config_valid:
+        console.print("[yellow]⚠ Config file is invalid JSON; the checks above ran on built-in defaults.[/yellow]")
+        console.print(f"Fix [cyan]{paths.config_path}[/cyan] (JSON allows no comments or trailing commas).")
     elif routing and routing.provider is None:
         console.print(
             f"[red]✗ Model [bold]{routing.model}[/bold] could not be routed to any configured provider.[/red]"

--- a/raven/cli/doctor_commands.py
+++ b/raven/cli/doctor_commands.py
@@ -75,6 +75,7 @@ class MemoryInfo:
     reports_capabilities: bool = False
     configured: list[str] = field(default_factory=list)
     capabilities: dict[str, bool] = field(default_factory=dict)
+    retrieval: Optional[str] = None
 
     @property
     def unbuilt(self) -> list[str]:
@@ -227,6 +228,9 @@ def _probe_memory(config: "RavenConfig") -> MemoryInfo:
     )
 
     info.configured = [s for s in (*REQUIRED_SECTIONS, *DEGRADING_SECTIONS) if everos_role_configured(s)]
+    # Recall quality is decided by the embedding role in the user-level
+    # everos.toml: with it recall matches meaning, without it only keywords.
+    info.retrieval = "semantic" if "embedding" in info.configured else "keyword-only"
     report = probe_capabilities(configured_base_url(config))
     info.server_running = report.reachable
     info.reports_capabilities = report.reports_capabilities
@@ -375,6 +379,10 @@ def _render_human_output(report: DoctorReport) -> None:
     if memory is not None and memory.backend:
         console.print("\n[bold]Memory[/bold]")
         console.print(f"  Backend:    {memory.backend}")
+        if memory.retrieval == "semantic":
+            console.print("  Retrieval:  semantic")
+        elif memory.retrieval:
+            console.print("  Retrieval:  [dim]keyword-only  (no embedding key)[/dim]")
         _render_memory_capabilities(memory)
 
     if report.probe is not None:

--- a/raven/cli/doctor_commands.py
+++ b/raven/cli/doctor_commands.py
@@ -34,6 +34,7 @@ class PathsInfo:
     config_path: str
     config_exists: bool
     config_valid: bool = False
+    config_invalid_reason: str = ""
     workspace_path: str = ""
     workspace_exists: bool = False
 
@@ -138,12 +139,7 @@ class DoctorReport:
 
 def _gather_static_checks() -> DoctorReport:
     """Inspect config / routing / features. Strictly zero-network."""
-    from raven.config.loader import (
-        ConfigReadError,
-        get_config_path,
-        load_config,
-        read_raw_or_raise,
-    )
+    from raven.config.loader import get_config_path, load_config
 
     config_path = get_config_path()
     paths = PathsInfo(
@@ -155,14 +151,22 @@ def _gather_static_checks() -> DoctorReport:
     if not paths.config_exists:
         return report
 
-    # Classify JSON validity directly: load_config swallows syntax errors
-    # and returns defaults, so it cannot distinguish valid from invalid.
+    # Classify config validity with load_config's eyes: a syntax error, an
+    # empty file, and a non-object top level all mean no settings were read.
+    # Inspect the file directly -- load_config swallows syntax errors into
+    # defaults, and read_raw_or_raise folds the last two cases into {} for
+    # its read-modify-write callers, so neither can classify all three.
     try:
-        read_raw_or_raise(config_path)
-    except ConfigReadError:
-        paths.config_valid = False
+        text = config_path.read_text(encoding="utf-8")
+        data = json.loads(text) if text.strip() else None
+    except (OSError, UnicodeDecodeError, ValueError):
+        paths.config_invalid_reason = "invalid JSON"
     else:
-        paths.config_valid = True
+        if not text.strip():
+            paths.config_invalid_reason = "empty"
+        elif not isinstance(data, dict):
+            paths.config_invalid_reason = "not a JSON object"
+    paths.config_valid = not paths.config_invalid_reason
 
     try:
         config = load_config()
@@ -327,7 +331,8 @@ def _render_human_output(report: DoctorReport) -> None:
     if not paths.config_exists:
         console.print(f"  Config:    {paths.config_path}  [red]✗  (not found)[/red]")
     elif not paths.config_valid:
-        console.print(f"  Config:    {paths.config_path}  [yellow]⚠  invalid JSON (running on defaults)[/yellow]")
+        reason = paths.config_invalid_reason or "invalid JSON"
+        console.print(f"  Config:    {paths.config_path}  [yellow]⚠  {reason} (running on defaults)[/yellow]")
     else:
         console.print(f"  Config:    {paths.config_path}  [green]✓[/green]")
     if paths.config_exists:
@@ -339,7 +344,14 @@ def _render_human_output(report: DoctorReport) -> None:
         return
 
     if not report.config_loaded:
-        console.print("\n[red]✗ Config schema invalid.[/red] Run [cyan]raven onboard --reset[/cyan] to recreate it.")
+        if paths.config_valid:
+            console.print(
+                "\n[red]✗ Config schema invalid.[/red] Run [cyan]raven onboard --reset[/cyan] to recreate it."
+            )
+        else:
+            reason = paths.config_invalid_reason or "invalid JSON"
+            console.print(f"\n[yellow]⚠ Config file is {reason}; the checks above ran on built-in defaults.[/yellow]")
+            console.print(f"Fix [cyan]{paths.config_path}[/cyan] or run [cyan]raven onboard --reset[/cyan].")
         return
 
     routing = report.routing
@@ -411,7 +423,8 @@ def _render_human_output(report: DoctorReport) -> None:
         else:
             console.print("[green]✓ All checks passed.[/green]")
     elif not paths.config_valid:
-        console.print("[yellow]⚠ Config file is invalid JSON; the checks above ran on built-in defaults.[/yellow]")
+        reason = paths.config_invalid_reason or "invalid JSON"
+        console.print(f"[yellow]⚠ Config file is {reason}; the checks above ran on built-in defaults.[/yellow]")
         console.print(f"Fix [cyan]{paths.config_path}[/cyan] (JSON allows no comments or trailing commas).")
     elif routing and routing.provider is None:
         console.print(

--- a/raven/config/loader.py
+++ b/raven/config/loader.py
@@ -127,6 +127,11 @@ def load_config(config_path: Path | None = None) -> Config:
                 print(f"WARNING: {msg}", file=sys.stderr)
             logging.getLogger(__name__).debug(msg)
         else:
+            # A clean parse re-arms the warning: the dedup exists to silence
+            # repeated loads of the same broken state within one command, not
+            # to spend the one warning a long-lived process (the TUI RPC
+            # server reloads every turn) gets for a later re-breakage.
+            _warned_paths.discard(str(path))
             try:
                 config = Config.model_validate(data)
             except ValidationError as e:

--- a/raven/config/loader.py
+++ b/raven/config/loader.py
@@ -1,11 +1,11 @@
 """Configuration loading utilities."""
 
 import json
+import logging
 import sys
 from pathlib import Path
 from typing import Any
 
-from loguru import logger
 from pydantic import ValidationError
 
 from raven.config.schema import Config
@@ -33,6 +33,10 @@ EXTENSION_KEYS = (
 
 # Global variable to store current config path (for multi-instance support)
 _current_config_path: Path | None = None
+
+# Paths already warned about as malformed in this process; repeated
+# load_config calls (status/doctor load more than once) warn only once.
+_warned_paths: set[str] = set()
 
 
 def set_config_path(path: Path) -> None:
@@ -113,8 +117,15 @@ def load_config(config_path: Path | None = None) -> Config:
                 f"config at {path} is not valid JSON ({e}) -- IGNORING it and running on "
                 "DEFAULTS. Fix the file (JSON allows no comments or trailing commas) and restart."
             )
-            print(f"WARNING: {msg}", file=sys.stderr)
-            logger.warning(msg)
+            # Single user-visible channel: the stderr print (visible under any
+            # loguru sink config). The log-file trace uses stdlib logging, NOT
+            # loguru — loguru's default sink echoes DEBUG to stderr, which
+            # would re-duplicate the warning on plain CLI runs; the stdlib
+            # record reaches the file sink via the CLI's logging intercept.
+            if str(path) not in _warned_paths:
+                _warned_paths.add(str(path))
+                print(f"WARNING: {msg}", file=sys.stderr)
+            logging.getLogger(__name__).debug(msg)
         else:
             try:
                 config = Config.model_validate(data)

--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -402,3 +402,22 @@ def test_doctor_bad_config_warns_exactly_once(tmp_path: Path) -> None:
     home = _write_home_config(tmp_path, "bad", '{"providers": {},}')
     out, _ = _run_doctor_subprocess(home)
     assert out.count("not valid JSON") == 1, out
+
+
+def test_doctor_config_line_three_states(tmp_path: Path) -> None:
+    import re
+
+    home_bad = _write_home_config(tmp_path, "bad", '{"providers": {},}')
+    out_bad, _ = _run_doctor_subprocess(home_bad)
+    config_line = next(line for line in out_bad.splitlines() if "Config:" in line)
+    assert "✓" not in config_line, out_bad
+    assert re.search(r"invalid JSON", out_bad), out_bad
+
+    home_missing = _write_home_config(tmp_path, "missing", None)
+    out_missing, _ = _run_doctor_subprocess(home_missing)
+    assert re.search(r"missing|not found", out_missing), out_missing
+
+    home_good = _write_home_config(tmp_path, "good", "{}")
+    out_good, _ = _run_doctor_subprocess(home_good)
+    config_line = next(line for line in out_good.splitlines() if "Config:" in line)
+    assert "✓" in config_line, out_good

--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -360,3 +360,45 @@ def test_memory_section_reaches_the_json_output(healthy_config: Path, no_memory_
     payload = json.loads(r.stdout)
     assert payload["memory"]["capabilities"] == {"llm": True, "embed": False}
     assert payload["memory"]["configured"] == ["llm", "embedding"]
+
+
+
+
+# --------------------------------------------------------------------------- config visibility
+
+
+def _run_doctor_subprocess(home: Path) -> tuple[str, int]:
+    """Run ``raven doctor`` in a subprocess with a sandbox HOME.
+
+    A subprocess (not CliRunner) is required here: the loader's duplicate
+    warning went out over two channels (print + loguru), and loguru's sink
+    holds the real stderr, invisible to in-process capture.
+    """
+    import os
+    import subprocess
+    import sys
+
+    env = {**os.environ, "HOME": str(home), "COLUMNS": "250"}
+    r = subprocess.run(
+        [sys.executable, "-m", "raven", "doctor"],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+    return r.stdout + r.stderr, r.returncode
+
+
+def _write_home_config(tmp_path: Path, name: str, body: str | None) -> Path:
+    home = tmp_path / name
+    (home / ".raven").mkdir(parents=True)
+    if body is not None:
+        (home / ".raven" / "config.json").write_text(body, encoding="utf-8")
+    return home
+
+
+def test_doctor_bad_config_warns_exactly_once(tmp_path: Path) -> None:
+    home = _write_home_config(tmp_path, "bad", '{"providers": {},}')
+    out, _ = _run_doctor_subprocess(home)
+    assert out.count("not valid JSON") == 1, out

--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -362,8 +362,6 @@ def test_memory_section_reaches_the_json_output(healthy_config: Path, no_memory_
     assert payload["memory"]["configured"] == ["llm", "embedding"]
 
 
-
-
 # --------------------------------------------------------------------------- config visibility
 
 
@@ -421,6 +419,28 @@ def test_doctor_config_line_three_states(tmp_path: Path) -> None:
     out_good, _ = _run_doctor_subprocess(home_good)
     config_line = next(line for line in out_good.splitlines() if "Config:" in line)
     assert "✓" in config_line, out_good
+
+
+def test_doctor_empty_config_is_invalid(tmp_path: Path) -> None:
+    """An empty config.json runs on defaults (load_config sees a JSON syntax
+    error), so doctor must not paint the Config line green."""
+    home = _write_home_config(tmp_path, "empty", "")
+    out, code = _run_doctor_subprocess(home)
+    config_line = next(line for line in out.splitlines() if "Config:" in line)
+    assert "✓" not in config_line, out
+    assert "empty" in config_line, out
+    assert code == 1, out
+
+
+def test_doctor_non_object_config_is_invalid(tmp_path: Path) -> None:
+    """A valid-JSON non-object top level (e.g. null) carries no settings, so
+    doctor must classify it invalid instead of green."""
+    home = _write_home_config(tmp_path, "nonobject", "null")
+    out, code = _run_doctor_subprocess(home)
+    config_line = next(line for line in out.splitlines() if "Config:" in line)
+    assert "✓" not in config_line, out
+    assert "not a JSON object" in config_line, out
+    assert code == 1, out
 
 
 def test_doctor_everos_without_embedding_shows_keyword_only(tmp_path: Path) -> None:

--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -421,3 +421,49 @@ def test_doctor_config_line_three_states(tmp_path: Path) -> None:
     out_good, _ = _run_doctor_subprocess(home_good)
     config_line = next(line for line in out_good.splitlines() if "Config:" in line)
     assert "✓" in config_line, out_good
+
+
+def test_doctor_everos_without_embedding_shows_keyword_only(tmp_path: Path) -> None:
+    """The Memory section must say recall is keyword-only when the embedding
+    role is not configured in the user-level everos.toml."""
+    import re
+
+    home = _write_home_config(tmp_path, "everos_nokey", json.dumps({"memory": {"backend": "everos"}}))
+    out, _ = _run_doctor_subprocess(home)
+    out = " ".join(out.split())
+    assert re.search(r"Retrieval:\s*keyword-only", out), out
+    assert "no embedding key" in out, out
+
+
+def test_doctor_everos_with_embedding_shows_semantic(tmp_path: Path) -> None:
+    import re
+
+    home = _write_home_config(tmp_path, "everos_key", json.dumps({"memory": {"backend": "everos"}}))
+    everos_dir = home / ".everos" / "raven"
+    everos_dir.mkdir(parents=True)
+    (everos_dir / "everos.toml").write_text(
+        '[embedding]\nmodel = "m"\napi_key = "sk-x"\nbase_url = "https://api.example.com/v1"\n',
+        encoding="utf-8",
+    )
+    out, _ = _run_doctor_subprocess(home)
+    out = " ".join(out.split())
+    assert re.search(r"Retrieval:\s*semantic", out), out
+
+
+def test_memory_retrieval_reaches_the_json_output(tmp_path: Path) -> None:
+    home = _write_home_config(tmp_path, "everos_json", json.dumps({"memory": {"backend": "everos"}}))
+    import os
+    import subprocess
+    import sys
+
+    env = {**os.environ, "HOME": str(home), "COLUMNS": "250"}
+    r = subprocess.run(
+        [sys.executable, "-m", "raven", "doctor", "--json"],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+    payload = json.loads(r.stdout[r.stdout.index("{") :])
+    assert payload["memory"]["retrieval"] == "keyword-only"

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -202,3 +202,14 @@ def test_config_read_error_is_not_runtimeerror() -> None:
 
     assert not issubclass(ConfigReadError, RuntimeError)
     assert issubclass(ConfigReadError, Exception)
+
+
+def test_bad_config_warns_exactly_once(tmp_path: Path, capsys) -> None:
+    """The user-visible bad-config warning fires once per path per process,
+    even across repeated ``load_config`` calls (status/doctor load twice)."""
+    p = tmp_path / "config.json"
+    p.write_text('{"providers": {},}', encoding="utf-8")
+    load_config(p)
+    load_config(p)
+    captured = capsys.readouterr()
+    assert (captured.out + captured.err).count("not valid JSON") == 1

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -213,3 +213,21 @@ def test_bad_config_warns_exactly_once(tmp_path: Path, capsys) -> None:
     load_config(p)
     captured = capsys.readouterr()
     assert (captured.out + captured.err).count("not valid JSON") == 1
+
+
+def test_bad_config_warns_again_after_recovery(tmp_path: Path, capsys) -> None:
+    """bad -> fixed -> bad again must warn on the second breakage.
+
+    The dedup exists to silence repeated loads of the same broken state
+    within one command; in a long-lived process (the TUI RPC server calls
+    load_config every turn) a permanent suppression would let a later
+    re-breakage run silently on defaults forever."""
+    p = tmp_path / "config.json"
+    p.write_text('{"providers": {},}', encoding="utf-8")
+    load_config(p)
+    p.write_text("{}", encoding="utf-8")
+    load_config(p)
+    p.write_text('{"agents": {},}', encoding="utf-8")
+    load_config(p)
+    captured = capsys.readouterr()
+    assert (captured.out + captured.err).count("not valid JSON") == 2


### PR DESCRIPTION
## Summary

Config visibility fixes found in an internal usability review of v0.1.11. A malformed config.json now warns exactly once
per process per path from the loader (stderr print kept, logger demoted
to stdlib debug): `raven doctor` on a bad config drops from four repeated
warnings to one. The doctor Config line becomes tri-state - valid /
invalid JSON (running on defaults) / missing - judged via the existing
read_raw_or_raise instead of a bare exists() check, and doctor exits 1 on
invalid instead of rendering a green check over defaults. The existing
doctor Memory section gains a Retrieval line (semantic / keyword-only
(no embedding key)), judged by the same everos_role_configured criterion
the section already uses, included in --json output.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_cli_doctor_commands.py tests/test_config_loader.py -x`: 41 passed.
- Full suite `uv run pytest -q`: 1 failed / 6151 passed; the single failure is the pre-existing test_read_file_image failure already present on main.
- Sandbox-HOME real runs on this branch vs main: bad config doctor warnings 4 -> 1; doctor Config line renders "invalid JSON (running on defaults)" with exit 1; Retrieval line renders both states depending on the everos.toml embedding config.
- Written red-first; red baselines were re-measured and archived on current main before the fix (main: status 3 warnings / doctor 4).

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Doctor now exits 1 on an invalid config file (previously 0); scripts
gating on doctor's exit code will surface broken configs instead of
passing silently, which is the intent. The loader's ConfigReadError
overwrite protection is untouched. Rollback = revert the branch.

## Related Issues

N/A - found in an internal usability review of v0.1.11; no tracked GitHub issues.

