### PR TITLE
feat(*): autoInstall consent mode, install metadata, and blocklist coverage

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -429,6 +429,15 @@ skill body (`~/.raven` is allowed; any other dotdir reference refuses the instal
 candidate whose detail fetch fails is unvetted and dropped — it never reaches `install()`.
 Every install that passes is appended to a JSONL audit trail
 (`<workspace>/skills/hub/installs.jsonl`, `skill_hub/audit.py`).
+`install_skip_reason()` is the separate operator-consent gate over the bundle download
+itself (`skillForge.autoInstall`: `auto` / `prompt` / `off`), consulted by both call sites
+right before `install()`, after all safety vetting. A consent decline is a **skip**, not a
+refusal: the already-vetted skill body still injects (and `read_skill` still works), only
+the on-disk bundle is withheld. Alongside the JSONL trail, a passing install stamps a
+one-time `.install-meta.json` into the skill directory (`write_install_meta`, first
+install wins) — the O(1) provenance source behind `raven skill list`'s Installed column.
+_Avoid_: calling an autoInstall skip a "refusal" or "block" — refusals are safety verdicts
+on the skill; a skip is withheld operator consent for the download.
 
 **Episode**:
 A distilled event note the Consolidation step writes to `episodes.md`.

--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -487,6 +487,7 @@ class AgentLoop:
             getattr(getattr(skill_forge_router_config, "hub", None), "min_safety", 0.7),
         )
         self._skill_blocklist = list(getattr(skill_forge_config, "blocklist", None) or [])
+        self._skill_auto_install = str(getattr(skill_forge_config, "auto_install", "auto") or "auto")
 
         self.context_engine: "ContextEngine" = build_context_engine(
             workspace=workspace,
@@ -865,6 +866,7 @@ class AgentLoop:
                     registry=skill_registry,
                     min_safety=self._skill_min_safety,
                     blocklist=self._skill_blocklist,
+                    auto_install=self._skill_auto_install,
                     install_audit_path=(
                         self.workspace / "skills" / "hub" / "installs.jsonl"
                         if self._skill_hub_client is not None

--- a/raven/agent/tools/skill_hub.py
+++ b/raven/agent/tools/skill_hub.py
@@ -31,7 +31,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from raven.agent.tools.base import Tool
-from raven.skill_hub.audit import record_install
+from raven.skill_hub.audit import record_install, write_install_meta
 from raven.skill_hub.policy import SkillPolicy, is_blocked
 
 if TYPE_CHECKING:
@@ -243,6 +243,12 @@ class UseSkillTool(Tool):
             trigger="use_skill",
             score_safety=score,
             skill_dir=info.get("dir"),
+        )
+        write_install_meta(
+            info.get("dir"),
+            slug=str(info.get("slug") or slug),
+            version=str(info.get("version") or ""),
+            trigger="use_skill",
         )
         logger.warning(
             "installed hub skill %s@%s via use_skill (score_safety=%s)",

--- a/raven/agent/tools/skill_hub.py
+++ b/raven/agent/tools/skill_hub.py
@@ -135,11 +135,16 @@ class UseSkillTool(Tool):
         *,
         min_safety: float = 0.7,
         blocklist: "Iterable[str] | None" = None,
+        auto_install: str = "auto",
         install_audit_path: "Path | None" = None,
     ) -> None:
         self._client = client
         self._registry = registry
-        self._policy = SkillPolicy.create(min_safety=min_safety, blocklist=blocklist)
+        self._policy = SkillPolicy.create(
+            min_safety=min_safety,
+            blocklist=blocklist,
+            auto_install=auto_install,
+        )
         self._install_audit_path = install_audit_path
 
     @property
@@ -221,6 +226,11 @@ class UseSkillTool(Tool):
         refusal = self._policy.refusal_for_detail(meta, native)
         if refusal is not None:
             return f"Error: refusing to install hub skill: {refusal}."
+
+        skip = self._policy.install_skip_reason(slug)
+        if skip is not None:
+            logger.info("use_skill install skipped: %s", skip)
+            return f"Skill install skipped: {skip}. Use read_skill to view the skill body."
 
         try:
             info = await self._client.install(native, prefetched_meta=meta)

--- a/raven/agent/tools/skill_hub.py
+++ b/raven/agent/tools/skill_hub.py
@@ -227,7 +227,7 @@ class UseSkillTool(Tool):
         if refusal is not None:
             return f"Error: refusing to install hub skill: {refusal}."
 
-        skip = self._policy.install_skip_reason(slug)
+        skip = await self._policy.install_skip_reason(slug)
         if skip is not None:
             logger.info("use_skill install skipped: %s", skip)
             return f"Skill install skipped: {skip}. Use read_skill to view the skill body."

--- a/raven/cli/skill_commands.py
+++ b/raven/cli/skill_commands.py
@@ -19,10 +19,14 @@ Lifecycle management (Hub install policy):
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import typer
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.table import Table
+from rich.text import Text
 
 console = Console()
 
@@ -36,8 +40,39 @@ def _build_skill_service():
 
     config = load_config()
     workspace = config.workspace_path
-    sf_cfg = getattr(config, "skill_forge", None)
+    sf_cfg = _load_skill_forge_config() or getattr(config, "skill_forge", None)
     return LocalSkillCatalog(workspace, config=sf_cfg, start_watcher=False)
+
+
+def _load_skill_forge_config():
+    """The on-disk extension-block SkillForgeConfig, or ``None``.
+
+    The base ``Config.skill_forge`` property only ever returns defaults —
+    user-set fields like ``blocklist`` live in the extension block that
+    ``load_raven_config`` reads.
+    """
+    try:
+        from raven.config.raven import load_raven_config
+
+        return load_raven_config().skill_forge
+    except Exception:
+        return None
+
+
+def _install_meta_cell(skill_md_path) -> str:
+    """``YYYY-MM-DD (source)`` from the skill dir's ``.install-meta.json``,
+    or an empty cell for skills without an install stamp."""
+    if not skill_md_path:
+        return ""
+    try:
+        record = json.loads(
+            (Path(str(skill_md_path)).parent / ".install-meta.json").read_text(encoding="utf-8"),
+        )
+    except (OSError, ValueError):
+        return ""
+    installed_at = str(record.get("installed_at") or "")[:10]
+    source = str(record.get("source") or "hub")
+    return f"{installed_at} ({source})" if installed_at else f"({source})"
 
 
 @skill_app.command("list")
@@ -58,13 +93,20 @@ def skill_list(
         console.print("[dim]No skills found.[/dim]")
         return
 
+    from raven.skill_hub.policy import is_blocked, normalize_blocklist
+
+    blocked = normalize_blocklist(getattr(_load_skill_forge_config(), "blocklist", None))
     table = Table(title=f"Skills ({len(metas)})")
     table.add_column("Name", style="cyan")
     table.add_column("Source", style="green")
     table.add_column("Description", overflow="fold")
+    table.add_column("Installed", style="dim")
     for m in metas:
         desc = (m.description or "")[:120]
-        table.add_row(m.name, m.source, desc)
+        name_cell = Text(m.name)
+        if is_blocked(blocked, m.name):
+            name_cell.append(" [blocked]", style="bold red")
+        table.add_row(name_cell, m.source, desc, _install_meta_cell(getattr(m, "path", None)))
     console.print(table)
 
 

--- a/raven/config/raven.py
+++ b/raven/config/raven.py
@@ -811,6 +811,15 @@ class SkillForgeConfig(_Base):
     ``use_skill``. Matched case-insensitively against the skill's name,
     slug, and native id."""
 
+    auto_install: Literal["auto", "prompt", "off"] = "auto"
+    """Consent policy for Hub bundle downloads (config key
+    ``skillForge.autoInstall``), applied on both install paths (context
+    auto-inject and ``use_skill``). ``auto`` installs silently (current
+    behavior); ``prompt`` asks for confirmation on an interactive
+    terminal and behaves like ``off`` when no TTY is attached; ``off``
+    skips the download with a one-line notice — skill bodies still
+    inject, only the on-disk bundle is withheld."""
+
     router: "SkillForgeRouterConfig" = Field(
         default_factory=lambda: SkillForgeRouterConfig(),
     )

--- a/raven/context_engine/factory.py
+++ b/raven/context_engine/factory.py
@@ -135,6 +135,7 @@ def build_context_engine(
             get_tool_definitions=get_tool_definitions,
             min_safety=skill_forge_router_config.hub.min_safety,
             blocklist=(getattr(skill_forge_config, "blocklist", None) if skill_forge_config is not None else None),
+            auto_install=str(getattr(skill_forge_config, "auto_install", "auto") or "auto"),
             install_audit_path=(
                 workspace / "skills" / "hub" / "installs.jsonl" if skill_hub_client is not None else None
             ),

--- a/raven/context_engine/segments/skills.py
+++ b/raven/context_engine/segments/skills.py
@@ -69,6 +69,7 @@ class SkillsSegmentBuilder:
         get_tool_definitions: "Any | None" = None,
         min_safety: float = 0.7,
         blocklist: "Iterable[str] | None" = None,
+        auto_install: str = "auto",
         install_audit_path: "Path | None" = None,
     ) -> None:
         self._router = router
@@ -81,7 +82,11 @@ class SkillsSegmentBuilder:
         self._pool_size = gate_pool_size if gate is not None else skill_top_k
         self._hub_client = hub_client
         self._get_tool_definitions = get_tool_definitions
-        self._policy = SkillPolicy.create(min_safety=min_safety, blocklist=blocklist)
+        self._policy = SkillPolicy.create(
+            min_safety=min_safety,
+            blocklist=blocklist,
+            auto_install=auto_install,
+        )
         self._install_audit_path = install_audit_path
         self._audited_installs: set[str] = set()
 
@@ -256,6 +261,13 @@ class SkillsSegmentBuilder:
                         "skipping install for %s: no vetted detail metadata",
                         h.qualified_id,
                     )
+                    return h
+                skip = self._policy.install_skip_reason(h.name)
+                if skip is not None:
+                    # Consent skip, not a failure: the body already
+                    # hydrated in step ③ still injects — only the bundle
+                    # download is withheld.
+                    log.info("hub auto-install skipped: %s", skip)
                     return h
                 try:
                     installed = await self._hub_client.install(

--- a/raven/context_engine/segments/skills.py
+++ b/raven/context_engine/segments/skills.py
@@ -262,7 +262,7 @@ class SkillsSegmentBuilder:
                         h.qualified_id,
                     )
                     return h
-                skip = self._policy.install_skip_reason(h.name)
+                skip = await self._policy.install_skip_reason(h.name)
                 if skip is not None:
                     # Consent skip, not a failure: the body already
                     # hydrated in step ③ still injects — only the bundle

--- a/raven/context_engine/segments/skills.py
+++ b/raven/context_engine/segments/skills.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING, Any
 from raven.context_engine.base import AssemblyContext, Segment
 from raven.context_engine.segments import render
 from raven.memory_engine.skill_forge.refs import resolve_refs
-from raven.skill_hub.audit import record_install
+from raven.skill_hub.audit import record_install, write_install_meta
 from raven.skill_hub.policy import SkillPolicy, is_blocked
 from raven.tracing import semconv, trace
 
@@ -326,6 +326,12 @@ class SkillsSegmentBuilder:
             trigger="auto_inject",
             score_safety=score,
             skill_dir=installed.get("dir"),
+        )
+        write_install_meta(
+            installed.get("dir"),
+            slug=slug,
+            version=version,
+            trigger="auto_inject",
         )
 
     def _collect_tool_names(self) -> list[str] | None:

--- a/raven/memory_engine/skill_forge/catalog.py
+++ b/raven/memory_engine/skill_forge/catalog.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 from raven.memory_engine.skill_local.local_pool import LocalPool
 from raven.memory_engine.skill_local.registry import SkillRegistry
 from raven.memory_engine.skill_local.types import SkillMeta
+from raven.skill_hub.policy import is_blocked, normalize_blocklist
 
 log = logging.getLogger(__name__)
 
@@ -73,10 +74,23 @@ class LocalSkillCatalog:
         )
 
         self._config = config
+        self._blocklist = normalize_blocklist(getattr(config, "blocklist", None))
 
         # Local-pool BM25 retrieval over file-based skills (workspace +
-        # builtin). Always available — no model, no GPU.
-        self._local_pool = LocalPool(self._registry)
+        # builtin). Always available — no model, no GPU. Blocklisted
+        # skills are hidden from the index via a filtered registry view
+        # so they never surface through retrieval; the router pool drop
+        # in SkillsSegmentBuilder stays the backstop for other sources.
+        pool_registry: Any = self._registry
+        if self._blocklist:
+            skipped = sorted({m.name for m in self._registry.list_all() if self._is_blocked(m.name)})
+            if skipped:
+                log.info(
+                    "skill blocklist: hiding blocked skill(s) from the local pool: %s",
+                    ", ".join(skipped),
+                )
+            pool_registry = _BlocklistRegistryView(self._registry, self._blocklist)
+        self._local_pool = LocalPool(pool_registry)
 
         # Background SKILL.md watcher. Auto-started by default so the
         # common long-lived consumer (ContextBuilder) picks up hand-edits
@@ -97,6 +111,9 @@ class LocalSkillCatalog:
             self.start_file_watcher()
 
     # ── Pool/registry access (for LocalSkillSource) ──────────────────
+
+    def _is_blocked(self, name: str) -> bool:
+        return is_blocked(self._blocklist, name)
 
     @property
     def registry(self) -> SkillRegistry:
@@ -213,7 +230,9 @@ class LocalSkillCatalog:
         # within each layer by discovery order.  Sort stably by
         # (source priority, name) so truncation is predictable.
         all_always = [
-            m for m in self._registry.list_all() if m.always and self._registry.check_available(m.name, source=m.source)
+            m
+            for m in self._registry.list_all()
+            if m.always and not self._is_blocked(m.name) and self._registry.check_available(m.name, source=m.source)
         ]
         all_always.sort(key=lambda m: (m.source, m.name))
         cap = int(getattr(self._config, "always_max", 5) or 5)
@@ -263,7 +282,7 @@ class LocalSkillCatalog:
             skills = resolved
         parts: list[str] = []
         for m in skills:
-            if not m.content:
+            if not m.content or self._is_blocked(m.name):
                 continue
             body = m.content
             # db-only rows without on-disk assets get a synthetic
@@ -398,6 +417,7 @@ class LocalSkillCatalog:
                         resolved.append(meta)
                 only = resolved
             metas = list(only)
+        metas = [m for m in metas if not self._is_blocked(m.name)]
         if not metas:
             return ""
 
@@ -426,8 +446,9 @@ class LocalSkillCatalog:
         (workspace, builtin, external mirrors).
 
         Used by CLI ``skill list`` / inspection helpers — gathers
-        everything unranked. Hot-path retrieval goes through
-        :class:`SkillForgeRouter` instead.
+        everything unranked, deliberately including blocklisted skills so
+        inspection can show a blocked-but-present skill. Hot-path
+        retrieval goes through :class:`SkillForgeRouter` instead.
         """
         return self._registry.list_all()
 
@@ -438,6 +459,22 @@ class LocalSkillCatalog:
     ) -> SkillMeta | None:
         """Resolve a (name, source) to a ``SkillMeta`` via the local registry."""
         return self._registry.get(name, source=source)
+
+
+class _BlocklistRegistryView:
+    """Registry proxy handed to :class:`LocalPool` — hides blocklisted
+    skills from the BM25 index while delegating everything else to the
+    real registry, so index rebuilds keep flowing through unchanged."""
+
+    def __init__(self, registry: SkillRegistry, blocklist: frozenset[str]) -> None:
+        self._registry = registry
+        self._blocklist = blocklist
+
+    def list_all(self) -> list[SkillMeta]:
+        return [m for m in self._registry.list_all() if not is_blocked(self._blocklist, m.name)]
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._registry, item)
 
 
 # ----------------------------------------------------------------------

--- a/raven/skill_hub/audit.py
+++ b/raven/skill_hub/audit.py
@@ -5,6 +5,15 @@ auto-inject path and explicit ``use_skill`` calls — so an operator can
 answer "what third-party code landed on this machine, when, and why".
 Best-effort by design: an audit write failure must never take down the
 install itself.
+
+Two artifacts with one writer each per install:
+
+- ``installs.jsonl`` (:func:`record_install`) — the append-only fact
+  stream, one line per observed install event.
+- ``.install-meta.json`` (:func:`write_install_meta`) — a single stamp
+  inside the skill directory itself, the O(1) provenance source for
+  ``raven skill list`` (no log scan needed). First install wins; later
+  observations of the same bundle never rewrite it.
 """
 
 from __future__ import annotations
@@ -45,4 +54,38 @@ def record_install(
         logger.warning("failed to append skill install audit record to %s", path, exc_info=True)
 
 
-__all__ = ["record_install"]
+def write_install_meta(
+    skill_dir: Path | str | None,
+    *,
+    slug: str,
+    version: str = "",
+    trigger: str,
+    source: str = "hub",
+) -> None:
+    """Stamp ``.install-meta.json`` into the skill directory, once.
+
+    An existing stamp is never rewritten (first install wins), so
+    ``installed_at`` keeps pointing at the original install even though
+    both call sites re-observe cached bundles on later turns. The target
+    directory is not created: no bundle directory means nothing was
+    installed there, so there is nothing to stamp.
+    """
+    if not skill_dir:
+        return
+    path = Path(skill_dir) / ".install-meta.json"
+    if path.exists():
+        return
+    record = {
+        "slug": slug,
+        "version": version,
+        "source": source,
+        "trigger": trigger,
+        "installed_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    try:
+        path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    except OSError:
+        logger.warning("failed to write install meta to %s", path, exc_info=True)
+
+
+__all__ = ["record_install", "write_install_meta"]

--- a/raven/skill_hub/policy.py
+++ b/raven/skill_hub/policy.py
@@ -121,10 +121,7 @@ class SkillPolicy:
             except (AttributeError, ValueError):
                 interactive = False
             if not interactive:
-                return (
-                    f"skill {name!r}: skillForge.autoInstall is 'prompt' "
-                    "but no interactive terminal is attached"
-                )
+                return f"skill {name!r}: skillForge.autoInstall is 'prompt' but no interactive terminal is attached"
             answer = input(f"Install skill {name!r} from the Skill Hub? [y/N] ")
             if answer.strip().casefold() in ("y", "yes"):
                 return None

--- a/raven/skill_hub/policy.py
+++ b/raven/skill_hub/policy.py
@@ -24,6 +24,7 @@ package is extracted for reuse outside Raven.
 
 from __future__ import annotations
 
+import asyncio
 import re
 import sys
 from dataclasses import dataclass, field
@@ -88,6 +89,12 @@ class SkillPolicy:
     min_safety: float = 0.7
     blocklist: frozenset[str] = field(default_factory=frozenset)
     auto_install: str = "auto"
+    _prompt_lock: asyncio.Lock = field(
+        default_factory=asyncio.Lock,
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
     @classmethod
     def create(
@@ -103,7 +110,7 @@ class SkillPolicy:
             auto_install=auto_install,
         )
 
-    def install_skip_reason(self, name: str) -> str | None:
+    async def install_skip_reason(self, name: str) -> str | None:
         """Consent reason to skip a Hub bundle download, or ``None`` to
         proceed (``skillForge.autoInstall``).
 
@@ -112,6 +119,11 @@ class SkillPolicy:
         declined; any other value (``auto`` included) proceeds. Distinct
         from :meth:`refusal_for_detail`: this is operator consent for the
         download itself, not a safety verdict on the skill.
+
+        Async on purpose: both install paths run on the agent's shared
+        event loop, so the blocking stdin read happens on a worker thread
+        (``asyncio.to_thread``); the per-policy lock keeps concurrently
+        gathered hydrates from interleaving two prompts on one stdin.
         """
         if self.auto_install == "off":
             return f"skill {name!r}: skillForge.autoInstall is 'off'"
@@ -122,7 +134,8 @@ class SkillPolicy:
                 interactive = False
             if not interactive:
                 return f"skill {name!r}: skillForge.autoInstall is 'prompt' but no interactive terminal is attached"
-            answer = input(f"Install skill {name!r} from the Skill Hub? [y/N] ")
+            async with self._prompt_lock:
+                answer = await asyncio.to_thread(input, f"Install skill {name!r} from the Skill Hub? [y/N] ")
             if answer.strip().casefold() in ("y", "yes"):
                 return None
             return f"skill {name!r}: install declined at the autoInstall prompt"

--- a/raven/skill_hub/policy.py
+++ b/raven/skill_hub/policy.py
@@ -14,6 +14,9 @@ one :class:`SkillPolicy` decision before any ``SkillHubClient.install``:
 - an external-home-directory lint over the skill body: a hub skill whose
   instructions point at another product's dotdir (``~/.openclaw`` and
   friends) is refused rather than rewritten.
+- the ``skillForge.autoInstall`` consent gate over the bundle download
+  itself (``auto`` / ``prompt`` / ``off``), consulted right before an
+  install would start.
 
 Stdlib-only on purpose: this module ships with the client when the
 package is extracted for reuse outside Raven.
@@ -22,6 +25,7 @@ package is extracted for reuse outside Raven.
 from __future__ import annotations
 
 import re
+import sys
 from dataclasses import dataclass, field
 from typing import Any, Iterable
 
@@ -83,10 +87,49 @@ class SkillPolicy:
 
     min_safety: float = 0.7
     blocklist: frozenset[str] = field(default_factory=frozenset)
+    auto_install: str = "auto"
 
     @classmethod
-    def create(cls, *, min_safety: float = 0.7, blocklist: Iterable[str] | None = None) -> "SkillPolicy":
-        return cls(min_safety=min_safety, blocklist=normalize_blocklist(blocklist))
+    def create(
+        cls,
+        *,
+        min_safety: float = 0.7,
+        blocklist: Iterable[str] | None = None,
+        auto_install: str = "auto",
+    ) -> "SkillPolicy":
+        return cls(
+            min_safety=min_safety,
+            blocklist=normalize_blocklist(blocklist),
+            auto_install=auto_install,
+        )
+
+    def install_skip_reason(self, name: str) -> str | None:
+        """Consent reason to skip a Hub bundle download, or ``None`` to
+        proceed (``skillForge.autoInstall``).
+
+        ``off`` always skips; ``prompt`` asks on an interactive stdin and
+        behaves like ``off`` when no TTY is attached or the prompt is
+        declined; any other value (``auto`` included) proceeds. Distinct
+        from :meth:`refusal_for_detail`: this is operator consent for the
+        download itself, not a safety verdict on the skill.
+        """
+        if self.auto_install == "off":
+            return f"skill {name!r}: skillForge.autoInstall is 'off'"
+        if self.auto_install == "prompt":
+            try:
+                interactive = sys.stdin is not None and sys.stdin.isatty()
+            except (AttributeError, ValueError):
+                interactive = False
+            if not interactive:
+                return (
+                    f"skill {name!r}: skillForge.autoInstall is 'prompt' "
+                    "but no interactive terminal is attached"
+                )
+            answer = input(f"Install skill {name!r} from the Skill Hub? [y/N] ")
+            if answer.strip().casefold() in ("y", "yes"):
+                return None
+            return f"skill {name!r}: install declined at the autoInstall prompt"
+        return None
 
     def refusal_for_detail(
         self,

--- a/tests/test_cli_skill_commands.py
+++ b/tests/test_cli_skill_commands.py
@@ -133,6 +133,53 @@ def test_skill_get_with_body_renders_markdown(tmp_config: Path, monkeypatch: pyt
     assert "SKILL.md" in r.stdout
 
 
+def test_skill_list_shows_installed_column(
+    tmp_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Skills whose dir carries .install-meta.json get an Installed cell
+    of the form ``YYYY-MM-DD (source)``; others stay blank."""
+    import json
+
+    skill_dir = tmp_path / "foo@v1"
+    skill_dir.mkdir()
+    (skill_dir / ".install-meta.json").write_text(
+        json.dumps({"installed_at": "2026-08-16T00:00:00+00:00", "source": "hub"}),
+        encoding="utf-8",
+    )
+    installed = SimpleNamespace(
+        name="foo", source="workspace", description="d", path=skill_dir / "SKILL.md"
+    )
+    fake_svc = SimpleNamespace(gather_all_skills=lambda: [installed, _make_meta("bare", desc="d")])
+    monkeypatch.setattr("raven.cli.skill_commands._build_skill_service", lambda: fake_svc)
+
+    r = runner.invoke(app, ["skill", "list"])
+    assert r.exit_code == 0
+    assert "Installed" in r.stdout
+    assert "2026-08-16" in r.stdout
+    assert "(hub)" in r.stdout
+
+
+def test_skill_list_marks_blocked(tmp_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Names on skillForge.blocklist get a [blocked] marker; the row still
+    renders (gather_all_skills stays unfiltered for inspection)."""
+    import json
+
+    tmp_config.write_text(
+        json.dumps({"skillForge": {"blocklist": ["Alpha"]}}),
+        encoding="utf-8",
+    )
+    fake_svc = SimpleNamespace(
+        gather_all_skills=lambda: [_make_meta("alpha", desc="d"), _make_meta("beta", desc="d")],
+    )
+    monkeypatch.setattr("raven.cli.skill_commands._build_skill_service", lambda: fake_svc)
+
+    r = runner.invoke(app, ["skill", "list"])
+    assert r.exit_code == 0
+    lines = r.stdout.splitlines()
+    assert any("alpha" in line and "[blocked]" in line for line in lines)
+    assert not any("beta" in line and "[blocked]" in line for line in lines)
+
+
 # ============================================================================
 # skill block / unblock  (on-disk skillForge.blocklist)
 # ============================================================================

--- a/tests/test_cli_skill_commands.py
+++ b/tests/test_cli_skill_commands.py
@@ -133,9 +133,7 @@ def test_skill_get_with_body_renders_markdown(tmp_config: Path, monkeypatch: pyt
     assert "SKILL.md" in r.stdout
 
 
-def test_skill_list_shows_installed_column(
-    tmp_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_skill_list_shows_installed_column(tmp_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Skills whose dir carries .install-meta.json get an Installed cell
     of the form ``YYYY-MM-DD (source)``; others stay blank."""
     import json
@@ -146,9 +144,7 @@ def test_skill_list_shows_installed_column(
         json.dumps({"installed_at": "2026-08-16T00:00:00+00:00", "source": "hub"}),
         encoding="utf-8",
     )
-    installed = SimpleNamespace(
-        name="foo", source="workspace", description="d", path=skill_dir / "SKILL.md"
-    )
+    installed = SimpleNamespace(name="foo", source="workspace", description="d", path=skill_dir / "SKILL.md")
     fake_svc = SimpleNamespace(gather_all_skills=lambda: [installed, _make_meta("bare", desc="d")])
     monkeypatch.setattr("raven.cli.skill_commands._build_skill_service", lambda: fake_svc)
 

--- a/tests/test_config_raven_sections.py
+++ b/tests/test_config_raven_sections.py
@@ -119,6 +119,15 @@ class TestKeyAliasing:
         assert c.hub.timeout_s == pytest.approx(5.0)
         assert c.hub.min_safety == pytest.approx(0.8)
 
+    def test_skill_forge_auto_install_tri_state(self) -> None:
+        assert SkillForgeConfig().auto_install == "auto"
+        c = SkillForgeConfig.model_validate({"autoInstall": "off"})
+        assert c.auto_install == "off"
+        c = SkillForgeConfig.model_validate({"auto_install": "prompt"})
+        assert c.auto_install == "prompt"
+        with pytest.raises(ValidationError):
+            SkillForgeConfig.model_validate({"autoInstall": "sometimes"})
+
 
 # ---------------------------------------------------------------------------
 # EXTENSION_KEYS includes the new sections

--- a/tests/test_skill_forge_loader_parity.py
+++ b/tests/test_skill_forge_loader_parity.py
@@ -472,6 +472,66 @@ class TestBuildSkillsSummary:
         assert svc.build_skills_summary(only=[]) == ""
 
 
+class TestCatalogBlocklist:
+    """skillForge.blocklist enforcement on the catalog paths that bypass
+    the router pool: BM25 index, always-skills, and prompt rendering."""
+
+    def _catalog(self, workspace, builtin, blocklist):
+        from types import SimpleNamespace
+
+        return LocalSkillCatalog(
+            workspace,
+            config=SimpleNamespace(blocklist=blocklist),
+            builtin_skills_dir=builtin,
+            start_watcher=False,
+        )
+
+    def test_pool_hides_blocked_skills(self, tmp_workspace, tmp_builtin):
+        allowed = self._catalog(tmp_workspace, tmp_builtin, [])
+        assert any(h.name == "simple" for h in allowed.pool.search("simple builtin skill"))
+        svc = self._catalog(tmp_workspace, tmp_builtin, ["SIMPLE"])
+        assert all(h.name != "simple" for h in svc.pool.search("simple builtin skill"))
+
+    def test_get_always_skills_excludes_blocked(self, tmp_workspace, tmp_builtin):
+        svc = self._catalog(tmp_workspace, tmp_builtin, ["always_flag_top"])
+        always = {m.name for m in svc.get_always_skills()}
+        assert "always_flag_top" not in always
+        assert "always_flag_nested" in always
+
+    def test_load_skills_for_context_excludes_blocked(self, tmp_workspace, tmp_builtin):
+        svc = self._catalog(tmp_workspace, tmp_builtin, ["simple"])
+        metas = [m for m in svc._registry.list_all() if m.name in {"simple", "always_flag_top"}]
+        out = svc.load_skills_for_context(metas)
+        assert "### Skill: simple" not in out
+        assert "### Skill: always_flag_top" in out
+
+    def test_build_skills_summary_excludes_blocked(self, tmp_workspace, tmp_builtin):
+        svc = self._catalog(tmp_workspace, tmp_builtin, ["user_custom"])
+        xml = svc.build_skills_summary()
+        assert "<name>user_custom</name>" not in xml
+        assert "<name>simple</name>" in xml
+
+    def test_gather_all_skills_keeps_blocked_for_inspection(self, tmp_workspace, tmp_builtin):
+        svc = self._catalog(tmp_workspace, tmp_builtin, ["simple"])
+        assert "simple" in {m.name for m in svc.gather_all_skills()}
+
+    def test_init_logs_one_line_skip_notice(self, tmp_workspace, tmp_builtin, caplog):
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="raven.memory_engine.skill_forge.catalog"):
+            self._catalog(tmp_workspace, tmp_builtin, ["simple"])
+        notices = [r for r in caplog.records if "blocklist" in r.getMessage()]
+        assert len(notices) == 1
+        assert "simple" in notices[0].getMessage()
+
+    def test_empty_blocklist_logs_nothing(self, tmp_workspace, tmp_builtin, caplog):
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="raven.memory_engine.skill_forge.catalog"):
+            self._catalog(tmp_workspace, tmp_builtin, [])
+        assert not [r for r in caplog.records if "blocklist" in r.getMessage()]
+
+
 # ----------------------------------------------------------------------
 # Rendering helpers
 # ----------------------------------------------------------------------

--- a/tests/test_skill_hub_policy.py
+++ b/tests/test_skill_hub_policy.py
@@ -116,32 +116,89 @@ class _FakeStdin(io.StringIO):
 
 
 class TestInstallSkipReason:
-    def test_auto_allows(self) -> None:
-        assert SkillPolicy.create().install_skip_reason("foo") is None
+    async def test_auto_allows(self) -> None:
+        assert await SkillPolicy.create().install_skip_reason("foo") is None
 
-    def test_unknown_mode_behaves_like_auto(self) -> None:
-        assert SkillPolicy.create(auto_install="sometimes").install_skip_reason("foo") is None
+    async def test_unknown_mode_behaves_like_auto(self) -> None:
+        assert await SkillPolicy.create(auto_install="sometimes").install_skip_reason("foo") is None
 
-    def test_off_skips(self) -> None:
-        reason = SkillPolicy.create(auto_install="off").install_skip_reason("foo")
+    async def test_off_skips(self) -> None:
+        reason = await SkillPolicy.create(auto_install="off").install_skip_reason("foo")
         assert reason is not None
         assert "'off'" in reason and "foo" in reason
 
-    def test_prompt_without_tty_behaves_like_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_prompt_without_tty_behaves_like_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=False))
-        reason = SkillPolicy.create(auto_install="prompt").install_skip_reason("foo")
+        reason = await SkillPolicy.create(auto_install="prompt").install_skip_reason("foo")
         assert reason is not None and "prompt" in reason
 
-    def test_prompt_tty_accepts_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_prompt_tty_accepts_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=True))
         monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
-        assert SkillPolicy.create(auto_install="prompt").install_skip_reason("foo") is None
+        assert await SkillPolicy.create(auto_install="prompt").install_skip_reason("foo") is None
 
-    def test_prompt_tty_declines_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_prompt_tty_declines_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=True))
         monkeypatch.setattr("builtins.input", lambda _prompt="": "")
-        reason = SkillPolicy.create(auto_install="prompt").install_skip_reason("foo")
+        reason = await SkillPolicy.create(auto_install="prompt").install_skip_reason("foo")
         assert reason is not None and "declined" in reason
+
+    async def test_prompt_confirm_does_not_block_the_event_loop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The pending stdin read must leave the event loop free: the fake
+        input() below is released only by code running ON the loop, so a
+        blocking implementation would dead-wait until the timeout."""
+        import asyncio
+        import threading
+
+        monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=True))
+        release = threading.Event()
+
+        def blocking_input(_prompt: str = "") -> str:
+            assert release.wait(timeout=5), "event loop never ran while input() was pending"
+            return "y"
+
+        monkeypatch.setattr("builtins.input", blocking_input)
+        policy = SkillPolicy.create(auto_install="prompt")
+        task = asyncio.ensure_future(policy.install_skip_reason("foo"))
+        loop_turns = 0
+        while not task.done() and loop_turns < 10:
+            await asyncio.sleep(0.01)
+            loop_turns += 1
+            if loop_turns >= 3:
+                release.set()
+        assert loop_turns >= 3
+        assert await task is None
+
+    async def test_concurrent_prompts_are_serialized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Two gathered hydrates must never interleave two stdin reads."""
+        import asyncio
+        import threading
+
+        monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=True))
+        active = 0
+        max_active = 0
+        lock = threading.Lock()
+
+        def counting_input(_prompt: str = "") -> str:
+            nonlocal active, max_active
+            with lock:
+                active += 1
+                max_active = max(max_active, active)
+            import time
+
+            time.sleep(0.02)
+            with lock:
+                active -= 1
+            return "y"
+
+        monkeypatch.setattr("builtins.input", counting_input)
+        policy = SkillPolicy.create(auto_install="prompt")
+        results = await asyncio.gather(
+            policy.install_skip_reason("a"),
+            policy.install_skip_reason("b"),
+        )
+        assert results == [None, None]
+        assert max_active == 1
 
 
 class TestWriteInstallMeta:

--- a/tests/test_skill_hub_policy.py
+++ b/tests/test_skill_hub_policy.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import io
 import json
+import sys
 from pathlib import Path
+
+import pytest
 
 from raven.skill_hub.audit import record_install
 from raven.skill_hub.policy import (
@@ -100,6 +104,44 @@ class TestSkillPolicy:
         policy = SkillPolicy.create(blocklist=["native-id"])
         reason = policy.refusal_for_detail({}, "native-id")
         assert reason is not None and "blocklist" in reason
+
+
+class _FakeStdin(io.StringIO):
+    def __init__(self, *, tty: bool) -> None:
+        super().__init__()
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+class TestInstallSkipReason:
+    def test_auto_allows(self) -> None:
+        assert SkillPolicy.create().install_skip_reason("foo") is None
+
+    def test_unknown_mode_behaves_like_auto(self) -> None:
+        assert SkillPolicy.create(auto_install="sometimes").install_skip_reason("foo") is None
+
+    def test_off_skips(self) -> None:
+        reason = SkillPolicy.create(auto_install="off").install_skip_reason("foo")
+        assert reason is not None
+        assert "'off'" in reason and "foo" in reason
+
+    def test_prompt_without_tty_behaves_like_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=False))
+        reason = SkillPolicy.create(auto_install="prompt").install_skip_reason("foo")
+        assert reason is not None and "prompt" in reason
+
+    def test_prompt_tty_accepts_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=True))
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+        assert SkillPolicy.create(auto_install="prompt").install_skip_reason("foo") is None
+
+    def test_prompt_tty_declines_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=True))
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+        reason = SkillPolicy.create(auto_install="prompt").install_skip_reason("foo")
+        assert reason is not None and "declined" in reason
 
 
 class TestRecordInstall:

--- a/tests/test_skill_hub_policy.py
+++ b/tests/test_skill_hub_policy.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from raven.skill_hub.audit import record_install
+from raven.skill_hub.audit import record_install, write_install_meta
 from raven.skill_hub.policy import (
     SkillPolicy,
     is_blocked,
@@ -142,6 +142,30 @@ class TestInstallSkipReason:
         monkeypatch.setattr("builtins.input", lambda _prompt="": "")
         reason = SkillPolicy.create(auto_install="prompt").install_skip_reason("foo")
         assert reason is not None and "declined" in reason
+
+
+class TestWriteInstallMeta:
+    def test_none_dir_is_noop(self) -> None:
+        write_install_meta(None, slug="x", version="v1", trigger="use_skill")
+
+    def test_writes_meta_into_skill_dir(self, tmp_path: Path) -> None:
+        write_install_meta(str(tmp_path), slug="foo", version="v2", trigger="auto_inject")
+        record = json.loads((tmp_path / ".install-meta.json").read_text(encoding="utf-8"))
+        assert record["slug"] == "foo"
+        assert record["version"] == "v2"
+        assert record["source"] == "hub"
+        assert record["trigger"] == "auto_inject"
+        assert record["installed_at"]
+
+    def test_first_install_wins(self, tmp_path: Path) -> None:
+        write_install_meta(tmp_path, slug="foo", version="v2", trigger="auto_inject")
+        write_install_meta(tmp_path, slug="foo", version="v2", trigger="use_skill")
+        record = json.loads((tmp_path / ".install-meta.json").read_text(encoding="utf-8"))
+        assert record["trigger"] == "auto_inject"
+
+    def test_missing_dir_is_best_effort_noop(self, tmp_path: Path) -> None:
+        write_install_meta(tmp_path / "ghost", slug="foo", version="v1", trigger="use_skill")
+        assert not (tmp_path / "ghost").exists()
 
 
 class TestRecordInstall:

--- a/tests/test_skill_hub_tools.py
+++ b/tests/test_skill_hub_tools.py
@@ -270,3 +270,53 @@ class TestUseSkillSafetyPolicy:
         rec = json.loads(audit.read_text(encoding="utf-8").strip())
         assert rec["slug"] == "foo"
         assert rec["trigger"] == "use_skill"
+
+
+class _FakeStdin:
+    def __init__(self, *, tty: bool) -> None:
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+class TestUseSkillAutoInstall:
+    """skillForge.autoInstall gates the Hub bundle download in use_skill."""
+
+    def _client(self) -> _FakeClient:
+        return _FakeClient(
+            get_result={"score_safety": 0.9, "slug": "foo", "skill_md": "ok"},
+            install_result={"slug": "foo", "version": "v1", "skill_md": "ok"},
+        )
+
+    async def test_off_skips_install_with_notice(self) -> None:
+        client = self._client()
+        out = await UseSkillTool(client=client, auto_install="off").execute(
+            skill_id="hub/foo",
+        )
+        assert out.startswith("Skill install skipped")
+        assert "'off'" in out
+        assert client.install_calls == []
+
+    async def test_prompt_without_tty_skips(self, monkeypatch) -> None:
+        import sys
+
+        monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=False))
+        client = self._client()
+        out = await UseSkillTool(client=client, auto_install="prompt").execute(
+            skill_id="hub/foo",
+        )
+        assert out.startswith("Skill install skipped")
+        assert client.install_calls == []
+
+    async def test_prompt_tty_confirmation_installs(self, monkeypatch) -> None:
+        import sys
+
+        monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=True))
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+        client = self._client()
+        out = await UseSkillTool(client=client, auto_install="prompt").execute(
+            skill_id="hub/foo",
+        )
+        assert not out.startswith("Error") and not out.startswith("Skill install skipped")
+        assert client.install_calls == ["foo"]

--- a/tests/test_skill_hub_tools.py
+++ b/tests/test_skill_hub_tools.py
@@ -271,6 +271,24 @@ class TestUseSkillSafetyPolicy:
         assert rec["slug"] == "foo"
         assert rec["trigger"] == "use_skill"
 
+    async def test_install_writes_install_meta(self, tmp_path: Path) -> None:
+        import json
+
+        skill_dir = tmp_path / "foo@v2"
+        skill_dir.mkdir()
+        client = _FakeClient(
+            get_result={"score_safety": 0.9, "slug": "foo", "version": "v2"},
+            install_result={"slug": "foo", "version": "v2", "skill_md": "ok", "dir": str(skill_dir)},
+        )
+        out = await UseSkillTool(client=client).execute(skill_id="hub/foo")
+        assert not out.startswith("Error")
+        rec = json.loads((skill_dir / ".install-meta.json").read_text(encoding="utf-8"))
+        assert rec["slug"] == "foo"
+        assert rec["version"] == "v2"
+        assert rec["source"] == "hub"
+        assert rec["trigger"] == "use_skill"
+        assert rec["installed_at"]
+
 
 class _FakeStdin:
     def __init__(self, *, tty: bool) -> None:

--- a/tests/test_skill_segment_builder.py
+++ b/tests/test_skill_segment_builder.py
@@ -444,6 +444,30 @@ async def test_hub_hit_without_vetted_meta_never_installs() -> None:
     assert hub.install_calls == []
 
 
+async def test_hub_auto_install_writes_install_meta(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "good-skill@v3"
+    skill_dir.mkdir()
+    src = _StubSource("hub", [_hit("hub/good1", "good-skill")])
+    hub = _StubHubClient(
+        {
+            "good1": {
+                "skill_md": "safe body",
+                "score_safety": 0.9,
+                "slug": "good-skill",
+                "version": "v3",
+                "_dir": str(skill_dir),
+            }
+        }
+    )
+    builder = SkillsSegmentBuilder(SkillForgeRouter([src]), hub_client=hub)
+    await builder.build(_ctx("remember this"))
+    rec = json.loads((skill_dir / ".install-meta.json").read_text(encoding="utf-8"))
+    assert rec["slug"] == "good-skill"
+    assert rec["version"] == "v3"
+    assert rec["trigger"] == "auto_inject"
+    assert rec["installed_at"]
+
+
 async def test_auto_install_off_keeps_body_skips_install(tmp_path: Path) -> None:
     """autoInstall=off skips only the bundle download: the body hydrated in
     the pre-gate step still injects, and nothing is installed or audited."""

--- a/tests/test_skill_segment_builder.py
+++ b/tests/test_skill_segment_builder.py
@@ -444,6 +444,24 @@ async def test_hub_hit_without_vetted_meta_never_installs() -> None:
     assert hub.install_calls == []
 
 
+async def test_auto_install_off_keeps_body_skips_install(tmp_path: Path) -> None:
+    """autoInstall=off skips only the bundle download: the body hydrated in
+    the pre-gate step still injects, and nothing is installed or audited."""
+    audit = tmp_path / "installs.jsonl"
+    src = _StubSource("hub", [_hit("hub/good1", "good-skill")])
+    hub = _StubHubClient({"good1": {"skill_md": "safe body", "score_safety": 0.9}})
+    builder = SkillsSegmentBuilder(
+        SkillForgeRouter([src]),
+        hub_client=hub,
+        auto_install="off",
+        install_audit_path=audit,
+    )
+    seg = await builder.build(_ctx("remember this"))
+    assert "safe body" in seg.text
+    assert hub.install_calls == []
+    assert not audit.exists()
+
+
 async def test_hub_auto_install_appends_audit_record(tmp_path: Path) -> None:
     audit = tmp_path / "installs.jsonl"
     src = _StubSource("hub", [_hit("hub/good1", "good-skill")])


### PR DESCRIPTION
## Summary

Builds on the skill-hub safety gate (merged in cb2524b) and adds the
governance features that gate deliberately left out, keeping SkillPolicy
as the single decision point:

1. autoInstall consent mode: skillForge.autoInstall
   ("auto" | "prompt" | "off", default auto) consulted after all safety
   vetting at both install call sites. off withholds the bundle download
   with a one-line notice (the vetted body excerpt still hydrates);
   prompt asks on a TTY - via asyncio.to_thread with a per-policy lock,
   so the event loop never blocks and concurrent hydrates cannot
   interleave two stdin reads - and behaves like off without a TTY.
2. skill list visibility: an Installed column (date + source, O(1) per
   row) and a [blocked] marker driven by the policy's own blocklist
   normalizer.
3. .install-meta.json written at both install tails next to the
   existing installs.jsonl: the jsonl stays the append-only audit
   stream, the meta file is the list command's O(1) data source.
4. Blocklist coverage for catalog paths that bypass the router pool
   (BM25 LocalPool, always-skills, context loader, skills summary). A
   hub search() filter was deliberately not added: the router pool drop
   plus the gate's fail-closed detail vetting already own that path.

CONTEXT.md's SkillPolicy entry gains the skip-vs-refusal distinction.

## Type

- [x] Feature
- [ ] Fix
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_cli_skill_commands.py tests/test_skill_hub_policy.py tests/test_skill_hub_tools.py tests/test_skill_segment_builder.py -q`: 101 passed (all pre-existing gate tests untouched and green).
- Event-loop liveness and prompt serialization are covered by dedicated tests that fail against a blocking implementation.
- Sandbox-HOME runs: skill list renders the Installed cell and [blocked] marker; with autoInstall off, use_skill returns the skip notice and install() is provably never reached; the gate's refusal behavior is unchanged.
- Full-suite failures match the two known pre-existing entries on main; nothing regressed.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

autoInstall defaults to auto, so behavior is unchanged unless opted in.
The meta file is best-effort and first-install-wins; a missing file only
blanks the Installed cell. Revert the branch to roll back.

## Related Issues

N/A - no tracked GitHub issues; unique remainder of the governance work
after deduplication against the merged safety gate.
