### PR TITLE
fix(cli): fold status output and add per-turn usage summary

### DIFF
--- a/raven/cli/_repl_spine.py
+++ b/raven/cli/_repl_spine.py
@@ -63,7 +63,9 @@ class TurnUsageSummary:
         parts = [f"{_fmt_tokens(in_tokens)} in / {_fmt_tokens(out_tokens)} out tokens"]
         cost = (total.estimated_cost_usd or 0.0) - (base.estimated_cost_usd or 0.0)
         if cost > 0:
-            parts.append("$" + f"{cost:.4f}".rstrip("0").rstrip("."))
+            # Below the 4-decimal render floor a real cost would round to "$0"
+            # and read as a free call; show the floor instead of a lie.
+            parts.append("<$0.0001" if cost < 0.0001 else "$" + f"{cost:.4f}".rstrip("0").rstrip("."))
         if self._started is not None:
             parts.append(f"{time.monotonic() - self._started:.1f}s")
         return " · ".join(parts)
@@ -103,7 +105,9 @@ def _build_turn_summary(agent_loop: Any) -> TurnUsageSummary | None:
 def _render_summary_line(line: str) -> None:
     from rich.console import Console
 
-    Console().print(f"[dim]↳ {line}[/dim]")
+    # Two-space indent matches the render_notice progress lines in
+    # agent_commands, so the summary sits in the same visual column.
+    Console().print(f"  [dim]↳ {line}[/dim]")
 
 
 class CliOutlet:

--- a/raven/cli/_repl_spine.py
+++ b/raven/cli/_repl_spine.py
@@ -6,6 +6,7 @@ The one-shot turn runs through spine (submit -> lane -> run_turn -> hub ->
 outlet). spine never imports cli; cli imports spine.
 """
 
+import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -17,9 +18,92 @@ from raven.spine import (
     OriginPools,
     Scheduler,
     Text,
+    TurnRequest,
 )
 from raven.spine.delivery import Capabilities, DeliveryHub, make_hub_sink
 from raven.spine.events import Reasoning
+
+
+def _fmt_tokens(n: int) -> str:
+    if n >= 1000:
+        return f"{n / 1000:.1f}".rstrip("0").rstrip(".") + "k"
+    return str(n)
+
+
+class TurnUsageSummary:
+    """Per-turn usage accounting for the CLI summary line.
+
+    Fed by an in-memory UsageTracker registered on the agent loop's TokenWise
+    registry (same source the persistent telemetry tracker reads). The runner
+    wrapper marks the turn start; the CliOutlet takes the delta after the
+    turn's reply renders. ``take_line`` advances the baseline so a second
+    deliverable in the same turn cannot double-report."""
+
+    def __init__(self, tracker: Any) -> None:
+        self._tracker = tracker
+        self._baseline = tracker.snapshot()
+        self._started: float | None = None
+
+    def turn_started(self) -> None:
+        self._baseline = self._tracker.snapshot()
+        self._started = time.monotonic()
+
+    def take_line(self) -> str | None:
+        total = self._tracker.snapshot()
+        base = self._baseline
+        self._baseline = total
+        in_tokens = (
+            (total.input_tokens - base.input_tokens)
+            + (total.cache_read_tokens - base.cache_read_tokens)
+            + (total.cache_write_tokens - base.cache_write_tokens)
+        )
+        out_tokens = total.output_tokens - base.output_tokens
+        if in_tokens <= 0 and out_tokens <= 0:
+            return None
+        parts = [f"{_fmt_tokens(in_tokens)} in / {_fmt_tokens(out_tokens)} out tokens"]
+        cost = (total.estimated_cost_usd or 0.0) - (base.estimated_cost_usd or 0.0)
+        if cost > 0:
+            parts.append("$" + f"{cost:.4f}".rstrip("0").rstrip("."))
+        if self._started is not None:
+            parts.append(f"{time.monotonic() - self._started:.1f}s")
+        return " · ".join(parts)
+
+
+class _SummaryTurnRunner:
+    """Marks the turn boundary for TurnUsageSummary; delegates the turn."""
+
+    def __init__(self, inner: Any, summary: TurnUsageSummary) -> None:
+        self._inner = inner
+        self._summary = summary
+
+    async def run(self, req: TurnRequest, emit: Any, drain: Any) -> Any:
+        self._summary.turn_started()
+        return await self._inner.run(req, emit, drain)
+
+
+def _build_turn_summary(agent_loop: Any) -> TurnUsageSummary | None:
+    """Wire the per-turn usage summary when the config switch is on.
+
+    Returns None (feature fully off, zero output) when ``cli.turn_summary``
+    is false or the loop has no TokenWise registry to observe (test stubs)."""
+    strategies = getattr(agent_loop, "strategies", None)
+    if strategies is None:
+        return None
+    from raven.config.loader import load_config
+
+    if not load_config().cli.turn_summary:
+        return None
+    from raven.token_wise.usage_tracker import UsageTracker
+
+    tracker = UsageTracker(persist=False)
+    strategies.register(tracker)
+    return TurnUsageSummary(tracker)
+
+
+def _render_summary_line(line: str) -> None:
+    from rich.console import Console
+
+    Console().print(f"[dim]↳ {line}[/dim]")
 
 
 class CliOutlet:
@@ -42,6 +126,7 @@ class CliOutlet:
         render_notice: Callable[[str], None] | None = None,
         send_progress: bool = False,
         send_tool_hints: bool = False,
+        summary: TurnUsageSummary | None = None,
     ) -> None:
         self.name = channel
         self.capabilities = Capabilities()
@@ -49,10 +134,15 @@ class CliOutlet:
         self._render_notice = render_notice
         self._send_progress = send_progress
         self._send_tool_hints = send_tool_hints
+        self._summary = summary
 
     async def deliver(self, out: Deliverable) -> None:
         if isinstance(out, Text):
             self._render(out.content)
+            if self._summary is not None:
+                line = self._summary.take_line()
+                if line:
+                    _render_summary_line(line)
         elif isinstance(out, Notice) and self._render_notice is not None:
             if out.kind is NoticeKind.PROGRESS and self._send_progress:
                 self._render_notice(out.detail or "")
@@ -85,7 +175,11 @@ def build_repl(
     covered.
 
     ``render_notice`` + the two config flags are threaded to the CliOutlet so
-    progress lines render; a caller that omits them keeps Notice eaten."""
+    progress lines render; a caller that omits them keeps Notice eaten.
+
+    The per-turn usage summary (cli.turn_summary) is wired here, at the
+    CliOutlet's deliver tail, so it renders once right after the reply."""
+    summary = _build_turn_summary(agent_loop)
     hub = DeliveryHub()
     hub.register(
         CliOutlet(
@@ -94,10 +188,14 @@ def build_repl(
             render_notice=render_notice,
             send_progress=send_progress,
             send_tool_hints=send_tool_hints,
+            summary=summary,
         )
     )
+    runner: Any = AgentTurnRunner(agent_loop, stream=False, inline_tool_stream=True)
+    if summary is not None:
+        runner = _SummaryTurnRunner(runner, summary)
     scheduler = Scheduler(
-        AgentTurnRunner(agent_loop, stream=False, inline_tool_stream=True),
+        runner,
         OriginPools(user=user_pool, system=system_pool),
         make_hub_sink(hub),
     )

--- a/raven/cli/status_commands.py
+++ b/raven/cli/status_commands.py
@@ -87,9 +87,7 @@ def register(app: typer.Typer) -> None:
                     state = "[green]✓[/green]"
                 console.print(f"{label}: {state}")
             if unconfigured:
-                console.print(
-                    f"[dim]{unconfigured} providers not configured (raven provider list to see all)[/dim]"
-                )
+                console.print(f"[dim]{unconfigured} providers not configured (raven provider list to see all)[/dim]")
 
 
 __all__ = ["register"]

--- a/raven/cli/status_commands.py
+++ b/raven/cli/status_commands.py
@@ -16,7 +16,12 @@ def register(app: typer.Typer) -> None:
     @app.command()
     def status():
         """Show Raven status."""
-        from raven.config.loader import get_config_path, load_config
+        from raven.config.loader import (
+            ConfigReadError,
+            get_config_path,
+            load_config,
+            read_raw_or_raise,
+        )
 
         config_path = get_config_path()
         config = load_config()
@@ -24,7 +29,19 @@ def register(app: typer.Typer) -> None:
 
         console.print(f"{__logo__} Raven Status\n")
 
-        console.print(f"Config: {config_path} {'[green]✓[/green]' if config_path.exists() else '[red]✗[/red]'}")
+        # Three states, not two: a present-but-unparseable file used to show the
+        # same checkmark as a healthy one, right before the provider walk below
+        # aborted on it. The detailed remedy still comes from that walk.
+        if not config_path.exists():
+            config_state = "[red]missing[/red]"
+        else:
+            try:
+                read_raw_or_raise(config_path)
+            except ConfigReadError:
+                config_state = "[red]invalid[/red]"
+            else:
+                config_state = "[green]✓[/green]"
+        console.print(f"Config: {config_path} {config_state}")
         console.print(f"Workspace: {workspace} {'[green]✓[/green]' if workspace.exists() else '[red]✗[/red]'}")
 
         if config_path.exists():
@@ -38,16 +55,25 @@ def register(app: typer.Typer) -> None:
             # the loaded config is the only view that includes credentials
             # supplied by environment variable, which the file on disk does not
             # hold. Reading either one alone shows a configured provider as unset.
+            # Only configured providers get a row; the rest fold into one count
+            # so a single-provider setup is not buried under 20 'not set' rows.
+            unconfigured = 0
             for info in list_providers():
                 label = info["display_name"] or info["name"]
                 section = config.providers.get(info["name"])
                 if info["is_oauth"]:
                     # The token lives in a file, so the listing is the only source.
-                    state = "[green]✓ (OAuth)[/green]" if info["configured"] else "[dim]not set (OAuth)[/dim]"
+                    if not info["configured"]:
+                        unconfigured += 1
+                        continue
+                    state = "[green]✓ (OAuth)[/green]"
                 elif info["is_local"]:
                     # Local deployments show api_base instead of api_key
                     api_base = (section.api_base if section else None) or info["api_base"]
-                    state = f"[green]✓ {api_base}[/green]" if api_base else "[dim]not set[/dim]"
+                    if not api_base:
+                        unconfigured += 1
+                        continue
+                    state = f"[green]✓ {api_base}[/green]"
                 else:
                     # `providers.auth`, like every other gate. Reading `api_key`
                     # here made this the one place that called Azure configured
@@ -55,9 +81,15 @@ def register(app: typer.Typer) -> None:
                     # holding only `api_key_list`.
                     from raven.providers.auth import credential_status
 
-                    status = credential_status(info["name"], section, include_external=True)
-                    state = "[green]✓[/green]" if status.ok else "[dim]not set[/dim]"
+                    if not credential_status(info["name"], section, include_external=True).ok:
+                        unconfigured += 1
+                        continue
+                    state = "[green]✓[/green]"
                 console.print(f"{label}: {state}")
+            if unconfigured:
+                console.print(
+                    f"[dim]{unconfigured} providers not configured (raven provider list to see all)[/dim]"
+                )
 
 
 __all__ = ["register"]

--- a/raven/config/schema.py
+++ b/raven/config/schema.py
@@ -824,10 +824,18 @@ class ToolsConfig(Base):
     (e.g. ``read_file``, ``web_search``, or ``mcp_bcp-search_search``)."""
 
 
+class CliConfig(Base):
+    """CLI surface configuration."""
+
+    turn_summary: bool = True
+    """Render a one-line tokens/cost summary after each successful CLI turn."""
+
+
 class Config(BaseSettings):
     """Root configuration for raven."""
 
     agents: AgentsConfig = Field(default_factory=AgentsConfig)
+    cli: CliConfig = Field(default_factory=CliConfig)
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)

--- a/raven/utils/helpers.py
+++ b/raven/utils/helpers.py
@@ -14,8 +14,11 @@ from loguru import logger
 
 # Workspace sync runs before the CLI decides logger.enable/disable("raven"),
 # so an unscoped debug in this module would spam stderr through loguru's
-# default sink on every first run. logger.enable("raven") lifts this for
-# processes that configure logging.
+# default sink on every first run. A later logger.enable("raven") still
+# lifts this rule (loguru drops descendant rules whenever a parent rule is
+# set), but the CLI flips logging only after its startup sync -- so the
+# per-file detail below reaches callers that enable logging before syncing
+# (tests, embedders), not the first sync of a `--logs` run.
 logger.disable(__name__)
 
 

--- a/raven/utils/helpers.py
+++ b/raven/utils/helpers.py
@@ -450,5 +450,5 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
 
         _c = Console(stderr=True)
         label = "Initialized workspace" if existed == 0 else "Updated workspace templates"
-        _c.print(f"  [dim]{label} ({len(added)} files)[/dim]")
+        _c.print(f"  [dim]{label} ({len(added)} file{'s' if len(added) != 1 else ''})[/dim]")
     return added

--- a/raven/utils/helpers.py
+++ b/raven/utils/helpers.py
@@ -10,6 +10,13 @@ from pathlib import Path
 from typing import Any, Literal, TypedDict
 
 import tiktoken
+from loguru import logger
+
+# Workspace sync runs before the CLI decides logger.enable/disable("raven"),
+# so an unscoped debug in this module would spam stderr through loguru's
+# default sink on every first run. logger.enable("raven") lifts this for
+# processes that configure logging.
+logger.disable(__name__)
 
 
 def detect_image_mime(data: bytes) -> str | None:
@@ -373,9 +380,12 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
         return []
 
     added: list[str] = []
+    existed = 0
 
     def _write(src, dest: Path):
+        nonlocal existed
         if dest.exists():
+            existed += 1
             return
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(src.read_text(encoding="utf-8") if src else "", encoding="utf-8")
@@ -429,10 +439,13 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
     _write(tpl / "HEARTBEAT.md", workspace / "HEARTBEAT.md")
     (workspace / "skills").mkdir(exist_ok=True)
 
+    if added:
+        for name in added:
+            logger.debug("workspace sync: created {}", name)
     if added and not silent:
         from rich.console import Console
 
         _c = Console(stderr=True)
-        for name in added:
-            _c.print(f"  [dim]Created {name}[/dim]")
+        label = "Initialized workspace" if existed == 0 else "Updated workspace templates"
+        _c.print(f"  [dim]{label} ({len(added)} files)[/dim]")
     return added

--- a/tests/test_cli_agent_commands.py
+++ b/tests/test_cli_agent_commands.py
@@ -577,6 +577,25 @@ def test_workspace_sync_prints_single_summary(tmp_path: Path, capsys: pytest.Cap
     assert (second.out + second.err).strip() == ""
 
 
+def test_workspace_sync_debug_detail_lifts_with_raven_logging(tmp_path: Path) -> None:
+    """The module-level logger.disable in helpers yields to a later
+    logger.enable('raven'): loguru drops descendant rules whenever a parent
+    rule is set, so callers that enable logging before syncing get the
+    per-file detail. Freezes the behavior the helpers comment relies on."""
+    from loguru import logger
+
+    from raven.utils.helpers import sync_workspace_templates
+
+    records: list[str] = []
+    sink_id = logger.add(lambda m: records.append(str(m)), level="DEBUG")
+    try:
+        logger.enable("raven")
+        sync_workspace_templates(tmp_path / "ws", silent=True)
+    finally:
+        logger.remove(sink_id)
+    assert any("workspace sync: created" in m for m in records)
+
+
 def _invoke_agent_with_usage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, turn_summary_off: bool = False):
     """Run ``agent -m`` with a stub AgentLoop that reports LLM usage through
     the TokenWise after-hook, mirroring how the real loop feeds UsageTracker."""

--- a/tests/test_cli_agent_commands.py
+++ b/tests/test_cli_agent_commands.py
@@ -555,8 +555,8 @@ def test_print_llm_error_non_auth_categories_get_apt_hint_not_key_guidance(
 
 
 # ---------------------------------------------------------------------------
-# RAV-011: workspace template sync prints one summary line, not one per file
-# RAV-012: per-turn tokens/cost summary line on the one-shot path
+# Workspace template sync prints one summary line, not one per file, and
+# the one-shot path renders a per-turn tokens/cost summary line.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_cli_agent_commands.py
+++ b/tests/test_cli_agent_commands.py
@@ -577,9 +577,7 @@ def test_workspace_sync_prints_single_summary(tmp_path: Path, capsys: pytest.Cap
     assert (second.out + second.err).strip() == ""
 
 
-def _invoke_agent_with_usage(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, turn_summary_off: bool = False
-):
+def _invoke_agent_with_usage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, turn_summary_off: bool = False):
     """Run ``agent -m`` with a stub AgentLoop that reports LLM usage through
     the TokenWise after-hook, mirroring how the real loop feeds UsageTracker."""
     import os as _os
@@ -642,8 +640,6 @@ def test_turn_summary_line_present(tmp_config: Path, tmp_path: Path, monkeypatch
     assert re.search(r"\d[\d.,k]*\s*(in|tokens)", r.output)
 
 
-def test_turn_summary_respects_config_off(
-    tmp_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_turn_summary_respects_config_off(tmp_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     r = _invoke_agent_with_usage(monkeypatch, tmp_path, turn_summary_off=True)
     assert not re.search(r"\d[\d.,k]*\s*(in|tokens)", r.output)

--- a/tests/test_cli_agent_commands.py
+++ b/tests/test_cli_agent_commands.py
@@ -8,6 +8,7 @@ Smoke-level coverage: ``--help`` works, options are surfaced, the
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -551,3 +552,98 @@ def test_print_llm_error_non_auth_categories_get_apt_hint_not_key_guidance(
         assert agent_commands._ONE_SHOT_EXIT["code"] == 1
     finally:
         agent_commands._ONE_SHOT_EXIT["code"] = 0
+
+
+# ---------------------------------------------------------------------------
+# RAV-011: workspace template sync prints one summary line, not one per file
+# RAV-012: per-turn tokens/cost summary line on the one-shot path
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_sync_prints_single_summary(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    from raven.utils.helpers import sync_workspace_templates
+
+    ws = tmp_path / "workspace"
+    added = sync_workspace_templates(ws)
+    first = capsys.readouterr()
+    first_text = first.out + first.err
+    assert added
+    assert "Initialized workspace" in first_text
+    assert first_text.count("Created") == 0
+
+    added_again = sync_workspace_templates(ws)
+    second = capsys.readouterr()
+    assert added_again == []
+    assert (second.out + second.err).strip() == ""
+
+
+def _invoke_agent_with_usage(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, turn_summary_off: bool = False
+):
+    """Run ``agent -m`` with a stub AgentLoop that reports LLM usage through
+    the TokenWise after-hook, mirroring how the real loop feeds UsageTracker."""
+    import os as _os
+
+    from raven.config.loader import save_config
+    from raven.config.schema import Config
+    from raven.spine import Text, TurnOutcome, Usage
+    from raven.token_wise.base import UsageSnapshot
+    from raven.token_wise.registry import StrategyRegistry
+
+    cfg = Config()
+    cfg.providers.openrouter.api_key = "stub-test-key"
+    if turn_summary_off:
+        cfg.cli.turn_summary = False
+    save_config(cfg)
+
+    class _StubSubagents:
+        def set_submit(self, _submit) -> None:
+            pass
+
+    class _StubAgentLoop:
+        def __init__(self, **kwargs):
+            self.channels_config = kwargs.get("channels_config")
+            self.subagents = _StubSubagents()
+            self.strategies = StrategyRegistry([])
+
+        def configure_personalization(self, *_args) -> None:
+            pass
+
+        async def run_turn(self, req, emit, drain, *, stream, **_kw) -> TurnOutcome:
+            await self.strategies.after_llm_call(
+                {"content": "stub"},
+                UsageSnapshot(
+                    model="stub-model",
+                    input_tokens=1200,
+                    output_tokens=340,
+                    estimated_cost_usd=0.004,
+                    session_key=req.conversation,
+                ),
+            )
+            await emit(Text(content="stub-response", source=req.source))
+            return TurnOutcome(usage=Usage(1200, 340, 1540), explicit_reply=True)
+
+        async def await_pending_extractions(self, **_kw) -> None:
+            pass
+
+        async def close_mcp(self) -> None:
+            pass
+
+    monkeypatch.setattr(_os, "_exit", lambda code: (_ for _ in ()).throw(SystemExit(code)))
+    monkeypatch.setattr("raven.cli.agent_commands.make_provider", lambda _: object())
+    monkeypatch.setattr("raven.agent.loop.AgentLoop", _StubAgentLoop)
+    monkeypatch.setattr("raven.cli.agent_commands.maybe_build_memory_backend", lambda *a, **k: None)
+    monkeypatch.setattr("raven.cli.agent_commands.build_plugin_tools", lambda *a, **k: [])
+    return runner.invoke(app, ["agent", "-m", "hi", "-w", str(tmp_path / "ws")])
+
+
+def test_turn_summary_line_present(tmp_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    r = _invoke_agent_with_usage(monkeypatch, tmp_path)
+    assert re.search(r"\d[\d.,k]*\s*(in|tokens)", r.output)
+
+
+def test_turn_summary_respects_config_off(
+    tmp_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    r = _invoke_agent_with_usage(monkeypatch, tmp_path, turn_summary_off=True)
+    assert not re.search(r"\d[\d.,k]*\s*(in|tokens)", r.output)

--- a/tests/test_cli_agent_commands.py
+++ b/tests/test_cli_agent_commands.py
@@ -576,6 +576,12 @@ def test_workspace_sync_prints_single_summary(tmp_path: Path, capsys: pytest.Cap
     assert added_again == []
     assert (second.out + second.err).strip() == ""
 
+    (ws / added[0]).unlink()
+    re_added = sync_workspace_templates(ws)
+    third = capsys.readouterr()
+    assert len(re_added) == 1
+    assert "(1 file)" in (third.out + third.err)
+
 
 def test_workspace_sync_debug_detail_lifts_with_raven_logging(tmp_path: Path) -> None:
     """The module-level logger.disable in helpers yields to a later

--- a/tests/test_cli_repl_spine.py
+++ b/tests/test_cli_repl_spine.py
@@ -3,6 +3,8 @@ import asyncio
 from raven.agent.spine_runner import AgentTurnRunner
 from raven.cli._repl_spine import (
     CliOutlet,
+    TurnUsageSummary,
+    _render_summary_line,
     build_repl,
     make_hub_sink,
 )
@@ -236,3 +238,51 @@ async def test_build_repl_teardown_leaves_no_pending_tasks():
     assert any(not t.done() for t in spawned)  # live spine tasks exist before teardown
     await teardown()  # the same teardown production runs in its finally
     assert all(t.done() for t in spawned)  # teardown stopped every one
+
+
+class _FakeUsageTracker:
+    """snapshot()-only stand-in; each set() swaps in a new lifetime total."""
+
+    def __init__(self) -> None:
+        from raven.token_wise.base import UsageSnapshot
+
+        self._snap = UsageSnapshot(model="stub")
+
+    def snapshot(self):
+        return self._snap
+
+    def set(self, **totals) -> None:
+        from raven.token_wise.base import UsageSnapshot
+
+        self._snap = UsageSnapshot(model="stub", **totals)
+
+
+def test_turn_summary_tiny_cost_shows_floor_not_free():
+    # 4 decimal places round a sub-cent cost like 0.00004 down to "$0",
+    # which reads as a free call; the line must show a floor instead.
+    tracker = _FakeUsageTracker()
+    summary = TurnUsageSummary(tracker)
+    summary.turn_started()
+    tracker.set(input_tokens=100, output_tokens=10, estimated_cost_usd=0.00004)
+    line = summary.take_line()
+    assert line is not None
+    assert "<$0.0001" in line
+    assert " $0 " not in f" {line} "
+
+
+def test_turn_summary_normal_cost_still_renders_exact():
+    tracker = _FakeUsageTracker()
+    summary = TurnUsageSummary(tracker)
+    summary.turn_started()
+    tracker.set(input_tokens=200, output_tokens=20, estimated_cost_usd=0.0042)
+    line = summary.take_line()
+    assert line is not None
+    assert "$0.0042" in line
+
+
+def test_summary_line_indented_like_progress_notices(capsys):
+    # agent_commands renders progress notices as '  [dim]. ...' (two-space
+    # indent); the summary line sits in the same visual column.
+    _render_summary_line("1.2k in / 340 out tokens")
+    out = capsys.readouterr().out
+    assert out.startswith("  ↳")

--- a/tests/test_cli_status_commands.py
+++ b/tests/test_cli_status_commands.py
@@ -75,8 +75,9 @@ def test_status_marks_oauth_providers_distinctly(tmp_config: Path, isolated_oaut
 
 
 # ---------------------------------------------------------------------------
-# RAV-009: fold unconfigured providers into one line
-# FIX-13 (status side): Config line must not show a checkmark on invalid JSON
+# Unconfigured providers fold into one summary line, and the Config line
+# resolves three states (ok / invalid / missing) instead of a checkmark
+# whenever the file merely exists.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_cli_status_commands.py
+++ b/tests/test_cli_status_commands.py
@@ -6,6 +6,7 @@ sandboxed tmp config via ``set_config_path``.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -56,14 +57,70 @@ def test_status_with_existing_config_shows_model(tmp_config: Path) -> None:
     assert "Anthropic" in r.stdout
 
 
-def test_status_marks_oauth_providers_distinctly(tmp_config: Path) -> None:
+def test_status_marks_oauth_providers_distinctly(tmp_config: Path, isolated_oauth_home: Path) -> None:
     """OAuth-based providers (openai_codex, github_copilot) display ``OAuth`` flag."""
     from raven.config.loader import save_config
     from raven.config.schema import Config
 
+    codex_auth = isolated_oauth_home / ".raven" / "oauth" / "chatgpt" / "auth.json"
+    codex_auth.parent.mkdir(parents=True, exist_ok=True)
+    codex_auth.write_text('{"access_token": "test-oauth-token"}', encoding="utf-8")
     save_config(Config())
 
     r = runner.invoke(app, ["status"])
     assert r.exit_code == 0
-    # OpenAI Codex is a pure-OAuth provider in the registry
+    # OpenAI Codex is a pure-OAuth provider in the registry; the token file
+    # above simulates a completed login so the row is shown as configured.
     assert "OAuth" in r.stdout
+
+
+# ---------------------------------------------------------------------------
+# RAV-009: fold unconfigured providers into one line
+# FIX-13 (status side): Config line must not show a checkmark on invalid JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_oauth_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point every OAuth token family at this test's tmp dir so a real login
+    on the developer machine cannot leak into the logged-in/out premise."""
+    home = tmp_path / "home"
+    oauth = home / ".raven" / "oauth"
+    oauth.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("CHATGPT_TOKEN_DIR", str(oauth / "chatgpt"))
+    monkeypatch.setenv("GITHUB_COPILOT_TOKEN_DIR", str(oauth / "github_copilot"))
+    monkeypatch.setenv("MINIMAX_OAUTH_TOKEN_DIR", str(oauth))
+    return home
+
+
+@pytest.fixture
+def tmp_home_one_provider(tmp_config: Path, isolated_oauth_home: Path) -> Path:
+    """Config with exactly one provider set; no OAuth token on disk."""
+    from raven.config.loader import save_config
+    from raven.config.schema import Config
+
+    cfg = Config()
+    cfg.providers.openrouter.api_key = "sk-or-test-key"
+    save_config(cfg)
+    return isolated_oauth_home
+
+
+def test_status_folds_unconfigured_providers(tmp_home_one_provider: Path) -> None:
+    out = runner.invoke(app, ["status"]).stdout
+    assert "not set" not in out
+    assert re.search(r"\d+ providers not configured", out)
+
+
+def test_status_oauth_no_false_checkmark(tmp_home_one_provider: Path) -> None:
+    out = runner.invoke(app, ["status"]).stdout
+    assert "✓ (OAuth)" not in out
+
+
+def test_status_config_line_flags_invalid_json(tmp_config: Path) -> None:
+    tmp_config.parent.mkdir(parents=True, exist_ok=True)
+    tmp_config.write_text('{"providers": {},}', encoding="utf-8")
+
+    out = runner.invoke(app, ["status"]).stdout
+    line = out[out.index("Config:") : out.index("Workspace:")]
+    assert "✓" not in line


### PR DESCRIPTION
## Summary

Follows the provider error rendering fix (#330). Three output-quality
fixes for the CLI:

- `raven status` listed every registry provider (21 lines, 19 of them
  "not set") even with a single provider configured. It now lists only
  configured providers and folds the rest into one line ("N providers
  not configured (raven provider list to see all)"), classifying oauth
  providers by their token file, local ones by api_base, and the rest
  by stored or environment credentials. The Config line now says
  valid / invalid / missing instead of showing a green check over a
  file that failed to parse.
- A fresh workspace printed ten "Created ..." lines on first run; it
  now prints a single "Initialized workspace (10 files)" summary and
  nothing on subsequent runs, with per-file detail kept at debug level.
- CLI turns gain an optional one-line usage summary after the reply
  (tokens in/out, cost when available, elapsed time), fed by an
  in-memory usage tracker on the one-shot delivery path and controlled
  by a new cli.turnSummary switch (default on). Error turns print no
  summary.

The old false OAuth checkmark half of the status issue was already
fixed upstream; a regression test pins that behavior without
reimplementing it.

## Type

- [x] Fix
- [x] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_cli_status_commands.py tests/test_cli_agent_commands.py -x`: 32 passed on the stacked base.
- Full suite (no -x) on the pre-stack base: 6234 passed / 2 failed, both pre-existing on main (the image-block test and the order-dependent theme test).
- Sandbox-HOME runs: first run prints the single summary line, second run prints nothing; single-provider status shows one configured line plus the fold; a corrupted config renders "invalid" with the upstream remedy and exit 1; the usage line renders with a stubbed tracker and disappears with cli.turnSummary=false and on error turns.
- New behavior landed red-first; assertions that were already satisfied by upstream fixes are marked as regression pins in the commit body.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Scripts that parsed the full provider list from status output will see
the folded form; the turn summary is a single dim line and can be
switched off per config. Revert the branch to roll back.

## Related Issues

N/A - no tracked GitHub issues.


