### PR TITLE
refactor(cli): drop the inert skill-extraction flags

### DIFF
--- a/benchmarks/proactivity_eval/runners/_common/raven_driver/driver.py
+++ b/benchmarks/proactivity_eval/runners/_common/raven_driver/driver.py
@@ -146,7 +146,6 @@ class RavenDriver:
         *,
         fake_now: str | None = None,
         session_id: str = "cli:direct",
-        wait_skill_extract: bool = False,
     ) -> AgentResponse:
         """Run ``raven agent --message <m> [--fake-now ...]`` once.
 
@@ -160,10 +159,6 @@ class RavenDriver:
         cmd.extend(["--session", session_id])
         cmd.append("--no-markdown")
         cmd.append("--no-logs")
-        if wait_skill_extract:
-            cmd.append("--wait-skill-extract")
-        else:
-            cmd.append("--no-wait-skill-extract")
         if fake_now:
             cmd.extend(["--fake-now", fake_now])
         return self._run(cmd)

--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -2421,25 +2421,6 @@ class AgentLoop:
             except Exception:
                 logger.exception("on_turn_complete callback failed")
 
-    async def await_pending_extractions(
-        self,
-        flush_session_id: str | None = None,
-        *,
-        wait: bool = True,
-    ) -> None:
-        """No-op retained for CLI / batch-mode call-site compatibility.
-
-        Previously this flushed the local skill-extraction buffer and
-        blocked on its in-flight tasks. That embedded pipeline was
-        removed — case-to-skill distillation now lives in the
-        :class:`MemoryBackend` plugin (``backend.store`` /
-        ``backend.feedback``), which the after-turn pipeline drives
-        directly. Kept so ``raven agent`` callers don't need changing;
-        the ``flush_session_id`` / ``wait`` knobs are inert.
-        """
-        del flush_session_id, wait
-        return None
-
     async def close_mcp(self) -> None:
         """Close MCP connections and the sandbox executor."""
         if self._mcp_stack:

--- a/raven/cli/agent_commands.py
+++ b/raven/cli/agent_commands.py
@@ -125,36 +125,6 @@ def register(app: typer.Typer) -> None:
         config: str | None = typer.Option(None, "--config", help="Config file path"),
         markdown: bool = typer.Option(True, "--markdown/--no-markdown", help="Render assistant output as Markdown"),
         logs: bool = typer.Option(False, "--logs/--no-logs", help="Show Raven runtime logs during chat"),
-        wait_skill_extract: bool = typer.Option(
-            False,
-            "--wait-skill-extract/--no-wait-skill-extract",
-            help=(
-                "Block exit until in-flight everos extraction tasks finish. "
-                "Off by default — extraction is fire-and-forget, so the CLI "
-                "returns as soon as the agent responds and any in-flight "
-                "boundary-detection / case-extraction LLM call may be "
-                "cancelled by interpreter shutdown. When on (without "
-                "--flush-skill-buffer), the per-session pending-turn buffer "
-                "is left intact for the next CLI invocation, which is the "
-                "mode you want for scripted multi-turn boundary-detection "
-                "testing (multiple ``-m`` calls sharing the same ``-s``)."
-            ),
-        ),
-        flush_skill_buffer: bool = typer.Option(
-            False,
-            "--flush-skill-buffer/--no-flush-skill-buffer",
-            help=(
-                "Send a ``session_end`` signal for this session before exit, "
-                "draining whatever turns are sitting in the everos "
-                "boundary-detection buffer through case + skill extraction. "
-                "Pair with --wait-skill-extract to actually block on the "
-                "resulting LLM calls (a flush without --wait-skill-extract "
-                "schedules the drain but won't survive interpreter "
-                "shutdown). Use on the final ``-m`` of a scripted "
-                "multi-turn session, or to force extraction after a single "
-                "``-m`` turn (a lone turn never trips a boundary on its own)."
-            ),
-        ),
         fake_now: str | None = typer.Option(
             None,
             "--fake-now",
@@ -373,20 +343,6 @@ def register(app: typer.Typer) -> None:
                     await handle.result()
                 await hub.wait_idle("cli")  # render barrier: CliOutlet caught up
                 await teardown()
-                if wait_skill_extract or flush_skill_buffer:
-                    # ``flush_skill_buffer`` sends session_end so any
-                    # buffered turns drain through extraction (a single
-                    # -m turn never trips a boundary on its own).
-                    # ``wait_skill_extract`` blocks on the in-flight
-                    # tasks; without it the flush schedules work that
-                    # interpreter shutdown will cancel. The two flags
-                    # are orthogonal — scripted multi-turn testing uses
-                    # --wait-skill-extract alone so the buffer survives
-                    # for the next CLI run.
-                    await agent_loop.await_pending_extractions(
-                        flush_session_id=session_id if flush_skill_buffer else None,
-                        wait=wait_skill_extract,
-                    )
                 await agent_loop.close_mcp()
             finally:
                 if backend is not None:

--- a/tests/integration/test_everos_channel_e2e.py
+++ b/tests/integration/test_everos_channel_e2e.py
@@ -69,7 +69,7 @@ def _run_agent(message: str, session: str, root: Path) -> str:
     """Send one message through the real agent CLI (mock channel)."""
     env = {**os.environ, "EVEROS_ROOT": str(root)}
     proc = subprocess.run(
-        [str(_RAVEN), "agent", "-m", message, "-s", session, "--wait-skill-extract", "--no-markdown", "--logs"],
+        [str(_RAVEN), "agent", "-m", message, "-s", session, "--no-markdown", "--logs"],
         env=env,
         capture_output=True,
         text=True,

--- a/tests/test_cli_agent_commands.py
+++ b/tests/test_cli_agent_commands.py
@@ -41,6 +41,16 @@ def test_agent_help_works() -> None:
     assert "--markdown" in r.stdout
 
 
+def test_agent_help_omits_removed_skill_extract_flags() -> None:
+    """The inert skill-extraction flags stay removed: the mechanism their
+    help text described was replaced by the MemoryBackend plugin, so the
+    flags never had any effect."""
+    r = runner.invoke(app, ["agent", "--help"])
+    assert r.exit_code == 0
+    assert "--wait-skill-extract" not in r.stdout
+    assert "--flush-skill-buffer" not in r.stdout
+
+
 def test_agent_without_message_prints_pointer_and_exits_nonzero(tmp_config: Path) -> None:
     """Bare ``raven agent`` no longer enters an interactive loop: it points
     at ``raven tui`` / ``agent -m`` and exits non-zero."""


### PR DESCRIPTION
## Summary

`raven agent -m` exposed two flags whose help text described a
mechanism that no longer exists: --wait-skill-extract and
--flush-skill-buffer only ever reached
AgentLoop.await_pending_extractions, which has been an explicit
documented no-op since the embedded extraction pipeline was replaced by
the memory-backend flush (extraction now fires every turn on the
backend side). The flags never changed any behavior; their help text
promised boundary-detection workflows that silently did nothing.

This removes both flags, their consumption block, and the no-op method
(its only real caller was that block). A guard test pins the help
output so the flags cannot silently return. The proactivity benchmark
driver, which unconditionally appended one of the flags to its CLI
invocations, is updated in the same change - it would have broken at
runtime otherwise (no caller uses its wait_skill_extract kwarg).

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [x] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_cli_agent_commands.py -x`: 29 passed, including the new guard test asserting `raven agent --help` mentions neither flag.
- Full suite (no -x): 6315 passed / 2 failed, both pre-existing on main (the image-block test and the order-dependent theme test).
- `uv run raven agent --help` on a real run shows no skill/extract/flush mention; `uv run ruff format` and `ruff check` clean across raven/, tests/, benchmarks/.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Scripts passing the removed flags will now get an unknown-option error
instead of a silent no-op; that is the honest outcome, since the flags
have not done anything for several releases. Revert the branch to roll
back.

## Related Issues

N/A - no tracked GitHub issues.
