### PR TITLE
feat(proactive_engine): add cron anti-runaway protection and missed-reminder notices

### DIFF
--- a/raven/cli/_cron_handler.py
+++ b/raven/cli/_cron_handler.py
@@ -10,16 +10,19 @@ re-routing.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from loguru import logger
 
 if TYPE_CHECKING:
+    from raven.proactive_engine.schedulers.cron.service import CronService
     from raven.proactive_engine.schedulers.cron.types import CronJob
     from raven.proactive_engine.sentinel.executor.runner import SentinelRunner
     from raven.proactive_engine.system_events import SystemEventQueue
     from raven.proactive_engine.wake import WakeScheduler
     from raven.spine import TurnHandle, TurnRequest
+
+_RECURRING_KINDS = ("every", "cron")
 
 
 def _ms_to_local_str(ms: int | None) -> str | None:
@@ -104,6 +107,7 @@ def make_on_cron_job(
     sentinel_runner: "SentinelRunner | None" = None,
     system_events: "SystemEventQueue | None" = None,
     wake: "WakeScheduler | None" = None,
+    cron_service: "CronService | None" = None,
 ) -> Callable[["CronJob"], Awaitable[str | None]]:
     """Build the CronService.on_job callback. Every cron turn runs through the
     spine ``submit`` as a CRON-origin turn.
@@ -142,6 +146,15 @@ def make_on_cron_job(
     follow-ups.
     Only effective for jobs executed in this process — a CLI test-fire
     runs in its own process and cannot reach the gateway's queue.
+
+    ``cron_service`` is optional. When wired, each successful recurring
+    fire ('every'/'cron' kinds; one-shots can't run away) is counted via
+    ``record_fire`` — the anti-runaway guard that auto-disables a job
+    after ``silent_fire_limit`` consecutive fires with no user activity
+    on its (channel, to). Failed turns are not counted: a job that never
+    delivers is a different problem than one that spams. On auto-disable
+    the in-memory job is flipped too, so the service's post-run writeback
+    persists the disable instead of recomputing a next run.
     """
 
     async def on_cron_job(job: "CronJob") -> str | None:
@@ -185,6 +198,25 @@ def make_on_cron_job(
         # capture, stored before result() resolved, and pop it so the
         # long-running map does not accumulate.
         response: str | None = readback_texts.pop(f"cron:{job.id}", None) if readback_texts is not None else None
+
+        # Anti-runaway: count this successful recurring fire. Best-effort —
+        # a store I/O failure must not turn a delivered reminder into an
+        # error status.
+        if cron_service is not None and job.schedule.kind in _RECURRING_KINDS:
+            try:
+                if cron_service.record_fire(job.id):
+                    # Flip the in-flight job too: _writeback_after_run patches
+                    # enabled/next_run from this object and would otherwise
+                    # clobber the disable record_fire just persisted.
+                    job.enabled = False
+                    job.state.next_run_at_ms = None
+            except Exception as exc:  # noqa: BLE001 — fire accounting is best-effort
+                logger.warning(
+                    "cron record_fire failed for {}: {}: {}",
+                    job.id,
+                    type(exc).__name__,
+                    exc,
+                )
 
         # F-G: tell the L3 Sentinel this surface just nudged the user (topic_fired_at
         # + record_dispatched), so its next tick on the same topic skips via
@@ -261,4 +293,91 @@ def _record_cron_dispatch_to_ledger(
         )
 
 
-__all__ = ["make_on_cron_job"]
+def make_on_missed_foreign(
+    system_events: "SystemEventQueue",
+    wake: "WakeScheduler",
+) -> Callable[[list["CronJob"]], None]:
+    """Build the ``CronService.on_missed_foreign`` observer for the gateway.
+
+    Each missed foreign one-shot (a tui / cli reminder whose session closed
+    before it fired) is surfaced ONCE as a system event with context_key
+    ``cron:<job_id>:missed`` plus a heartbeat wake request — the heartbeat's
+    existing target selection delivers the notice; there is no new delivery
+    path, and the foreign job itself is never touched.
+
+    Dedup is two-layer: while queued, the SystemEventQueue replaces events
+    sharing a context_key (same semantics _emit_cron_event relies on); after
+    the heartbeat consumed one, the in-process ``notified`` set stops any
+    re-enqueue on later wake passes. The set is process-local by design —
+    after a gateway restart a still-missed job may notify once more
+    (accepted v1 trade-off; persisting would mean mutating a foreign job
+    or growing a side store).
+    """
+    notified: set[str] = set()
+
+    def on_missed_foreign(jobs: "list[CronJob]") -> None:
+        from raven.proactive_engine.system_events import SystemEvent
+
+        for job in jobs:
+            if job.id in notified:
+                continue
+            fire_at = _ms_to_local_str(job.schedule.at_ms) or "?"
+            channel = job.payload.channel or "?"
+            context_key = f"cron:{job.id}:missed"
+            text = f"Reminder '{job.name}' (scheduled {fire_at} on {channel}) was missed - its session was closed."
+            try:
+                system_events.enqueue(SystemEvent(text=text, source="cron", context_key=context_key))
+                wake.request_wake_now(context_key)
+            except Exception as exc:  # noqa: BLE001 — per-job, retried next pass
+                logger.warning(
+                    "missed-reminder event emit failed for {}: {}: {}",
+                    job.id,
+                    type(exc).__name__,
+                    exc,
+                )
+                continue
+            # Marked only after a successful enqueue so a transient emit
+            # failure is retried on the next wake pass.
+            notified.add(job.id)
+            logger.info("Cron: missed-reminder event enqueued for '{}' ({})", job.name, job.id)
+
+    return on_missed_foreign
+
+
+def chain_cron_activity_reset(
+    cron_service: "CronService",
+    inner: "Callable[[TurnRequest], Any] | None" = None,
+) -> "Callable[[TurnRequest], Any]":
+    """Compose an AgentLoop ``on_user_inbound`` callback that resets the
+    anti-runaway silent-fire counters on genuine user activity, chained
+    after ``inner`` (the Sentinel engagement hook — preserved, not
+    replaced).
+
+    Only ``Origin.USER`` turns reset: the user-inbound hook chain also
+    runs for CRON / HEARTBEAT origin turns (only SENTINEL / SUBAGENT are
+    skipped at the AgentLoop gate), and a cron fire resetting its own
+    counter would defeat the guard entirely.
+
+    Returns ``inner``'s result so an async inner is still awaited by the
+    OnUserInboundAdapter; the reset itself is synchronous and best-effort.
+    """
+
+    def on_user_inbound(req: "TurnRequest") -> Any:
+        result = inner(req) if inner is not None else None
+        try:
+            from raven.spine import Origin
+
+            if req.origin is Origin.USER and req.source is not None:
+                cron_service.notify_user_active(req.source.channel, req.source.chat_id)
+        except Exception as exc:  # noqa: BLE001 — reset is best-effort
+            logger.warning(
+                "cron notify_user_active failed: {}: {}",
+                type(exc).__name__,
+                exc,
+            )
+        return result
+
+    return on_user_inbound
+
+
+__all__ = ["make_on_cron_job", "make_on_missed_foreign", "chain_cron_activity_reset"]

--- a/raven/cli/_cron_handler.py
+++ b/raven/cli/_cron_handler.py
@@ -210,6 +210,23 @@ def make_on_cron_job(
                     # clobber the disable record_fire just persisted.
                     job.enabled = False
                     job.state.next_run_at_ms = None
+                    # Auto-disable must be user-visible, not a log line: ride
+                    # the same event/heartbeat path as missed notices.
+                    if system_events is not None and wake is not None:
+                        from raven.proactive_engine.system_events import SystemEvent
+
+                        system_events.enqueue(
+                            SystemEvent(
+                                text=(
+                                    f"Recurring reminder '{job.name}' was auto-disabled after "
+                                    f"{job.silent_fire_limit} fires with no reply from you. "
+                                    f"Re-enable it with: raven cron enable {job.id}"
+                                ),
+                                source="cron",
+                                context_key=f"cron:{job.id}:autodisabled",
+                            )
+                        )
+                        wake.request_wake_now(f"cron:{job.id}:autodisabled")
             except Exception as exc:  # noqa: BLE001 — fire accounting is best-effort
                 logger.warning(
                     "cron record_fire failed for {}: {}: {}",

--- a/raven/cli/cron_commands.py
+++ b/raven/cli/cron_commands.py
@@ -152,6 +152,15 @@ def _format_next_run(j: CronJob) -> str:
     return ts.strftime("%Y-%m-%d %H:%M")
 
 
+def _format_silent(j: CronJob) -> str:
+    n = j.state.silent_fire_count
+    if n == 0:
+        return "0"
+    if n >= 5:
+        return f"[yellow]{n} ⚠[/yellow]"
+    return str(n)
+
+
 def _resolve_id(service: CronService, prefix: str, *, include_disabled: bool = True) -> CronJob:
     """Find a job by full id or unique prefix. Exits with friendly
     error on no-match or ambiguous-prefix."""
@@ -238,6 +247,7 @@ def cron_list(
 
     Helps answer:
     - "What reminders does the user currently have?"
+    - "Which jobs are firing too often (silent-fire ≥ 5)?"
     - "When's the next wake-up?"
 
     Default hides disabled jobs; pass ``--all`` to include them.
@@ -281,6 +291,7 @@ def cron_list(
     table.add_column("Schedule")
     table.add_column("Next Run")
     table.add_column("Last", style="dim")
+    table.add_column("Silent", justify="right")
     table.add_column("Channel")
     table.add_column("Name")
     for j in jobs:
@@ -298,6 +309,7 @@ def cron_list(
             _format_schedule(j.schedule),
             _format_next_run(j),
             last_styled,
+            _format_silent(j),
             j.payload.channel or "-",
             (j.name or "-")[:36],
         )
@@ -312,7 +324,7 @@ def cron_get(
     id_prefix: str = typer.Argument(..., metavar="ID", help="Job id or unique prefix"),
 ):
     """Show full detail of one cron job (schedule, payload, state,
-    claim status).
+    silent-fire counter, claim status).
 
     Helps answer:
     - "Why is this job firing weird?"
@@ -331,6 +343,7 @@ def cron_get(
     table.add_row("Enabled", "[green]True[/green]" if job.enabled else "[red]False[/red]")
     table.add_row("Schedule", _format_schedule(job.schedule))
     table.add_row("delete_after_run", str(job.delete_after_run))
+    table.add_row("silent_fire_limit", str(job.silent_fire_limit) if job.silent_fire_limit else "-")
 
     # Payload
     table.add_row("─ Payload ─", "")
@@ -354,6 +367,7 @@ def cron_get(
     table.add_row("last_status", job.state.last_status or "-")
     if job.state.last_error:
         table.add_row("last_error", f"[red]{job.state.last_error[:200]}[/red]")
+    table.add_row("silent_fire_count", _format_silent(job))
     if job.state.claimed_by_pid:
         table.add_row("claimed_by_pid", str(job.state.claimed_by_pid))
         if job.state.claimed_at_ms:

--- a/raven/cli/cron_commands.py
+++ b/raven/cli/cron_commands.py
@@ -282,6 +282,22 @@ def cron_list(
     )
     _print_runner_status(service)
 
+    if not all_:
+        # An auto-disabled reminder (counter at its limit) would otherwise
+        # vanish from the default view without a trace.
+        auto_disabled = [
+            j
+            for j in service.list_jobs(include_disabled=True)
+            if not j.enabled and j.silent_fire_limit and j.state.silent_fire_count >= j.silent_fire_limit
+        ]
+        if auto_disabled:
+            names = ", ".join(f"'{j.name}' ({j.id})" for j in auto_disabled[:3])
+            more = "..." if len(auto_disabled) > 3 else ""
+            console.print(
+                f"[yellow]⚠[/yellow] {len(auto_disabled)} reminder(s) auto-disabled after repeated "
+                f"fires with no reply: {names}{more} — re-enable with `raven cron enable <id>`"
+            )
+
     if not jobs:
         console.print("[dim]  (no jobs to list — pass --all to include disabled)[/dim]")
         return

--- a/raven/cli/gateway_commands.py
+++ b/raven/cli/gateway_commands.py
@@ -230,6 +230,13 @@ def register(app: typer.Typer) -> None:
             now_fn=parse_fake_now(fake_now),
         )
 
+        # Anti-runaway reset: genuine user activity on a (channel, chat_id)
+        # zeroes the silent-fire counters of the jobs bound to it. Chained
+        # after the Sentinel engagement hook, not replacing it.
+        from raven.cli._cron_handler import chain_cron_activity_reset
+
+        on_user_inbound = chain_cron_activity_reset(cron, inner=sentinel_on_user_inbound)
+
         # Gateway-side memory-backend wiring. Mirrors the REPL
         # bootstrap (cli/agent_commands.py). Returns ``None`` when no
         # plugin contributes the configured backend — AgentLoop falls
@@ -270,7 +277,7 @@ def register(app: typer.Typer) -> None:
             # gets a key and can receive a recovery block on its next call).
             interactive=True,
             response_modifier=sentinel_response_modifier,
-            on_user_inbound=sentinel_on_user_inbound,
+            on_user_inbound=on_user_inbound,
             backend=backend,
             memory_config=ec_config.memory,
             skill_forge_router_config=ec_config.skill_forge.router,
@@ -409,7 +416,19 @@ def register(app: typer.Typer) -> None:
                     default_channel="tui",
                     system_events=system_events,
                     wake=wake,
+                    cron_service=cron,
                 )
+                # Missed-reminder observer: past-due tui/cli one-shots whose
+                # session closed before firing surface once through the same
+                # system-event -> heartbeat wake path as cron completions.
+                # Needs the event-wake plumbing; without it there is no sink,
+                # so the observer stays off (as it does with notify_missed
+                # false). Wired before cron.start() — the start-time check is
+                # the first observation pass.
+                if system_events is not None and wake is not None and config.cron.notify_missed:
+                    from raven.cli._cron_handler import make_on_missed_foreign
+
+                    cron.on_missed_foreign = make_on_missed_foreign(system_events, wake)
 
                 from raven.spine import ChatType, Origin, Source, TurnRequest
 

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -432,6 +432,7 @@ def _build_tui_agent_loop():
     try:
         from raven.agent.loop import AgentLoop
         from raven.agent.loop.recovery import limits_from_defaults
+        from raven.cli._cron_handler import chain_cron_activity_reset
         from raven.cli._helpers import load_runtime_config, make_lazy_provider
         from raven.cli._plugin_stack import (
             build_plugin_registry,
@@ -495,6 +496,11 @@ def _build_tui_agent_loop():
             plugin_tools=plugin_tools,
             # TUI is always a multi-turn interactive session.
             interactive=True,
+            # Anti-runaway reset: user turns arrive as (tui, default), the
+            # same pair CronTool.set_context binds into new jobs, so genuine
+            # TUI activity zeroes the silent-fire counters counted by this
+            # process's on_cron_job (no Sentinel hook in the TUI to chain).
+            on_user_inbound=chain_cron_activity_reset(cron),
         )
         agent_loop.configure_personalization(
             config.agents.defaults.enable_personalization,
@@ -674,6 +680,7 @@ async def _run_rpc_server_until_done(
                 submit=turn_scheduler.submit,
                 readback_texts=cron_readback,
                 default_channel="tui",
+                cron_service=agent_loop.cron_service,
             )
             agent_loop.cron_service.on_job = _build_cron_callback_spine(base_on_cron, emitter)
             await agent_loop.cron_service.start()

--- a/raven/config/schema.py
+++ b/raven/config/schema.py
@@ -319,6 +319,13 @@ class CronConfig(Base):
     default_timezone: str = "Asia/Shanghai"
     """Default IANA timezone for cron expressions without explicit ``--tz``."""
 
+    notify_missed: bool = True
+    """When True, the gateway observes one-shot reminders bound to other
+    partitions (tui / cli sessions) that went past due unfired — their
+    session was closed — and surfaces each once as a system event through
+    the heartbeat wake path. Read-only observation: the foreign job itself
+    is never mutated."""
+
 
 class ModelOverlay(Base):
     """A name for a model no catalogue carries.

--- a/raven/proactive_engine/schedulers/cron/service.py
+++ b/raven/proactive_engine/schedulers/cron/service.py
@@ -918,6 +918,10 @@ class CronService:
                     job.updated_at_ms = self._now_ms()
                     if enabled:
                         job.state.next_run_at_ms = _compute_next_run(job.schedule, self._now_ms())
+                        # Re-enabling is deliberate user engagement with this
+                        # job: without a counter reset, one auto-disabled at
+                        # the limit would re-disable on its very next fire.
+                        job.state.silent_fire_count = 0
                     else:
                         job.state.next_run_at_ms = None
                     self._save_store()

--- a/raven/proactive_engine/schedulers/cron/service.py
+++ b/raven/proactive_engine/schedulers/cron/service.py
@@ -40,6 +40,10 @@ _MAX_WAKE_INTERVAL_S = 30.0
 # Backoff after a failed tick so a persistent error cannot spin the loop.
 _ERROR_BACKOFF_S = 5.0
 
+# Grace before a past-due foreign one-shot counts as "missed" — its owning
+# session may just be slow (a long agent turn) rather than closed.
+_MISSED_GRACE_MS = 5 * 60 * 1000
+
 
 def _now_ms() -> int:
     return int(time.time() * 1000)
@@ -127,6 +131,10 @@ class CronService:
         self.lock_path = store_path.with_suffix(store_path.suffix + ".lock")
         self.on_job = on_job
         self.allowed_channels = allowed_channels
+        # Missed-reminder observer (gateway wires this): called with the
+        # past-due foreign one-shots on start and once per wake-loop pass.
+        # Read-only towards the store — the callback must not mutate jobs.
+        self.on_missed_foreign: Callable[[list[CronJob]], None] | None = None
         self._store: CronStore | None = None
         # Nanosecond precision: float st_mtime collapses writes ~238ns apart
         # into one value, serving a stale cache after an external rewrite.
@@ -216,10 +224,12 @@ class CronService:
                                 last_error=j.get("state", {}).get("lastError"),
                                 claimed_by_pid=j.get("state", {}).get("claimedByPid"),
                                 claimed_at_ms=j.get("state", {}).get("claimedAtMs"),
+                                silent_fire_count=j.get("state", {}).get("silentFireCount", 0),
                             ),
                             created_at_ms=j.get("createdAtMs", 0),
                             updated_at_ms=j.get("updatedAtMs", 0),
                             delete_after_run=j.get("deleteAfterRun", False),
+                            silent_fire_limit=j.get("silentFireLimit", 12),
                         )
                     )
                 self._store = CronStore(jobs=jobs)
@@ -265,10 +275,12 @@ class CronService:
                         "lastError": j.state.last_error,
                         "claimedByPid": j.state.claimed_by_pid,
                         "claimedAtMs": j.state.claimed_at_ms,
+                        "silentFireCount": j.state.silent_fire_count,
                     },
                     "createdAtMs": j.created_at_ms,
                     "updatedAtMs": j.updated_at_ms,
                     "deleteAfterRun": j.delete_after_run,
+                    "silentFireLimit": j.silent_fire_limit,
                 }
                 for j in self._store.jobs
             ],
@@ -294,6 +306,7 @@ class CronService:
             self._load_store()
             self._recompute_next_runs()
             self._save_store()
+        self._check_missed_foreign()
         self._loop_task = asyncio.create_task(self._run_loop())
         logger.info("Cron service started with {} jobs", len(self._store.jobs if self._store else []))
 
@@ -394,6 +407,7 @@ class CronService:
             except Exception:
                 logger.exception("Cron: wake tick failed; continuing in {}s", _ERROR_BACKOFF_S)
                 await asyncio.sleep(_ERROR_BACKOFF_S)
+            self._check_missed_foreign()
             delay = self._compute_wake_delay()
             try:
                 await asyncio.wait_for(self._wake_event.wait(), timeout=delay)
@@ -507,8 +521,11 @@ class CronService:
                     j.state.last_run_at_ms = job.state.last_run_at_ms
                     j.state.last_status = job.state.last_status
                     j.state.last_error = job.state.last_error
-                    j.state.next_run_at_ms = job.state.next_run_at_ms
-                    j.enabled = job.enabled
+                    # A store-side disable is sticky: record_fire's auto-disable
+                    # (or a user disabling mid-run) lands between claim and this
+                    # writeback, and the in-memory copy must not resurrect it.
+                    j.enabled = j.enabled and job.enabled
+                    j.state.next_run_at_ms = job.state.next_run_at_ms if j.enabled else None
                     j.updated_at_ms = job.updated_at_ms
                     break
             # Handle "at"-kind delete_after_run (_execute_job removed from
@@ -556,11 +573,112 @@ class CronService:
 
     # ========== Public API ==========
 
+    def record_fire(self, job_id: str) -> bool:
+        """Increment silent_fire_count for a recurring job; auto-disable when
+        it crosses silent_fire_limit. Called by the delivery handler
+        (make_on_cron_job) right after a successful cron fire. Returns True
+        if the job was auto-disabled this call.
+
+        One-shot 'at' jobs are ignored (they cannot run away). The store
+        write persists the count, but the caller executing the job must
+        also flip its in-memory job.enabled on a True return —
+        _writeback_after_run patches enabled/next_run from the in-memory
+        job and would otherwise clobber the disable written here.
+        """
+        with self._locked():
+            self._store = None
+            store = self._load_store()
+            for j in store.jobs:
+                if j.id != job_id:
+                    continue
+                if j.schedule.kind not in ("every", "cron"):
+                    return False
+                j.state.silent_fire_count += 1
+                limit = j.silent_fire_limit
+                disabled = False
+                if limit is not None and limit > 0 and j.state.silent_fire_count >= limit:
+                    j.enabled = False
+                    j.state.next_run_at_ms = None
+                    disabled = True
+                    logger.warning(
+                        "Cron: auto-disabled job '{}' ({}) — {} silent fires without user activity (limit={})",
+                        j.name,
+                        j.id,
+                        j.state.silent_fire_count,
+                        limit,
+                    )
+                self._save_store()
+                return disabled
+            return False
+
+    def notify_user_active(self, channel: str | None = None, to: str | None = None) -> int:
+        """Reset silent_fire_count for jobs matching (channel, to) — call
+        whenever a genuine user-originated message arrives so recently-
+        firing crons don't decay toward auto-disable. None matches all.
+        Returns count of jobs whose state was reset."""
+        reset = 0
+        with self._locked():
+            self._store = None
+            store = self._load_store()
+            for j in store.jobs:
+                if not j.enabled or j.state.silent_fire_count == 0:
+                    continue
+                if channel is not None and j.payload.channel != channel:
+                    continue
+                if to is not None and j.payload.to != to:
+                    continue
+                j.state.silent_fire_count = 0
+                reset += 1
+            if reset > 0:
+                self._save_store()
+        return reset
+
     def list_jobs(self, include_disabled: bool = False) -> list[CronJob]:
         """List all jobs."""
         store = self._load_store()
         jobs = store.jobs if include_disabled else [j for j in store.jobs if j.enabled]
         return sorted(jobs, key=lambda j: j.state.next_run_at_ms or float("inf"))
+
+    def list_missed_foreign_oneshots(self, grace_ms: int = _MISSED_GRACE_MS) -> list[CronJob]:
+        """Read-only: one-shot 'at' jobs owned by another partition whose
+        fire time is more than ``grace_ms`` in the past — their owning
+        session (tui / cli) was closed before they could fire.
+
+        Foreign jobs are exactly the ones this runner may never claim or
+        clean up (partition rules), so observing is the only way the
+        gateway can tell the user a reminder was stranded. A job with a
+        fresh peer claim is excluded: the owning process is delivering it
+        right now. Falsy channels (legacy, pre-attribution) are never
+        foreign.
+        """
+        store = self._load_store()
+        now = self._now_ms()
+        missed: list[CronJob] = []
+        for j in store.jobs:
+            if j.schedule.kind != "at" or not j.enabled:
+                continue
+            if self._owns_channel(j.payload.channel):
+                continue
+            at_ms = j.schedule.at_ms
+            if at_ms is None or now - at_ms < grace_ms:
+                continue
+            cb, ca = j.state.claimed_by_pid, j.state.claimed_at_ms
+            if cb is not None and ca is not None and (now - ca) < _CLAIM_TTL_MS:
+                continue
+            missed.append(j)
+        return missed
+
+    def _check_missed_foreign(self) -> None:
+        """Feed past-due foreign one-shots to the observer, best-effort.
+        A callback failure must never break start() or the wake loop."""
+        if self.on_missed_foreign is None:
+            return
+        try:
+            missed = self.list_missed_foreign_oneshots()
+            if missed:
+                self.on_missed_foreign(missed)
+        except Exception:
+            logger.exception("Cron: missed-foreign observer failed; continuing")
 
     def add_job(
         self,

--- a/raven/proactive_engine/schedulers/cron/service.py
+++ b/raven/proactive_engine/schedulers/cron/service.py
@@ -614,7 +614,11 @@ class CronService:
     def notify_user_active(self, channel: str | None = None, to: str | None = None) -> int:
         """Reset silent_fire_count for jobs matching (channel, to) — call
         whenever a genuine user-originated message arrives so recently-
-        firing crons don't decay toward auto-disable. None matches all.
+        firing crons don't decay toward auto-disable. ``None`` on the call
+        side matches every job; a falsy channel/to on the JOB side is a
+        wildcard too — legacy pre-attribution jobs are claimable by any
+        runner, so symmetrically any user activity resets them (otherwise
+        their counter could only ever climb and unfairly auto-disable).
         Returns count of jobs whose state was reset."""
         reset = 0
         with self._locked():
@@ -623,9 +627,9 @@ class CronService:
             for j in store.jobs:
                 if not j.enabled or j.state.silent_fire_count == 0:
                     continue
-                if channel is not None and j.payload.channel != channel:
+                if channel is not None and j.payload.channel and j.payload.channel != channel:
                     continue
-                if to is not None and j.payload.to != to:
+                if to is not None and j.payload.to and j.payload.to != to:
                     continue
                 j.state.silent_fire_count = 0
                 reset += 1

--- a/raven/proactive_engine/schedulers/cron/types.py
+++ b/raven/proactive_engine/schedulers/cron/types.py
@@ -47,6 +47,12 @@ class CronJobState:
     # Cleared post-run. Stale claims (older than CLAIM_TTL_MS) are stolen.
     claimed_by_pid: int | None = None
     claimed_at_ms: int | None = None
+    # Anti-runaway tracking: count of consecutive fires without intervening
+    # user activity (any user-originated message on the same channel/to
+    # resets this to 0 via CronService.notify_user_active). Used to
+    # auto-disable runaway recurring jobs the LLM created (e.g.
+    # every_seconds=3000 forever).
+    silent_fire_count: int = 0
 
 
 @dataclass
@@ -62,6 +68,11 @@ class CronJob:
     created_at_ms: int = 0
     updated_at_ms: int = 0
     delete_after_run: bool = False
+    # Anti-runaway limit: when state.silent_fire_count reaches this value,
+    # the job is auto-disabled. None = no limit (runs until explicit
+    # removal). Default 12 strikes a balance: gives ~1 day of hourly fires
+    # before declaring "user not engaging".
+    silent_fire_limit: int | None = 12
 
 
 @dataclass

--- a/tests/test_cli_cron_commands.py
+++ b/tests/test_cli_cron_commands.py
@@ -953,3 +953,51 @@ def test_config_set_then_get_round_trip(runner, isolated_config):
     r = runner.invoke(cron_app, ["config", "get", "--default-timezone"])
     assert r.exit_code == 0, r.output
     assert "America/New_York" in r.stdout
+
+
+def test_list_default_view_hints_hidden_auto_disabled(runner, fake_cron_dir):
+    """An auto-disabled reminder is hidden by the default view but must not
+    vanish without a trace: the default view prints a hint naming it, and
+    --all still lists the job itself."""
+    svc = CronService(fake_cron_dir / "jobs.json")
+    job = svc.add_job(
+        name="daily meds",
+        schedule=CronSchedule(kind="every", every_ms=3600 * 1000),
+        message="take meds",
+        channel="tui",
+        to="direct",
+    )
+    stored = next(j for j in svc._load_store().jobs if j.id == job.id)
+    stored.silent_fire_limit = 2
+    svc._save_store()
+    svc.record_fire(job.id)
+    assert svc.record_fire(job.id) is True  # auto-disabled at the limit
+
+    r = runner.invoke(cron_app, ["list"])
+    assert r.exit_code == 0
+    assert "auto-disabled" in r.stdout
+    assert job.id in r.stdout  # named in the hint even though hidden from the table
+
+    r_all = runner.invoke(cron_app, ["list", "--all"])
+    assert r_all.exit_code == 0
+    assert job.id in r_all.stdout
+
+
+def test_list_all_view_shows_no_auto_disabled_hint(runner, fake_cron_dir):
+    """--all already shows the job row itself; the hint is default-view-only."""
+    svc = CronService(fake_cron_dir / "jobs.json")
+    job = svc.add_job(
+        name="daily meds",
+        schedule=CronSchedule(kind="every", every_ms=3600 * 1000),
+        message="take meds",
+        channel="tui",
+        to="direct",
+    )
+    stored = next(j for j in svc._load_store().jobs if j.id == job.id)
+    stored.silent_fire_limit = 1
+    svc._save_store()
+    svc.record_fire(job.id)
+
+    r_all = runner.invoke(cron_app, ["list", "--all"])
+    assert r_all.exit_code == 0
+    assert "auto-disabled after repeated" not in r_all.stdout

--- a/tests/test_cli_cron_commands.py
+++ b/tests/test_cli_cron_commands.py
@@ -108,6 +108,20 @@ def test_list_all_includes_disabled(runner, populated_cron):
         assert j.id in result.stdout
 
 
+def test_list_shows_silent_column(runner, populated_cron):
+    """The Silent column surfaces the anti-runaway counter; counts >= 5
+    carry a warning marker so runaway recurring jobs stand out."""
+    jobs = populated_cron.list_jobs()
+    hot = next(j for j in jobs if j.schedule.kind == "every")
+    for _ in range(7):
+        populated_cron.record_fire(hot.id)
+
+    result = runner.invoke(cron_app, ["list"])
+    assert result.exit_code == 0
+    assert "Silent" in result.stdout
+    assert "7 ⚠" in result.stdout
+
+
 # ── get ──────────────────────────────────────────────────────────────
 
 
@@ -161,6 +175,21 @@ def test_get_shows_topic_tag_dash_when_absent(runner, populated_cron):
     )
     assert topic_line is not None
     assert "-" in topic_line
+
+
+def test_get_shows_silent_fire_fields(runner, populated_cron):
+    """``cron get`` renders the anti-runaway counter and its limit so an
+    operator can see how close a recurring job is to auto-disable."""
+    job = next(j for j in populated_cron.list_jobs() if j.schedule.kind == "every")
+    for _ in range(3):
+        populated_cron.record_fire(job.id)
+
+    result = runner.invoke(cron_app, ["get", job.id])
+    assert result.exit_code == 0
+    assert "silent_fire_count" in result.stdout.replace("\n", "")
+    assert "silent_fire_limit" in result.stdout.replace("\n", "")
+    assert "3" in result.stdout
+    assert "12" in result.stdout
 
 
 def test_get_prefix_match(runner, populated_cron):

--- a/tests/test_cli_cron_handler.py
+++ b/tests/test_cli_cron_handler.py
@@ -33,12 +33,20 @@ def _make_job(
     channel: str | None = "tui",
     to: str | None = "direct",
     name: str = "test_job",
+    kind: str = "at",
 ) -> CronJob:
+    schedule = (
+        CronSchedule(kind="at", at_ms=1000)
+        if kind == "at"
+        else CronSchedule(kind="every", every_ms=60_000)
+        if kind == "every"
+        else CronSchedule(kind="cron", expr="0 9 * * *")
+    )
     return CronJob(
         id=f"job_{name}",
         name=name,
         enabled=True,
-        schedule=CronSchedule(kind="at", at_ms=1000),
+        schedule=schedule,
         payload=CronPayload(
             message="reminder body source",
             channel=channel,
@@ -204,6 +212,158 @@ async def test_turn_failure_emits_failed_event_and_reraises():
     event = system_events.enqueue.call_args.args[0]
     assert "failed" in event.text
     assert event.context_key.endswith(":fail")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Anti-runaway count point: record_fire after a successful recurring turn
+# ─────────────────────────────────────────────────────────────────────
+
+
+async def test_record_fire_called_on_successful_recurring_turn(spine):
+    cron_service = MagicMock()
+    cron_service.record_fire.return_value = False
+    handler = make_on_cron_job(submit=spine.submit, readback_texts=spine.readback, cron_service=cron_service)
+
+    job = _make_job(name="r1", kind="every")
+    await handler(job)
+
+    cron_service.record_fire.assert_called_once_with("job_r1")
+    assert job.enabled is True
+
+
+async def test_record_fire_not_called_on_turn_failure():
+    cron_service = MagicMock()
+
+    class _Handle:
+        async def result(self):
+            raise RuntimeError("provider down")
+
+    handler = make_on_cron_job(submit=lambda req: _Handle(), readback_texts={}, cron_service=cron_service)
+
+    with pytest.raises(RuntimeError, match="provider down"):
+        await handler(_make_job(name="r2", kind="every"))
+
+    cron_service.record_fire.assert_not_called()
+
+
+async def test_record_fire_not_called_for_oneshot_at_job(spine):
+    cron_service = MagicMock()
+    handler = make_on_cron_job(submit=spine.submit, readback_texts=spine.readback, cron_service=cron_service)
+
+    await handler(_make_job(name="r3", kind="at"))
+
+    cron_service.record_fire.assert_not_called()
+
+
+async def test_auto_disable_flips_the_inflight_job(spine):
+    """record_fire returning True (limit hit) must flip the in-memory job:
+    the service's post-run writeback patches enabled/next_run from it and
+    would otherwise clobber the persisted disable."""
+    cron_service = MagicMock()
+    cron_service.record_fire.return_value = True
+    handler = make_on_cron_job(submit=spine.submit, readback_texts=spine.readback, cron_service=cron_service)
+
+    job = _make_job(name="r4", kind="cron")
+    job.state.next_run_at_ms = 999_999
+    await handler(job)
+
+    assert job.enabled is False
+    assert job.state.next_run_at_ms is None
+
+
+async def test_record_fire_error_does_not_fail_the_turn(spine):
+    cron_service = MagicMock()
+    cron_service.record_fire.side_effect = OSError("store locked")
+    handler = make_on_cron_job(submit=spine.submit, readback_texts=spine.readback, cron_service=cron_service)
+
+    response = await handler(_make_job(name="r5", kind="every"))
+
+    assert response == "resolved body"
+
+
+async def test_without_cron_service_no_counting(spine):
+    handler = make_on_cron_job(submit=spine.submit, readback_texts=spine.readback)
+    job = _make_job(name="r6", kind="every")
+
+    assert await handler(job) == "resolved body"
+    assert job.enabled is True
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Anti-runaway reset point: chain_cron_activity_reset
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _user_req(*, origin=None, channel: str = "telegram", chat_id: str = "chat9"):
+    from raven.spine import ChatType, Origin, Source, TurnRequest
+
+    return TurnRequest(
+        origin=origin or Origin.USER,
+        source=Source(
+            channel=channel,
+            chat_id=chat_id,
+            sender_id="u1",
+            chat_type=ChatType.DM,
+        ),
+        text="hello",
+    )
+
+
+def test_chain_resets_on_user_origin():
+    from raven.cli._cron_handler import chain_cron_activity_reset
+
+    cron_service = MagicMock()
+    hook = chain_cron_activity_reset(cron_service)
+
+    hook(_user_req(channel="telegram", chat_id="chat9"))
+
+    cron_service.notify_user_active.assert_called_once_with("telegram", "chat9")
+
+
+def test_chain_ignores_non_user_origins():
+    """CRON / HEARTBEAT turns run the user-inbound hook chain too (only
+    SENTINEL / SUBAGENT are skipped at the AgentLoop gate) — a cron fire
+    resetting its own counter would defeat the guard."""
+    from raven.cli._cron_handler import chain_cron_activity_reset
+    from raven.spine import Origin
+
+    cron_service = MagicMock()
+    hook = chain_cron_activity_reset(cron_service)
+
+    hook(_user_req(origin=Origin.CRON))
+    hook(_user_req(origin=Origin.HEARTBEAT))
+
+    cron_service.notify_user_active.assert_not_called()
+
+
+def test_chain_calls_inner_first_and_returns_its_result():
+    from raven.cli._cron_handler import chain_cron_activity_reset
+
+    calls: list[str] = []
+    cron_service = MagicMock()
+    cron_service.notify_user_active.side_effect = lambda *a: calls.append("reset")
+    sentinel_result = object()
+
+    def inner(req):
+        calls.append("sentinel")
+        return sentinel_result
+
+    hook = chain_cron_activity_reset(cron_service, inner=inner)
+
+    assert hook(_user_req()) is sentinel_result
+    assert calls == ["sentinel", "reset"]
+
+
+def test_chain_reset_error_is_swallowed():
+    from raven.cli._cron_handler import chain_cron_activity_reset
+
+    cron_service = MagicMock()
+    cron_service.notify_user_active.side_effect = OSError("store locked")
+    inner = MagicMock(return_value=None)
+    hook = chain_cron_activity_reset(cron_service, inner=inner)
+
+    assert hook(_user_req()) is None
+    inner.assert_called_once()
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/test_cli_gateway_commands.py
+++ b/tests/test_cli_gateway_commands.py
@@ -197,6 +197,47 @@ def test_stop_dispatch_cancels_both_scheduler_and_subagents() -> None:
     assert "stopped +=" in stop_branch
 
 
+def test_cron_config_notify_missed_defaults_on() -> None:
+    from raven.config.schema import CronConfig
+
+    assert CronConfig().notify_missed is True
+    assert CronConfig.model_validate({"notify_missed": False}).notify_missed is False
+
+
+def test_gateway_wires_anti_runaway_count_and_reset() -> None:
+    """The anti-runaway guard must be WIRED, not just defined: the cron
+    handler gets the service to count fires on (``cron_service=cron``) and
+    the AgentLoop's user-inbound hook chains the counter reset after the
+    Sentinel hook. Like the /stop test above, these live in closures inside
+    the serve command with no import seam, so pin the command source.
+    """
+    import inspect
+
+    from raven.cli import gateway_commands
+
+    src = inspect.getsource(gateway_commands.register)
+    assert "cron_service=cron," in src
+    assert "chain_cron_activity_reset(cron, inner=sentinel_on_user_inbound)" in src
+    assert "on_user_inbound=on_user_inbound," in src
+
+
+def test_gateway_wires_missed_reminder_observer_behind_config() -> None:
+    """The missed-reminder observer must be wired onto the gateway's cron
+    service, gated on the event-wake plumbing existing AND
+    ``cron.notify_missed`` — with either off there is no sink, so the
+    observer must stay unset."""
+    import inspect
+
+    from raven.cli import gateway_commands
+
+    src = inspect.getsource(gateway_commands.register)
+    gate = src.split("cron.on_missed_foreign", 1)[0].rsplit("if ", 1)[1]
+    assert "system_events is not None" in gate
+    assert "wake is not None" in gate
+    assert "config.cron.notify_missed" in gate
+    assert "cron.on_missed_foreign = make_on_missed_foreign(system_events, wake)" in src
+
+
 # ---------------------------------------------------------------------------
 # build_model_routing — routing backend selection
 # ---------------------------------------------------------------------------

--- a/tests/test_cron_service_missed.py
+++ b/tests/test_cron_service_missed.py
@@ -1,0 +1,223 @@
+"""Missed foreign one-shot observation in CronService.
+
+``list_missed_foreign_oneshots`` is the read-only helper behind the
+gateway's missed-reminder sink: one-shot 'at' jobs bound to another
+partition (tui / cli) whose fire time is past the grace window — their
+owning session was closed before they could fire. Partition rules forbid
+mutating foreign jobs, so observing is all this does.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+
+from raven.proactive_engine.schedulers.cron.service import CronService
+
+_GRACE_MS = 5 * 60 * 1000
+
+
+def _at_job(
+    job_id: str,
+    at_ms: int,
+    *,
+    channel: str | None = "tui",
+    kind: str = "at",
+    enabled: bool = True,
+    claimed_by_pid: int | None = None,
+    claimed_at_ms: int | None = None,
+) -> dict:
+    schedule = {"kind": kind, "atMs": at_ms} if kind == "at" else {"kind": kind, "everyMs": 60_000}
+    return {
+        "id": job_id,
+        "name": f"reminder {job_id}",
+        "enabled": enabled,
+        "schedule": schedule,
+        "payload": {"message": "stretch", "channel": channel, "to": "default"},
+        "state": {
+            "nextRunAtMs": at_ms,
+            "claimedByPid": claimed_by_pid,
+            "claimedAtMs": claimed_at_ms,
+        },
+        "createdAtMs": at_ms - 60_000,
+        "updatedAtMs": at_ms - 60_000,
+    }
+
+
+def _write_store(store_path: Path, jobs: list[dict]) -> None:
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    store_path.write_text(json.dumps({"version": 1, "jobs": jobs}), encoding="utf-8")
+
+
+def _gateway_svc(store_path: Path) -> CronService:
+    return CronService(store_path, allowed_channels={"weixin"})
+
+
+def test_missed_requires_grace_window(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    now = int(time.time() * 1000)
+    _write_store(
+        store_path,
+        [
+            _at_job("fresh", now - 60_000),  # 1 min late: session may just be slow
+            _at_job("stale", now - _GRACE_MS - 60_000),  # 6 min late: missed
+        ],
+    )
+
+    missed = _gateway_svc(store_path).list_missed_foreign_oneshots()
+    assert [j.id for j in missed] == ["stale"]
+
+
+def test_missed_is_foreign_only(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    now = int(time.time() * 1000)
+    past = now - _GRACE_MS - 60_000
+    _write_store(
+        store_path,
+        [
+            _at_job("own", past, channel="weixin"),
+            _at_job("legacy", past, channel=None),
+            _at_job("foreign", past, channel="tui"),
+        ],
+    )
+
+    missed = _gateway_svc(store_path).list_missed_foreign_oneshots()
+    assert [j.id for j in missed] == ["foreign"], (
+        "own-partition and legacy (channel=None) jobs are never missed-foreign"
+    )
+
+
+def test_missed_is_oneshot_only(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    now = int(time.time() * 1000)
+    past = now - _GRACE_MS - 60_000
+    _write_store(
+        store_path,
+        [
+            _at_job("recurring", past, kind="every"),
+            _at_job("oneshot", past),
+        ],
+    )
+
+    missed = _gateway_svc(store_path).list_missed_foreign_oneshots()
+    assert [j.id for j in missed] == ["oneshot"], "recurring jobs self-heal on their next tick; only 'at' can strand"
+
+
+def test_missed_excludes_disabled_jobs(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    now = int(time.time() * 1000)
+    _write_store(store_path, [_at_job("done", now - _GRACE_MS - 60_000, enabled=False)])
+
+    assert _gateway_svc(store_path).list_missed_foreign_oneshots() == []
+
+
+def test_missed_excludes_freshly_claimed_jobs(tmp_path: Path) -> None:
+    """A live peer claim means the owning process is delivering right now;
+    a stale claim (crashed peer) still counts as missed."""
+    store_path = tmp_path / "jobs.json"
+    now = int(time.time() * 1000)
+    past = now - _GRACE_MS - 60_000
+    _write_store(
+        store_path,
+        [
+            _at_job("inflight", past, claimed_by_pid=os.getpid() + 1, claimed_at_ms=now - 1_000),
+            _at_job("crashed", past, claimed_by_pid=os.getpid() + 1, claimed_at_ms=now - 31 * 60 * 1000),
+        ],
+    )
+
+    missed = _gateway_svc(store_path).list_missed_foreign_oneshots()
+    assert [j.id for j in missed] == ["crashed"]
+
+
+def test_missed_custom_grace_window(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    now = int(time.time() * 1000)
+    _write_store(store_path, [_at_job("j1", now - 90_000)])
+    svc = _gateway_svc(store_path)
+
+    assert [j.id for j in svc.list_missed_foreign_oneshots(grace_ms=60_000)] == ["j1"]
+    assert svc.list_missed_foreign_oneshots(grace_ms=120_000) == []
+
+
+def test_missed_listing_is_read_only(tmp_path: Path) -> None:
+    """Partition rules forbid touching foreign jobs — the helper must not
+    write the store (no drop, no recompute, no claim)."""
+    store_path = tmp_path / "jobs.json"
+    now = int(time.time() * 1000)
+    _write_store(store_path, [_at_job("ro1", now - _GRACE_MS - 60_000)])
+    before = store_path.read_text(encoding="utf-8")
+
+    missed = _gateway_svc(store_path).list_missed_foreign_oneshots()
+
+    assert [j.id for j in missed] == ["ro1"]
+    assert store_path.read_text(encoding="utf-8") == before
+
+
+async def test_start_invokes_missed_observer_and_leaves_job_intact(tmp_path: Path) -> None:
+    """start() runs an observation pass; the foreign job survives the
+    startup recompute (which only drops past-due one-shots the runner
+    owns) and reaches the observer callback."""
+    store_path = tmp_path / "jobs.json"
+    now = int(time.time() * 1000)
+    _write_store(store_path, [_at_job("m1", now - _GRACE_MS - 60_000)])
+
+    svc = _gateway_svc(store_path)
+    seen: list[list] = []
+    svc.on_missed_foreign = lambda jobs: seen.append([j.id for j in jobs])
+    await svc.start()
+    svc.stop()
+
+    assert seen and seen[0] == ["m1"]
+    data = json.loads(store_path.read_text(encoding="utf-8"))
+    assert [j["id"] for j in data["jobs"]] == ["m1"], "observed job must not be dropped or mutated"
+
+
+async def test_observer_error_breaks_neither_start_nor_loop(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    now = int(time.time() * 1000)
+    _write_store(store_path, [_at_job("boom", now - _GRACE_MS - 60_000)])
+
+    svc = _gateway_svc(store_path)
+
+    def _explode(jobs) -> None:
+        raise RuntimeError("observer bug")
+
+    svc.on_missed_foreign = _explode
+    await svc.start()
+    await asyncio.sleep(0.05)  # let the first wake-loop pass run
+    svc.stop()
+
+    assert svc._loop_task is None  # stop() ran; no crash escaped
+
+
+async def test_wake_loop_pass_invokes_missed_observer(tmp_path: Path) -> None:
+    """A job crossing the grace window while the service is running is
+    picked up by a later wake-loop pass, not only by start(). The service
+    re-reports on every pass while the job stays missed — once-only
+    notification is the observer callback's job (make_on_missed_foreign's
+    notified set), not the service's."""
+    store_path = tmp_path / "jobs.json"
+    _write_store(store_path, [])
+
+    svc = _gateway_svc(store_path)
+    seen: list[str] = []
+    svc.on_missed_foreign = lambda jobs: seen.extend(j.id for j in jobs)
+    await svc.start()
+    try:
+        assert seen == []
+        # A peer (the tui process) writes a job that is already past grace,
+        # then signals the loop the way any store mutation does.
+        now = int(time.time() * 1000)
+        _write_store(store_path, [_at_job("late1", now - _GRACE_MS - 60_000)])
+        svc._signal_wake()
+        for _ in range(50):
+            if seen:
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        svc.stop()
+
+    assert seen and set(seen) == {"late1"}

--- a/tests/test_cron_service_silent_fire.py
+++ b/tests/test_cron_service_silent_fire.py
@@ -1,0 +1,272 @@
+"""Anti-runaway silent-fire guard in CronService.
+
+``record_fire`` counts consecutive recurring fires; ``notify_user_active``
+resets the counters on genuine user activity; at ``silent_fire_limit`` the
+job is auto-disabled so an LLM-created every_seconds-forever job cannot
+fire unattended all night. Counter state persists in jobs.json under the
+legacy key names (silentFireCount / silentFireLimit) so old stores load.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from raven.proactive_engine.schedulers.cron.service import CronService
+from raven.proactive_engine.schedulers.cron.types import CronSchedule
+
+
+def _add_every_job(svc: CronService, *, channel: str = "tui", to: str = "default", limit: int | None = None) -> str:
+    job = svc.add_job(
+        name=f"every {channel}:{to}",
+        schedule=CronSchedule(kind="every", every_ms=60_000),
+        message="drink water",
+        channel=channel,
+        to=to,
+    )
+    if limit is not None:
+        stored = next(j for j in svc._store.jobs if j.id == job.id)
+        stored.silent_fire_limit = limit
+        svc._save_store()
+    return job.id
+
+
+def _stored(store_path: Path, job_id: str) -> dict:
+    data = json.loads(store_path.read_text(encoding="utf-8"))
+    return next(j for j in data["jobs"] if j["id"] == job_id)
+
+
+# ── record_fire: count + persist ──────────────────────────────────────
+
+
+def test_record_fire_increments_and_persists(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    svc = CronService(store_path)
+    job_id = _add_every_job(svc)
+
+    assert svc.record_fire(job_id) is False
+    assert svc.record_fire(job_id) is False
+
+    stored = _stored(store_path, job_id)
+    assert stored["state"]["silentFireCount"] == 2
+    assert stored["enabled"] is True
+
+
+def test_record_fire_auto_disables_at_limit(tmp_path: Path) -> None:
+    from loguru import logger
+
+    store_path = tmp_path / "jobs.json"
+    svc = CronService(store_path)
+    job_id = _add_every_job(svc, limit=2)
+
+    lines: list[str] = []
+    sink_id = logger.add(lambda m: lines.append(str(m)), level="WARNING")
+    try:
+        assert svc.record_fire(job_id) is False
+        assert svc.record_fire(job_id) is True
+    finally:
+        logger.remove(sink_id)
+
+    stored = _stored(store_path, job_id)
+    assert stored["enabled"] is False
+    assert stored["state"]["nextRunAtMs"] is None
+    assert stored["state"]["silentFireCount"] == 2
+    assert any("auto-disabled" in ln for ln in lines), f"expected an auto-disable warning, got {lines}"
+
+
+def test_record_fire_ignores_oneshot_at_jobs(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    svc = CronService(store_path)
+    job = svc.add_job(
+        name="one shot",
+        schedule=CronSchedule(kind="at", at_ms=int(time.time() * 1000) + 3_600_000),
+        message="once",
+        channel="tui",
+        to="default",
+    )
+
+    assert svc.record_fire(job.id) is False
+
+    assert _stored(store_path, job.id)["state"]["silentFireCount"] == 0
+
+
+def test_record_fire_unknown_id_returns_false(tmp_path: Path) -> None:
+    svc = CronService(tmp_path / "jobs.json")
+    assert svc.record_fire("nope") is False
+
+
+def test_record_fire_no_limit_never_disables(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    svc = CronService(store_path)
+    job_id = _add_every_job(svc, limit=None)
+    stored = next(j for j in svc._store.jobs if j.id == job_id)
+    stored.silent_fire_limit = None
+    svc._save_store()
+
+    for _ in range(20):
+        assert svc.record_fire(job_id) is False
+
+    stored_json = _stored(store_path, job_id)
+    assert stored_json["enabled"] is True
+    assert stored_json["state"]["silentFireCount"] == 20
+
+
+# ── notify_user_active: reset scoped to (channel, to) ─────────────────
+
+
+def test_notify_user_active_resets_only_matching_binding(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    svc = CronService(store_path)
+    tui_id = _add_every_job(svc, channel="tui", to="default")
+    im_id = _add_every_job(svc, channel="telegram", to="chat9")
+    svc.record_fire(tui_id)
+    svc.record_fire(im_id)
+
+    assert svc.notify_user_active("telegram", "chat9") == 1
+
+    assert _stored(store_path, im_id)["state"]["silentFireCount"] == 0
+    assert _stored(store_path, tui_id)["state"]["silentFireCount"] == 1
+
+
+def test_notify_user_active_none_matches_all(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    svc = CronService(store_path)
+    a = _add_every_job(svc, channel="tui", to="default")
+    b = _add_every_job(svc, channel="telegram", to="chat9")
+    svc.record_fire(a)
+    svc.record_fire(b)
+
+    assert svc.notify_user_active() == 2
+
+    assert _stored(store_path, a)["state"]["silentFireCount"] == 0
+    assert _stored(store_path, b)["state"]["silentFireCount"] == 0
+
+
+def test_notify_user_active_zero_counts_touch_nothing(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    svc = CronService(store_path)
+    _add_every_job(svc)
+
+    assert svc.notify_user_active("tui", "default") == 0
+
+
+# ── persistence: legacy JSON keys ─────────────────────────────────────
+
+
+def test_legacy_store_keys_load(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    now_ms = int(time.time() * 1000)
+    store_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "jobs": [
+                    {
+                        "id": "old1",
+                        "name": "legacy job",
+                        "enabled": True,
+                        "schedule": {"kind": "every", "everyMs": 60_000},
+                        "payload": {"message": "ping", "channel": "tui", "to": "default"},
+                        "state": {"nextRunAtMs": now_ms + 60_000, "silentFireCount": 5},
+                        "createdAtMs": now_ms,
+                        "updatedAtMs": now_ms,
+                        "silentFireLimit": 3,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    svc = CronService(store_path)
+    job = svc.list_jobs()[0]
+    assert job.state.silent_fire_count == 5
+    assert job.silent_fire_limit == 3
+    # Already past its (tighter) legacy limit: the next fire disables.
+    assert svc.record_fire("old1") is True
+
+
+def test_store_without_silent_keys_defaults(tmp_path: Path) -> None:
+    store_path = tmp_path / "jobs.json"
+    now_ms = int(time.time() * 1000)
+    store_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "jobs": [
+                    {
+                        "id": "bare1",
+                        "name": "no silent keys",
+                        "enabled": True,
+                        "schedule": {"kind": "every", "everyMs": 60_000},
+                        "payload": {"message": "ping", "channel": "tui", "to": "default"},
+                        "state": {"nextRunAtMs": now_ms + 60_000},
+                        "createdAtMs": now_ms,
+                        "updatedAtMs": now_ms,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    job = CronService(store_path).list_jobs()[0]
+    assert job.state.silent_fire_count == 0
+    assert job.silent_fire_limit == 12
+
+
+# ── end-to-end: auto-disable survives the wake loop's writeback ───────
+
+
+async def test_auto_disable_survives_process_due_writeback(tmp_path: Path) -> None:
+    """The critical seam: record_fire runs inside on_job, mid-execution;
+    _writeback_after_run then patches enabled/next_run from the in-memory
+    job. The handler flips job.enabled on disable, so the writeback must
+    persist the disable rather than clobber it with a recomputed next run.
+    """
+    from raven.cli._cron_handler import make_on_cron_job
+
+    store_path = tmp_path / "jobs.json"
+    svc = CronService(store_path, allowed_channels={"tui"})
+    job_id = _add_every_job(svc, limit=1)
+    due = next(j for j in svc._store.jobs if j.id == job_id)
+    due.state.next_run_at_ms = 1
+    svc._save_store()
+
+    class _Handle:
+        async def result(self):
+            return None
+
+    svc.on_job = make_on_cron_job(submit=lambda req: _Handle(), cron_service=svc)
+    await svc._process_due()
+
+    stored = _stored(store_path, job_id)
+    assert stored["enabled"] is False, "writeback must not clobber the auto-disable"
+    assert stored["state"]["nextRunAtMs"] is None
+    assert stored["state"]["silentFireCount"] == 1
+    assert stored["state"]["claimedByPid"] is None
+    assert stored["state"]["silentFireCount"] == 1
+    assert stored["state"]["claimedByPid"] is None
+
+
+async def test_writeback_does_not_resurrect_store_side_disable(tmp_path):
+    """A caller that only invokes record_fire (no in-flight job flip) must
+    still end disabled: the writeback treats a store-side disable as sticky
+    instead of patching enabled=True back from the in-memory copy."""
+    store_path = tmp_path / "jobs.json"
+    svc = CronService(store_path, allowed_channels={"tui"})
+    job_id = _add_every_job(svc, limit=1)
+    due = next(j for j in svc._store.jobs if j.id == job_id)
+    due.state.next_run_at_ms = 1
+    svc._save_store()
+
+    async def on_job(job):
+        svc.record_fire(job.id)
+
+    svc.on_job = on_job
+    await svc._process_due()
+
+    stored = _stored(store_path, job_id)
+    assert stored["enabled"] is False, "store-side disable must survive the writeback"
+    assert stored["state"]["nextRunAtMs"] is None

--- a/tests/test_cron_service_silent_fire.py
+++ b/tests/test_cron_service_silent_fire.py
@@ -270,3 +270,22 @@ async def test_writeback_does_not_resurrect_store_side_disable(tmp_path):
     stored = _stored(store_path, job_id)
     assert stored["enabled"] is False, "store-side disable must survive the writeback"
     assert stored["state"]["nextRunAtMs"] is None
+
+
+async def test_reset_matches_legacy_jobs_without_channel_attribution(tmp_path):
+    """A pre-attribution job (payload.channel/to None) is claimable by any
+    runner, so any genuine user activity must reset its counter too - an
+    exact-match rule would let its count only ever climb until an unfair
+    auto-disable."""
+    store_path = tmp_path / "jobs.json"
+    svc = CronService(store_path, allowed_channels=None)
+    job = svc.add_job(
+        name="legacy",
+        schedule=CronSchedule(kind="every", every_ms=3600_000),
+        message="pre-attribution reminder",
+    )
+    svc.record_fire(job.id)
+    assert next(j for j in svc._load_store().jobs).state.silent_fire_count == 1
+
+    assert svc.notify_user_active(channel="telegram", to="tg_1") == 1
+    assert next(j for j in svc._load_store().jobs).state.silent_fire_count == 0

--- a/tests/test_cron_service_silent_fire.py
+++ b/tests/test_cron_service_silent_fire.py
@@ -289,3 +289,23 @@ async def test_reset_matches_legacy_jobs_without_channel_attribution(tmp_path):
 
     assert svc.notify_user_active(channel="telegram", to="tg_1") == 1
     assert next(j for j in svc._load_store().jobs).state.silent_fire_count == 0
+
+
+async def test_reenable_resets_the_runaway_counter(tmp_path):
+    """Re-enabling an auto-disabled job is deliberate user engagement: the
+    counter must reset, or the very next fire would re-disable it at the
+    still-saturated limit."""
+    store_path = tmp_path / "jobs.json"
+    svc = CronService(store_path, allowed_channels={"tui"})
+    job_id = _add_every_job(svc, limit=2)
+    svc.record_fire(job_id)
+    disabled = svc.record_fire(job_id)
+    assert disabled is True
+    assert _stored(store_path, job_id)["enabled"] is False
+
+    svc.enable_job(job_id, enabled=True)
+    stored = _stored(store_path, job_id)
+    assert stored["enabled"] is True
+    assert stored["state"]["silentFireCount"] == 0
+    # The next fire counts from zero instead of insta-disabling again.
+    assert svc.record_fire(job_id) is False

--- a/tests/test_event_wake.py
+++ b/tests/test_event_wake.py
@@ -491,3 +491,144 @@ async def test_cron_without_wake_wiring_unchanged():
     on_job = make_on_cron_job(submit=submit, readback_texts=readback)
     result = await on_job(_make_job())
     assert result == "resolved body"
+
+
+# ---------------------------------------------------------------------------
+# Producer wiring — make_on_missed_foreign (missed-reminder sink)
+# ---------------------------------------------------------------------------
+
+
+def _make_missed_job(job_id: str = "job_missed", *, minutes_late: int = 6):
+    import time as _time
+
+    from raven.proactive_engine.schedulers.cron.types import (
+        CronJob,
+        CronJobState,
+        CronPayload,
+        CronSchedule,
+    )
+
+    at_ms = int(_time.time() * 1000) - minutes_late * 60 * 1000
+    return CronJob(
+        id=job_id,
+        name="stretch break",
+        enabled=True,
+        schedule=CronSchedule(kind="at", at_ms=at_ms),
+        payload=CronPayload(message="stretch", channel="tui", to="default"),
+        state=CronJobState(next_run_at_ms=at_ms),
+    )
+
+
+async def test_missed_foreign_enqueues_one_event_and_wakes():
+    from raven.cli._cron_handler import make_on_missed_foreign
+
+    queue = SystemEventQueue()
+    wake = WakeScheduler(coalesce_s=0.01)
+    observer = make_on_missed_foreign(queue, wake)
+    job = _make_missed_job()
+
+    # The service re-reports the still-missed job on every wake pass; the
+    # observer must surface exactly one event.
+    observer([job])
+    observer([job])
+    observer([job])
+
+    events = queue.peek_all()
+    assert len(events) == 1
+    assert events[0].source == "cron"
+    assert events[0].context_key == "cron:job_missed:missed"
+    assert "stretch break" in events[0].text
+    assert "was missed" in events[0].text
+    assert "tui" in events[0].text
+
+    await asyncio.sleep(0.05)
+    assert wake.wake_event.is_set()
+    assert wake.consume_reasons() == ["cron:job_missed:missed"]
+
+
+async def test_missed_foreign_not_reenqueued_after_heartbeat_consumed():
+    """After the heartbeat acks the event, later wake passes must not
+    re-notify (in-process notified set — the second dedup layer, past the
+    queue's context_key replacement)."""
+    from raven.cli._cron_handler import make_on_missed_foreign
+
+    queue = SystemEventQueue()
+    wake = WakeScheduler(coalesce_s=0.01)
+    observer = make_on_missed_foreign(queue, wake)
+    job = _make_missed_job()
+
+    observer([job])
+    queue.ack(queue.peek_all())  # heartbeat tick consumed it
+    observer([job])
+
+    assert queue.peek_all() == []
+
+
+async def test_missed_foreign_emit_failure_retried_next_pass():
+    from raven.cli._cron_handler import make_on_missed_foreign
+
+    queue = MagicMock()
+    queue.enqueue.side_effect = [ValueError("queue broken"), None]
+    wake = WakeScheduler(coalesce_s=0.01)
+    observer = make_on_missed_foreign(queue, wake)
+    job = _make_missed_job()
+
+    observer([job])  # first pass: enqueue blew up — must not mark notified
+    observer([job])  # second pass: retried and succeeds
+    observer([job])  # third pass: now deduped
+
+    assert queue.enqueue.call_count == 2
+
+
+async def test_missed_foreign_end_to_end_service_start(tmp_path: Path):
+    """Full wiring: a gateway-partitioned CronService with a stranded tui
+    one-shot notifies the heartbeat sink exactly once across start plus
+    wake-loop passes."""
+    import json
+    import time as _time
+
+    from raven.cli._cron_handler import make_on_missed_foreign
+    from raven.proactive_engine.schedulers.cron.service import CronService
+
+    store_path = tmp_path / "jobs.json"
+    at_ms = int(_time.time() * 1000) - 6 * 60 * 1000
+    store_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "jobs": [
+                    {
+                        "id": "tuiX",
+                        "name": "call mom",
+                        "enabled": True,
+                        "schedule": {"kind": "at", "atMs": at_ms},
+                        "payload": {"message": "call mom", "channel": "tui", "to": "default"},
+                        "state": {"nextRunAtMs": at_ms},
+                        "createdAtMs": at_ms - 60_000,
+                        "updatedAtMs": at_ms - 60_000,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    queue = SystemEventQueue()
+    wake = WakeScheduler(coalesce_s=0.01)
+    svc = CronService(store_path, allowed_channels={"weixin"})
+    svc.on_missed_foreign = make_on_missed_foreign(queue, wake)
+
+    await svc.start()
+    try:
+        await asyncio.sleep(0.05)  # let the first wake-loop pass re-observe
+    finally:
+        svc.stop()
+
+    events = queue.peek_all()
+    assert len(events) == 1, "start + loop passes must surface exactly one event"
+    assert events[0].context_key == "cron:tuiX:missed"
+    assert "call mom" in events[0].text
+    # The foreign job itself is untouched (read-only observation).
+    data = json.loads(store_path.read_text(encoding="utf-8"))
+    assert [j["id"] for j in data["jobs"]] == ["tuiX"]
+    assert data["jobs"][0]["enabled"] is True

--- a/tests/test_tui_cron_tool_wired.py
+++ b/tests/test_tui_cron_tool_wired.py
@@ -85,6 +85,7 @@ def patched_tui_build_deps(monkeypatch: pytest.MonkeyPatch, tmp_path):
             self.allowed_channels = allowed_channels or set()
             self.on_job = None
             self.started = False
+            self.notify_user_active = MagicMock()
             type(self).instances.append(self)
 
         async def start(self):
@@ -165,3 +166,54 @@ def test_tui_cron_on_job_wired_in_run_not_build(patched_tui_build_deps) -> None:
 # cron now runs as a spine CRON turn and the reply is fanned out as
 # cron.delivered by ``_build_cron_callback_spine`` (covered in
 # test_tui_cron_delivered_event.py), so no bus publish / callback swap remains.
+
+
+# ---------------------------------------------------------------------------
+# Anti-runaway wiring: reset hook on the AgentLoop, count on the handler
+# ---------------------------------------------------------------------------
+
+
+def test_tui_on_user_inbound_resets_cron_counters(patched_tui_build_deps) -> None:
+    """The TUI AgentLoop's ``on_user_inbound`` chains the anti-runaway
+    reset: a genuine USER turn on (tui, default) — the same pair
+    CronTool.set_context binds into new jobs — zeroes silent-fire counts."""
+    from raven.cli.tui_commands import _build_tui_agent_loop
+    from raven.spine import ChatType, Origin, Source, TurnRequest
+
+    _build_tui_agent_loop()
+
+    kwargs = patched_tui_build_deps["agent_loop_kwargs"]
+    hook = kwargs.get("on_user_inbound")
+    assert hook is not None, "TUI AgentLoop must wire the silent-fire reset hook"
+
+    cron = patched_tui_build_deps["cron_service_class"].instances[0]
+    hook(
+        TurnRequest(
+            origin=Origin.USER,
+            source=Source(channel="tui", chat_id="default", sender_id="user", chat_type=ChatType.DM),
+            text="hi",
+        )
+    )
+    cron.notify_user_active.assert_called_once_with("tui", "default")
+
+    hook(
+        TurnRequest(
+            origin=Origin.CRON,
+            source=Source(channel="tui", chat_id="default", sender_id="cron", chat_type=ChatType.DM),
+            text="[Scheduled Task]",
+        )
+    )
+    cron.notify_user_active.assert_called_once()  # CRON turn must not reset
+
+
+def test_tui_run_loop_passes_cron_service_to_handler() -> None:
+    """The run loop's ``make_on_cron_job`` call must hand over the cron
+    service so recurring TUI fires are counted (anti-runaway). The wiring
+    lives in a closure with no import seam, so pin the source (same
+    pattern as the gateway /stop test)."""
+    import inspect
+
+    from raven.cli import tui_commands
+
+    src = inspect.getsource(tui_commands._run_rpc_server_until_done)
+    assert "cron_service=agent_loop.cron_service," in src


### PR DESCRIPTION
## Summary

Two follow-ups that complete the fire-at-origin cron story, both built
end-to-end.

Anti-runaway protection: a recurring reminder the user never engages
with now disables itself. Fires are counted at the delivery point
(after a successful turn, recurring schedules only), the counter resets
whenever a genuine user message arrives on the job's channel/chat
(chained after the existing user-inbound hook and guarded to USER
origin, so a cron fire can never reset its own counter), and crossing
the per-job limit (default 12) disables the job with a warning log.
The store-side disable is sticky against the post-run writeback, and
cron list/get surface the live counter.

Missed-reminder notices: the gateway observes - read-only, never
mutating jobs it does not own - one-shot reminders bound to interactive
surfaces that are more than a grace window past due (their session was
closed at fire time), and enqueues one deduplicated system event per
job; the heartbeat surfaces it to the user. Gated by
cron.notify_missed (default on).

## Type

- [x] Feature

## Verification

- `uv run pytest tests/ --ignore=tests/integration` on this branch:
  6053 passed / 2 failed, both failures pre-existing on main run the
  same way (test_read_file_image, plus the order-dependent
  test_cli_theme flake that fails whenever its file runs as a whole) -
  zero failures introduced.
- Affected-area suites (silent-fire, missed notices, cron handler/CLI,
  claim/wake, event wake, gateway/tui wiring): 209 passed.
- Review rounds added: user-activity reset for legacy jobs without
  channel attribution, a counter reset on re-enable (auto-disable is no
  longer a one-way door), a user-visible auto-disable notice riding the
  heartbeat path plus a default-view list hint - each with tests.
- Real-machine harness (real CLI subprocesses, real CronService driver
  processes, a real `raven gateway`, isolated HOME): full 11 scenarios /
  46 checks green, including the anti-runaway scenario (recurring job
  auto-disables at the limit and never overruns) and the
  missed-notification scenario (a real gateway enqueues the notice
  exactly once across wake passes, and the config toggle silences it).
- `uv run ruff format --check` and `uv run ruff check`: clean.

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Old jobs.json files load unchanged (the counter fields reuse the JSON
names an earlier build wrote, and readers tolerate their absence).
Both features are conservative by default: the runaway limit only
disables after 12 unengaged fires and logs loudly; the missed-notice
observer is read-only over foreign jobs and can be turned off with
cron.notify_missed=false. Rollback = revert the squash commit.

## Related Issues

N/A

