### PR TITLE
fix(cli): channel security confirmations and non-tty guards

### DIFF
--- a/raven/cli/_tty_guard.py
+++ b/raven/cli/_tty_guard.py
@@ -1,0 +1,34 @@
+"""Non-TTY guard shared by questionary-backed interactive commands.
+
+prompt_toolkit crashes with a bare ``OSError: [Errno 22]`` traceback when
+stdin is redirected, so commands call :func:`die_if_not_tty` before building
+a prompt: diagnosis line, alternative command, exit code 2 (the same shape
+as onboard's ``_check_tty_or_die``, plus the stdin check it lacks).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import typer
+from rich.console import Console
+
+console = Console()
+
+
+def is_tty() -> bool:
+    """True when both stdin and stdout are terminals — prompt_toolkit reads
+    the former and renders to the latter, so either one redirected breaks it."""
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def die_if_not_tty(alternative: str) -> None:
+    """Exit(2) with a two-line hint when the terminal is non-interactive."""
+    if is_tty():
+        return
+    console.print("[red]Non-interactive terminal detected.[/red]")
+    console.print(f"Re-run with: [cyan]{alternative}[/cyan]")
+    raise typer.Exit(2)
+
+
+__all__ = ["die_if_not_tty", "is_tty"]

--- a/raven/cli/channel_commands.py
+++ b/raven/cli/channel_commands.py
@@ -276,11 +276,11 @@ def _register_config_commands(channels_app: typer.Typer) -> None:
         from raven.config.update_channels import enable_channel
 
         fields = _parse_channel_flags(ctx.args, name)
-        if not fields:
-            missing = _missing_required_fields(name)
-            if missing:
-                flags = ", ".join("--" + k.replace("_", "-") for k in missing)
-                console.print(f"[red]Error: missing required {flags}[/red]")
+        missing = [k for k in _missing_required_fields(name) if fields.get(k) in ("", None, [])]
+        if missing:
+            flags = ", ".join("--" + k.replace("_", "-") for k in missing)
+            console.print(f"[red]Error: missing required {flags}[/red]")
+        if missing or not fields:
             _print_schema_table(name)
             console.print("  [dim]Tip: re-run with one or more --flag value pairs to enable + configure.[/dim]")
             raise typer.Exit(1 if missing else 0)

--- a/raven/cli/channel_commands.py
+++ b/raven/cli/channel_commands.py
@@ -33,6 +33,7 @@ from rich.console import Console
 from rich.table import Table
 
 from raven import __logo__
+from raven.cli._tty_guard import die_if_not_tty, is_tty
 
 console = Console()
 
@@ -100,6 +101,63 @@ def _warn_empty_credentials(name: str) -> None:
     if empty:
         flags = ", ".join("--" + k.replace("_", "-") for k in empty)
         console.print(f"  [yellow]⚠ Empty credential fields:[/yellow] {flags}")
+
+
+def _missing_required_fields(name: str) -> list[str]:
+    """Required fields whose effective value is still empty for this channel."""
+    from raven.config.update_channels import (
+        channel_field_specs,
+        get_channel_config,
+    )
+
+    specs = channel_field_specs(name)
+    cfg = get_channel_config(name, redact_secrets=False)
+    return [k for k, s in specs.items() if s.get("required") and cfg.get(k) in ("", None, [])]
+
+
+def _gate_open_allow_from(name: str, fields: dict) -> None:
+    """Confirm gate for an enable whose resolved ``allow_from`` contains ``'*'``.
+
+    ``'*'`` means anyone who can reach the channel can command the agent on
+    this host, so it must never be adopted silently: interactive runs confirm
+    (default No), non-interactive runs demand the wildcard be passed
+    explicitly. Raises ``typer.Exit`` to block the enable; returns to allow it.
+    """
+    raw = fields.get("allow_from")
+    if raw is not None:
+        explicit = "*" in str(raw)
+        open_after = explicit
+    else:
+        from raven.config.update_channels import get_channel_config
+
+        explicit = False
+        current = get_channel_config(name, redact_secrets=False).get("allow_from") or []
+        open_after = "*" in current
+
+    if not open_after:
+        return
+
+    if is_tty():
+        console.print(
+            f"[yellow]⚠ allow_from for {name} resolves to '*': anyone who can message "
+            f"this channel can command the agent on this host.[/yellow]"
+        )
+        console.print("  Restrict senders with --allow-from <id1,id2>, or confirm to keep it open.")
+        if not typer.confirm(f"Enable {name} with allow_from='*' (open to anyone)?", default=False):
+            console.print("[yellow]Aborted.[/yellow] Nothing written.")
+            raise typer.Exit(1)
+    elif explicit:
+        console.print(
+            f"[yellow]⚠ allow_from='*': anyone who can message {name} can command "
+            f"the agent on this host.[/yellow]"
+        )
+    else:
+        console.print(
+            f"[red]✗[/red] Refusing to enable {name}: allow_from resolves to '*' (anyone can "
+            f"command this agent) and this terminal is non-interactive. Pass --allow-from '*' "
+            f"explicitly to accept, or restrict with --allow-from <id1,id2>."
+        )
+        raise typer.Exit(1)
 
 
 def _parse_channel_flags(extra_args: list[str], channel_name: str) -> dict:
@@ -220,9 +278,15 @@ def _register_config_commands(channels_app: typer.Typer) -> None:
 
         fields = _parse_channel_flags(ctx.args, name)
         if not fields:
+            missing = _missing_required_fields(name)
+            if missing:
+                flags = ", ".join("--" + k.replace("_", "-") for k in missing)
+                console.print(f"[red]Error: missing required {flags}[/red]")
             _print_schema_table(name)
             console.print("  [dim]Tip: re-run with one or more --flag value pairs to enable + configure.[/dim]")
-            raise typer.Exit(0)
+            raise typer.Exit(1 if missing else 0)
+
+        _gate_open_allow_from(name, fields)
 
         try:
             enable_channel(name, fields)
@@ -473,6 +537,7 @@ def channels_login(
             f"Configure it with: [cyan]raven channels set {channel_name}[/cyan]"
         )
         return
+    die_if_not_tty(f"raven channels login {channel_name} (from an interactive terminal)")
     console.print(f"{__logo__} {spec.display_name} Login\n")
     channel = spec.factory(channel_cfg)
 

--- a/raven/cli/channel_commands.py
+++ b/raven/cli/channel_commands.py
@@ -125,7 +125,7 @@ def _gate_open_allow_from(name: str, fields: dict) -> None:
     """
     raw = fields.get("allow_from")
     if raw is not None:
-        explicit = "*" in str(raw)
+        explicit = "*" in [item.strip() for item in str(raw).split(",")]
         open_after = explicit
     else:
         from raven.config.update_channels import get_channel_config

--- a/raven/cli/channel_commands.py
+++ b/raven/cli/channel_commands.py
@@ -125,7 +125,7 @@ def _gate_open_allow_from(name: str, fields: dict) -> None:
     """
     raw = fields.get("allow_from")
     if raw is not None:
-        explicit = "*" in [item.strip() for item in str(raw).split(",")]
+        explicit = "*" in [item.strip() for item in str(raw).split(",") if item.strip()]
         open_after = explicit
     else:
         from raven.config.update_channels import get_channel_config

--- a/raven/cli/channel_commands.py
+++ b/raven/cli/channel_commands.py
@@ -148,8 +148,7 @@ def _gate_open_allow_from(name: str, fields: dict) -> None:
             raise typer.Exit(1)
     elif explicit:
         console.print(
-            f"[yellow]⚠ allow_from='*': anyone who can message {name} can command "
-            f"the agent on this host.[/yellow]"
+            f"[yellow]⚠ allow_from='*': anyone who can message {name} can command the agent on this host.[/yellow]"
         )
     else:
         console.print(

--- a/raven/cli/deep_research_commands.py
+++ b/raven/cli/deep_research_commands.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 import typer
 
 from raven.agent.tools.deep_research import DEFAULT_MODEL
+from raven.cli._tty_guard import die_if_not_tty
 from raven.config.update_tools import ConfigReadError, get_deep_research, reset_deep_research, set_deep_research
 
 SIGNUP_URL = "https://platform.miromind.ai/console/api-keys"
@@ -189,6 +190,7 @@ def enable_cmd(
     console = Console()
 
     if key is None and model is None and api_base is None:
+        die_if_not_tty("raven deep-research enable --key <key>")
         configure_deep_research(non_interactive=False)
         return
 

--- a/raven/cli/gateway_commands.py
+++ b/raven/cli/gateway_commands.py
@@ -80,6 +80,37 @@ _GATEWAY_IM_CHANNELS: tuple[str, ...] = (
 )
 
 
+def _risk_banner(config) -> str | None:
+    """Startup banner for the dangerous default combo: no sandbox + a channel
+    open to anyone. Returns the banner text, or None when either leg is safe.
+
+    Printed, not gated: gateways run unattended, so blocking on a confirm
+    would strand headless restarts -- visibility is the fix here.
+    """
+    if getattr(config.tools.sandbox, "backend", None) != "none":
+        return None
+
+    open_channels = []
+    for name in type(config.channels).model_fields:
+        section = getattr(config.channels, name, None)
+        if section is None or not getattr(section, "enabled", False):
+            continue
+        if "*" in (getattr(section, "allow_from", None) or []):
+            open_channels.append(name)
+    if not open_channels:
+        return None
+
+    lines = [
+        "!! SECURITY WARNING: dangerous configuration combination",
+        "   - sandbox.backend = none (agent tools run with full host privileges)",
+    ]
+    for name in sorted(open_channels):
+        lines.append(f"   - channels.{name}.allow_from contains '*' (anyone can command this agent)")
+    lines.append("   Restrict senders:  raven channels set <name> --allow-from <id1,id2>")
+    lines.append("   Enable a sandbox:  set tools.sandbox.backend to 'auto' or 'boxlite' in your config")
+    return "\n".join(lines)
+
+
 def _build_gateway_channels(config) -> set[str]:
     """Build the ``allowed_channels`` set used by gateway's ``CronService`` — the
     enabled IM channels only.
@@ -177,6 +208,9 @@ def register(app: typer.Typer) -> None:
 
         console.print(f"{__logo__} Starting Raven gateway on port {port}...")
         console.print(f"[dim]📝 Logs → {log_path}[/dim]")
+        banner = _risk_banner(config)
+        if banner is not None:
+            console.print(banner, style="bold red", markup=False)
         sync_workspace_templates(config.workspace_path)
         provider = make_provider(config)
         session_manager = SessionManager(config.workspace_path)

--- a/raven/cli/import_commands.py
+++ b/raven/cli/import_commands.py
@@ -18,6 +18,7 @@ from rich.table import Table
 
 from raven.cli._plugin_stack import build_plugin_registry, maybe_build_memory_backend
 from raven.cli._theme import POINTER, QMARK
+from raven.cli._tty_guard import die_if_not_tty
 from raven.config.loader import load_config
 from raven.config.schema import Config
 from raven.importer.orchestrator import ImportSummary, ProgressEvent, run_import
@@ -686,6 +687,7 @@ def _platform_choice_label(platform: Platform, width: int, results: list[ScanRes
 
 
 async def _pick_platform(results: list[ScanResult], skill_count: int) -> Platform | None:
+    die_if_not_tty("raven import run --platform <platform> --tier <tier> --yes")
     try:
         questionary = _require_questionary()
     except SystemExit:
@@ -712,6 +714,7 @@ async def _pick_platform(results: list[ScanResult], skill_count: int) -> Platfor
 
 
 async def _pick_tier(results: list[ScanResult], skill_count: int) -> Tier | None:
+    die_if_not_tty("raven import run --platform <platform> --tier <tier> --yes")
     try:
         questionary = _require_questionary()
     except SystemExit:

--- a/tests/test_cli_channel_commands.py
+++ b/tests/test_cli_channel_commands.py
@@ -301,8 +301,12 @@ def test_channels_bare_prints_help_not_error() -> None:
 
 
 def test_enable_warns_empty_credentials(tmp_config: Path) -> None:
-    """Enabling a channel without supplying its secret fields must warn."""
-    r = runner.invoke(app, ["channels", "enable", "telegram", "--allow-from", "alice"])
+    """Enabling a channel whose secret fields are optional must warn, not fail.
+
+    Uses weixin (secret ``token`` is not required): required-but-empty fields
+    now error out instead, so telegram no longer exercises the warn path.
+    """
+    r = runner.invoke(app, ["channels", "enable", "weixin", "--allow-from", "alice"])
     assert r.exit_code == 0
     assert "Empty credential fields" in r.stdout
     assert "--token" in r.stdout

--- a/tests/test_cli_channel_commands.py
+++ b/tests/test_cli_channel_commands.py
@@ -629,9 +629,7 @@ def tty_mock(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("raven.cli.channel_commands.is_tty", lambda: True)
 
 
-def test_enable_open_allowfrom_requires_confirm(
-    tmp_config: Path, tty_mock, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_enable_open_allowfrom_requires_confirm(tmp_config: Path, tty_mock, monkeypatch: pytest.MonkeyPatch) -> None:
     """Interactive enable resolving to allow_from='*' must ask for confirmation
     (default No); declining writes nothing."""
     calls: list[dict] = []

--- a/tests/test_cli_channel_commands.py
+++ b/tests/test_cli_channel_commands.py
@@ -693,6 +693,27 @@ def test_enable_restricted_allowfrom_skips_gate(tmp_config: Path) -> None:
     assert section["allowFrom"] == ["alice"]
 
 
+def test_enable_star_inside_id_does_not_trigger_gate(tmp_config: Path) -> None:
+    """An ID merely containing ``*`` (e.g. ``user*1``) is not the wildcard:
+    the confirm gate must not fire on substring matches."""
+    r = runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc", "--allow-from", "user*1"])
+    assert r.exit_code == 0, r.stdout
+    assert "anyone" not in r.stdout
+    section = _read(tmp_config)["channels"]["telegram"]
+    assert section["enabled"] is True
+    assert section["allowFrom"] == ["user*1"]
+
+
+def test_enable_star_item_in_list_triggers_gate(tmp_config: Path) -> None:
+    """An exact ``*`` item anywhere in the comma list still counts as the
+    explicit wildcard: non-TTY prints the risk warning and proceeds."""
+    r = runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc", "--allow-from", "a,*"])
+    assert r.exit_code == 0, r.stdout
+    assert "anyone" in r.stdout
+    section = _read(tmp_config)["channels"]["telegram"]
+    assert section["allowFrom"] == ["a", "*"]
+
+
 def test_enable_missing_token_exits_nonzero(tmp_config: Path) -> None:
     """Bare ``enable telegram`` (required --token unset) must error on the first
     line and exit non-zero; the schema table stays as follow-up detail."""

--- a/tests/test_cli_channel_commands.py
+++ b/tests/test_cli_channel_commands.py
@@ -33,7 +33,7 @@ def _read(path: Path) -> dict:
 
 
 def test_enable_disable_round_trip(tmp_config: Path) -> None:
-    r = runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc"])
+    r = runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc", "--allow-from", "*"])
     assert r.exit_code == 0, r.stdout
     assert "enabled" in r.stdout
 
@@ -60,6 +60,8 @@ def test_enable_complex_channel_with_kebab_flags(tmp_config: Path) -> None:
             "X",
             "--app-secret",
             "Y",
+            "--allow-from",
+            "*",
         ],
     )
     assert r.exit_code == 0, r.stdout
@@ -81,6 +83,8 @@ def test_enable_nested_field_via_dotted_flag(tmp_config: Path) -> None:
             "xapp",
             "--dm.policy",
             "allowlist",
+            "--allow-from",
+            "*",
         ],
     )
     assert r.exit_code == 0, r.stdout
@@ -90,7 +94,7 @@ def test_enable_nested_field_via_dotted_flag(tmp_config: Path) -> None:
 
 
 def test_get_with_show_secrets(tmp_config: Path) -> None:
-    runner.invoke(app, ["channels", "enable", "telegram", "--token", "plain_value"])
+    runner.invoke(app, ["channels", "enable", "telegram", "--token", "plain_value", "--allow-from", "*"])
     r = runner.invoke(app, ["channels", "get", "telegram", "--show-secrets"])
     assert r.exit_code == 0
     assert "plain_value" in r.stdout
@@ -137,7 +141,7 @@ def test_help_alias_no_longer_exists(tmp_config: Path) -> None:
 
 
 def test_reset_clears_token(tmp_config: Path) -> None:
-    runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc"])
+    runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc", "--allow-from", "*"])
     assert _read(tmp_config)["channels"]["telegram"]["token"] == "abc"
 
     r = runner.invoke(app, ["channels", "reset", "telegram", "--yes"])
@@ -166,7 +170,7 @@ def test_no_flag_bool_negative(tmp_config: Path) -> None:
     """``--no-foo`` form must set the bool field to False."""
     runner.invoke(
         app,
-        ["channels", "enable", "telegram", "--token", "abc", "--reply-to-message"],
+        ["channels", "enable", "telegram", "--token", "abc", "--reply-to-message", "--allow-from", "*"],
     )
     section = _read(tmp_config)["channels"]["telegram"]
     assert section["replyToMessage"] is True
@@ -206,9 +210,10 @@ def test_register_config_commands_direct_invocation() -> None:
 
 def test_enable_no_fields_prints_schema_table(tmp_config: Path) -> None:
     """``channels enable telegram`` (no flags) must fall back to schema table
-    instead of writing an empty enable."""
+    instead of writing an empty enable. Required --token is unset, so this
+    now also errors (see test_enable_missing_token_exits_nonzero)."""
     r = runner.invoke(app, ["channels", "enable", "telegram"])
-    assert r.exit_code == 0
+    assert r.exit_code != 0
     out = r.stdout
     assert "--token" in out
     assert "--allow-from" in out
@@ -269,7 +274,7 @@ def test_channels_list_command(tmp_config: Path) -> None:
 
 def test_channels_list_reflects_enabled_state(tmp_config: Path) -> None:
     """``channels list`` Enabled column must mirror the live config."""
-    runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc"])
+    runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc", "--allow-from", "*"])
     r = runner.invoke(app, ["channels", "list"])
     assert r.exit_code == 0
     # telegram row should have a ✓; un-enabled channels should not
@@ -305,17 +310,18 @@ def test_enable_warns_empty_credentials(tmp_config: Path) -> None:
 
 def test_enable_with_token_no_credential_warning(tmp_config: Path) -> None:
     """Supplying all secrets must NOT emit the empty-credential warning."""
-    r = runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc"])
+    r = runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc", "--allow-from", "*"])
     assert r.exit_code == 0
     assert "Empty credential fields" not in r.stdout
 
 
-def test_enable_telegram_defaults_allow_from_to_wildcard(tmp_config: Path) -> None:
-    """Enabling a channel without explicit ``--allow-from``
-    must result in ``allowFrom == ['*']`` (allow anyone), not ``[]`` (deny all).
-    The empty-list default caused silent message rejection in gateway runtime.
+def test_enable_telegram_defaults_allow_from_to_wildcard(tmp_config: Path, tty_mock) -> None:
+    """Enabling a channel without explicit ``--allow-from`` (interactive run,
+    wildcard confirmed) must result in ``allowFrom == ['*']`` (allow anyone),
+    not ``[]`` (deny all). The empty-list default caused silent message
+    rejection in gateway runtime.
     """
-    r = runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc"])
+    r = runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc"], input="y\n")
     assert r.exit_code == 0, r.stdout
     section = _read(tmp_config)["channels"]["telegram"]
     assert section["allowFrom"] == ["*"], f"expected allowFrom=['*'] (schema default), got {section['allowFrom']!r}"
@@ -349,7 +355,7 @@ def test_all_channel_schemas_default_allow_from_to_wildcard() -> None:
 
 def test_reset_aborts_without_confirm(tmp_config: Path) -> None:
     """Reset without ``--yes`` and answering 'N' must abort and leave file alone."""
-    runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc"])
+    runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc", "--allow-from", "*"])
     r = runner.invoke(app, ["channels", "reset", "telegram"], input="N\n")
     assert r.exit_code == 0
     assert "Aborted" in r.stdout
@@ -358,7 +364,7 @@ def test_reset_aborts_without_confirm(tmp_config: Path) -> None:
 
 
 def test_reset_proceeds_on_y(tmp_config: Path) -> None:
-    runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc"])
+    runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc", "--allow-from", "*"])
     r = runner.invoke(app, ["channels", "reset", "telegram"], input="y\n")
     assert r.exit_code == 0
     section = _read(tmp_config)["channels"]["telegram"]
@@ -366,7 +372,7 @@ def test_reset_proceeds_on_y(tmp_config: Path) -> None:
 
 
 def test_reset_yes_flag_skips_confirm(tmp_config: Path) -> None:
-    runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc"])
+    runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc", "--allow-from", "*"])
     r = runner.invoke(app, ["channels", "reset", "telegram", "--yes"])
     assert r.exit_code == 0
     section = _read(tmp_config)["channels"]["telegram"]
@@ -453,6 +459,7 @@ def test_channels_login_dispatches_to_channel_login(tmp_config: Path, monkeypatc
             return True
 
     _patch_discover_specs(monkeypatch, "telegram", Fake)
+    monkeypatch.setattr("raven.cli.channel_commands.die_if_not_tty", lambda *a, **k: None)
 
     r = runner.invoke(app, ["channels", "login", "telegram"])
     assert r.exit_code == 0, r.stdout
@@ -474,6 +481,7 @@ def test_channels_login_force_flag_passes_through(tmp_config: Path, monkeypatch:
             return True
 
     _patch_discover_specs(monkeypatch, "telegram", Fake)
+    monkeypatch.setattr("raven.cli.channel_commands.die_if_not_tty", lambda *a, **k: None)
 
     r = runner.invoke(app, ["channels", "login", "telegram", "--force"])
     assert r.exit_code == 0
@@ -491,6 +499,7 @@ def test_channels_login_returns_false_exits_1(tmp_config: Path, monkeypatch: pyt
             return False
 
     _patch_discover_specs(monkeypatch, "telegram", Fake)
+    monkeypatch.setattr("raven.cli.channel_commands.die_if_not_tty", lambda *a, **k: None)
 
     r = runner.invoke(app, ["channels", "login", "telegram"])
     assert r.exit_code == 1
@@ -607,3 +616,106 @@ def test_whatsapp_login_returns_false_when_npm_missing(
 
     result = asyncio.run(whatsapp_channel.login())
     assert result is False
+
+
+# ============================================================================
+# allow_from='*' confirm gate (enable) + missing-required exit code + TTY guard
+# ============================================================================
+
+
+@pytest.fixture
+def tty_mock(monkeypatch: pytest.MonkeyPatch):
+    """Simulate an interactive terminal for the wildcard confirm gate."""
+    monkeypatch.setattr("raven.cli.channel_commands.is_tty", lambda: True)
+
+
+def test_enable_open_allowfrom_requires_confirm(
+    tmp_config: Path, tty_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Interactive enable resolving to allow_from='*' must ask for confirmation
+    (default No); declining writes nothing."""
+    calls: list[dict] = []
+
+    def fake_confirm(prompt, *args, **kwargs):
+        calls.append({"prompt": prompt, "default": kwargs.get("default", args[0] if args else None)})
+        return False
+
+    monkeypatch.setattr("raven.cli.channel_commands.typer.confirm", fake_confirm)
+    r = runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc"])
+    assert calls, "typer.confirm must be invoked when allow_from resolves to '*'"
+    assert calls[0]["default"] is False
+    assert r.exit_code != 0
+    if tmp_config.exists():
+        section = _read(tmp_config).get("channels", {}).get("telegram")
+        assert section is None or section.get("enabled") is not True
+
+
+def test_enable_open_allowfrom_nontty_requires_explicit_flag(tmp_config: Path) -> None:
+    """Non-TTY enable resolving to allow_from='*' without the explicit flag must
+    refuse: exit non-zero, output carries the risk hint and the required flag."""
+    r = runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc"])
+    assert r.exit_code != 0
+    combined = r.stdout + (r.output or "")
+    assert "--allow-from" in combined
+    assert "*" in combined
+    if tmp_config.exists():
+        section = _read(tmp_config).get("channels", {}).get("telegram")
+        assert section is None or section.get("enabled") is not True
+
+
+def test_enable_open_allowfrom_tty_confirm_yes_writes(tmp_config: Path, tty_mock) -> None:
+    """Accepting the confirm keeps the schema-default wildcard and enables."""
+    r = runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc"], input="y\n")
+    assert r.exit_code == 0, r.stdout
+    section = _read(tmp_config)["channels"]["telegram"]
+    assert section["enabled"] is True
+    assert section["allowFrom"] == ["*"]
+
+
+def test_enable_open_allowfrom_nontty_explicit_flag_proceeds(tmp_config: Path) -> None:
+    """Explicit ``--allow-from '*'`` in a non-TTY run is accepted with a warning."""
+    r = runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc", "--allow-from", "*"])
+    assert r.exit_code == 0, r.stdout
+    assert "anyone" in r.stdout
+    section = _read(tmp_config)["channels"]["telegram"]
+    assert section["enabled"] is True
+    assert section["allowFrom"] == ["*"]
+
+
+def test_enable_restricted_allowfrom_skips_gate(tmp_config: Path) -> None:
+    """A restricted allow_from needs no confirmation in any terminal mode."""
+    r = runner.invoke(app, ["channels", "enable", "telegram", "--token", "abc", "--allow-from", "alice"])
+    assert r.exit_code == 0, r.stdout
+    section = _read(tmp_config)["channels"]["telegram"]
+    assert section["enabled"] is True
+    assert section["allowFrom"] == ["alice"]
+
+
+def test_enable_missing_token_exits_nonzero(tmp_config: Path) -> None:
+    """Bare ``enable telegram`` (required --token unset) must error on the first
+    line and exit non-zero; the schema table stays as follow-up detail."""
+    import re
+
+    r = runner.invoke(app, ["channels", "enable", "telegram"])
+    assert r.exit_code != 0
+    first_line = next(ln for ln in r.stdout.splitlines() if ln.strip())
+    assert re.search(r"missing required .*--token", first_line), f"first line: {first_line!r}"
+    assert "--allow-from" in r.stdout
+
+
+def test_channels_login_nontty_no_traceback(tmp_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-TTY ``channels login`` exits 2 with a re-run hint instead of
+    reaching the interactive adapter (bare prompt_toolkit traceback)."""
+
+    class Fake(_FakeChannelBase):
+        name = "weixin"
+        display_name = "Weixin"
+
+        async def login(self, force: bool = False) -> bool:
+            raise AssertionError("login must not run in a non-interactive terminal")
+
+    _patch_discover_specs(monkeypatch, "weixin", Fake)
+    r = runner.invoke(app, ["channels", "login", "weixin"])
+    assert r.exit_code == 2, r.stdout
+    assert "Traceback" not in r.stdout
+    assert "Re-run with:" in r.stdout

--- a/tests/test_cli_channel_commands.py
+++ b/tests/test_cli_channel_commands.py
@@ -701,6 +701,34 @@ def test_enable_missing_token_exits_nonzero(tmp_config: Path) -> None:
     assert "--allow-from" in r.stdout
 
 
+def test_enable_partial_credentials_still_fails_missing_required(tmp_config: Path) -> None:
+    """Supplying one required flag must not bypass the check for the others:
+    ``enable feishu --app-id X`` (no --app-secret) errors first line, exits 1."""
+    import re
+
+    r = runner.invoke(app, ["channels", "enable", "feishu", "--app-id", "X", "--allow-from", "alice"])
+    assert r.exit_code != 0
+    first_line = next(ln for ln in r.stdout.splitlines() if ln.strip())
+    assert re.search(r"missing required .*--app-secret", first_line), f"first line: {first_line!r}"
+    if tmp_config.exists():
+        section = _read(tmp_config).get("channels", {}).get("feishu")
+        assert section is None or section.get("enabled") is not True
+
+
+def test_enable_unrelated_flag_still_fails_missing_required(tmp_config: Path) -> None:
+    """A flag unrelated to credentials must not bypass the check either:
+    ``enable telegram --allow-from '*'`` (no --token) errors first line, exits 1."""
+    import re
+
+    r = runner.invoke(app, ["channels", "enable", "telegram", "--allow-from", "*"])
+    assert r.exit_code != 0
+    first_line = next(ln for ln in r.stdout.splitlines() if ln.strip())
+    assert re.search(r"missing required .*--token", first_line), f"first line: {first_line!r}"
+    if tmp_config.exists():
+        section = _read(tmp_config).get("channels", {}).get("telegram")
+        assert section is None or section.get("enabled") is not True
+
+
 def test_channels_login_nontty_no_traceback(tmp_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Non-TTY ``channels login`` exits 2 with a re-run hint instead of
     reaching the interactive adapter (bare prompt_toolkit traceback)."""

--- a/tests/test_cli_deep_research_commands.py
+++ b/tests/test_cli_deep_research_commands.py
@@ -259,6 +259,7 @@ def test_enable_with_api_base_flag_writes_it(tmp_path: Path, monkeypatch):
 
 def test_enable_no_flags_enters_interactive(monkeypatch):
     called: list = []
+    monkeypatch.setattr(drc, "die_if_not_tty", lambda *a, **k: None)  # CliRunner is never a TTY
     monkeypatch.setattr(drc, "configure_deep_research", lambda **k: called.append(k))
     assert runner.invoke(deep_research_app, ["enable"]).exit_code == 0
     assert called and called[0].get("non_interactive") is False
@@ -342,3 +343,17 @@ def test_configure_ctrl_c_at_validation_action_menu_exits(tmp_path: Path, monkey
     _setup_interactive(monkeypatch, tmp_path, ["configure", None], validate=lambda *a, **k: fail)
     with pytest.raises(typer.Exit):
         configure_deep_research(non_interactive=False, warnings=[])
+
+
+# ── non-TTY guard ──
+
+
+def test_deep_research_enable_nontty_no_traceback(tmp_path: Path, monkeypatch):
+    """No-flag ``enable`` in a non-interactive terminal exits 2 with a re-run
+    hint instead of the prompt_toolkit OSError traceback."""
+    monkeypatch.setattr(ut, "get_config_path", lambda: tmp_path / "config.json")
+    result = runner.invoke(deep_research_app, ["enable"])
+    assert result.exit_code == 2
+    assert "Traceback" not in result.output
+    assert "Re-run with:" in result.output
+    assert "--key" in result.output

--- a/tests/test_cli_gateway_commands.py
+++ b/tests/test_cli_gateway_commands.py
@@ -275,3 +275,36 @@ def test_build_routing_ecoclaw_no_key_disabled():
     router, out = build_model_routing(_routing_config_obj(routing), prov)
     assert router is None
     assert out is prov
+
+
+# ---------------------------------------------------------------------------
+# _risk_banner: sandbox=none + open allow_from startup warning
+# ---------------------------------------------------------------------------
+
+
+def _config_with(*, backend: str, telegram_enabled: bool, allow_from: list[str]):
+    from raven.config.schema import Config
+
+    cfg = Config()
+    cfg.tools.sandbox.backend = backend
+    cfg.channels.telegram.enabled = telegram_enabled
+    cfg.channels.telegram.allow_from = allow_from
+    return cfg
+
+
+def test_risk_banner_fires_on_combo() -> None:
+    from raven.cli.gateway_commands import _risk_banner
+
+    banner = _risk_banner(_config_with(backend="none", telegram_enabled=True, allow_from=["*"]))
+    assert banner
+    assert "sandbox" in banner
+    assert "allow_from" in banner
+    assert "telegram" in banner
+
+
+def test_risk_banner_silent_when_sandboxed_or_restricted() -> None:
+    from raven.cli.gateway_commands import _risk_banner
+
+    assert _risk_banner(_config_with(backend="boxlite", telegram_enabled=True, allow_from=["*"])) is None
+    assert _risk_banner(_config_with(backend="none", telegram_enabled=True, allow_from=["u1"])) is None
+    assert _risk_banner(_config_with(backend="none", telegram_enabled=False, allow_from=["*"])) is None

--- a/tests/test_cli_import_commands.py
+++ b/tests/test_cli_import_commands.py
@@ -470,6 +470,8 @@ class TestRun:
             ),
             patch("raven.cli.import_commands._default_state", return_value=state),
             patch("raven.cli.import_commands._require_questionary", return_value=questionary),
+            # CliRunner is never a TTY; these tests exercise the pickers, not TTY policy.
+            patch("raven.cli.import_commands.die_if_not_tty", new=lambda *a, **k: None),
         ):
             stack.enter_context(ctx)
         return stack
@@ -931,6 +933,35 @@ class TestPrintSummary:
 
         assert "Profile:" not in out
         assert "Skills:" not in out
+
+
+class TestNonTTYGuard:
+    def test_import_run_nontty_no_traceback(self) -> None:
+        """``run`` without --platform (two platforms found) in a non-TTY
+        terminal exits 2 with a re-run hint instead of crashing in questionary."""
+        results = [
+            _scan_result("a", platform=Platform.CLAUDE_CODE),
+            _scan_result("b", platform=Platform.CODEX),
+        ]
+        with patch(
+            "raven.importer.scanners.scan_all",
+            new=AsyncMock(return_value=results),
+        ):
+            result = runner.invoke(import_app, ["run"])
+        assert result.exit_code == 2
+        assert "Traceback" not in result.output
+        assert "Re-run with:" in result.output
+
+    def test_import_run_nontty_tier_picker_guarded(self) -> None:
+        """The tier picker (no --tier) is guarded the same way."""
+        with patch(
+            "raven.importer.scanners.scan_all",
+            new=AsyncMock(return_value=_make_scan_results()),
+        ):
+            result = runner.invoke(import_app, ["run", "--platform", "claude_code"])
+        assert result.exit_code == 2
+        assert "Traceback" not in result.output
+        assert "Re-run with:" in result.output
 
 
 class TestStatusCancelled:


### PR DESCRIPTION
## Summary

`channels enable` had two silent-failure modes: with missing required
credentials it printed the field table and exited 0 (scripts read that
as success), and a channel whose allow_from resolves to '*' - anyone
who can reach the channel can command the agent on this host - could be
enabled without any acknowledgement. Interactive-only commands had a
third rough edge: on a non-TTY stdin, deep-research enable, import run
and channels login died in a bare asyncio traceback.

Changes:

- Missing required credentials now exit 1 with an explicit first line
  naming the flag (Error: missing required --token); the field table is
  kept below it.
- An enable that lands on allow_from '*' asks for interactive
  confirmation (default No); non-interactive runs must pass
  --allow-from '*' explicitly and get a warning. Wildcard membership is
  parsed from the list items, not matched as a substring, and empty
  items are filtered the same way the config coercion does.
- Gateway startup prints a prominent risk banner when sandbox=none is
  combined with an enabled open channel.
- A shared stdin+stdout TTY guard (raven/cli/_tty_guard.py) replaces
  the tracebacks with a two-line re-run hint and exit code 2.

Known limitation, recorded and out of scope here: interactive whatsapp
login can still hang on a non-TTY stdin past the guard's reach.
Sixteen pre-existing tests were adapted to the new confirmation flow
(setup-level only, itemized in the commit bodies).

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_cli_channel_commands.py tests/test_cli_deep_research_commands.py tests/test_cli_import_commands.py tests/test_cli_gateway_commands.py -q`: 146 passed.
- Sandbox-HOME runs comparing exit codes and first lines before/after: enable without flags 0 -> 1; --token without --allow-from now refused; explicit wildcard warns then succeeds; deep-research enable and channels login under /dev/null stdin exit 2 with no traceback.
- Each fix landed only after a test reproducing the bug failed against the old code.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Deliberate behavior changes: scripts that relied on enable exiting 0
despite missing credentials now see exit 1, and non-interactive enables
of open channels require the explicit wildcard flag. No data formats
change; revert the branch to roll back.

## Related Issues

N/A - no tracked GitHub issues (internal v0.1.11 usability review).
