### PR TITLE
fix: provider auth error rendering with exit codes and guidance

### DIFF
--- a/raven/cli/_helpers.py
+++ b/raven/cli/_helpers.py
@@ -70,10 +70,7 @@ def check_provider_credentials(config: Config) -> None:
         raise MissingCredentialsError(
             status.summary,
             provider=provider_name,
-            remedy=(
-                "Run: raven provider set <name> --api-key <key>\n"
-                "Or run `raven onboard` for guided setup."
-            ),
+            remedy=("Run: raven provider set <name> --api-key <key>\nOr run `raven onboard` for guided setup."),
         )
 
 

--- a/raven/cli/_helpers.py
+++ b/raven/cli/_helpers.py
@@ -70,7 +70,7 @@ def check_provider_credentials(config: Config) -> None:
         raise MissingCredentialsError(
             status.summary,
             provider=provider_name,
-            remedy=("Run: raven provider set <name> --api-key <key>\nOr run `raven onboard` for guided setup."),
+            remedy="Run `raven onboard` for guided setup.",
         )
 
 

--- a/raven/cli/_helpers.py
+++ b/raven/cli/_helpers.py
@@ -59,12 +59,19 @@ def check_provider_credentials(config: Config) -> None:
             "no provider configured",
             # A command, not a config path: the old text pointed at
             # ~/.raven/config.json, the layout the CLI exists to hide.
-            remedy="Run: raven provider set <name> --api-key <key>, then raven provider use <name>/<model>",
+            remedy=(
+                "Run: raven provider set <name> --api-key <key>, then raven provider use <name>/<model>\n"
+                "Or run `raven onboard` for guided setup."
+            ),
         )
 
     status = credential_status(provider_name, config.providers.get(provider_name), include_external=True)
     if not status.ok:
-        raise MissingCredentialsError(status.summary, provider=provider_name)
+        raise MissingCredentialsError(
+            status.summary,
+            provider=provider_name,
+            remedy="Or run `raven onboard` for guided setup.",
+        )
 
 
 def make_provider(config: Config):

--- a/raven/cli/_helpers.py
+++ b/raven/cli/_helpers.py
@@ -70,7 +70,10 @@ def check_provider_credentials(config: Config) -> None:
         raise MissingCredentialsError(
             status.summary,
             provider=provider_name,
-            remedy="Or run `raven onboard` for guided setup.",
+            remedy=(
+                "Run: raven provider set <name> --api-key <key>\n"
+                "Or run `raven onboard` for guided setup."
+            ),
         )
 
 

--- a/raven/cli/agent_commands.py
+++ b/raven/cli/agent_commands.py
@@ -53,6 +53,20 @@ def _print_agent_response(response: str, render_markdown: bool) -> None:
     console.print()
 
 
+# Category-apt hints for non-auth provider errors. Credential guidance would
+# mislead here: a rate limit or a network drop is not fixed by re-checking the
+# key. Categories absent from this map (invalid_request, unknown, ...) render
+# the error line alone.
+_NON_AUTH_HINTS = {
+    "rate_limit": "Hint: the provider is rate limiting; retry in a moment.",
+    "network": "Hint: network problem; check connectivity and retry.",
+    "context_overflow": "Hint: the input exceeds the model's context window; shorten it.",
+    "server": "Hint: provider-side error; retry later or switch models.",
+    "model_unavailable": "Hint: model not served; pick another with raven provider use <name>/<model>.",
+    "billing": "Hint: billing or quota issue; check your provider account.",
+}
+
+
 def _print_llm_error(content: str) -> bool:
     """Render a provider error as a diagnosis + fix hint instead of a fake
     agent reply. Returns True when handled; marks the one-shot path to exit
@@ -69,10 +83,13 @@ def _print_llm_error(content: str) -> bool:
     if category == "auth":
         where = f"{provider} 401" if provider else "401"
         console.print(f"[red]Error: API key invalid ({escape(where)}).[/red]")
+        target = provider or "<name>"
+        console.print(f"Fix: raven provider test {escape(target)}  or  raven onboard")
     else:
         console.print(f"[red]Error: LLM call failed ({escape(category)}): {escape(detail[:200])}[/red]")
-    target = provider or "<name>"
-    console.print(f"Fix: raven provider test {escape(target)}  or  raven onboard")
+        hint = _NON_AUTH_HINTS.get(category)
+        if hint:
+            console.print(hint)
     console.print()
     _ONE_SHOT_EXIT["code"] = 1
     return True

--- a/raven/cli/agent_commands.py
+++ b/raven/cli/agent_commands.py
@@ -81,8 +81,11 @@ def _print_llm_error(content: str) -> bool:
     category, provider, detail = parsed
     console.print()
     if category == "auth":
-        where = f"{provider} 401" if provider else "401"
-        console.print(f"[red]Error: API key invalid ({escape(where)}).[/red]")
+        # No status code here: the auth bucket also fires on 403, on
+        # PermissionDeniedError and on substring matches, so naming one would
+        # be a guess. The detail carries the provider's own reason instead.
+        where = f" ({escape(provider)})" if provider else ""
+        console.print(f"[red]Error: provider rejected the credentials{where}: {escape(detail[:200])}[/red]")
         target = provider or "<name>"
         console.print(f"Fix: raven provider test {escape(target)}  or  raven onboard")
     else:

--- a/raven/cli/agent_commands.py
+++ b/raven/cli/agent_commands.py
@@ -35,14 +35,47 @@ from raven.utils.helpers import sync_workspace_templates
 console = Console()
 
 
+# One-shot ``-m`` exit code: set by the error renderer, checked after the
+# turn. Module-level because the render callback runs inside the delivery
+# hub's worker task, where raising typer.Exit would be swallowed.
+_ONE_SHOT_EXIT = {"code": 0}
+
+
 def _print_agent_response(response: str, render_markdown: bool) -> None:
     """Render assistant response with consistent terminal styling."""
     content = response or ""
+    if _print_llm_error(content):
+        return
     body = Markdown(content) if render_markdown else Text(content)
     console.print()
     console.print(f"[cyan]{__logo__} Raven[/cyan]")
     console.print(body)
     console.print()
+
+
+def _print_llm_error(content: str) -> bool:
+    """Render a provider error as a diagnosis + fix hint instead of a fake
+    agent reply. Returns True when handled; marks the one-shot path to exit
+    non-zero."""
+    from rich.markup import escape
+
+    from raven.providers.base import parse_llm_error
+
+    parsed = parse_llm_error(content)
+    if parsed is None:
+        return False
+    category, provider, detail = parsed
+    console.print()
+    if category == "auth":
+        where = f"{provider} 401" if provider else "401"
+        console.print(f"[red]Error: API key invalid ({escape(where)}).[/red]")
+    else:
+        console.print(f"[red]Error: LLM call failed ({escape(category)}): {escape(detail[:200])}[/red]")
+    target = provider or "<name>"
+    console.print(f"Fix: raven provider test {escape(target)}  or  raven onboard")
+    console.print()
+    _ONE_SHOT_EXIT["code"] = 1
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -344,11 +377,14 @@ def register(app: typer.Typer) -> None:
                             "memory backend stop failed; continuing shutdown",
                         )
 
+        _ONE_SHOT_EXIT["code"] = 0
         asyncio.run(run_once())
         # Native runtimes loaded by the agent loop (lancedb's Rust/tokio
         # thread, torch) segfault during interpreter finalization. The exit
         # chokepoint in raven.cli.commands.run hard-exits past finalization
         # when that hazard is live, so this path just returns normally.
+        if _ONE_SHOT_EXIT["code"]:
+            raise typer.Exit(_ONE_SHOT_EXIT["code"])
 
 
 __all__ = ["register"]

--- a/raven/memory_engine/skill_forge/rewriter.py
+++ b/raven/memory_engine/skill_forge/rewriter.py
@@ -108,7 +108,10 @@ class QueryRewriter:
             if getattr(resp, "finish_reason", None) == "error":
                 raise RuntimeError(content or "provider error")
         except Exception as e:
-            log.warning("query rewrite failed (%s); defaulting to retrieval", e)
+            # debug, not warning: rewrite failure silently falls back to plain
+            # retrieval, and the main turn surfaces the provider error itself —
+            # a user-visible line here would just duplicate it.
+            log.debug("query rewrite failed (%s); defaulting to retrieval", e)
             return RewriteResult(need_retrieval=True)
         return self._parse(content)
 

--- a/raven/providers/azure_openai_provider.py
+++ b/raven/providers/azure_openai_provider.py
@@ -10,7 +10,7 @@ from urllib.parse import urljoin
 import httpx
 import json_repair
 
-from raven.providers.base import LLMProvider, LLMResponse, ProviderHTTPError, ToolCallRequest
+from raven.providers.base import LLMProvider, LLMResponse, ProviderHTTPError, ToolCallRequest, format_llm_error
 
 _AZURE_MSG_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name"})
 
@@ -171,20 +171,22 @@ class AzureOpenAIProvider(LLMProvider):
                     exc = ProviderHTTPError(
                         response.status_code, f"Azure OpenAI API Error {response.status_code}: {response.text}"
                     )
+                    classification = self.classify_error(exc)
                     return LLMResponse(
-                        content=str(exc),
+                        content=format_llm_error(exc, classification, provider="azure_openai"),
                         finish_reason="error",
-                        error_classification=self.classify_error(exc),
+                        error_classification=classification,
                     )
 
                 response_data = response.json()
                 return self._parse_response(response_data)
 
         except Exception as e:
+            classification = self.classify_error(e)
             return LLMResponse(
-                content=f"Error calling Azure OpenAI: {repr(e)}",
+                content=format_llm_error(e, classification, provider="azure_openai"),
                 finish_reason="error",
-                error_classification=self.classify_error(e),
+                error_classification=classification,
             )
 
     def _parse_response(self, response: dict[str, Any]) -> LLMResponse:
@@ -229,9 +231,12 @@ class AzureOpenAIProvider(LLMProvider):
             )
 
         except (KeyError, IndexError) as e:
+            err = ValueError(f"unexpected Azure OpenAI response shape: {e!r}")
+            classification = self.classify_error(err)
             return LLMResponse(
-                content=f"Error parsing Azure OpenAI response: {str(e)}",
+                content=format_llm_error(err, classification, provider="azure_openai"),
                 finish_reason="error",
+                error_classification=classification,
             )
 
     def get_default_model(self) -> str:

--- a/raven/providers/base.py
+++ b/raven/providers/base.py
@@ -78,18 +78,25 @@ _LLM_ERROR_CONTENT_RE = re.compile(
 
 
 def _strip_json_error_body(text: str) -> str:
-    """Replace a raw JSON error body with its human-readable message."""
+    """Replace a raw JSON error body with its human-readable message.
+
+    Rewrites only when a message is actually extracted, and only within the
+    parsed object's own boundary -- trailing text after the JSON survives, and
+    a body yielding no message leaves the text unchanged rather than truncated.
+    """
     idx = text.find("{")
     if idx == -1:
         return text
-    candidate = text[idx:].strip()
+    candidate = text[idx:]
     if not candidate.startswith(('{"', "{'")):
         return text
-    message = ""
     try:
-        obj = json.loads(candidate)
+        obj, end = json.JSONDecoder().raw_decode(candidate)
     except ValueError:
-        obj = None
+        # Malformed JSON has no knowable boundary; treat the rest of the text
+        # as the body, which is the shape the swallowed litellm errors have.
+        obj, end = None, len(candidate)
+    message = ""
     if isinstance(obj, dict):
         err = obj.get("error")
         found = err.get("message") if isinstance(err, dict) else None
@@ -97,12 +104,13 @@ def _strip_json_error_body(text: str) -> str:
         if isinstance(found, str):
             message = found.strip()
     if not message:
-        m = _JSON_MESSAGE_RE.search(candidate)
+        m = _JSON_MESSAGE_RE.search(candidate[:end])
         message = m.group(1).strip() if m else ""
+    if not message:
+        return text
     head = text[:idx].rstrip()
-    if message:
-        return f"{head} {message}".strip()
-    return head if head else text
+    tail = candidate[end:].strip()
+    return " ".join(part for part in (head, message, tail) if part)
 
 
 def format_llm_error(

--- a/raven/providers/base.py
+++ b/raven/providers/base.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import random
+import re
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field, replace
@@ -66,6 +67,80 @@ class ErrorClassification:
     #: whether ``str()`` carried that body is a property of the client that
     #: raised it. Deciding while the exception is alive makes it one answer.
     refuses_prompt_cache: bool = False
+
+
+_EXC_NAME_PREFIX_RE = re.compile(r"^([A-Za-z_][\w.]*(?:Error|Exception))\s*:\s*")
+_JSON_MESSAGE_RE = re.compile(r'"message"\s*:\s*"([^"]*)"')
+_LLM_ERROR_CONTENT_RE = re.compile(
+    r"^Error calling LLM \((?P<category>[a-z_]+)(?:@(?P<provider>[A-Za-z0-9._-]+))?\):\s*(?P<detail>.*)$",
+    re.DOTALL,
+)
+
+
+def _strip_json_error_body(text: str) -> str:
+    """Replace a raw JSON error body with its human-readable message."""
+    idx = text.find("{")
+    if idx == -1:
+        return text
+    candidate = text[idx:].strip()
+    if not candidate.startswith(('{"', "{'")):
+        return text
+    message = ""
+    try:
+        obj = json.loads(candidate)
+    except ValueError:
+        obj = None
+    if isinstance(obj, dict):
+        err = obj.get("error")
+        found = err.get("message") if isinstance(err, dict) else None
+        found = found or obj.get("message")
+        if isinstance(found, str):
+            message = found.strip()
+    if not message:
+        m = _JSON_MESSAGE_RE.search(candidate)
+        message = m.group(1).strip() if m else ""
+    head = text[:idx].rstrip()
+    if message:
+        return f"{head} {message}".strip()
+    return head if head else text
+
+
+def format_llm_error(
+    exc: BaseException,
+    classification: ErrorClassification,
+    provider: str | None = None,
+) -> str:
+    """Build the canonical content for a failed LLM call.
+
+    Shape: ``Error calling LLM (<category>[@<provider>]): <detail>``. The head
+    is machine-parseable (see ``parse_llm_error``) so rendering surfaces can
+    show a diagnosis + fix hint instead of the raw exception; the detail drops
+    duplicated exception-name prefixes and raw JSON error bodies.
+    """
+    detail = str(exc).strip()
+    names: list[str] = []
+    while True:
+        m = _EXC_NAME_PREFIX_RE.match(detail)
+        if not m:
+            break
+        name = m.group(1).rsplit(".", 1)[-1]
+        if name not in names:
+            names.append(name)
+        detail = detail[m.end() :]
+    detail = _strip_json_error_body(detail).strip()
+    prefix = "".join(f"{n}: " for n in names)
+    detail = f"{prefix}{detail}".strip().rstrip(":-").strip() or type(exc).__name__
+    head = f"{classification.category}@{provider}" if provider else classification.category
+    return f"Error calling LLM ({head}): {detail}"
+
+
+def parse_llm_error(content: str | None) -> tuple[str, str | None, str] | None:
+    """Parse content built by ``format_llm_error`` back into
+    ``(category, provider, detail)``; ``None`` when the text is not one."""
+    m = _LLM_ERROR_CONTENT_RE.match((content or "").strip())
+    if not m:
+        return None
+    return m.group("category"), m.group("provider"), m.group("detail").strip()
 
 
 class ProviderHTTPError(RuntimeError):
@@ -569,15 +644,17 @@ class LLMProvider(ABC):
                 raise
             except Exception as e:
                 exc = e
-                response = LLMResponse(content=f"Error calling LLM: {e}", finish_reason="error")
+                response = LLMResponse(content=None, finish_reason="error")
 
             if response.finish_reason != "error":
                 return response
 
             # Prefer a provider-attached classification (it had the live
             # exception); else classify the exception we caught, else the string.
-            classification = response.error_classification or self.classify_error(exc, response.content)
+            classification = response.error_classification or self.classify_error(exc, response.content or None)
             response.error_classification = classification
+            if exc is not None and not response.content:
+                response.content = format_llm_error(exc, classification, provider=getattr(self, "provider_name", None))
             last_response = response
 
             # Why an upstream can refuse this at all: see

--- a/raven/providers/litellm_provider.py
+++ b/raven/providers/litellm_provider.py
@@ -14,7 +14,7 @@ import json_repair
 from loguru import logger
 
 from raven.providers import prompt_cache
-from raven.providers.base import LLMProvider, LLMResponse, StreamDelta, ToolCallRequest
+from raven.providers.base import LLMProvider, LLMResponse, StreamDelta, ToolCallRequest, format_llm_error
 from raven.providers.litellm_setup import import_litellm
 from raven.providers.prompt_cache import CACHE_CONTROL
 from raven.providers.reasoning import split_orphan_think
@@ -468,10 +468,12 @@ class LiteLLMProvider(LLMProvider):
             # Return error as content for graceful handling, but classify the
             # live exception here (status_code + type) before it's lost to a
             # string — the retry/fallback layer reads this verdict.
+            classification = self.classify_error(e)
+            head = self._provider_name or (self._gateway.name if self._gateway else None)
             return LLMResponse(
-                content=f"Error calling LLM: {str(e)}",
+                content=format_llm_error(e, classification, provider=head),
                 finish_reason="error",
-                error_classification=self.classify_error(e),
+                error_classification=classification,
             )
 
     async def chat_stream(

--- a/raven/providers/openai_codex_provider.py
+++ b/raven/providers/openai_codex_provider.py
@@ -22,7 +22,7 @@ from typing import Any, AsyncGenerator
 import httpx
 from loguru import logger
 
-from raven.providers.base import LLMProvider, LLMResponse, ProviderHTTPError, ToolCallRequest
+from raven.providers.base import LLMProvider, LLMResponse, ProviderHTTPError, ToolCallRequest, format_llm_error
 
 DEFAULT_CODEX_URL = "https://chatgpt.com/backend-api/codex/responses"
 DEFAULT_ORIGINATOR = "raven"
@@ -98,10 +98,11 @@ class OpenAICodexProvider(LLMProvider):
                 finish_reason=finish_reason,
             )
         except Exception as e:
+            classification = self.classify_error(e)
             return LLMResponse(
-                content=f"Error calling Codex: {str(e)}",
+                content=format_llm_error(e, classification, provider="openai_codex"),
                 finish_reason="error",
-                error_classification=self.classify_error(e),
+                error_classification=classification,
             )
 
     def get_default_model(self) -> str:

--- a/tests/test_azure_openai_provider.py
+++ b/tests/test_azure_openai_provider.py
@@ -130,3 +130,74 @@ def test_the_api_version_comes_from_config_rather_than_the_client() -> None:
     """A tenant on another version had no way to say so while it was hardcoded."""
     provider = AzureOpenAIProvider(api_key="k", api_base="https://x.openai.azure.com", api_version="2025-01-01")
     assert provider._build_chat_url("d").endswith("?api-version=2025-01-01")
+
+
+@pytest.mark.asyncio
+async def test_a_non_200_renders_the_canonical_error_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Azure's error content must carry the canonical
+    ``Error calling LLM (<category>@<provider>)`` shape: the CLI's
+    diagnosis + fix-hint renderer keys off it, and a raw body here renders
+    as a fake agent reply with exit 0."""
+    from raven.providers.base import parse_llm_error
+
+    monkeypatch.setattr(
+        "raven.providers.azure_openai_provider.httpx.AsyncClient",
+        _non_ok_client_cls(401, '{"error":{"message":"invalid subscription key","code":"401"}}'),
+    )
+    provider = _make_provider(timeout=5.0)
+    resp = await provider.chat(messages=[{"role": "user", "content": "hi"}], model="gpt-4o")
+
+    assert resp.finish_reason == "error"
+    parsed = parse_llm_error(resp.content)
+    assert parsed is not None, resp.content
+    category, provider_name, detail = parsed
+    assert category == "auth"
+    assert provider_name == "azure_openai"
+    assert "invalid subscription key" in detail
+    assert '{"error"' not in (resp.content or "")
+
+
+@pytest.mark.asyncio
+async def test_a_raised_exception_renders_the_canonical_error_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The swallowed-exception branch must also produce the canonical shape,
+    not a raw ``Error calling Azure OpenAI: repr(e)`` string."""
+    from raven.providers.base import parse_llm_error
+
+    class _RaisingClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_RaisingClient":
+            return self
+
+        async def __aexit__(self, *args: Any) -> bool:
+            return False
+
+        async def post(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("connection reset by peer")
+
+    monkeypatch.setattr("raven.providers.azure_openai_provider.httpx.AsyncClient", _RaisingClient)
+    provider = _make_provider(timeout=5.0)
+    resp = await provider.chat(messages=[{"role": "user", "content": "hi"}], model="gpt-4o")
+
+    assert resp.finish_reason == "error"
+    parsed = parse_llm_error(resp.content)
+    assert parsed is not None, resp.content
+    category, provider_name, detail = parsed
+    assert category == "network"
+    assert provider_name == "azure_openai"
+    assert "connection reset by peer" in detail
+
+
+def test_an_unparseable_response_shape_renders_the_canonical_error_content() -> None:
+    """The response-parsing branch is an error outlet too and must not leak
+    a raw ``Error parsing Azure OpenAI response`` string past the renderer."""
+    from raven.providers.base import parse_llm_error
+
+    provider = _make_provider(timeout=5.0)
+    resp = provider._parse_response({})
+
+    assert resp.finish_reason == "error"
+    parsed = parse_llm_error(resp.content)
+    assert parsed is not None, resp.content
+    assert parsed[1] == "azure_openai"

--- a/tests/test_cli_agent_commands.py
+++ b/tests/test_cli_agent_commands.py
@@ -365,3 +365,121 @@ def test_agent_message_mode_mocked_provider(tmp_config: Path, monkeypatch: pytes
         assert not isinstance(r.exception, (NameError, AttributeError, ImportError)), (
             f"Crash-class exception leaked through: {r.exception!r}"
         )
+
+
+# ============================================================================
+# Provider error rendering
+# ============================================================================
+
+
+def test_agent_auth_error_exit_nonzero_with_guidance(
+    tmp_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 401 from the provider must exit non-zero, show a fix hint, and must
+    not dump the duplicated exception name or the raw JSON error body.
+
+    The provider is a real ``LiteLLMProvider`` whose ``acompletion`` is stubbed
+    to raise the same exception shape litellm raises on an OpenRouter 401 —
+    no network involved.
+    """
+    import os as _os
+
+    from raven.config.loader import save_config
+    from raven.config.schema import Config
+    from raven.spine import Text, TurnOutcome, Usage
+
+    cfg = Config()
+    cfg.providers.openrouter.api_key = "sk-or-v1-stub-invalid"
+    save_config(cfg)
+
+    class AuthenticationError(Exception):
+        status_code = 401
+
+    async def _raise_401(**_kwargs):
+        raise AuthenticationError(
+            "litellm.AuthenticationError: AuthenticationError: OpenrouterException - "
+            '{"error":{"message":"User not found.","code":401}}'
+        )
+
+    # Pre-register the env var with monkeypatch so the provider's _setup_env
+    # write is rolled back with the test instead of leaking a fake key.
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-stub-invalid")
+    monkeypatch.setattr("raven.providers.litellm_provider.acompletion", _raise_401)
+
+    class _StubSubagents:
+        def set_submit(self, _submit) -> None:
+            pass
+
+    class _AuthFailAgentLoop:
+        def __init__(self, **kwargs):
+            self.channels_config = kwargs.get("channels_config")
+            self.subagents = _StubSubagents()
+
+        def configure_personalization(self, *_args) -> None:
+            pass
+
+        async def run_turn(self, req, emit, drain, *, stream, **_kw) -> TurnOutcome:
+            from raven.providers.litellm_provider import LiteLLMProvider
+
+            provider = LiteLLMProvider(
+                api_key="sk-or-v1-stub-invalid",
+                default_model="anthropic/claude-opus-4-5",
+                provider_name="openrouter",
+            )
+            resp = await provider.chat_with_retry(messages=[{"role": "user", "content": req.text}])
+            await emit(Text(content=resp.content or "", source=req.source))
+            return TurnOutcome(usage=Usage(0, 0, 0), explicit_reply=True)
+
+        async def await_pending_extractions(self, **_kw) -> None:
+            pass
+
+        async def close_mcp(self) -> None:
+            pass
+
+    monkeypatch.setattr(_os, "_exit", lambda code: (_ for _ in ()).throw(SystemExit(code)))
+    monkeypatch.setattr("raven.cli.agent_commands.make_provider", lambda _: object())
+    monkeypatch.setattr("raven.agent.loop.AgentLoop", _AuthFailAgentLoop)
+    monkeypatch.setattr("raven.cli.agent_commands.maybe_build_memory_backend", lambda *a, **k: None)
+    monkeypatch.setattr("raven.cli.agent_commands.build_plugin_tools", lambda *a, **k: [])
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    result = runner.invoke(app, ["agent", "-m", "hi", "-w", str(ws)])
+
+    assert result.exit_code != 0
+    assert result.output.count("AuthenticationError") <= 1
+    assert "raven provider" in result.output
+    assert '{"error"' not in result.output
+
+
+def test_print_llm_error_renders_diagnosis_and_marks_exit(capsys: pytest.CaptureFixture) -> None:
+    """``_print_llm_error`` turns the canonical error content into a
+    diagnosis + fix hint and marks the one-shot exit code; ordinary reply
+    content is left for the normal renderer."""
+    from raven.cli import agent_commands
+    from raven.providers.base import LLMProvider, format_llm_error
+
+    class _AuthError(Exception):
+        status_code = 401
+
+    exc = _AuthError(
+        "litellm.AuthenticationError: AuthenticationError: OpenrouterException - "
+        '{"error":{"message":"User not found.","code":401}}'
+    )
+    content = format_llm_error(exc, LLMProvider.classify_error(exc), provider="openrouter")
+
+    agent_commands._ONE_SHOT_EXIT["code"] = 0
+    try:
+        assert agent_commands._print_llm_error(content) is True
+        out = capsys.readouterr().out
+        assert "API key invalid" in out
+        assert "openrouter 401" in out
+        assert "raven provider test openrouter" in out
+        assert '{"error"' not in out
+        assert agent_commands._ONE_SHOT_EXIT["code"] == 1
+
+        agent_commands._ONE_SHOT_EXIT["code"] = 0
+        assert agent_commands._print_llm_error("just a normal reply") is False
+        assert agent_commands._ONE_SHOT_EXIT["code"] == 0
+    finally:
+        agent_commands._ONE_SHOT_EXIT["code"] = 0

--- a/tests/test_cli_agent_commands.py
+++ b/tests/test_cli_agent_commands.py
@@ -483,3 +483,42 @@ def test_print_llm_error_renders_diagnosis_and_marks_exit(capsys: pytest.Capture
         assert agent_commands._ONE_SHOT_EXIT["code"] == 0
     finally:
         agent_commands._ONE_SHOT_EXIT["code"] = 0
+
+
+def test_print_llm_error_non_auth_categories_get_apt_hint_not_key_guidance(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Non-auth categories must not print the credential fix line: a rate
+    limit or a network drop is not fixed by re-checking the key. Each gets a
+    category-apt hint instead; categories with no apt one-liner render the
+    error line alone."""
+    from raven.cli import agent_commands
+
+    cases = {
+        "rate_limit": "retry",
+        "network": "connectivity",
+        "context_overflow": "shorten",
+        "server": "retry",
+        "model_unavailable": "provider use",
+        "billing": "account",
+    }
+    try:
+        for category, expected in cases.items():
+            agent_commands._ONE_SHOT_EXIT["code"] = 0
+            content = f"Error calling LLM ({category}@openrouter): something went wrong"
+            assert agent_commands._print_llm_error(content) is True, category
+            out = capsys.readouterr().out
+            assert "raven provider test" not in out, category
+            assert "raven onboard" not in out, category
+            assert expected in out, f"{category}: missing apt hint in {out!r}"
+            assert agent_commands._ONE_SHOT_EXIT["code"] == 1, category
+
+        agent_commands._ONE_SHOT_EXIT["code"] = 0
+        assert agent_commands._print_llm_error("Error calling LLM (unknown): boom") is True
+        out = capsys.readouterr().out
+        assert "raven provider test" not in out
+        assert "Fix:" not in out
+        assert "Hint:" not in out
+        assert agent_commands._ONE_SHOT_EXIT["code"] == 1
+    finally:
+        agent_commands._ONE_SHOT_EXIT["code"] = 0

--- a/tests/test_cli_agent_commands.py
+++ b/tests/test_cli_agent_commands.py
@@ -472,8 +472,9 @@ def test_print_llm_error_renders_diagnosis_and_marks_exit(capsys: pytest.Capture
     try:
         assert agent_commands._print_llm_error(content) is True
         out = capsys.readouterr().out
-        assert "API key invalid" in out
-        assert "openrouter 401" in out
+        assert "provider rejected the credentials" in out
+        assert "openrouter" in out
+        assert "User not found." in out
         assert "raven provider test openrouter" in out
         assert '{"error"' not in out
         assert agent_commands._ONE_SHOT_EXIT["code"] == 1
@@ -481,6 +482,34 @@ def test_print_llm_error_renders_diagnosis_and_marks_exit(capsys: pytest.Capture
         agent_commands._ONE_SHOT_EXIT["code"] = 0
         assert agent_commands._print_llm_error("just a normal reply") is False
         assert agent_commands._ONE_SHOT_EXIT["code"] == 0
+    finally:
+        agent_commands._ONE_SHOT_EXIT["code"] = 0
+
+
+def test_print_llm_error_auth_does_not_fabricate_a_status_code(capsys: pytest.CaptureFixture) -> None:
+    """The auth bucket also fires on 403 / PermissionDeniedError, so the
+    rendered line must not claim 401; the provider's own reason is what the
+    user needs to tell an invalid key from a key without access."""
+    from raven.cli import agent_commands
+    from raven.providers.base import LLMProvider, format_llm_error
+
+    class _PermissionDeniedError(Exception):
+        status_code = 403
+
+    exc = _PermissionDeniedError("permission denied: your key has no access to anthropic/claude-opus-4-5")
+    classification = LLMProvider.classify_error(exc)
+    assert classification.category == "auth"
+    content = format_llm_error(exc, classification, provider="openrouter")
+
+    agent_commands._ONE_SHOT_EXIT["code"] = 0
+    try:
+        assert agent_commands._print_llm_error(content) is True
+        out = capsys.readouterr().out
+        assert "401" not in out
+        assert "provider rejected the credentials (openrouter)" in out
+        assert "no access to anthropic/claude-opus-4-5" in out
+        assert "raven provider test openrouter" in out
+        assert agent_commands._ONE_SHOT_EXIT["code"] == 1
     finally:
         agent_commands._ONE_SHOT_EXIT["code"] = 0
 

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -467,3 +467,39 @@ def test_make_provider_rejects_endpoints_on_providers_that_cannot_rotate(
 
     with pytest.raises(MissingCredentialsError, match="endpoints"):
         _helpers.make_provider(config)
+
+
+# ---------------------------------------------------------------------------
+# check_provider_credentials — onboard guidance
+# ---------------------------------------------------------------------------
+
+
+def test_no_api_key_error_mentions_onboard(tmp_path: Path) -> None:
+    """Zero-provider config: the credentials gate every LLM-needing command
+    runs through must point at ``raven onboard`` alongside the provider set
+    command. Carried on the exception so the single outlet renders it."""
+    from raven.config.loader import load_config
+    from raven.providers.auth import MissingCredentialsError
+
+    p = tmp_path / "config.json"
+    p.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(MissingCredentialsError) as excinfo:
+        _helpers.check_provider_credentials(load_config(p))
+
+    assert "raven onboard" in f"{excinfo.value.summary} {excinfo.value.remedy}"
+
+
+def test_azure_missing_key_same_onboard_guidance(tmp_path: Path) -> None:
+    """The azure branch flows through the same gate and must carry the same
+    ``raven onboard`` guidance as the generic no-key branch, not its own
+    hand-edit-config wording."""
+    from raven.config.loader import load_config
+    from raven.providers.auth import MissingCredentialsError
+
+    cfg = _config_for(tmp_path, "azure_openai", "my-deployment", {"apiBase": "https://example.openai.azure.com"})
+
+    with pytest.raises(MissingCredentialsError) as excinfo:
+        _helpers.check_provider_credentials(load_config(cfg))
+
+    assert "raven onboard" in f"{excinfo.value.summary} {excinfo.value.remedy}"

--- a/tests/test_error_classification.py
+++ b/tests/test_error_classification.py
@@ -133,3 +133,46 @@ def test_jitter_within_ten_percent():
 
 def test_jitter_zero_stays_zero():
     assert LLMProvider._jittered(0) == 0.0
+
+
+# --- format_llm_error / parse_llm_error / _strip_json_error_body ------------- #
+
+
+def test_format_llm_error_collapses_prefixes_and_json_body():
+    from raven.providers.base import format_llm_error, parse_llm_error
+
+    exc = _StatusError(
+        "litellm.AuthenticationError: AuthenticationError: OpenrouterException - "
+        '{"error":{"message":"User not found.","code":401}}',
+        status_code=401,
+    )
+    content = format_llm_error(exc, LLMProvider.classify_error(exc), provider="openrouter")
+
+    assert content == (
+        "Error calling LLM (auth@openrouter): AuthenticationError: OpenrouterException - User not found."
+    )
+    assert parse_llm_error(content) == (
+        "auth",
+        "openrouter",
+        "AuthenticationError: OpenrouterException - User not found.",
+    )
+
+
+def test_parse_llm_error_rejects_ordinary_content():
+    from raven.providers.base import parse_llm_error
+
+    assert parse_llm_error("a normal reply that mentions Error calling LLM") is None
+    assert parse_llm_error(None) is None
+
+
+def test_strip_json_error_body_keeps_trailing_text():
+    from raven.providers.base import _strip_json_error_body
+
+    assert _strip_json_error_body('X - {"error":{"message":"boom"}} (request id: abc)') == "X - boom (request id: abc)"
+
+
+def test_strip_json_error_body_without_a_message_leaves_text_alone():
+    from raven.providers.base import _strip_json_error_body
+
+    text = 'Config invalid: {"foo": "bar"} retry with a valid key'
+    assert _strip_json_error_body(text) == text

--- a/tests/test_openai_codex_provider.py
+++ b/tests/test_openai_codex_provider.py
@@ -324,3 +324,51 @@ def test_litellm_still_filters_out_the_cache_key() -> None:
         "through LiteLLMProvider is gone, so re-read this provider's docstring and decide "
         "whether it still has a reason to exist."
     )
+
+
+def test_chat_error_content_renders_the_canonical_shape(monkeypatch):
+    """Codex's swallowed error must carry the canonical
+    ``Error calling LLM (<category>@<provider>)`` content the CLI renderer
+    parses, not a raw ``Error calling Codex`` string that renders as a fake
+    agent reply with exit 0."""
+    from raven.providers.base import parse_llm_error
+
+    monkeypatch.setattr("raven.providers.chatgpt_token.access_token_and_account", lambda: ("tok", "acct"))
+
+    class _Resp:
+        status_code = 401
+
+        async def aread(self):
+            return b"Unauthorized"
+
+    class _StreamCM:
+        async def __aenter__(self):
+            return _Resp()
+
+        async def __aexit__(self, *args):
+            return False
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        def stream(self, *args, **kwargs):
+            return _StreamCM()
+
+    monkeypatch.setattr("raven.providers.openai_codex_provider.httpx.AsyncClient", _Client)
+    provider = OpenAICodexProvider(default_model="gpt-5")
+
+    resp = asyncio.run(provider.chat(messages=[{"role": "user", "content": "hi"}], model="gpt-5"))
+
+    assert resp.finish_reason == "error"
+    parsed = parse_llm_error(resp.content)
+    assert parsed is not None, resp.content
+    category, provider_name, _detail = parsed
+    assert category == "auth"
+    assert provider_name == "openai_codex"


### PR DESCRIPTION
## Summary

Stacked on the REPL retirement (#329); retargets automatically as the
chain merges. Provider authentication failures used to reach the user
as a raw exception dump - the exception class name printed twice, the
provider's JSON error body rendered as if it were the agent's reply,
the process exited 0, and the memory query-rewrite layer echoed the
same failure once more. A zero-credential first run pointed at hand
editing config.json and never mentioned the guided path.

Changes:

- Provider errors carry the existing error classification through to
  the CLI instead of being stringified into content. The one-shot path
  renders an auth failure as two lines (Error: API key invalid
  (openrouter 401). / Fix: raven provider test openrouter  or  raven
  onboard) and exits 1 via an exit-code seam that survives the
  delivery-hub worker boundary, where a plain typer.Exit would be
  swallowed.
- The raw JSON error body and the duplicated exception prefix are
  stripped from the canonical message; the retry ladder and failover
  semantics are untouched.
- The query-rewrite failure echo drops to debug (it already falls back
  to plain retrieval).
- Both zero-credential raise sites in check_provider_credentials append
  "Or run raven onboard for guided setup." to the existing remedy line.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_cli_helpers.py tests/test_cli_agent_commands.py -x`: 48 passed.
- Full suite (no -x): 6232 passed / 2 failed, both pre-existing on main (the image-block test and the order-dependent theme test).
- Live sandbox with a fake OpenRouter key (real 401): before - bare exception double-write, JSON body, exit 0, rewrite warning; after - the two-line message, exit 1, zero AuthenticationError occurrences. Zero-config sandbox now prints the onboard line and exits 1.
- Each change landed only after a test reproducing the old behavior failed against the unmodified base.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Scripts that relied on a zero exit code from a failed one-shot turn
will now see exit 1; that is the point of the fix. Revert the branch to
roll back.

## Related Issues

N/A - no tracked GitHub issues (internal v0.1.11 usability review).
