### PR TITLE
feat(session): auto-name sessions and persist bare create

### DIFF
--- a/raven/cli/session_commands.py
+++ b/raven/cli/session_commands.py
@@ -4,14 +4,15 @@ User-facing "session id" is the bare chat_id (strip "cli:" prefix for
 display; re-prepend internally). Full session key = "cli:<chat_id>".
 
 Persistence semantics:
-- ``session create`` (bare): mints a new id and prints it. Nothing is
-  written to disk — the id materialises on first use (lazy). Note: a
-  lazily-minted id that was never used cannot be found by ``resume``
-  because no file exists yet; the output includes a reminder.
-- ``session create --title TEXT``: mints + immediately persists metadata
-  so the title survives process exit. This diverges from the TUI's lazy
-  semantics because the CLI process dies immediately after the command
-  returns, leaving no opportunity for a later lazy flush.
+- ``session create`` mints a new id and immediately persists minimal
+  metadata (zero messages, title optional), so the id shows up in
+  ``list`` and can be ``resume``d or ``delete``d right away. The CLI
+  process dies as soon as the command returns, so a lazy (in-memory)
+  session would be lost — hence eager persistence, diverging from the
+  TUI's lazy semantics.
+- Untitled sessions are auto-named from their first user message (see
+  ``raven.session.manager``); ``--title`` names the session up front
+  and is never overwritten.
 """
 
 from __future__ import annotations
@@ -114,28 +115,27 @@ def resolve_session_cross_channel(manager: SessionManager, value: str) -> str:
 def session_create(
     title: str | None = typer.Option(None, "--title", "-t", help="Optional session title"),
 ) -> None:
-    """Mint a new session id.
+    """Mint a new session id and persist it immediately.
 
-    Without --title: prints the bare id only; nothing is written to disk.
-    The id materialises on first use when ``raven agent --session`` is
-    called with it.
-
-    With --title: persists session metadata immediately so the title
-    survives process exit.
+    Minimal metadata is written to disk right away (zero messages), so
+    the new id shows up in ``list`` and can be deleted. Without --title
+    the session is auto-named from its first user message.
     """
     chat_id = new_chat_id()
     key = f"{_CLI_CHANNEL}:{chat_id}"
 
+    manager = _open_manager()
+    session = manager.get_or_create(key)
     if title is not None:
-        manager = _open_manager()
-        session = manager.get_or_create(key)
         session.metadata["title"] = title
-        manager.save(session)
+    manager.save(session)
+
+    if title is not None:
         console.print(f"[green]✓[/green] Created session [cyan]{chat_id}[/cyan] (title: {title!r})")
         console.print(f"  Use with: raven agent --session {key}")
     else:
         console.print(chat_id)
-        console.print(f"[dim]  (lazy — materialises on first use: raven agent --session {key})[/dim]")
+        console.print(f"[dim]  (use: raven agent --session {key})[/dim]")
 
 
 # ── list ──────────────────────────────────────────────────────────────

--- a/raven/cli/session_commands.py
+++ b/raven/cli/session_commands.py
@@ -127,7 +127,7 @@ def session_create(
     manager = _open_manager()
     session = manager.get_or_create(key)
     if title is not None:
-        session.metadata["title"] = title
+        session.set_title(title)
     manager.save(session)
 
     if title is not None:

--- a/raven/session/manager.py
+++ b/raven/session/manager.py
@@ -25,6 +25,29 @@ def new_chat_id(now: datetime | None = None) -> str:
     return f"{ts}_{uuid.uuid4().hex[:6]}"
 
 
+_AUTO_TITLE_MAX_CHARS = 40
+
+
+def _derive_title(content: Any) -> str | None:
+    """Derive an auto-title from message content: first non-empty line,
+    whitespace collapsed, truncated to 40 characters. None when the
+    content is not a usable string (e.g. structured multimodal parts)."""
+    if not isinstance(content, str):
+        return None
+    stripped = content.strip()
+    if not stripped:
+        return None
+    collapsed = " ".join(stripped.splitlines()[0].split())
+    return collapsed[:_AUTO_TITLE_MAX_CHARS] or None
+
+
+def _first_user_auto_title(messages: list[dict[str, Any]]) -> str | None:
+    for m in messages:
+        if m.get("role") == "user":
+            return _derive_title(m.get("content"))
+    return None
+
+
 @dataclass(frozen=True)
 class SessionResolution:
     """Outcome of resolving a user-supplied session id to a full key.
@@ -334,8 +357,19 @@ class SessionManager:
         under a cross-process lock, so concurrent writers never lose each
         other's turns and a turn's messages stay contiguous. A shrunken
         message list (clear) rewrites the file atomically instead.
+
+        An untitled session is auto-named here from its first user message
+        (first line, collapsed whitespace, capped at 40 chars); a title set
+        by the user is never overwritten. Forked children are excluded —
+        their first user message names the fork point's ancestor, not the
+        fork — so they stay untitled unless titled explicitly.
         """
         path = self._get_session_path(session.key)
+
+        if not session.metadata.get("title") and not session.metadata.get("parent_session_id"):
+            auto_title = _first_user_auto_title(session.messages)
+            if auto_title:
+                session.metadata["title"] = auto_title
 
         channel, _, chat_id = session.key.partition(":")
         reserved = {
@@ -420,6 +454,11 @@ class SessionManager:
         matches the source at the fork point) and resets ``pending_clarification``
         (interaction wait-state is not history). The child is persisted eagerly.
 
+        Only a human-given source title is inherited (as ``<title> (fork)``);
+        a title that equals the auto-derived title of the source's first user
+        message is treated as auto-named and not carried over, so children of
+        never-explicitly-titled sessions stay untitled.
+
         Returns the persisted child, or None when the source does not exist or
         has zero messages (a fork of an empty session has no value).
         """
@@ -437,7 +476,7 @@ class SessionManager:
             child.metadata["title"] = title
         else:
             parent_title = (source.metadata or {}).get("title")
-            if parent_title:
+            if parent_title and parent_title != _first_user_auto_title(source.messages):
                 child.metadata["title"] = f"{parent_title} (fork)"
         child.metadata["parent_session_id"] = source_key
         self.save(child)

--- a/raven/session/manager.py
+++ b/raven/session/manager.py
@@ -224,6 +224,11 @@ class SessionManager:
         to get the authoritative session key ``<channel>:<chat_id>`` and
         ``updated_at``; recency is decided by ``updated_at``, falling back
         to file mtime for files that lack it.
+
+        Sessions with messages take priority: a freshly minted zero-message
+        session (``sessions create``) must not hijack delivery away from the
+        user's real last conversation. Empty sessions are only considered
+        when the channel has no session with messages at all.
         """
         channel_dir = self.sessions_dir / safe_filename(channel)
         if not channel_dir.is_dir():
@@ -231,8 +236,10 @@ class SessionManager:
 
         best_chat_id: str | None = None
         best_updated = ""
+        best_empty_chat_id: str | None = None
+        best_empty_updated = ""
         for p in channel_dir.glob("*.jsonl"):
-            meta, _count = self._scan_file(p)
+            meta, count = self._scan_file(p)
             if meta is None:
                 continue
             key_val = meta.get("key", "")
@@ -247,10 +254,14 @@ class SessionManager:
                     updated = datetime.fromtimestamp(p.stat().st_mtime).isoformat()
                 except OSError:
                     continue
-            if updated > best_updated:
-                best_chat_id = chat_id
-                best_updated = updated
-        return best_chat_id
+            if count > 0:
+                if updated > best_updated:
+                    best_chat_id = chat_id
+                    best_updated = updated
+            elif updated > best_empty_updated:
+                best_empty_chat_id = chat_id
+                best_empty_updated = updated
+        return best_chat_id if best_chat_id is not None else best_empty_chat_id
 
     @staticmethod
     def _scan_file(path: Path) -> tuple[dict[str, Any] | None, int]:

--- a/raven/session/manager.py
+++ b/raven/session/manager.py
@@ -94,6 +94,16 @@ class Session:
         """Add a message to the session."""
         self.record({"role": role, "content": content, **kwargs})
 
+    def set_title(self, title: str) -> None:
+        """Set a human-given title.
+
+        Clears the ``title_auto`` marker so fork inheritance treats the
+        title as human even when the session was auto-named before. Every
+        rename path must come through here, not assign metadata directly.
+        """
+        self.metadata["title"] = title
+        self.metadata.pop("title_auto", None)
+
     def record(self, msg: dict[str, Any]) -> None:
         """Append a message dict, stamping a wall-clock timestamp.
 
@@ -381,6 +391,7 @@ class SessionManager:
             auto_title = _first_user_auto_title(session.messages)
             if auto_title:
                 session.metadata["title"] = auto_title
+                session.metadata["title_auto"] = True
 
         channel, _, chat_id = session.key.partition(":")
         reserved = {
@@ -466,9 +477,11 @@ class SessionManager:
         (interaction wait-state is not history). The child is persisted eagerly.
 
         Only a human-given source title is inherited (as ``<title> (fork)``);
-        a title that equals the auto-derived title of the source's first user
-        message is treated as auto-named and not carried over, so children of
-        never-explicitly-titled sessions stay untitled.
+        a title stamped with the ``title_auto`` metadata marker (written by
+        ``save`` when it auto-names) is not carried over, so children of
+        never-explicitly-titled sessions stay untitled. A title without the
+        marker counts as human, which keeps sessions saved before the marker
+        existed inheriting as before.
 
         Returns the persisted child, or None when the source does not exist or
         has zero messages (a fork of an empty session has no value).
@@ -487,7 +500,7 @@ class SessionManager:
             child.metadata["title"] = title
         else:
             parent_title = (source.metadata or {}).get("title")
-            if parent_title and parent_title != _first_user_auto_title(source.messages):
+            if parent_title and not (source.metadata or {}).get("title_auto"):
                 child.metadata["title"] = f"{parent_title} (fork)"
         child.metadata["parent_session_id"] = source_key
         self.save(child)

--- a/raven/tui_rpc/methods/session.py
+++ b/raven/tui_rpc/methods/session.py
@@ -445,7 +445,7 @@ async def session_title(
 
     if title is not None:
         session = mgr.get_or_create(session_key)
-        session.metadata["title"] = title
+        session.set_title(title)
         if mgr.exists(session_key):
             try:
                 mgr.save(session)

--- a/tests/test_cli_session_commands.py
+++ b/tests/test_cli_session_commands.py
@@ -109,13 +109,12 @@ def test_create_prints_id(patched_workspace: Path) -> None:
     assert re.fullmatch(r"\d{8}_\d{6}_[0-9a-f]{6}", first_line), f"expected bare chat_id on line 1, got {first_line!r}"
 
 
-def test_create_lazy_no_file(patched_workspace: Path) -> None:
+def test_create_bare_persists_file(patched_workspace: Path) -> None:
     r = runner.invoke(session_app, ["create"])
     assert r.exit_code == 0
     sessions_dir = patched_workspace / "sessions" / "cli"
-    assert not sessions_dir.exists() or not list(sessions_dir.glob("*.jsonl")), (
-        "bare `session create` must not write a file (lazy)"
-    )
+    jsonl_files = list(sessions_dir.glob("*.jsonl")) if sessions_dir.exists() else []
+    assert jsonl_files, "bare `sessions create` must persist metadata immediately"
 
 
 def test_create_with_title_persists(patched_workspace: Path) -> None:
@@ -403,3 +402,67 @@ def test_export_write_failure_exits_cleanly(patched_workspace: Path, manager: Se
     r = runner.invoke(session_app, ["export", cid, "--output", str(dest)])
     assert r.exit_code != 0
     assert r.exception is None or isinstance(r.exception, SystemExit)
+
+
+# ── create/delete roundtrip (frozen acceptance) ───────────────────────
+
+
+def test_session_create_list_delete_roundtrip(patched_workspace: Path) -> None:
+    created = runner.invoke(session_app, ["create"])
+    assert created.exit_code == 0
+    sid = created.stdout.splitlines()[0].strip()
+
+    listed = runner.invoke(session_app, ["list"])
+    assert sid in listed.stdout
+
+    deleted = runner.invoke(session_app, ["delete", sid])
+    assert deleted.exit_code == 0
+
+
+def test_session_delete_unknown_id_still_clear(patched_workspace: Path) -> None:
+    r = runner.invoke(session_app, ["delete", "20990101_000000_deadbe"])
+    assert r.exit_code == 1
+    assert "not found" in r.output.lower()
+
+
+# ── auto-title (frozen acceptance) ────────────────────────────────────
+
+
+def test_session_autotitle_from_first_message(patched_workspace: Path, manager: SessionManager) -> None:
+    msg = "hello raven"
+    cid = new_chat_id()
+    s = manager.get_or_create(f"cli:{cid}")
+    s.add_message("user", msg)
+    manager.save(s)
+
+    reloaded = manager.peek(f"cli:{cid}")
+    assert reloaded is not None
+    title = reloaded.metadata.get("title")
+    assert title
+    assert msg.startswith(title)
+    assert len(title) <= 40
+
+    r = runner.invoke(session_app, ["list"])
+    assert r.exit_code == 0
+    row = next(line for line in r.stdout.splitlines() if cid in line)
+    cells = [c.strip() for c in row.split("│") if c.strip()]
+    assert cells[1] == title
+    assert cells[1] != "-"
+
+
+def test_session_explicit_title_not_overwritten(patched_workspace: Path, manager: SessionManager) -> None:
+    import re
+
+    created = runner.invoke(session_app, ["create", "--title", "X"])
+    assert created.exit_code == 0
+    match = re.search(r"\d{8}_\d{6}_[0-9a-f]{6}", created.stdout)
+    assert match, created.stdout
+    cid = match.group(0)
+
+    s = manager.get_or_create(f"cli:{cid}")
+    s.add_message("user", "a completely different first message")
+    manager.save(s)
+
+    reloaded = manager.peek(f"cli:{cid}")
+    assert reloaded is not None
+    assert reloaded.metadata.get("title") == "X"

--- a/tests/test_cli_session_commands.py
+++ b/tests/test_cli_session_commands.py
@@ -404,7 +404,7 @@ def test_export_write_failure_exits_cleanly(patched_workspace: Path, manager: Se
     assert r.exception is None or isinstance(r.exception, SystemExit)
 
 
-# ── create/delete roundtrip (frozen acceptance) ───────────────────────
+# ── create/delete roundtrip ───────────────────────────────────────────
 
 
 def test_session_create_list_delete_roundtrip(patched_workspace: Path) -> None:
@@ -425,7 +425,7 @@ def test_session_delete_unknown_id_still_clear(patched_workspace: Path) -> None:
     assert "not found" in r.output.lower()
 
 
-# ── auto-title (frozen acceptance) ────────────────────────────────────
+# ── auto-title ────────────────────────────────────────────────────────
 
 
 def test_session_autotitle_from_first_message(patched_workspace: Path, manager: SessionManager) -> None:

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -785,10 +785,13 @@ def test_fork_deepcopies_messages(tmp_path: Path):
 
 
 def test_fork_default_title_appends_fork_suffix(tmp_path: Path):
-    """Without an explicit title, a titled parent yields '<title> (fork)'."""
+    """Without an explicit title, a titled parent yields '<title> (fork)'.
+
+    The parent was auto-named on its first save; the human rename via
+    set_title clears the marker, so the new title is inherited."""
     mgr = SessionManager(tmp_path)
     src = _seed(mgr, "cli:src10", ("user", "x"))
-    src.metadata["title"] = "My chat"
+    src.set_title("My chat")
     mgr.save(src)
 
     child = mgr.fork("cli:src10")
@@ -814,6 +817,36 @@ def test_fork_explicit_title_overrides(tmp_path: Path):
     child = mgr.fork("cli:src12", title="Custom")
 
     assert child.metadata["title"] == "Custom"
+
+
+def test_fork_inherits_human_title_equal_to_auto_derivation(tmp_path: Path):
+    """A human title that happens to equal the auto-derived text of the first
+    user message is still human: the child inherits '<title> (fork)'."""
+    mgr = SessionManager(tmp_path)
+    src = mgr.get_or_create("cli:src13")
+    src.set_title("Plan the trip")
+    src.add_message("user", "Plan the trip")
+    mgr.save(src)
+
+    child = mgr.fork("cli:src13")
+
+    assert child.metadata["title"] == "Plan the trip (fork)"
+
+
+def test_fork_skips_auto_named_title_via_marker(tmp_path: Path):
+    """An auto-named source carries title_auto in its persisted metadata and
+    the child does not inherit the title, even after a disk round-trip."""
+    mgr = SessionManager(tmp_path)
+    _seed(mgr, "cli:src14", ("user", "Plan the trip"))
+
+    reloaded_mgr = SessionManager(tmp_path)
+    source = reloaded_mgr.peek("cli:src14")
+    assert source.metadata.get("title") == "Plan the trip"
+    assert source.metadata.get("title_auto") is True
+
+    child = reloaded_mgr.fork("cli:src14")
+
+    assert child.metadata.get("title") is None
 
 
 # ── resolve_key (shared cross-channel resolution core) ─────────────────

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -278,6 +278,33 @@ def test_find_most_recent_reflects_latest_append(tmp_path: Path):
     assert mgr.find_most_recent_chat_id("tui") == "first"
 
 
+def test_find_most_recent_prefers_sessions_with_messages(tmp_path: Path):
+    """A freshly minted zero-message session (bare ``sessions create``) must
+    not hijack recency: the newest session WITH messages wins even when an
+    empty one carries a later updated_at."""
+    mgr = SessionManager(tmp_path)
+    real = mgr.get_or_create("cli:real01")
+    real.add_message("user", "hello")
+    real.updated_at = datetime(2026, 6, 10, 10, 0, 0)
+    mgr.save(real)
+
+    empty = mgr.get_or_create("cli:empty01")
+    empty.updated_at = datetime(2026, 6, 10, 11, 0, 0)
+    mgr.save(empty)
+
+    assert mgr.find_most_recent_chat_id("cli") == "real01"
+
+
+def test_find_most_recent_falls_back_to_empty_when_all_empty(tmp_path: Path):
+    """When every session on the channel has zero messages, the newest empty
+    one is still returned rather than None."""
+    _seed_nested(tmp_path, "cli", "older", "2026-06-10T10:00:00")
+    _seed_nested(tmp_path, "cli", "newer", "2026-06-10T11:00:00")
+
+    mgr = SessionManager(tmp_path)
+    assert mgr.find_most_recent_chat_id("cli") == "newer"
+
+
 def test_loader_skips_partial_trailing_line(tmp_path: Path):
     """A crash mid-append leaves a partial trailing line; loader skips it."""
     session_dir = tmp_path / "sessions" / "tui"


### PR DESCRIPTION
## Summary

Session UX improvements found in an internal usability review of v0.1.11.
`sessions create` now persists minimal metadata immediately (with or
without --title), so create/list/delete round-trips work instead of
create handing out an id that list cannot see and delete reports as not
found. Sessions are auto-titled from the first user message (first line,
whitespace-collapsed, 40-char cap) at save time; explicit titles are
never overwritten, and forks only inherit human-given titles. One
pre-existing test was renamed and inverted (test_create_lazy_no_file to
test_create_bare_persists_file) because it pinned the exact lazy behavior
this change removes.

## Type

- [x] Fix
- [x] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_cli_session_commands.py tests/test_session_manager.py tests/test_session_export.py -x`: 117 passed.
- Full suite `uv run pytest -q`: 1 failed / 6149 passed; the single failure is the pre-existing test_read_file_image failure already present on main.
- Sandbox-HOME real runs: create -> id visible in list (Messages=0) -> delete exits 0; deleting an unknown id still reports not found with exit 1; a real turn produces a 40-char truncated EN title and a correctly rendered CJK title.
- All changes were written red-first against frozen acceptance assertions.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Behavior change by design: bare `sessions create` now writes a metadata
file immediately instead of being lazy. Existing sessions are untouched;
old sessions without titles keep showing "-". Rollback = revert the
branch; the metadata format is unchanged.

## Related Issues

N/A - found in an internal usability review of v0.1.11; no tracked GitHub issues.

