### PR TITLE
fix(*): enforce skill hub install safety policy at a SkillPolicy gate

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -418,6 +418,18 @@ candidates into the weighted RRF (weight 0.85, below Local 1.0 and Everos 0.9), 
 `read_skill` / `use_skill` tools do on-demand body fetch / script materialization. Replaces
 the retired "Mass" source.
 
+**SkillPolicy** (`skill_hub/policy.py`):
+The install-time safety decision both Hub install paths consult before any
+`SkillHubClient.install()` — the segment builder's post-gate hydrate and the `use_skill`
+tool. `refusal_for_detail()` checks, in order: the operator blocklist
+(`skillForge.blocklist`, matched case-insensitively against name / slug / native id), the
+`min_safety` bar against the *detail*-level `score_safety` (the catalog payload omits the
+score; a missing or malformed score passes), and an external home-dotdir lint over the
+skill body (`~/.raven` is allowed; any other dotdir reference refuses the install). A hub
+candidate whose detail fetch fails is unvetted and dropped — it never reaches `install()`.
+Every install that passes is appended to a JSONL audit trail
+(`<workspace>/skills/hub/installs.jsonl`, `skill_hub/audit.py`).
+
 **Episode**:
 A distilled event note the Consolidation step writes to `episodes.md`.
 

--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -481,6 +481,12 @@ class AgentLoop:
             workspace,
             skill_forge_router_config,
         )
+        # Install-policy knobs for the use_skill tool (registered later in
+        # ``_register_builtin_tools``, which no longer sees these configs).
+        self._skill_min_safety = float(
+            getattr(getattr(skill_forge_router_config, "hub", None), "min_safety", 0.7),
+        )
+        self._skill_blocklist = list(getattr(skill_forge_config, "blocklist", None) or [])
 
         self.context_engine: "ContextEngine" = build_context_engine(
             workspace=workspace,
@@ -854,7 +860,17 @@ class AgentLoop:
             from raven.agent.tools.skill_hub import ReadSkillTool, UseSkillTool
 
             self.tools.register(
-                UseSkillTool(client=self._skill_hub_client, registry=skill_registry),
+                UseSkillTool(
+                    client=self._skill_hub_client,
+                    registry=skill_registry,
+                    min_safety=self._skill_min_safety,
+                    blocklist=self._skill_blocklist,
+                    install_audit_path=(
+                        self.workspace / "skills" / "hub" / "installs.jsonl"
+                        if self._skill_hub_client is not None
+                        else None
+                    ),
+                ),
             )
             if self._skill_hub_client is not None:
                 self.tools.register(

--- a/raven/agent/tools/skill_hub.py
+++ b/raven/agent/tools/skill_hub.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any
 
 from raven.agent.tools.base import Tool
 from raven.skill_hub.audit import record_install
-from raven.skill_hub.policy import is_blocked, normalize_blocklist, refuses_low_safety
+from raven.skill_hub.policy import SkillPolicy, is_blocked
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -139,8 +139,7 @@ class UseSkillTool(Tool):
     ) -> None:
         self._client = client
         self._registry = registry
-        self._min_safety = min_safety
-        self._blocklist = normalize_blocklist(blocklist)
+        self._policy = SkillPolicy.create(min_safety=min_safety, blocklist=blocklist)
         self._install_audit_path = install_audit_path
 
     @property
@@ -180,7 +179,7 @@ class UseSkillTool(Tool):
             return "Error: 'skill_id' is required — a skill's qualified id like 'hub/<slug>'."
         source, native = _split_qualified_id(skill_id)
 
-        if is_blocked(self._blocklist, native):
+        if is_blocked(self._policy.blocklist, native):
             return (
                 f"Error: skill {native!r} is on the operator blocklist "
                 f"(skillForge.blocklist) and cannot be used."
@@ -221,17 +220,10 @@ class UseSkillTool(Tool):
             return f"Error: failed to install skill {native!r} from the Hub: {e}"
 
         slug = str(meta.get("slug") or meta.get("name") or native)
-        if is_blocked(self._blocklist, slug, meta.get("skill_id"), meta.get("name")):
-            return (
-                f"Error: skill {slug!r} is on the operator blocklist "
-                f"(skillForge.blocklist) and cannot be used."
-            )
         score = meta.get("score_safety")
-        if refuses_low_safety(score, self._min_safety):
-            return (
-                f"Error: refusing to install hub skill {slug!r}: "
-                f"score_safety {score} is below the configured minimum {self._min_safety}."
-            )
+        refusal = self._policy.refusal_for_detail(meta, native)
+        if refusal is not None:
+            return f"Error: refusing to install hub skill: {refusal}."
 
         try:
             info = await self._client.install(native, prefetched_meta=meta)

--- a/raven/agent/tools/skill_hub.py
+++ b/raven/agent/tools/skill_hub.py
@@ -31,8 +31,13 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from raven.agent.tools.base import Tool
+from raven.skill_hub.audit import record_install
+from raven.skill_hub.policy import is_blocked, normalize_blocklist, refuses_low_safety
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
     from raven.memory_engine.skill_local.registry import SkillRegistry
     from raven.skill_hub import SkillHubClient
 
@@ -127,9 +132,16 @@ class UseSkillTool(Tool):
         self,
         client: "SkillHubClient | None" = None,
         registry: "SkillRegistry | None" = None,
+        *,
+        min_safety: float = 0.7,
+        blocklist: "Iterable[str] | None" = None,
+        install_audit_path: "Path | None" = None,
     ) -> None:
         self._client = client
         self._registry = registry
+        self._min_safety = min_safety
+        self._blocklist = normalize_blocklist(blocklist)
+        self._install_audit_path = install_audit_path
 
     @property
     def name(self) -> str:
@@ -168,6 +180,12 @@ class UseSkillTool(Tool):
             return "Error: 'skill_id' is required — a skill's qualified id like 'hub/<slug>'."
         source, native = _split_qualified_id(skill_id)
 
+        if is_blocked(self._blocklist, native):
+            return (
+                f"Error: skill {native!r} is on the operator blocklist "
+                f"(skillForge.blocklist) and cannot be used."
+            )
+
         if source in ("local", "everos"):
             return self._use_on_disk(source, native)
         if source == "hub":
@@ -188,13 +206,51 @@ class UseSkillTool(Tool):
         return f"## {meta.name}\n(no bundled scripts — pure-instruction skill; follow the body)\n\n{meta.content}"
 
     async def _use_hub(self, native: str) -> str:
-        """Download + extract a Hub skill, then expose its scripts dir."""
+        """Policy-check, then download + extract a Hub skill.
+
+        The detail metadata is fetched first because it is the only
+        payload that carries ``score_safety`` (catalog search omits it);
+        on pass it doubles as ``prefetched_meta`` so install() skips the
+        redundant round-trip.
+        """
         if self._client is None:
             return "Error: Skill Hub is not configured; cannot fetch a remote skill."
         try:
-            info = await self._client.install(native)
+            meta = await self._client.get(native)
         except Exception as e:  # noqa: BLE001 — surface as tool error, not a crash
             return f"Error: failed to install skill {native!r} from the Hub: {e}"
+
+        slug = str(meta.get("slug") or meta.get("name") or native)
+        if is_blocked(self._blocklist, slug, meta.get("skill_id"), meta.get("name")):
+            return (
+                f"Error: skill {slug!r} is on the operator blocklist "
+                f"(skillForge.blocklist) and cannot be used."
+            )
+        score = meta.get("score_safety")
+        if refuses_low_safety(score, self._min_safety):
+            return (
+                f"Error: refusing to install hub skill {slug!r}: "
+                f"score_safety {score} is below the configured minimum {self._min_safety}."
+            )
+
+        try:
+            info = await self._client.install(native, prefetched_meta=meta)
+        except Exception as e:  # noqa: BLE001 — surface as tool error, not a crash
+            return f"Error: failed to install skill {native!r} from the Hub: {e}"
+        record_install(
+            self._install_audit_path,
+            slug=str(info.get("slug") or slug),
+            version=str(info.get("version") or ""),
+            trigger="use_skill",
+            score_safety=score,
+            skill_dir=info.get("dir"),
+        )
+        logger.warning(
+            "installed hub skill %s@%s via use_skill (score_safety=%s)",
+            info.get("slug") or slug,
+            info.get("version") or "",
+            score,
+        )
         # Best-effort: make the freshly extracted skill visible to the
         # registry on subsequent turns. No-op if the cache isn't a scanned
         # source yet; the returned scripts_dir is usable this turn regardless.

--- a/raven/agent/tools/skill_hub.py
+++ b/raven/agent/tools/skill_hub.py
@@ -180,10 +180,7 @@ class UseSkillTool(Tool):
         source, native = _split_qualified_id(skill_id)
 
         if is_blocked(self._policy.blocklist, native):
-            return (
-                f"Error: skill {native!r} is on the operator blocklist "
-                f"(skillForge.blocklist) and cannot be used."
-            )
+            return f"Error: skill {native!r} is on the operator blocklist (skillForge.blocklist) and cannot be used."
 
         if source in ("local", "everos"):
             return self._use_on_disk(source, native)

--- a/raven/cli/skill_commands.py
+++ b/raven/cli/skill_commands.py
@@ -7,6 +7,12 @@ Read-only inspection (registry-level):
 - ``skill list``                — list skills visible to SkillForge
 - ``skill get <name>``          — show one skill's metadata (and optionally body)
 
+Lifecycle management (Hub install policy):
+
+- ``skill block <name>``        — add to skillForge.blocklist (refused everywhere)
+- ``skill unblock <name>``      — remove from skillForge.blocklist
+- ``skill remove <name>``       — delete an installed Hub bundle from the workspace
+
 ``commands.py`` imports :data:`skill_app` and registers it on the top-level
 ``app`` via ``app.add_typer(skill_app, name="skill")``.
 """
@@ -21,7 +27,7 @@ from rich.table import Table
 console = Console()
 
 
-skill_app = typer.Typer(help="Inspect SkillForge registry (read-only)")
+skill_app = typer.Typer(help="Inspect and manage SkillForge skills")
 
 
 def _build_skill_service():
@@ -83,6 +89,56 @@ def skill_get(
         if body:
             console.print("\n[bold]── SKILL.md ──[/bold]")
             console.print(Markdown(body))
+
+
+@skill_app.command("block")
+def skill_block(name: str = typer.Argument(..., help="Skill name / slug to refuse everywhere")):
+    """Add a skill to skillForge.blocklist (dropped from the injection pool
+    and refused by use_skill on the next agent/gateway start)."""
+    from raven.config.update import set_skill_blocked
+
+    blocklist = set_skill_blocked(name, True)
+    console.print(f"[green]Blocked[/green] {name!r}. skillForge.blocklist = {blocklist}")
+    console.print("[dim]Takes effect on the next agent/gateway start.[/dim]")
+
+
+@skill_app.command("unblock")
+def skill_unblock(name: str = typer.Argument(..., help="Skill name / slug to allow again")):
+    """Remove a skill from skillForge.blocklist."""
+    from raven.config.update import set_skill_blocked
+
+    blocklist = set_skill_blocked(name, False)
+    console.print(f"[green]Unblocked[/green] {name!r}. skillForge.blocklist = {blocklist}")
+    console.print("[dim]Takes effect on the next agent/gateway start.[/dim]")
+
+
+@skill_app.command("remove")
+def skill_remove(
+    name: str = typer.Argument(..., help="Installed Hub skill slug to delete"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt"),
+):
+    """Delete an installed Hub bundle (<workspace>/skills/hub/<slug>@<version>).
+
+    Removal alone does not stop a re-install on the next catalog hit —
+    pair it with ``skill block`` to keep the skill out."""
+    import shutil
+
+    from raven.config.loader import load_config
+
+    hub_dir = load_config().workspace_path / "skills" / "hub"
+    matches = [d for d in hub_dir.glob("*@*") if d.is_dir() and d.name.rsplit("@", 1)[0].casefold() == name.casefold()]
+    if not matches:
+        console.print(f"[red]No installed Hub bundle found for {name!r} under {hub_dir}[/red]")
+        raise typer.Exit(1)
+
+    for d in matches:
+        console.print(f"  {d}")
+    if not yes and not typer.confirm(f"Delete {len(matches)} bundle dir(s)?"):
+        raise typer.Exit(1)
+    for d in matches:
+        shutil.rmtree(d)
+    console.print(f"[green]Removed[/green] {len(matches)} bundle(s) of {name!r}.")
+    console.print("[dim]Tip: `raven skill block " + name + "` prevents silent re-install.[/dim]")
 
 
 __all__ = ["skill_app"]

--- a/raven/config/raven.py
+++ b/raven/config/raven.py
@@ -805,6 +805,12 @@ class SkillForgeConfig(_Base):
     """Master switch (R8: default True). Activates the SkillForge
     retrieval/injection pipeline."""
 
+    blocklist: list[str] = Field(default_factory=list)
+    """Skill names refused everywhere (config key ``skillForge.blocklist``):
+    dropped from the injection pool for every source and refused by
+    ``use_skill``. Matched case-insensitively against the skill's name,
+    slug, and native id."""
+
     router: "SkillForgeRouterConfig" = Field(
         default_factory=lambda: SkillForgeRouterConfig(),
     )
@@ -1152,8 +1158,11 @@ class HubSourceConfig(_Base):
     """Per-request timeout (hot turn-path)."""
 
     min_safety: float = 0.7
-    """Skills with ``score_safety`` below this are filtered out of the
-    catalog (and refused by ``use_skill``)."""
+    """Skills with ``score_safety`` below this are dropped. Catalog hits
+    that carry a score are filtered by ``HubSkillSource``; the standard
+    catalog payload omits the score, so the authoritative check runs on
+    the detail metadata — ``SkillsSegmentBuilder`` drops low-scored hits
+    after the pre-gate hydrate, and ``use_skill`` refuses the install."""
 
     source: str = "raven"
     """Download ``source`` tag for Hub usage stats."""

--- a/raven/config/update.py
+++ b/raven/config/update.py
@@ -162,6 +162,39 @@ def set_sentinel_nudge_quota(
     return changed
 
 
+def set_skill_blocked(
+    name: str,
+    blocked: bool,
+    *,
+    config_path: Path | None = None,
+) -> list[str]:
+    """Add/remove a skill name on ``skillForge.blocklist``; returns the new
+    list. Matching is case-insensitive; adding an already-listed name or
+    removing an absent one is a no-op (the file is still not rewritten).
+
+    The blocklist is read at process start (AgentLoop / context engine
+    construction), so a change takes effect on the next agent/gateway
+    start, not on a running process.
+    """
+    path = config_path or get_config_path()
+    data = read_raw_or_raise(path)
+    section = data.setdefault("skillForge", {})
+    current = [str(x) for x in (section.get("blocklist") or [])]
+    lowered = {x.casefold() for x in current}
+    if blocked:
+        if name.casefold() in lowered:
+            return current
+        current.append(name)
+    else:
+        if name.casefold() not in lowered:
+            return current
+        current = [x for x in current if x.casefold() != name.casefold()]
+    section["blocklist"] = current
+    _write_atomic(path, data)
+    logger.info("config/update: skillForge.blocklist now {!r} ({} {!r})", current, "blocked" if blocked else "unblocked", name)
+    return current
+
+
 def set_language(
     language: str,
     *,

--- a/raven/config/update.py
+++ b/raven/config/update.py
@@ -388,5 +388,6 @@ __all__ = [
     "set_default_model",
     "set_sandbox_backend",
     "set_memory_backend",
+    "set_skill_blocked",
     "init_extension_block_defaults",
 ]

--- a/raven/config/update.py
+++ b/raven/config/update.py
@@ -191,7 +191,9 @@ def set_skill_blocked(
         current = [x for x in current if x.casefold() != name.casefold()]
     section["blocklist"] = current
     _write_atomic(path, data)
-    logger.info("config/update: skillForge.blocklist now {!r} ({} {!r})", current, "blocked" if blocked else "unblocked", name)
+    logger.info(
+        "config/update: skillForge.blocklist now {!r} ({} {!r})", current, "blocked" if blocked else "unblocked", name
+    )
     return current
 
 

--- a/raven/context_engine/factory.py
+++ b/raven/context_engine/factory.py
@@ -133,6 +133,11 @@ def build_context_engine(
             ),
             hub_client=skill_hub_client,
             get_tool_definitions=get_tool_definitions,
+            min_safety=skill_forge_router_config.hub.min_safety,
+            blocklist=(getattr(skill_forge_config, "blocklist", None) if skill_forge_config is not None else None),
+            install_audit_path=(
+                workspace / "skills" / "hub" / "installs.jsonl" if skill_hub_client is not None else None
+            ),
         ),
         CuratorSegmentBuilder(
             workspace=workspace,

--- a/raven/context_engine/segments/skills.py
+++ b/raven/context_engine/segments/skills.py
@@ -35,7 +35,7 @@ from raven.context_engine.base import AssemblyContext, Segment
 from raven.context_engine.segments import render
 from raven.memory_engine.skill_forge.refs import resolve_refs
 from raven.skill_hub.audit import record_install
-from raven.skill_hub.policy import is_blocked, normalize_blocklist, refuses_low_safety
+from raven.skill_hub.policy import SkillPolicy, is_blocked
 from raven.tracing import semconv, trace
 
 if TYPE_CHECKING:
@@ -81,8 +81,7 @@ class SkillsSegmentBuilder:
         self._pool_size = gate_pool_size if gate is not None else skill_top_k
         self._hub_client = hub_client
         self._get_tool_definitions = get_tool_definitions
-        self._min_safety = min_safety
-        self._blocklist = normalize_blocklist(blocklist)
+        self._policy = SkillPolicy.create(min_safety=min_safety, blocklist=blocklist)
         self._install_audit_path = install_audit_path
         self._audited_installs: set[str] = set()
 
@@ -129,10 +128,10 @@ class SkillsSegmentBuilder:
         )
 
         # ── ②b Blocklist — hard drop across every source ──────────────
-        if self._blocklist:
+        if self._policy.blocklist:
             kept: list["RouterHit"] = []
             for c in candidates:
-                if is_blocked(self._blocklist, c.name, c.meta.get("skill_id")):
+                if is_blocked(self._policy.blocklist, c.name, c.meta.get("skill_id")):
                     log.warning("dropping blocklisted skill from pool: %s", c.qualified_id)
                 else:
                     kept.append(c)
@@ -203,17 +202,13 @@ class SkillsSegmentBuilder:
         for (i, c), m in zip(targets, metas):
             if m is None:
                 continue
-            # Authoritative min_safety check: the catalog payload omits
+            # Authoritative policy check: the catalog payload omits
             # score_safety (HubSkillSource's guard no-ops there), so the
-            # detail metadata fetched here is the first place the score
-            # is actually available.
-            if refuses_low_safety(m.get("score_safety"), self._min_safety):
-                log.warning(
-                    "dropping hub skill %s: score_safety %s below min_safety %.2f",
-                    c.qualified_id,
-                    m.get("score_safety"),
-                    self._min_safety,
-                )
+            # detail metadata fetched here is the first place the full
+            # policy (safety bar + blocklist + body path lint) can run.
+            refusal = self._policy.refusal_for_detail(m, c.name)
+            if refusal is not None:
+                log.warning("dropping hub skill %s: %s", c.qualified_id, refusal)
                 dropped.add(i)
                 continue
             prefetched_meta[c.qualified_id] = m

--- a/raven/context_engine/segments/skills.py
+++ b/raven/context_engine/segments/skills.py
@@ -185,10 +185,8 @@ class SkillsSegmentBuilder:
             try:
                 return await self._hub_client.get(c.meta["id"])
             except Exception as e:
-                # warning, not debug: a body-hydrate miss means the gate
-                # only sees catalog metadata for this candidate and may
-                # silently down-rank it for the wrong reason. Same level
-                # as the post-gate install failure further down.
+                # warning, not debug: a failed detail fetch means the
+                # candidate cannot be vetted and is dropped below.
                 log.warning(
                     "hub body hydrate failed for %s: %s",
                     c.meta.get("id"),
@@ -201,6 +199,16 @@ class SkillsSegmentBuilder:
         dropped: set[int] = set()
         for (i, c), m in zip(targets, metas):
             if m is None:
+                # Fail closed: the policy runs on the detail metadata, so a
+                # candidate whose detail fetch failed is unvetted. Leaving it
+                # in the pool would let the post-gate step call install()
+                # with prefetched_meta=None, whose internal re-fetch bypasses
+                # SkillPolicy entirely.
+                log.warning(
+                    "dropping hub skill %s: detail fetch failed, cannot vet",
+                    c.qualified_id,
+                )
+                dropped.add(i)
                 continue
             # Authoritative policy check: the catalog payload omits
             # score_safety (HubSkillSource's guard no-ops there), so the
@@ -240,10 +248,19 @@ class SkillsSegmentBuilder:
                 resolved, _ = resolve_refs(h.content, h.meta.get("skill_dir"))
                 return replace(h, content=resolved)
             if source == "hub" and self._hub_client is not None:
+                vetted = prefetched_meta.get(h.qualified_id)
+                if vetted is None:
+                    # Never hand install() a hub hit without vetted detail
+                    # metadata — its internal re-fetch would skip SkillPolicy.
+                    log.warning(
+                        "skipping install for %s: no vetted detail metadata",
+                        h.qualified_id,
+                    )
+                    return h
                 try:
                     installed = await self._hub_client.install(
                         h.meta["id"],
-                        prefetched_meta=prefetched_meta.get(h.qualified_id),
+                        prefetched_meta=vetted,
                     )
                 except Exception as e:
                     # Install failures fall back to the unresolved body
@@ -256,7 +273,7 @@ class SkillsSegmentBuilder:
                         e,
                     )
                     return h
-                self._notify_install(installed, prefetched_meta.get(h.qualified_id))
+                self._notify_install(installed, vetted)
                 body = installed.get("skill_md", "") or h.content
                 resolved, _ = resolve_refs(body, installed.get("dir"))
                 new_meta = dict(h.meta)

--- a/raven/context_engine/segments/skills.py
+++ b/raven/context_engine/segments/skills.py
@@ -34,9 +34,14 @@ from typing import TYPE_CHECKING, Any
 from raven.context_engine.base import AssemblyContext, Segment
 from raven.context_engine.segments import render
 from raven.memory_engine.skill_forge.refs import resolve_refs
+from raven.skill_hub.audit import record_install
+from raven.skill_hub.policy import is_blocked, normalize_blocklist, refuses_low_safety
 from raven.tracing import semconv, trace
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
     from raven.memory_engine.skill_forge import SkillForgeRouter
     from raven.memory_engine.skill_forge.gate import LLMGateFilter
     from raven.memory_engine.skill_forge.rewriter import QueryRewriter
@@ -62,6 +67,9 @@ class SkillsSegmentBuilder:
         gate_pool_size: int = 10,
         hub_client: "SkillHubClient | None" = None,
         get_tool_definitions: "Any | None" = None,
+        min_safety: float = 0.7,
+        blocklist: "Iterable[str] | None" = None,
+        install_audit_path: "Path | None" = None,
     ) -> None:
         self._router = router
         self._skill_top_k = skill_top_k
@@ -73,6 +81,10 @@ class SkillsSegmentBuilder:
         self._pool_size = gate_pool_size if gate is not None else skill_top_k
         self._hub_client = hub_client
         self._get_tool_definitions = get_tool_definitions
+        self._min_safety = min_safety
+        self._blocklist = normalize_blocklist(blocklist)
+        self._install_audit_path = install_audit_path
+        self._audited_installs: set[str] = set()
 
     def set_provider(self, provider: "LLMProvider", model: str) -> None:
         """Hand a live ``/model`` switch down to the two LLM users in this
@@ -115,6 +127,16 @@ class SkillsSegmentBuilder:
                 k=self._pool_size,
             )
         )
+
+        # ── ②b Blocklist — hard drop across every source ──────────────
+        if self._blocklist:
+            kept: list["RouterHit"] = []
+            for c in candidates:
+                if is_blocked(self._blocklist, c.name, c.meta.get("skill_id")):
+                    log.warning("dropping blocklisted skill from pool: %s", c.qualified_id)
+                else:
+                    kept.append(c)
+            candidates = kept
 
         # ── ③ Pre-gate body hydrate (Hub only) ────────────────────────
         # Side-channel: keep the metadata dict so post-gate install can
@@ -177,11 +199,27 @@ class SkillsSegmentBuilder:
 
         metas = await asyncio.gather(*(_one(c) for _, c in targets))
         out = list(candidates)
+        dropped: set[int] = set()
         for (i, c), m in zip(targets, metas):
             if m is None:
                 continue
+            # Authoritative min_safety check: the catalog payload omits
+            # score_safety (HubSkillSource's guard no-ops there), so the
+            # detail metadata fetched here is the first place the score
+            # is actually available.
+            if refuses_low_safety(m.get("score_safety"), self._min_safety):
+                log.warning(
+                    "dropping hub skill %s: score_safety %s below min_safety %.2f",
+                    c.qualified_id,
+                    m.get("score_safety"),
+                    self._min_safety,
+                )
+                dropped.add(i)
+                continue
             prefetched_meta[c.qualified_id] = m
             out[i] = replace(c, content=m.get("skill_md", "") or "")
+        if dropped:
+            out = [c for i, c in enumerate(out) if i not in dropped]
         return out
 
     async def _hydrate_refs(
@@ -223,6 +261,7 @@ class SkillsSegmentBuilder:
                         e,
                     )
                     return h
+                self._notify_install(installed, prefetched_meta.get(h.qualified_id))
                 body = installed.get("skill_md", "") or h.content
                 resolved, _ = resolve_refs(body, installed.get("dir"))
                 new_meta = dict(h.meta)
@@ -232,6 +271,38 @@ class SkillsSegmentBuilder:
             return h
 
         return list(await asyncio.gather(*(_hydrate_one(h) for h in gated)))
+
+    def _notify_install(
+        self,
+        installed: dict[str, Any],
+        detail_meta: dict[str, Any] | None,
+    ) -> None:
+        """Surface + audit an auto-inject install, once per slug@version.
+
+        ``install()`` is called every turn for selected Hub hits (cache
+        hits are cheap), so without the dedup a long-lived gateway would
+        re-log and re-audit the same bundle each turn.
+        """
+        slug = str(installed.get("slug") or "?")
+        version = str(installed.get("version") or "")
+        key = f"{slug}@{version}"
+        if key in self._audited_installs:
+            return
+        self._audited_installs.add(key)
+        score = (detail_meta or {}).get("score_safety")
+        log.warning(
+            "installed hub skill %s (auto-injected into context, score_safety=%s)",
+            key,
+            score,
+        )
+        record_install(
+            self._install_audit_path,
+            slug=slug,
+            version=version,
+            trigger="auto_inject",
+            score_safety=score,
+            skill_dir=installed.get("dir"),
+        )
 
     def _collect_tool_names(self) -> list[str] | None:
         """Return tool names for the gate's hard-constraint block.

--- a/raven/skill_hub/audit.py
+++ b/raven/skill_hub/audit.py
@@ -1,0 +1,48 @@
+"""Append-only JSONL audit of Hub skill installs.
+
+Every install that passes policy is recorded — both the silent
+auto-inject path and explicit ``use_skill`` calls — so an operator can
+answer "what third-party code landed on this machine, when, and why".
+Best-effort by design: an audit write failure must never take down the
+install itself.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def record_install(
+    path: Path | None,
+    *,
+    slug: str,
+    version: str = "",
+    trigger: str,
+    score_safety: float | None = None,
+    skill_dir: str | None = None,
+) -> None:
+    """Append one install record; ``path=None`` disables auditing."""
+    if path is None:
+        return
+    record = {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "slug": slug,
+        "version": version,
+        "trigger": trigger,
+        "score_safety": score_safety,
+        "dir": skill_dir,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except OSError:
+        logger.warning("failed to append skill install audit record to %s", path, exc_info=True)
+
+
+__all__ = ["record_install"]

--- a/raven/skill_hub/policy.py
+++ b/raven/skill_hub/policy.py
@@ -1,0 +1,53 @@
+"""Install-time safety policy shared by both Hub install paths.
+
+The two call sites — the ``SkillsSegmentBuilder`` post-gate hydrate
+(auto-inject) and the ``use_skill`` tool — apply the same checks before
+any ``SkillHubClient.install``:
+
+- ``refuses_low_safety`` — the ``score_safety`` bar. Catalog search
+  payloads omit the score, so the authoritative check runs on the
+  *detail* metadata (already fetched by both paths); a missing score
+  passes to keep score-less deployments working.
+- ``is_blocked`` — the operator blocklist (``skillForge.blocklist``),
+  matched case-insensitively against any known identifier of the skill
+  (name / slug / native id).
+
+Stdlib-only on purpose: this module ships with the client when the
+package is extracted for reuse outside Raven.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def normalize_blocklist(names: Iterable[str] | None) -> frozenset[str]:
+    """Casefold + trim a user-supplied blocklist into a match set."""
+    if not names:
+        return frozenset()
+    return frozenset(n.strip().casefold() for n in names if n and n.strip())
+
+
+def is_blocked(blocklist: frozenset[str], *identifiers: str | None) -> bool:
+    """True when any identifier of the skill is on the blocklist."""
+    if not blocklist:
+        return False
+    return any(i is not None and i.casefold() in blocklist for i in identifiers)
+
+
+def refuses_low_safety(score: object, min_safety: float) -> bool:
+    """True when a present, parseable ``score_safety`` is below the bar.
+
+    A missing or malformed score passes: catalog/detail payloads without
+    scores are a supported deployment shape, and the guard must not turn
+    them into a hard outage.
+    """
+    if score is None:
+        return False
+    try:
+        return float(score) < min_safety  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return False
+
+
+__all__ = ["is_blocked", "normalize_blocklist", "refuses_low_safety"]

--- a/raven/skill_hub/policy.py
+++ b/raven/skill_hub/policy.py
@@ -1,16 +1,19 @@
 """Install-time safety policy shared by both Hub install paths.
 
 The two call sites — the ``SkillsSegmentBuilder`` post-gate hydrate
-(auto-inject) and the ``use_skill`` tool — apply the same checks before
-any ``SkillHubClient.install``:
+(auto-inject) and the ``use_skill`` tool — route every Hub skill through
+one :class:`SkillPolicy` decision before any ``SkillHubClient.install``:
 
-- ``refuses_low_safety`` — the ``score_safety`` bar. Catalog search
-  payloads omit the score, so the authoritative check runs on the
-  *detail* metadata (already fetched by both paths); a missing score
-  passes to keep score-less deployments working.
-- ``is_blocked`` — the operator blocklist (``skillForge.blocklist``),
-  matched case-insensitively against any known identifier of the skill
+- the ``score_safety`` bar. Catalog search payloads omit the score, so
+  the authoritative check runs on the *detail* metadata (already fetched
+  by both paths); a missing score passes to keep score-less deployments
+  working.
+- the operator blocklist (``skillForge.blocklist``), matched
+  case-insensitively against any known identifier of the skill
   (name / slug / native id).
+- an external-home-directory lint over the skill body: a hub skill whose
+  instructions point at another product's dotdir (``~/.openclaw`` and
+  friends) is refused rather than rewritten.
 
 Stdlib-only on purpose: this module ships with the client when the
 package is extracted for reuse outside Raven.
@@ -18,7 +21,9 @@ package is extracted for reuse outside Raven.
 
 from __future__ import annotations
 
-from typing import Iterable
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable
 
 
 def normalize_blocklist(names: Iterable[str] | None) -> frozenset[str]:
@@ -50,4 +55,68 @@ def refuses_low_safety(score: object, min_safety: float) -> bool:
         return False
 
 
-__all__ = ["is_blocked", "normalize_blocklist", "refuses_low_safety"]
+# ``~/.foo`` / ``$HOME/.foo`` / ``/Users/x/.foo`` / ``/home/x/.foo`` —
+# any home dotdir reference in a skill body. Only ``~/.raven`` is ours;
+# everything else is another product's (or the user's private) data.
+_EXTERNAL_HOME_RE = re.compile(
+    r"(?:~|\$HOME|/Users/[A-Za-z0-9_][\w.-]*|/home/[A-Za-z0-9_][\w.-]*)/\.(?P<name>[A-Za-z0-9][\w-]*)",
+)
+_ALLOWED_HOME_DOTDIRS = frozenset({"raven"})
+
+
+def lint_external_paths(text: str | None) -> list[str]:
+    """Foreign home-dotdir references found in a skill body, deduped and
+    sorted (e.g. ``["~/.openclaw"]``). Empty list = clean."""
+    if not text:
+        return []
+    found = {
+        f"~/.{m.group('name')}"
+        for m in _EXTERNAL_HOME_RE.finditer(text)
+        if m.group("name").casefold() not in _ALLOWED_HOME_DOTDIRS
+    }
+    return sorted(found)
+
+
+@dataclass(frozen=True)
+class SkillPolicy:
+    """The single install-policy decision both Hub install paths consult."""
+
+    min_safety: float = 0.7
+    blocklist: frozenset[str] = field(default_factory=frozenset)
+
+    @classmethod
+    def create(cls, *, min_safety: float = 0.7, blocklist: Iterable[str] | None = None) -> "SkillPolicy":
+        return cls(min_safety=min_safety, blocklist=normalize_blocklist(blocklist))
+
+    def refusal_for_detail(
+        self,
+        meta: dict[str, Any],
+        *extra_identifiers: str | None,
+    ) -> str | None:
+        """Refusal reason for a hub skill's detail metadata, or ``None`` to
+        allow. Checks blocklist, then the safety bar, then the body lint."""
+        slug = str(next((i for i in (meta.get("slug"), meta.get("name"), *extra_identifiers) if i), "?"))
+        if is_blocked(
+            self.blocklist,
+            meta.get("slug"),
+            meta.get("name"),
+            meta.get("skill_id"),
+            *extra_identifiers,
+        ):
+            return f"skill {slug!r} is on the operator blocklist (skillForge.blocklist)"
+        score = meta.get("score_safety")
+        if refuses_low_safety(score, self.min_safety):
+            return f"skill {slug!r}: score_safety {score} is below the configured minimum {self.min_safety}"
+        flagged = lint_external_paths(meta.get("skill_md"))
+        if flagged:
+            return f"skill {slug!r} references external home directories: {', '.join(flagged)}"
+        return None
+
+
+__all__ = [
+    "SkillPolicy",
+    "is_blocked",
+    "lint_external_paths",
+    "normalize_blocklist",
+    "refuses_low_safety",
+]

--- a/tests/test_cli_skill_commands.py
+++ b/tests/test_cli_skill_commands.py
@@ -34,11 +34,11 @@ def tmp_config(tmp_path: Path) -> Path:
 def test_skill_help_lists_all_subcommands() -> None:
     r = runner.invoke(app, ["skill", "--help"])
     assert r.exit_code == 0
-    for sub in ("list", "get"):
+    for sub in ("list", "get", "block", "unblock", "remove"):
         assert sub in r.stdout, f"missing subcommand in --help: {sub}"
 
 
-@pytest.mark.parametrize("subcmd", ["list", "get"])
+@pytest.mark.parametrize("subcmd", ["list", "get", "block", "unblock", "remove"])
 def test_skill_subcommand_help_works(subcmd: str) -> None:
     """Every skill subcommand exposes ``--help`` without crashing."""
     r = runner.invoke(app, ["skill", subcmd, "--help"])
@@ -131,3 +131,80 @@ def test_skill_get_with_body_renders_markdown(tmp_config: Path, monkeypatch: pyt
     r = runner.invoke(app, ["skill", "get", "alpha", "--with-body"])
     assert r.exit_code == 0
     assert "SKILL.md" in r.stdout
+
+
+# ============================================================================
+# skill block / unblock  (on-disk skillForge.blocklist)
+# ============================================================================
+
+
+def _read_blocklist(cfg: Path) -> list[str]:
+    import json
+
+    data = json.loads(cfg.read_text(encoding="utf-8"))
+    return data.get("skillForge", {}).get("blocklist", [])
+
+
+def test_skill_block_adds_to_config(tmp_config: Path) -> None:
+    r = runner.invoke(app, ["skill", "block", "tag-memory"])
+    assert r.exit_code == 0
+    assert "tag-memory" in r.stdout
+    assert _read_blocklist(tmp_config) == ["tag-memory"]
+
+
+def test_skill_block_is_idempotent_case_insensitive(tmp_config: Path) -> None:
+    runner.invoke(app, ["skill", "block", "tag-memory"])
+    r = runner.invoke(app, ["skill", "block", "Tag-Memory"])
+    assert r.exit_code == 0
+    assert _read_blocklist(tmp_config) == ["tag-memory"]
+
+
+def test_skill_unblock_removes_from_config(tmp_config: Path) -> None:
+    runner.invoke(app, ["skill", "block", "tag-memory"])
+    runner.invoke(app, ["skill", "block", "other"])
+    r = runner.invoke(app, ["skill", "unblock", "Tag-Memory"])
+    assert r.exit_code == 0
+    assert _read_blocklist(tmp_config) == ["other"]
+
+
+def test_skill_unblock_absent_is_noop(tmp_config: Path) -> None:
+    r = runner.invoke(app, ["skill", "unblock", "ghost"])
+    assert r.exit_code == 0
+
+
+# ============================================================================
+# skill remove  (installed Hub bundle dirs)
+# ============================================================================
+
+
+def _workspace_config(cfg: Path, tmp_path: Path) -> Path:
+    import json
+
+    ws = tmp_path / "ws"
+    (ws / "skills" / "hub").mkdir(parents=True)
+    cfg.write_text(
+        json.dumps({"agents": {"defaults": {"workspace": str(ws)}}}),
+        encoding="utf-8",
+    )
+    return ws
+
+
+def test_skill_remove_deletes_matching_bundles(tmp_config: Path, tmp_path: Path) -> None:
+    ws = _workspace_config(tmp_config, tmp_path)
+    bundle = ws / "skills" / "hub" / "tag-memory@v1"
+    bundle.mkdir()
+    (bundle / "SKILL.md").write_text("x", encoding="utf-8")
+    other = ws / "skills" / "hub" / "keep-me@v2"
+    other.mkdir()
+
+    r = runner.invoke(app, ["skill", "remove", "Tag-Memory", "--yes"])
+    assert r.exit_code == 0
+    assert not bundle.exists()
+    assert other.exists()
+
+
+def test_skill_remove_unknown_exits_1(tmp_config: Path, tmp_path: Path) -> None:
+    _workspace_config(tmp_config, tmp_path)
+    r = runner.invoke(app, ["skill", "remove", "ghost", "--yes"])
+    assert r.exit_code == 1
+    assert "No installed Hub bundle" in r.stdout

--- a/tests/test_skill_hub_policy.py
+++ b/tests/test_skill_hub_policy.py
@@ -6,7 +6,13 @@ import json
 from pathlib import Path
 
 from raven.skill_hub.audit import record_install
-from raven.skill_hub.policy import is_blocked, normalize_blocklist, refuses_low_safety
+from raven.skill_hub.policy import (
+    SkillPolicy,
+    is_blocked,
+    lint_external_paths,
+    normalize_blocklist,
+    refuses_low_safety,
+)
 
 
 class TestNormalizeBlocklist:
@@ -48,6 +54,52 @@ class TestRefusesLowSafety:
     def test_malformed_score_passes(self) -> None:
         assert not refuses_low_safety("n/a", 0.7)
         assert not refuses_low_safety({}, 0.7)
+
+
+class TestLintExternalPaths:
+    def test_empty_and_clean_bodies(self) -> None:
+        assert lint_external_paths(None) == []
+        assert lint_external_paths("") == []
+        assert lint_external_paths("run scripts/db.py --db ./data.db") == []
+
+    def test_own_dotdir_allowed(self) -> None:
+        assert lint_external_paths("state lives in ~/.raven/skills") == []
+
+    def test_foreign_dotdirs_flagged_deduped(self) -> None:
+        body = (
+            "python scripts/db.py --db ~/.openclaw/tag-memory/db.sqlite\n"
+            "or $HOME/.openclaw/config.json, also /Users/bob/.claude/skills\n"
+            "and /home/alice/.openclaw/x"
+        )
+        assert lint_external_paths(body) == ["~/.claude", "~/.openclaw"]
+
+
+class TestSkillPolicy:
+    def test_allows_clean_meta(self) -> None:
+        policy = SkillPolicy.create()
+        assert policy.refusal_for_detail({"slug": "ok", "score_safety": 0.9, "skill_md": "clean"}) is None
+
+    def test_refuses_in_order_blocklist_first(self) -> None:
+        policy = SkillPolicy.create(blocklist=["bad"])
+        reason = policy.refusal_for_detail({"slug": "bad", "score_safety": 0.1})
+        assert reason is not None and "blocklist" in reason
+
+    def test_refuses_low_safety(self) -> None:
+        policy = SkillPolicy.create(min_safety=0.7)
+        reason = policy.refusal_for_detail({"slug": "x", "score_safety": 0.2})
+        assert reason is not None and "score_safety" in reason
+
+    def test_refuses_external_paths_in_body(self) -> None:
+        policy = SkillPolicy.create()
+        reason = policy.refusal_for_detail(
+            {"slug": "tag-memory", "score_safety": 0.9, "skill_md": "write to ~/.openclaw/db"},
+        )
+        assert reason is not None and "~/.openclaw" in reason
+
+    def test_extra_identifiers_hit_blocklist(self) -> None:
+        policy = SkillPolicy.create(blocklist=["native-id"])
+        reason = policy.refusal_for_detail({}, "native-id")
+        assert reason is not None and "blocklist" in reason
 
 
 class TestRecordInstall:

--- a/tests/test_skill_hub_policy.py
+++ b/tests/test_skill_hub_policy.py
@@ -1,0 +1,66 @@
+"""Unit tests for the install-time policy helpers (policy.py + audit.py)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from raven.skill_hub.audit import record_install
+from raven.skill_hub.policy import is_blocked, normalize_blocklist, refuses_low_safety
+
+
+class TestNormalizeBlocklist:
+    def test_empty_and_none(self) -> None:
+        assert normalize_blocklist(None) == frozenset()
+        assert normalize_blocklist([]) == frozenset()
+        assert normalize_blocklist(["", "  "]) == frozenset()
+
+    def test_casefold_and_trim(self) -> None:
+        assert normalize_blocklist([" Tag-Memory ", "OTHER"]) == frozenset({"tag-memory", "other"})
+
+
+class TestIsBlocked:
+    def test_empty_blocklist_never_blocks(self) -> None:
+        assert not is_blocked(frozenset(), "anything")
+
+    def test_matches_any_identifier_case_insensitively(self) -> None:
+        bl = normalize_blocklist(["tag-memory"])
+        assert is_blocked(bl, "Tag-Memory")
+        assert is_blocked(bl, "other", "TAG-MEMORY")
+        assert not is_blocked(bl, "fine-skill", None)
+
+    def test_none_identifiers_ignored(self) -> None:
+        assert not is_blocked(normalize_blocklist(["x"]), None, None)
+
+
+class TestRefusesLowSafety:
+    def test_missing_score_passes(self) -> None:
+        assert not refuses_low_safety(None, 0.7)
+
+    def test_low_score_refused(self) -> None:
+        assert refuses_low_safety(0.2, 0.7)
+        assert refuses_low_safety("0.69", 0.7)
+
+    def test_at_or_above_bar_passes(self) -> None:
+        assert not refuses_low_safety(0.7, 0.7)
+        assert not refuses_low_safety(0.93, 0.7)
+
+    def test_malformed_score_passes(self) -> None:
+        assert not refuses_low_safety("n/a", 0.7)
+        assert not refuses_low_safety({}, 0.7)
+
+
+class TestRecordInstall:
+    def test_none_path_is_noop(self) -> None:
+        record_install(None, slug="x", trigger="use_skill")
+
+    def test_appends_jsonl_and_creates_parent(self, tmp_path: Path) -> None:
+        audit = tmp_path / "nested" / "installs.jsonl"
+        record_install(audit, slug="a", version="v1", trigger="auto_inject", score_safety=0.9)
+        record_install(audit, slug="b", trigger="use_skill", skill_dir="/tmp/b")
+        lines = [json.loads(line) for line in audit.read_text(encoding="utf-8").strip().splitlines()]
+        assert [r["slug"] for r in lines] == ["a", "b"]
+        assert lines[0]["trigger"] == "auto_inject"
+        assert lines[0]["score_safety"] == 0.9
+        assert lines[1]["dir"] == "/tmp/b"
+        assert all(r["ts"] for r in lines)

--- a/tests/test_skill_hub_tools.py
+++ b/tests/test_skill_hub_tools.py
@@ -241,6 +241,18 @@ class TestUseSkillSafetyPolicy:
         assert client.get_calls == ["foo"]
         assert client.install_meta == [{"score_safety": 0.9, "slug": "foo"}]
 
+    async def test_external_path_in_body_refused(self) -> None:
+        client = _FakeClient(
+            get_result={
+                "score_safety": 0.9,
+                "slug": "tag-memory",
+                "skill_md": "python scripts/db.py --db ~/.openclaw/db.sqlite",
+            },
+        )
+        out = await UseSkillTool(client=client).execute(skill_id="hub/tag-memory")
+        assert out.startswith("Error") and "~/.openclaw" in out
+        assert client.install_calls == []
+
     async def test_install_appends_audit_record(self, tmp_path: Path) -> None:
         import json
 

--- a/tests/test_skill_hub_tools.py
+++ b/tests/test_skill_hub_tools.py
@@ -35,6 +35,7 @@ class _FakeClient:
         self._raises = raises
         self.get_calls: list[str] = []
         self.install_calls: list[str] = []
+        self.install_meta: list[dict | None] = []
 
     async def get(self, skill_id: str):
         self.get_calls.append(skill_id)
@@ -42,8 +43,9 @@ class _FakeClient:
             raise RuntimeError("boom")
         return self._get_result
 
-    async def install(self, skill_id: str):
+    async def install(self, skill_id: str, *, prefetched_meta=None):
         self.install_calls.append(skill_id)
+        self.install_meta.append(prefetched_meta)
         if self._raises:
             raise RuntimeError("boom")
         return self._install_result
@@ -182,3 +184,77 @@ class TestUseSkill:
         client = _FakeClient(raises=True)
         out = await UseSkillTool(client=client).execute(skill_id="hub/foo")
         assert out.startswith("Error") and "failed to install" in out
+
+
+class TestUseSkillSafetyPolicy:
+    """Install-time policy: min_safety and blocklist must gate use_skill."""
+
+    async def test_low_safety_hub_skill_refused(self) -> None:
+        client = _FakeClient(
+            get_result={"score_safety": 0.2, "slug": "tag-memory", "skill_md": "evil"},
+            install_result={"slug": "tag-memory", "version": "v1", "skill_md": "evil"},
+        )
+        out = await UseSkillTool(client=client, min_safety=0.7).execute(
+            skill_id="hub/tag-memory",
+        )
+        assert out.startswith("Error")
+        assert "score_safety" in out
+        assert client.install_calls == []
+
+    async def test_score_missing_allows_install(self) -> None:
+        client = _FakeClient(
+            get_result={"slug": "foo"},
+            install_result={"slug": "foo", "version": "v1", "skill_md": "ok"},
+        )
+        out = await UseSkillTool(client=client, min_safety=0.7).execute(
+            skill_id="hub/foo",
+        )
+        assert not out.startswith("Error")
+        assert client.install_calls == ["foo"]
+
+    async def test_blocklisted_hub_skill_refused_before_network(self) -> None:
+        client = _FakeClient(get_result={"slug": "tag-memory"})
+        out = await UseSkillTool(client=client, blocklist=["Tag-Memory"]).execute(
+            skill_id="hub/tag-memory",
+        )
+        assert out.startswith("Error") and "blocklist" in out
+        assert client.get_calls == []
+        assert client.install_calls == []
+
+    async def test_blocklisted_local_skill_refused(self, tmp_path: Path) -> None:
+        meta = _meta(tmp_path, "x", "body", with_scripts=True)
+        reg = _FakeRegistry({("local", "x"): meta})
+        out = await UseSkillTool(registry=reg, blocklist=["x"]).execute(
+            skill_id="local/x",
+        )
+        assert out.startswith("Error") and "blocklist" in out
+
+    async def test_policy_pass_reuses_prefetched_meta(self) -> None:
+        client = _FakeClient(
+            get_result={"score_safety": 0.9, "slug": "foo"},
+            install_result={"slug": "foo", "version": "v1", "skill_md": "ok"},
+        )
+        out = await UseSkillTool(client=client, min_safety=0.7).execute(
+            skill_id="hub/foo",
+        )
+        assert not out.startswith("Error")
+        assert client.get_calls == ["foo"]
+        assert client.install_meta == [{"score_safety": 0.9, "slug": "foo"}]
+
+    async def test_install_appends_audit_record(self, tmp_path: Path) -> None:
+        import json
+
+        audit = tmp_path / "installs.jsonl"
+        client = _FakeClient(
+            get_result={"score_safety": 0.9, "slug": "foo", "version": "v2"},
+            install_result={"slug": "foo", "version": "v2", "skill_md": "ok", "dir": "/cache/foo"},
+        )
+        out = await UseSkillTool(
+            client=client,
+            min_safety=0.7,
+            install_audit_path=audit,
+        ).execute(skill_id="hub/foo")
+        assert not out.startswith("Error")
+        rec = json.loads(audit.read_text(encoding="utf-8").strip())
+        assert rec["slug"] == "foo"
+        assert rec["trigger"] == "use_skill"

--- a/tests/test_skill_segment_builder.py
+++ b/tests/test_skill_segment_builder.py
@@ -405,9 +405,7 @@ async def test_hub_hit_with_external_paths_dropped() -> None:
     """A hub skill whose body points at another product's home dotdir is
     dropped at the same policy point as the safety bar."""
     src = _StubSource("hub", [_hit("hub/tm1", "tag-memory")])
-    hub = _StubHubClient(
-        {"tm1": {"skill_md": "store at ~/.openclaw/tag-memory/db.sqlite", "score_safety": 0.9}}
-    )
+    hub = _StubHubClient({"tm1": {"skill_md": "store at ~/.openclaw/tag-memory/db.sqlite", "score_safety": 0.9}})
     builder = SkillsSegmentBuilder(SkillForgeRouter([src]), hub_client=hub)
     seg = await builder.build(_ctx("remember this"))
     assert "tag-memory" not in (seg.text or "")

--- a/tests/test_skill_segment_builder.py
+++ b/tests/test_skill_segment_builder.py
@@ -347,3 +347,76 @@ async def test_get_tool_names_extracts_from_openai_schema() -> None:
     )
     await builder.build(_ctx("task"))
     assert captured == [["read_file", "exec", "flat_form"]]
+
+
+# ----------------------------------------------------------------------
+# Safety policy — min_safety after detail hydrate, blocklist, install audit
+# ----------------------------------------------------------------------
+
+
+async def test_low_safety_hub_hit_dropped_after_hydrate() -> None:
+    """A hub skill whose detail metadata carries a score_safety below the
+    bar must be dropped from the pool: never injected, never installed."""
+    src = _StubSource("hub", [_hit("hub/bad1", "tag-memory")])
+    hub = _StubHubClient({"bad1": {"skill_md": "evil body", "score_safety": 0.2}})
+    builder = SkillsSegmentBuilder(SkillForgeRouter([src]), hub_client=hub)
+    seg = await builder.build(_ctx("remember this"))
+    assert "tag-memory" not in (seg.text or "")
+    assert "evil body" not in (seg.text or "")
+    assert hub.install_calls == []
+    assert seg.meta["injected_skill_ids"] == []
+
+
+async def test_safe_hub_hit_still_injected() -> None:
+    src = _StubSource("hub", [_hit("hub/good1", "good-skill")])
+    hub = _StubHubClient({"good1": {"skill_md": "safe body", "score_safety": 0.93}})
+    builder = SkillsSegmentBuilder(SkillForgeRouter([src]), hub_client=hub)
+    seg = await builder.build(_ctx("remember this"))
+    assert "good-skill" in seg.text
+    assert len(hub.install_calls) == 1
+
+
+async def test_hub_hit_without_score_passes() -> None:
+    """Deployments whose detail payload omits score_safety keep working."""
+    src = _StubSource("hub", [_hit("hub/nos1", "scoreless")])
+    hub = _StubHubClient({"nos1": {"skill_md": "body"}})
+    builder = SkillsSegmentBuilder(SkillForgeRouter([src]), hub_client=hub)
+    seg = await builder.build(_ctx("remember this"))
+    assert "scoreless" in seg.text
+
+
+async def test_blocklisted_hit_dropped_any_source() -> None:
+    """Blocklist drops matching candidates from every source before the
+    gate, case-insensitively."""
+    local = _StubSource("local", [_hit("local/tm", "Tag-Memory", "local body")])
+    hub = _StubSource("hub", [_hit("hub/ok", "fine-skill")])
+    client = _StubHubClient({"ok": {"skill_md": "fine body", "score_safety": 0.9}})
+    builder = SkillsSegmentBuilder(
+        SkillForgeRouter([local, hub]),
+        hub_client=client,
+        blocklist=["tag-memory"],
+    )
+    seg = await builder.build(_ctx("remember this"))
+    assert "Tag-Memory" not in seg.text
+    assert "fine-skill" in seg.text
+
+
+async def test_hub_auto_install_appends_audit_record(tmp_path: Path) -> None:
+    audit = tmp_path / "installs.jsonl"
+    src = _StubSource("hub", [_hit("hub/good1", "good-skill")])
+    hub = _StubHubClient(
+        {"good1": {"skill_md": "safe body", "score_safety": 0.9, "slug": "good-skill", "version": "v3"}}
+    )
+    builder = SkillsSegmentBuilder(
+        SkillForgeRouter([src]),
+        hub_client=hub,
+        install_audit_path=audit,
+    )
+    await builder.build(_ctx("remember this"))
+    lines = audit.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["slug"] == "good-skill"
+    assert rec["trigger"] == "auto_inject"
+    assert rec["score_safety"] == 0.9
+    assert rec["ts"]

--- a/tests/test_skill_segment_builder.py
+++ b/tests/test_skill_segment_builder.py
@@ -414,6 +414,38 @@ async def test_hub_hit_with_external_paths_dropped() -> None:
     assert hub.install_calls == []
 
 
+class _FlakyGetClient(_StubHubClient):
+    """get() always fails transiently; install() would succeed if reached."""
+
+    async def get(self, skill_id: str) -> dict[str, Any]:
+        self.get_calls.append(skill_id)
+        raise RuntimeError("transient 503")
+
+
+async def test_hub_hit_dropped_when_detail_fetch_fails() -> None:
+    """A hub candidate whose detail fetch fails is unvetted and must be
+    dropped: leaving it in the pool lets the post-gate step call
+    install(prefetched_meta=None), whose internal re-fetch bypasses
+    SkillPolicy entirely."""
+    src = _StubSource("hub", [_hit("hub/flaky1", "flaky-skill")])
+    hub = _FlakyGetClient({"flaky1": {"skill_md": "body", "score_safety": 0.2, "slug": "flaky-skill"}})
+    builder = SkillsSegmentBuilder(SkillForgeRouter([src]), hub_client=hub)
+    seg = await builder.build(_ctx("remember this"))
+    assert "flaky-skill" not in (seg.text or "")
+    assert hub.install_calls == []
+
+
+async def test_hub_hit_without_vetted_meta_never_installs() -> None:
+    """A hub hit that skipped the hydrate (content prefilled) carries no
+    vetted detail metadata; the install step must refuse rather than let
+    install() re-fetch unvetted."""
+    src = _StubSource("hub", [_hit("hub/pre1", "prefilled", "already has body")])
+    hub = _StubHubClient({"pre1": {"skill_md": "already has body", "score_safety": 0.9}})
+    builder = SkillsSegmentBuilder(SkillForgeRouter([src]), hub_client=hub)
+    await builder.build(_ctx("remember this"))
+    assert hub.install_calls == []
+
+
 async def test_hub_auto_install_appends_audit_record(tmp_path: Path) -> None:
     audit = tmp_path / "installs.jsonl"
     src = _StubSource("hub", [_hit("hub/good1", "good-skill")])

--- a/tests/test_skill_segment_builder.py
+++ b/tests/test_skill_segment_builder.py
@@ -401,6 +401,19 @@ async def test_blocklisted_hit_dropped_any_source() -> None:
     assert "fine-skill" in seg.text
 
 
+async def test_hub_hit_with_external_paths_dropped() -> None:
+    """A hub skill whose body points at another product's home dotdir is
+    dropped at the same policy point as the safety bar."""
+    src = _StubSource("hub", [_hit("hub/tm1", "tag-memory")])
+    hub = _StubHubClient(
+        {"tm1": {"skill_md": "store at ~/.openclaw/tag-memory/db.sqlite", "score_safety": 0.9}}
+    )
+    builder = SkillsSegmentBuilder(SkillForgeRouter([src]), hub_client=hub)
+    seg = await builder.build(_ctx("remember this"))
+    assert "tag-memory" not in (seg.text or "")
+    assert hub.install_calls == []
+
+
 async def test_hub_auto_install_appends_audit_record(tmp_path: Path) -> None:
     audit = tmp_path / "installs.jsonl"
     src = _StubSource("hub", [_hit("hub/good1", "good-skill")])


### PR DESCRIPTION
## Summary

Fixes a critical skill hub supply-chain gap: a low-quality or
malicious hub skill could be silently installed and take over a core
capability with zero user awareness, because no install-time policy
existed anywhere between hub content and host execution.

What was broken:

- The `min_safety` guard was a no-op on the standard path: the catalog
  payload omits `score_safety` (it only exists in the detail response),
  and nothing checked the detail-level score. The config docstring
  claimed `use_skill` refuses low-scored skills; the implementation had
  no such check.
- The post-gate hydrate installed hub bundles silently on the context
  assembly hot path: no notification, no audit trail, no uninstall.
- No operator kill switch existed for a bad skill, and a skill body
  pointing at another product's home dotdir (the tag-memory
  `~/.openclaw` incident) installed without objection.

What this PR adds, in two commits:

1. `fix(*)`: enforce the safety bar on both install paths. The segment
   builder drops hub hits whose detail `score_safety` is below
   `min_safety` right after the pre-gate hydrate (the first place the
   score is actually available), and `use_skill` refuses before
   download, reusing the vetted detail metadata as `prefetched_meta` so
   no extra round-trip is added. Adds `skillForge.blocklist` (dropped
   from the pool for every source, case-insensitive) plus an install
   audit JSONL and a one-line install notice on both paths.
2. `feat(*)`: consolidate all checks into a single `SkillPolicy`
   chokepoint (`raven/skill_hub/policy.py`) that both install paths
   consult: blocklist, safety bar, and a new external home-dotdir lint
   that refuses skills referencing foreign product directories rather
   than rewriting them. Adds `raven skill block/unblock/remove` for the
   operator lifecycle.

Release note for existing installs: users who already have tag-memory
on disk should run `raven skill block tag-memory && raven skill remove
tag-memory --yes` after upgrading; a server-side takedown cannot clean
already-installed bundles.

Follow-ups tracked outside this PR: server-side takedown and publish CI,
`score_safety` in the catalog payload, and the `autoInstall`
prompt/auto/off consent modes (stacked PR `feat/skill_consent_visibility`
builds on this branch).

## Type

- [x] Fix
- [x] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_skill_hub_policy.py tests/test_skill_segment_builder.py tests/test_skill_hub_tools.py tests/test_cli_skill_commands.py -q` - 79 passed (41 new tests, written failing-first to reproduce the gap)
- `uv run pytest -q` on this branch rebased onto upstream main (cd68645) - 1 failed / 6186 passed; the single failure is the documented pre-existing red (`test_read_file_image.py::test_image_block_is_the_only_place_the_shape_is_written`, see `.design/94b-upstream-baseline-failures.txt`), zero regression from this change
- `uv run ruff check` on all touched files - clean
- Isolated real-machine acceptance (fresh HOME, real LLM, local hub stub mirroring the real catalog shape): low-score skill dropped with zero disk writes and no foreign dotdir created; a 0.9-scored skill with a foreign-path body refused by the lint alone; blocklist enforced for hub hits and for an already-installed copy surfacing via the local registry; `use_skill` refusal verified with the model actively calling it; install audit record written; `skill remove` deletes the bundle

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [ ] Rollback path is clear for risky changes

Security: this PR is itself a security hardening; the lint refuses
rather than rewrites, so no third-party content is modified.
Backward compatibility: deployments whose detail payload omits
`score_safety` keep working (missing score passes); `blocklist`
defaults to empty; the audit file is append-only and best-effort.
Rollback: revert the two commits; no data migration involved.

## Related Issues

N/A - found in an internal security review of the skill hub; no tracked GitHub issues.

