### PR TITLE
feat(tui): surface reminders missed while the tui was closed

### DIFF
--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -353,6 +353,35 @@ async def _fanout_cron_delivered(emitter, *, job_id, name, text, fired_at) -> No
         await emitter.emit(session_key, {"type": "cron.delivered", "payload": payload})
 
 
+async def _fanout_cron_missed(emitter, *, drops) -> None:
+    """Fan a ``cron.missed`` event out to every active TUI session.
+
+    Fired once, right after ``cron_service.start()`` dropped past-due one-shot
+    reminders. At that point the client has not called ``turn.subscribe`` yet
+    (server bring-up precedes the handshake), so with no active session the
+    event is queued on the emitter and flushed to the first subscription that
+    registers — unlike ``cron.delivered``, whose no-subscriber case is a
+    silent no-op because a job fire always happens after the client attached.
+    """
+    from datetime import datetime, timezone
+
+    items = [
+        {
+            "name": d.name,
+            "scheduled_at": datetime.fromtimestamp(d.at_ms / 1000, tz=timezone.utc).isoformat(),
+            "message": d.message,
+        }
+        for d in drops
+    ]
+    event = {"type": "cron.missed", "payload": {"count": len(items), "items": items}}
+    sessions = list(emitter._by_session.keys())
+    if not sessions:
+        emitter.queue_startup_event(event)
+        return
+    for session_key in sessions:
+        await emitter.emit(session_key, event)
+
+
 def _build_cron_callback_spine(base_on_cron, emitter):
     """Wrap the spine cron callback so a job's reply is fanned out as a
     ``cron.delivered`` event. ``base_on_cron`` (``make_on_cron_job`` with
@@ -648,6 +677,10 @@ async def _run_rpc_server_until_done(
             )
             agent_loop.cron_service.on_job = _build_cron_callback_spine(base_on_cron, emitter)
             await agent_loop.cron_service.start()
+            # start() dropped past-due one-shot reminders on this runner's
+            # partition; surface them as one cron.missed startup notice.
+            if agent_loop.cron_service.last_startup_drops:
+                await _fanout_cron_missed(emitter, drops=agent_loop.cron_service.last_startup_drops)
 
     # Wrap system.hello to latch the handshake event; the umbrella below
     # registers everything else (cli.dispatch + setup.status + reload.mcp +

--- a/raven/proactive_engine/schedulers/cron/service.py
+++ b/raven/proactive_engine/schedulers/cron/service.py
@@ -18,7 +18,14 @@ from typing import Any, Callable, Coroutine, Iterator
 
 from loguru import logger
 
-from raven.proactive_engine.schedulers.cron.types import CronJob, CronJobState, CronPayload, CronSchedule, CronStore
+from raven.proactive_engine.schedulers.cron.types import (
+    CronJob,
+    CronJobState,
+    CronPayload,
+    CronSchedule,
+    CronStartupDrop,
+    CronStore,
+)
 
 # Stale-claim TTL — if a claim is older than this, another process may steal
 # it (the original process likely crashed mid-job).
@@ -137,6 +144,10 @@ class CronService:
         # so newly created jobs' next_run_at_ms aligns with simulated time
         # rather than real wall-clock.
         self._now_fn = now_fn
+        # Past-due one-shot reminders dropped by the last start() recompute,
+        # kept so the embedding process can surface them to the user (the
+        # drop itself only leaves a warning log).
+        self.last_startup_drops: list[CronStartupDrop] = []
 
     def _now_ms(self) -> int:
         """Return current time in ms, honouring fake-clock injection."""
@@ -307,7 +318,9 @@ class CronService:
         Past-due one-shot 'at' reminders are dropped — we don't re-deliver
         reminders missed while the service was down (matches iOS /
         Slack / Google Calendar behavior). A warning log records each
-        drop so users can audit via gateway logs.
+        drop so users can audit via gateway logs, and the drops are kept
+        on ``last_startup_drops`` so the embedding process can surface a
+        missed-reminders notice to the user.
 
         Recurring ('every', 'cron') jobs just advance to the next future
         run — missed intervals are skipped, not backfilled.
@@ -320,7 +333,7 @@ class CronService:
         if not self._store:
             return
         now = self._now_ms()
-        dropped: list[str] = []
+        dropped: list[CronStartupDrop] = []
         kept = []
         for job in self._store.jobs:
             if not job.enabled or not self._owns_channel(job.payload.channel):
@@ -328,17 +341,23 @@ class CronService:
                 continue
             next_run = _compute_next_run(job.schedule, now)
             if job.schedule.kind == "at" and next_run is None:
-                stale_ms = now - (job.schedule.at_ms or 0)
-                dropped.append(f"{job.name!r} ({stale_ms // 1000}s late)")
+                dropped.append(
+                    CronStartupDrop(
+                        name=job.name,
+                        message=job.payload.message,
+                        at_ms=job.schedule.at_ms or 0,
+                    )
+                )
                 continue
             job.state.next_run_at_ms = next_run
             kept.append(job)
         self._store.jobs = kept
+        self.last_startup_drops = dropped
         if dropped:
             logger.warning(
                 "Cron: dropped {} past-due one-shot reminder(s) on startup: {}",
                 len(dropped),
-                "; ".join(dropped),
+                "; ".join(f"{d.name!r} ({(now - d.at_ms) // 1000}s late)" for d in dropped),
             )
 
     def _get_next_wake_ms(self) -> int | None:

--- a/raven/proactive_engine/schedulers/cron/types.py
+++ b/raven/proactive_engine/schedulers/cron/types.py
@@ -65,6 +65,15 @@ class CronJob:
 
 
 @dataclass
+class CronStartupDrop:
+    """A past-due one-shot reminder dropped by the startup recompute."""
+
+    name: str
+    message: str
+    at_ms: int
+
+
+@dataclass
 class CronStore:
     """Persistent store for cron jobs."""
 

--- a/raven/tui_rpc/models.py
+++ b/raven/tui_rpc/models.py
@@ -233,6 +233,22 @@ class CronDeliveredEvent(_Strict):
     payload: CronDeliveredPayload
 
 
+class CronMissedItem(_Strict):
+    name: str
+    scheduled_at: str
+    message: str
+
+
+class CronMissedPayload(_Strict):
+    count: int
+    items: list[CronMissedItem]
+
+
+class CronMissedEvent(_Strict):
+    type: Literal["cron.missed"]
+    payload: CronMissedPayload
+
+
 TurnEvent = Annotated[
     Union[
         MessageStartEvent,
@@ -245,6 +261,7 @@ TurnEvent = Annotated[
         MessageCompleteEvent,
         ErrorEvent,
         CronDeliveredEvent,
+        CronMissedEvent,
     ],
     Field(discriminator="type"),
 ]
@@ -985,6 +1002,9 @@ __all__ = [
     "ErrorEvent",
     "CronDeliveredEvent",
     "CronDeliveredPayload",
+    "CronMissedEvent",
+    "CronMissedItem",
+    "CronMissedPayload",
     # registry
     "METHOD_MODELS",
 ]

--- a/raven/tui_rpc/subscriptions.py
+++ b/raven/tui_rpc/subscriptions.py
@@ -44,9 +44,24 @@ class SubscriptionEmitter:
         self._send_frame = send_frame
         self._by_session: dict[str, list[Subscription]] = {}
         self._by_id: dict[str, Subscription] = {}
+        self._startup_events: list[dict[str, Any]] = []
+
+    def queue_startup_event(self, event: dict[str, Any]) -> None:
+        """Buffer an event produced before any subscription exists.
+
+        Server bring-up (cron start, agent-loop build) precedes the client's
+        ``turn.subscribe``, so an ``emit`` at that point is a silent no-op.
+        Buffered events are flushed to the first subscription that registers,
+        then dropped — they are one-shot startup notices, not a replay log.
+        """
+        self._startup_events.append(event)
 
     async def register(self, session_key: str) -> str:
-        """Create a subscription, start its coalesce loop, return the sub_id."""
+        """Create a subscription, start its coalesce loop, return the sub_id.
+
+        Any queued startup events are flushed to this subscription's session
+        if it is the first to register (see ``queue_startup_event``).
+        """
         sub = Subscription(
             sub_id=uuid4().hex,
             session_key=session_key,
@@ -55,6 +70,10 @@ class SubscriptionEmitter:
         sub.coalesce_task = asyncio.create_task(self._coalesce_loop(sub))
         self._by_session.setdefault(session_key, []).append(sub)
         self._by_id[sub.sub_id] = sub
+        if self._startup_events:
+            pending, self._startup_events = self._startup_events, []
+            for event in pending:
+                await self.emit(session_key, event)
         return sub.sub_id
 
     async def unregister(self, sub_id: str) -> bool:

--- a/tests/test_cron_service_startup.py
+++ b/tests/test_cron_service_startup.py
@@ -122,3 +122,39 @@ async def test_startup_leaves_own_disabled_job_untouched(tmp_path: Path) -> None
 
     data = json.loads(store_path.read_text(encoding="utf-8"))
     assert [j["id"] for j in data["jobs"]] == ["tui1"], "disabled jobs are never dropped by startup recompute"
+
+
+async def test_startup_drop_records_structured_info(tmp_path: Path) -> None:
+    """Each startup drop SHALL be recorded on ``last_startup_drops`` with the
+    job's name, payload message, and scheduled at_ms, so the embedding process
+    can surface a missed-reminders notice."""
+    from raven.proactive_engine.schedulers.cron.types import CronStartupDrop
+
+    store_path = tmp_path / "jobs.json"
+    now_ms = int(time.time() * 1000)
+    _write_store(store_path, [_past_due_tui_at_job(now_ms)])
+
+    svc = CronService(store_path, allowed_channels={"tui"})
+    assert svc.last_startup_drops == [], "readable before start()"
+    await svc.start()
+    svc.stop()
+
+    assert svc.last_startup_drops == [
+        CronStartupDrop(name="tui reminder", message="stretch", at_ms=now_ms - 60_000),
+    ]
+
+
+async def test_startup_drop_records_empty_for_foreign_or_clean_start(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    now_ms = int(time.time() * 1000)
+    _write_store(store_path, [_past_due_tui_at_job(now_ms)])
+
+    svc = CronService(store_path, allowed_channels={"weixin"})
+    await svc.start()
+    svc.stop()
+    assert svc.last_startup_drops == [], "foreign past-due job must not be recorded as this runner's drop"
+
+    svc2 = CronService(tmp_path / "empty.json", allowed_channels={"tui"})
+    await svc2.start()
+    svc2.stop()
+    assert svc2.last_startup_drops == []

--- a/tests/test_subscription_emitter.py
+++ b/tests/test_subscription_emitter.py
@@ -266,3 +266,50 @@ async def test_closed_subscription_does_not_receive_new_events(
     await asyncio.sleep(COALESCE_WINDOW_S * 3)
     post_count = send_frame.call_count
     assert post_count == pre_count, f"closed sub received events after unregister: pre={pre_count} post={post_count}"
+
+
+# ---------------------------------------------------------------------------
+# startup-event buffer (queue_startup_event → flushed on first register)
+# ---------------------------------------------------------------------------
+
+
+async def test_startup_event_flushed_to_first_registration(
+    emitter: SubscriptionEmitter,
+    send_frame: AsyncMock,
+) -> None:
+    """An event queued before any subscription exists SHALL be delivered to
+    the first subscription that registers."""
+    event = {"type": "cron.missed", "payload": {"count": 1, "items": []}}
+    emitter.queue_startup_event(event)
+    await emitter.register("tui:default")
+    await asyncio.sleep(COALESCE_WINDOW_S * 3)
+
+    events = _collect_emitted_events(send_frame)
+    assert events == [event]
+
+
+async def test_startup_event_not_redelivered_to_later_registrations(
+    emitter: SubscriptionEmitter,
+    send_frame: AsyncMock,
+) -> None:
+    """The buffer is one-shot: a second registration (re-attach, session
+    switch) SHALL NOT receive the startup events again."""
+    emitter.queue_startup_event({"type": "cron.missed", "payload": {"count": 1, "items": []}})
+    sub_id = await emitter.register("tui:default")
+    await asyncio.sleep(COALESCE_WINDOW_S * 3)
+    await emitter.unregister(sub_id)
+    first_count = len(_collect_emitted_events(send_frame))
+
+    await emitter.register("tui:other")
+    await asyncio.sleep(COALESCE_WINDOW_S * 3)
+
+    assert len(_collect_emitted_events(send_frame)) == first_count == 1
+
+
+async def test_register_without_startup_events_emits_nothing(
+    emitter: SubscriptionEmitter,
+    send_frame: AsyncMock,
+) -> None:
+    await emitter.register("tui:default")
+    await asyncio.sleep(COALESCE_WINDOW_S * 3)
+    assert _collect_emitted_events(send_frame) == []

--- a/tests/test_tui_cron_delivered_event.py
+++ b/tests/test_tui_cron_delivered_event.py
@@ -158,3 +158,101 @@ async def test_cron_callback_spine_fans_out_reply(emitter_spy: MagicMock) -> Non
     silent = SimpleNamespace(id="j8", name="silent")
     await wrapped(silent)
     emitter_spy.emit.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# cron.missed — startup notice for reminders dropped by the startup recompute
+# ---------------------------------------------------------------------------
+
+
+def test_cron_missed_event_pydantic_validates() -> None:
+    """``CronMissedEvent`` SHALL be a member of the ``TurnEvent`` discriminated
+    union with payload {count, items: [{name, scheduled_at, message}]}."""
+    from raven.tui_rpc.models import CronMissedEvent
+
+    event = CronMissedEvent(
+        type="cron.missed",
+        payload={
+            "count": 2,
+            "items": [
+                {"name": "hydrate", "scheduled_at": "2026-06-04T10:23:00+00:00", "message": "记得喝水"},
+                {"name": "stretch", "scheduled_at": "2026-06-04T11:00:00+00:00", "message": "起来活动一下"},
+            ],
+        },
+    )
+    assert event.type == "cron.missed"
+    assert event.payload.count == 2
+    assert event.payload.items[0].name == "hydrate"
+    assert event.payload.items[0].scheduled_at == "2026-06-04T10:23:00+00:00"
+    assert event.payload.items[1].message == "起来活动一下"
+
+
+def test_cron_missed_event_in_turn_event_union() -> None:
+    from pydantic import TypeAdapter
+
+    from raven.tui_rpc.models import CronMissedEvent, TurnEvent
+
+    adapter = TypeAdapter(TurnEvent)
+    parsed = adapter.validate_python(
+        {
+            "type": "cron.missed",
+            "payload": {
+                "count": 1,
+                "items": [{"name": "meds", "scheduled_at": "2026-06-04T08:00:00+00:00", "message": "吃药"}],
+            },
+        }
+    )
+    assert isinstance(parsed, CronMissedEvent)
+
+
+def _drop(name: str, message: str, at_ms: int):
+    from raven.proactive_engine.schedulers.cron.types import CronStartupDrop
+
+    return CronStartupDrop(name=name, message=message, at_ms=at_ms)
+
+
+async def test_fanout_cron_missed_active_session(emitter_spy: MagicMock) -> None:
+    """With an attached session, ``_fanout_cron_missed`` SHALL emit one
+    cron.missed event carrying every drop, scheduled_at as ISO-8601 UTC."""
+    from raven.cli.tui_commands import _fanout_cron_missed
+
+    await _fanout_cron_missed(
+        emitter_spy,
+        drops=[
+            _drop("hydrate", "记得喝水", 1_749_031_380_000),
+            _drop("stretch", "起来活动一下", 1_749_033_600_000),
+        ],
+    )
+
+    emitter_spy.emit.assert_awaited_once()
+    session_key, event = emitter_spy.emit.await_args.args
+    assert session_key == "sess_user_default"
+    assert event["type"] == "cron.missed"
+    assert event["payload"]["count"] == 2
+    assert [i["name"] for i in event["payload"]["items"]] == ["hydrate", "stretch"]
+    assert event["payload"]["items"][0]["message"] == "记得喝水"
+    assert event["payload"]["items"][0]["scheduled_at"] == "2025-06-04T10:03:00+00:00"
+
+
+async def test_fanout_cron_missed_no_session_queues_startup_event() -> None:
+    """With no subscription yet (server bring-up precedes turn.subscribe), the
+    event SHALL be queued on the emitter for the first registration instead of
+    being dropped like the cron.delivered no-subscriber no-op."""
+    from raven.cli.tui_commands import _fanout_cron_missed
+
+    emitter = MagicMock()
+    emitter._by_session = {}
+    emitter.emit = AsyncMock()
+
+    await _fanout_cron_missed(emitter, drops=[_drop("meds", "吃药", 1_749_024_000_000)])
+
+    emitter.emit.assert_not_awaited()
+    emitter.queue_startup_event.assert_called_once()
+    event = emitter.queue_startup_event.call_args.args[0]
+    assert event["type"] == "cron.missed"
+    assert event["payload"]["count"] == 1
+    assert event["payload"]["items"][0] == {
+        "name": "meds",
+        "scheduled_at": "2025-06-04T08:00:00+00:00",
+        "message": "吃药",
+    }

--- a/ui-tui/rpc-schema/openrpc.json
+++ b/ui-tui/rpc-schema/openrpc.json
@@ -1847,6 +1847,35 @@
           }
         }
       },
+      "CronMissedEvent": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "payload"],
+        "properties": {
+          "type": { "type": "string", "const": "cron.missed" },
+          "payload": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["count", "items"],
+            "properties": {
+              "count": { "type": "integer" },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["name", "scheduled_at", "message"],
+                  "properties": {
+                    "name": { "type": "string" },
+                    "scheduled_at": { "type": "string" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "TurnEvent": {
         "description": "Discriminated union of turn streaming events. The 'type' field is the discriminator.",
         "oneOf": [
@@ -1859,7 +1888,8 @@
           { "$ref": "#/components/schemas/ToolCompleteEvent" },
           { "$ref": "#/components/schemas/MessageCompleteEvent" },
           { "$ref": "#/components/schemas/ErrorEvent" },
-          { "$ref": "#/components/schemas/CronDeliveredEvent" }
+          { "$ref": "#/components/schemas/CronDeliveredEvent" },
+          { "$ref": "#/components/schemas/CronMissedEvent" }
         ],
         "discriminator": {
           "propertyName": "type",
@@ -1873,7 +1903,8 @@
             "tool.complete": "#/components/schemas/ToolCompleteEvent",
             "message.complete": "#/components/schemas/MessageCompleteEvent",
             "error": "#/components/schemas/ErrorEvent",
-            "cron.delivered": "#/components/schemas/CronDeliveredEvent"
+            "cron.delivered": "#/components/schemas/CronDeliveredEvent",
+            "cron.missed": "#/components/schemas/CronMissedEvent"
           }
         }
       }

--- a/ui-tui/src/__tests__/chatStream.test.ts
+++ b/ui-tui/src/__tests__/chatStream.test.ts
@@ -410,3 +410,43 @@ describe('createChatStream — cancel preserves streamed content', () => {
     expect(sysCalls).toContain('interrupted')
   })
 })
+
+describe('createChatStream — cron.missed startup notice', () => {
+  beforeEach(() => {
+    resetTurnState()
+    resetUiState()
+    turnController.fullReset()
+  })
+
+  it('renders one compact summary block via sys with per-item name and scheduled HH:MM', async () => {
+    const fake = makeFakeRpc()
+    const sysCalls: string[] = []
+    const stream = createChatStream({
+      rpcClient: fake,
+      sessionKey: 'tui:default',
+      sys: m => sysCalls.push(m)
+    })
+    await stream.attach()
+
+    fake.__pushEvent({
+      type: 'cron.missed',
+      payload: {
+        count: 2,
+        items: [
+          { message: '记得喝水', name: 'hydrate', scheduled_at: '2025-06-04T10:03:00+00:00' },
+          { message: '起来活动一下', name: 'stretch', scheduled_at: '2025-06-04T10:40:00+00:00' }
+        ]
+      }
+    })
+
+    expect(sysCalls).toHaveLength(1)
+    const block = sysCalls[0]
+    expect(block).toContain('错过 2 条提醒')
+    expect(block).toContain('hydrate — 原定')
+    expect(block).toContain('stretch — 原定')
+    // scheduled_at renders as local HH:MM, so assert the shape, not the value.
+    expect(block).toMatch(/原定 \d{2}:\d{2}/)
+    // A missed notice is a transcript block, not a turn — the UI must stay idle.
+    expect(stream.isTurnActive()).toBe(false)
+  })
+})

--- a/ui-tui/src/__tests__/chatStream.test.ts
+++ b/ui-tui/src/__tests__/chatStream.test.ts
@@ -441,11 +441,11 @@ describe('createChatStream — cron.missed startup notice', () => {
 
     expect(sysCalls).toHaveLength(1)
     const block = sysCalls[0]
-    expect(block).toContain('错过 2 条提醒')
-    expect(block).toContain('hydrate — 原定')
-    expect(block).toContain('stretch — 原定')
+    expect(block).toContain('missed 2 reminders')
+    expect(block).toContain('hydrate — scheduled')
+    expect(block).toContain('stretch — scheduled')
     // scheduled_at renders as local HH:MM, so assert the shape, not the value.
-    expect(block).toMatch(/原定 \d{2}:\d{2}/)
+    expect(block).toMatch(/scheduled \d{2}:\d{2}/)
     // A missed notice is a transcript block, not a turn — the UI must stay idle.
     expect(stream.isTurnActive()).toBe(false)
   })

--- a/ui-tui/src/__tests__/chatStream.test.ts
+++ b/ui-tui/src/__tests__/chatStream.test.ts
@@ -442,11 +442,14 @@ describe('createChatStream — cron.missed startup notice', () => {
     expect(sysCalls).toHaveLength(1)
     const block = sysCalls[0]
     expect(block).toContain('missed 2 reminders')
-    // Fixed 2025 timestamps are never "today": the dated form must render.
-    expect(block).toMatch(/hydrate — scheduled 06-04 \d{2}:\d{2}: 记得喝水/)
-    expect(block).toMatch(/stretch — scheduled 06-04 \d{2}:\d{2}: 起来活动一下/)
-    // Non-today timestamps render the dated local form: MM-DD HH:MM.
-    expect(block).toMatch(/scheduled 06-04 \d{2}:\d{2}/)
+    // Fixed 2025 timestamps are never "today" in any timezone: the dated
+    // form must render — but the calendar day is LOCAL while the fixture is
+    // UTC, so assert the shape, never a literal date.
+    expect(block).toMatch(/hydrate — scheduled \d{2}-\d{2} \d{2}:\d{2}: 记得喝水/)
+    expect(block).toMatch(/stretch — scheduled \d{2}-\d{2} \d{2}:\d{2}: 起来活动一下/)
+    // Non-today timestamps render the dated local form (shape only: the
+    // local calendar day shifts with the machine's timezone).
+    expect(block).toMatch(/scheduled \d{2}-\d{2} \d{2}:\d{2}/)
     // A missed notice is a transcript block, not a turn — the UI must stay idle.
     expect(stream.isTurnActive()).toBe(false)
   })

--- a/ui-tui/src/__tests__/chatStream.test.ts
+++ b/ui-tui/src/__tests__/chatStream.test.ts
@@ -442,11 +442,37 @@ describe('createChatStream — cron.missed startup notice', () => {
     expect(sysCalls).toHaveLength(1)
     const block = sysCalls[0]
     expect(block).toContain('missed 2 reminders')
-    expect(block).toContain('hydrate — scheduled')
-    expect(block).toContain('stretch — scheduled')
-    // scheduled_at renders as local HH:MM, so assert the shape, not the value.
-    expect(block).toMatch(/scheduled \d{2}:\d{2}/)
+    // Fixed 2025 timestamps are never "today": the dated form must render.
+    expect(block).toMatch(/hydrate — scheduled 06-04 \d{2}:\d{2}: 记得喝水/)
+    expect(block).toMatch(/stretch — scheduled 06-04 \d{2}:\d{2}: 起来活动一下/)
+    // Non-today timestamps render the dated local form: MM-DD HH:MM.
+    expect(block).toMatch(/scheduled 06-04 \d{2}:\d{2}/)
     // A missed notice is a transcript block, not a turn — the UI must stay idle.
     expect(stream.isTurnActive()).toBe(false)
+  })
+
+  it('renders a bare HH:MM when the missed reminder was scheduled today', async () => {
+    const fake = makeFakeRpc()
+    const sysCalls: string[] = []
+    const stream = createChatStream({
+      rpcClient: fake,
+      sessionKey: 'tui:default',
+      sys: m => sysCalls.push(m)
+    })
+    await stream.attach()
+
+    const today = new Date()
+    today.setHours(9, 30, 0, 0)
+    fake.__pushEvent({
+      type: 'cron.missed',
+      payload: {
+        count: 1,
+        items: [{ message: 'drink water', name: 'hydrate', scheduled_at: today.toISOString() }]
+      }
+    })
+
+    expect(sysCalls).toHaveLength(1)
+    expect(sysCalls[0]).toContain('hydrate — scheduled 09:30: drink water')
+    expect(sysCalls[0]).not.toMatch(/scheduled \d{2}-\d{2} /)
   })
 })

--- a/ui-tui/src/app/chatStream.ts
+++ b/ui-tui/src/app/chatStream.ts
@@ -159,8 +159,9 @@ const dispatch = (
     case 'cron.missed': {
       if (sys) {
         const { count, items } = event.payload
-        const lines = items.map(item => `${item.name} — 原定 ${formatScheduledAt(item.scheduled_at)}`)
-        sys(`─── ⏰ 错过 ${count} 条提醒 ───\n${lines.join('\n')}\n${'─'.repeat(40)}`)
+        const lines = items.map(item => `${item.name} — scheduled ${formatScheduledAt(item.scheduled_at)}`)
+        const noun = count === 1 ? 'reminder' : 'reminders'
+        sys(`─── ⏰ missed ${count} ${noun} ───\n${lines.join('\n')}\n${'─'.repeat(40)}`)
       }
       return
     }

--- a/ui-tui/src/app/chatStream.ts
+++ b/ui-tui/src/app/chatStream.ts
@@ -100,6 +100,16 @@ interface InternalState {
   turnId: string | null
 }
 
+// Render an ISO timestamp as local HH:MM for the cron.missed summary block;
+// falls back to the raw string when unparseable.
+const formatScheduledAt = (iso: string): string => {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) {
+    return iso
+  }
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+}
+
 const dispatch = (
   state: InternalState,
   event: TurnEvent,
@@ -143,6 +153,14 @@ const dispatch = (
         const { name, text, fired_at } = event.payload
         const tag = fired_at ? `${name} @ ${fired_at}` : name
         sys(`─── ⏰ ${tag} ───\n${text}\n${'─'.repeat(40)}`)
+      }
+      return
+    }
+    case 'cron.missed': {
+      if (sys) {
+        const { count, items } = event.payload
+        const lines = items.map(item => `${item.name} — 原定 ${formatScheduledAt(item.scheduled_at)}`)
+        sys(`─── ⏰ 错过 ${count} 条提醒 ───\n${lines.join('\n')}\n${'─'.repeat(40)}`)
       }
       return
     }

--- a/ui-tui/src/app/chatStream.ts
+++ b/ui-tui/src/app/chatStream.ts
@@ -100,14 +100,24 @@ interface InternalState {
   turnId: string | null
 }
 
-// Render an ISO timestamp as local HH:MM for the cron.missed summary block;
-// falls back to the raw string when unparseable.
+// Render an ISO timestamp for the cron.missed summary block: local HH:MM
+// when the reminder was scheduled today, MM-DD HH:MM otherwise - a missed
+// notice's whole point is how long ago, and a bare "09:00" after a weekend
+// away reads like this morning. Falls back to the raw string when
+// unparseable.
 const formatScheduledAt = (iso: string): string => {
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) {
     return iso
   }
-  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+  const hhmm = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+  const now = new Date()
+  const sameDay =
+    d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth() && d.getDate() === now.getDate()
+  if (sameDay) {
+    return hhmm
+  }
+  return `${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${hhmm}`
 }
 
 const dispatch = (
@@ -159,7 +169,7 @@ const dispatch = (
     case 'cron.missed': {
       if (sys) {
         const { count, items } = event.payload
-        const lines = items.map(item => `${item.name} — scheduled ${formatScheduledAt(item.scheduled_at)}`)
+        const lines = items.map(item => `${item.name} — scheduled ${formatScheduledAt(item.scheduled_at)}: ${item.message}`)
         const noun = count === 1 ? 'reminder' : 'reminders'
         sys(`─── ⏰ missed ${count} ${noun} ───\n${lines.join('\n')}\n${'─'.repeat(40)}`)
       }

--- a/ui-tui/src/rpc/generated.ts
+++ b/ui-tui/src/rpc/generated.ts
@@ -33,7 +33,8 @@ export type TurnEvent =
   | ToolCompleteEvent
   | MessageCompleteEvent
   | ErrorEvent
-  | CronDeliveredEvent;
+  | CronDeliveredEvent
+  | CronMissedEvent;
 
 /**
  * This interface was referenced by `RavenRpcRoot`'s JSON-Schema
@@ -418,6 +419,21 @@ export interface CronDeliveredEvent {
     name: string;
     text: string;
     fired_at: string;
+  };
+}
+/**
+ * This interface was referenced by `RavenRpcRoot`'s JSON-Schema
+ * via the `definition` "CronMissedEvent".
+ */
+export interface CronMissedEvent {
+  type: 'cron.missed';
+  payload: {
+    count: number;
+    items: {
+      name: string;
+      scheduled_at: string;
+      message: string;
+    }[];
   };
 }
 /**


### PR DESCRIPTION
## Summary

Complete the missed-reminder story for tui-bound one-shot reminders.
Under fire-at-origin ownership, a one-shot reminder bound to the tui
lapses at the next tui startup when its session was closed at fire
time - previously with only a warning log the user never sees. Now:

- The startup cleanup records each dropped reminder as structured data
  (name, message, originally scheduled time) instead of only logging.
- The tui backend fans them out as a single `cron.missed` event right
  after its cron service starts.
- The frontend renders one compact summary block: "missed N reminders",
  one line per item with the originally scheduled local time.

Startup events race the client's subscription (the event fired before
`turn.subscribe` was previously lost), so `SubscriptionEmitter` gains a
one-shot startup buffer flushed to the first subscriber. The new event
is registered in the RPC schema and `generated.ts` is regenerated.

This matches how established reminder systems treat a closed surface:
the notification ping is best-effort, and the store's overdue state is
shown at the next open.

## Type

- [x] Feature

## Verification

- `uv run pytest tests/ --ignore=tests/integration` on this branch:
  6000 passed / 2 failed, both failures pre-existing on main run the
  same way (test_read_file_image, plus the order-dependent
  test_cli_theme flake that fails whenever its file runs as a whole) -
  zero failures introduced.
- Affected-area suites (tui events, subscription emitter, cron startup,
  tui bootstrap/commands, rpc models): 178 passed.
- `make lint-tui`: eslint zero errors, RPC drift check reports
  generated.ts in sync; `ui-tui` vitest: 984 passed, covering the
  summary rendering across its review rounds (English chrome, dated
  form for non-today timestamps vs bare HH:MM today, and the reminder
  message text).
- `uv run ruff format --check` and `uv run ruff check`: clean.
- New tests: startup-drop collection, cron.missed model and fanout,
  emitter startup buffer, frontend rendering.

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Additive feature: no schema or storage format changes beyond a new
event type; clients that never subscribe simply never receive it.
Rollback = revert the squash commit.

## Related Issues

N/A

