### PR TITLE
fix(*): stop an old default from capping every model's context window

### DIFF
--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -392,18 +392,12 @@ class AgentLoop:
         # real window. ("Explicit", not "pinned" -- Provider Pin is a different
         # registered term, see CONTEXT.md.)
         self._context_window_explicit = bool(context_window_tokens)
-        if context_window_tokens == 65536:
-            # The retired schema default, which the old bootstrap wrote to
-            # disk verbatim -- so on upgraded installs this exact value is
-            # more often a fossil than a choice. The config is deliberately
-            # not rewritten (a value the user can see in their own file stays
-            # theirs); this line is what keeps that stance from failing
-            # silently.
-            logger.warning(
-                "contextWindowTokens: 65536 is pinning the context window (the old default, "
-                "written out by earlier versions); remove the line from config.json to size "
-                "it from each model's real window"
-            )
+        # No special case for 65536 here any more: the retired default the old
+        # bootstrap wrote to disk is cleared where it lives, once, by
+        # ``config.loader._migrate_legacy_context_window``. Whatever reaches
+        # this constructor is therefore a real choice, and warning about a real
+        # choice would just be noise.
+        #
         # allow_fetch=False: construction must not block on a synchronous
         # network call for an OpenRouter model's window -- whatever is already
         # cached (in-process or on disk, any age) answers instead. See

--- a/raven/cli/_helpers.py
+++ b/raven/cli/_helpers.py
@@ -352,6 +352,19 @@ def print_deprecated_memory_window_notice(config: Config) -> None:
         )
 
 
+def print_config_migration_notices() -> None:
+    """Tell the user about any config line a migration just changed for them.
+
+    The migrations run inside the loader, which has no terminal; this is the
+    place that does. Call it after the config is loaded and before the command
+    takes over the screen -- once printed, the notices are gone.
+    """
+    from raven.config.loader import drain_migration_notices
+
+    for notice in drain_migration_notices():
+        console.print(f"[yellow]Config updated:[/yellow] {notice}")
+
+
 __all__ = [
     "DEFAULT_PROBE_MESSAGE",
     "make_provider",
@@ -360,4 +373,5 @@ __all__ = [
     "load_runtime_config",
     "parse_fake_now",
     "print_deprecated_memory_window_notice",
+    "print_config_migration_notices",
 ]

--- a/raven/cli/agent_commands.py
+++ b/raven/cli/agent_commands.py
@@ -23,6 +23,7 @@ from raven.cli._helpers import (
     load_runtime_config,
     make_provider,
     parse_fake_now,
+    print_config_migration_notices,
     print_deprecated_memory_window_notice,
 )
 from raven.cli._plugin_stack import (
@@ -168,6 +169,7 @@ def register(app: typer.Typer) -> None:
         sentinel_cfg = ec_config.sentinel
         skill_forge_cfg = ec_config.skill_forge
         print_deprecated_memory_window_notice(config)
+        print_config_migration_notices()
         sync_workspace_templates(config.workspace_path)
 
         provider = make_provider(config)

--- a/raven/cli/commands.py
+++ b/raven/cli/commands.py
@@ -172,6 +172,15 @@ def run() -> None:
 
         Console(stderr=True).print(f"[red]✗[/red] {exc}")
         raise SystemExit(1) from exc
+    finally:
+        # Every command loads the config, so any of them can be the one that
+        # migrates it -- `status`, `provider list`, `cron list`. Only `agent` and
+        # `gateway` say so up front, and an unsaid notice is lost rather than
+        # deferred: the watermark leaves the next load with nothing to report.
+        # So this is the catch-all for every other command.
+        from raven.cli._helpers import print_config_migration_notices
+
+        print_config_migration_notices()
 
 
 if __name__ == "__main__":

--- a/raven/cli/gateway_commands.py
+++ b/raven/cli/gateway_commands.py
@@ -22,6 +22,7 @@ from raven.cli._helpers import (
     load_runtime_config,
     make_provider,
     parse_fake_now,
+    print_config_migration_notices,
     print_deprecated_memory_window_notice,
 )
 from raven.cli._plugin_stack import maybe_build_memory_backend
@@ -187,6 +188,7 @@ def register(app: typer.Typer) -> None:
         sentinel_cfg = ec_config.sentinel
         skill_forge_cfg = ec_config.skill_forge
         print_deprecated_memory_window_notice(config)
+        print_config_migration_notices()
         port = port if port is not None else config.gateway.port
 
         console.print(f"{__logo__} Starting Raven gateway on port {port}...")

--- a/raven/config/loader.py
+++ b/raven/config/loader.py
@@ -2,13 +2,21 @@
 
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Any
 
 from pydantic import ValidationError
 
-from raven.config.schema import Config
+from raven.config.schema import CURRENT_CONFIG_VERSION, Config
+
+# The context window every pre-0.1.11 bootstrap wrote to disk verbatim: back
+# then ``AgentDefaults.context_window_tokens`` defaulted to this number and
+# ``save_config`` dumped every default. A pin is honoured over the model's real
+# window by design, so on an upgraded install this exact value silently caps
+# every model at 64k -- see ``_migrate_legacy_context_window``.
+LEGACY_CONTEXT_WINDOW_TOKENS = 65_536
 
 # Single source of truth for Raven extension block keys.
 # Both _migrate_config (pop before base Config validates) and
@@ -37,6 +45,14 @@ _current_config_path: Path | None = None
 # Paths already warned about as malformed in this process; repeated
 # load_config calls (status/doctor load more than once) warn only once.
 _warned_paths: set[str] = set()
+
+# User-facing lines produced by a migration that actually changed something,
+# waiting to be printed by whichever CLI entry point owns the terminal.
+# Migrations run inside the loader, which has no console of its own and whose
+# logs land in a file nobody reads; a config the user can see us edit has to be
+# announced where the user is looking. Drained, not read, so N loads per
+# process yield one telling.
+_migration_notices: list[str] = []
 
 
 def set_config_path(path: Path) -> None:
@@ -90,6 +106,117 @@ def read_raw_or_raise(path: Path) -> dict[str, Any]:
         ) from exc
 
 
+def drain_migration_notices() -> list[str]:
+    """Take the pending migration notices, clearing them.
+
+    Drained rather than read so that a process loading the config several times
+    (status and doctor do; the TUI RPC server reloads every turn) tells the user
+    once. Callers own a console -- see ``cli._helpers``.
+    """
+    notices = list(_migration_notices)
+    _migration_notices.clear()
+    return notices
+
+
+def _config_version(data: dict[str, Any]) -> int:
+    """The migration generation stamped on a raw config mapping.
+
+    Absent / unparseable means generation 0, i.e. a file written before the
+    stamp existed -- every migration still owes it a pass.
+    """
+    raw = data.get("configVersion", data.get("config_version"))
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _migrate_legacy_context_window(data: dict[str, Any], *, notify: bool = False) -> bool:
+    """Clear the retired 65536 context-window pin. True when ``data`` changed.
+
+    Gated on the stamp, and stamps in turn, because the value carries no
+    provenance: 65536 written by the old bootstrap and 65536 chosen by a user
+    are the same three bytes. Running once means we clear what we planted; from
+    then on the number is the user's, and the ladder in
+    ``providers.rates.effective_context_window`` honours it like any other pin.
+
+    ``notify`` is for the caller that has a user to tell -- the persist pass
+    re-runs this on the raw file and must not double-announce.
+
+    Nothing found means nothing written: the stamp lands only on a file we
+    actually edited, so a config that never carried the fossil is left byte for
+    byte alone. The cost is a narrow hole -- someone who hand-sets 65536 on a
+    still-unstamped config has it cleared once, with the notice explaining why,
+    and their second attempt sticks (that first clear stamps the file). Paid
+    knowingly: touching every config on earth to close it is the worse trade.
+    """
+    if _config_version(data) >= CURRENT_CONFIG_VERSION:
+        return False
+
+    agents = data.get("agents")
+    defaults = agents.get("defaults") if isinstance(agents, dict) else None
+    if not isinstance(defaults, dict):
+        return False
+
+    changed = False
+    for legacy_key in ("contextWindowTokens", "context_window_tokens"):
+        if defaults.get(legacy_key) == LEGACY_CONTEXT_WINDOW_TOKENS:
+            defaults.pop(legacy_key)
+            changed = True
+            logging.getLogger(__name__).info(
+                "Migrated: dropped agents.defaults.%s (the retired 65536 default)",
+                legacy_key,
+            )
+
+    if not changed:
+        return False
+
+    notice = (
+        f"Removed the leftover `contextWindowTokens: {LEGACY_CONTEXT_WINDOW_TOKENS}` from your config (an old "
+        "default, written there by earlier versions). The context window now follows each model's real size. "
+        "Put the line back if you did want that number -- for an endpoint served with a smaller window, for "
+        "instance."
+    )
+    # Deduped, not just drained: the extension loader migrates its own read of
+    # the same file, so one command can walk this path twice before anything is
+    # printed.
+    if notify and notice not in _migration_notices:
+        _migration_notices.append(notice)
+    data["configVersion"] = CURRENT_CONFIG_VERSION
+    return True
+
+
+def _persist_migrated_config(path: Path) -> None:
+    """Apply the stamped migrations to the file itself. Best effort, once.
+
+    Re-reads the raw file instead of reusing the mapping ``load_config`` already
+    migrated: that one has the extension blocks popped (see
+    ``pop_extension_keys``), so writing it back would delete the user's memory /
+    plugins / skillForge sections. ``save_config`` is no use here either -- it
+    dumps every default (~8 KB), re-planting the very kind of fossil this
+    migration exists to pull out. So: surgical edit, atomic replace.
+
+    Silent on failure (read-only home, a lost race with another process): the
+    in-memory migration already made this process correct, and the write only
+    serves to keep the file from disagreeing with it. Two processes racing here
+    write byte-identical content.
+    """
+    try:
+        raw = read_raw_or_raise(path)
+    except ConfigReadError:
+        return
+    if not raw or not _migrate_legacy_context_window(raw):
+        return
+
+    tmp = path.with_name(path.name + ".migrating")
+    try:
+        tmp.write_text(json.dumps(raw, indent=2, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError as exc:
+        logging.getLogger(__name__).debug("Could not persist config migration to %s: %s", path, exc)
+        tmp.unlink(missing_ok=True)
+
+
 def load_config(config_path: Path | None = None) -> Config:
     """
     Load configuration from file or create default.
@@ -107,7 +234,13 @@ def load_config(config_path: Path | None = None) -> Config:
         try:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
+            # The stamp before and after: a migration only stamps a file it
+            # actually changed, so this pair is also the "did anything happen"
+            # signal -- and the reason an untouched config costs no extra file
+            # read per load (the TUI RPC server reloads every turn).
+            unstamped = _config_version(data) < CURRENT_CONFIG_VERSION
             data = _migrate_config(data)
+            migrated = unstamped and _config_version(data) >= CURRENT_CONFIG_VERSION
         except json.JSONDecodeError as e:
             # Boot on defaults for a malformed file (a transient mid-write race
             # shouldn't brick callers) but warn LOUDLY -- a persistent syntax
@@ -142,6 +275,10 @@ def load_config(config_path: Path | None = None) -> Config:
                 raise ValueError(
                     f"Config at {path} fails schema validation:\n{e}",
                 ) from e
+            # Only once the migrated data is known to validate: a file we
+            # cannot load is a file we have no business rewriting.
+            if migrated:
+                _persist_migrated_config(path)
 
     if config is None:
         config = Config()
@@ -177,6 +314,11 @@ def _migrate_config(data: dict, *, pop_extension_keys: bool = True) -> dict:
     import logging as _logging
 
     _log = _logging.getLogger(__name__)
+
+    # Stamped, run-once migrations first: they are the ones allowed to reach
+    # back out to disk (see _persist_migrated_config), and the stamp they set
+    # must not be confused by anything the shims below do.
+    _migrate_legacy_context_window(data, notify=True)
 
     # Move tools.exec.restrictToWorkspace → tools.restrictToWorkspace
     tools = data.get("tools", {})

--- a/raven/config/loader.py
+++ b/raven/config/loader.py
@@ -9,7 +9,14 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from raven.config.schema import CURRENT_CONFIG_VERSION, Config
+from raven.config.schema import Config
+
+# Generation counter for the run-once config migrations below. Bump it, and add
+# the matching rule, when a migration must run exactly once per config rather
+# than on every load -- the watermark is what lets a user re-set by hand
+# whatever a migration cleared. Kept out of the schema on purpose: see
+# ``_stamp_path``.
+CURRENT_CONFIG_VERSION = 1
 
 # The context window every pre-0.1.11 bootstrap wrote to disk verbatim: back
 # then ``AgentDefaults.context_window_tokens`` defaulted to this number and
@@ -118,41 +125,64 @@ def drain_migration_notices() -> list[str]:
     return notices
 
 
-def _config_version(data: dict[str, Any]) -> int:
-    """The migration generation stamped on a raw config mapping.
+def _stamp_path(config_path: Path) -> Path:
+    """Where the migration watermark for ``config_path`` lives.
 
-    Absent / unparseable means generation 0, i.e. a file written before the
-    stamp existed -- every migration still owes it a pass.
+    Deliberately NOT inside the config: ``Config`` is ``extra='forbid'`` and
+    ``load_config`` raises on a validation error, so a key this build knows and
+    an older one does not turns every older build into a hard boot failure --
+    a reverted release, a pinned older version, or just a second checkout
+    sharing the same ~/.raven. A sidecar is ours to write and invisible to any
+    build that has never heard of it, which also keeps a revert of this change
+    clean.
+
+    Sibling of the config so a ``--config`` path or a second instance gets its
+    own watermark rather than borrowing the default one's.
     """
-    raw = data.get("configVersion", data.get("config_version"))
+    return config_path.with_name(config_path.stem + ".migrations.json")
+
+
+def _migration_version(config_path: Path) -> int:
+    """Which generation of stamped migrations ``config_path`` has been through.
+
+    Absent / unreadable / malformed all mean generation 0: the migrations are
+    written to be safe to re-run, so erring towards running them beats trusting
+    a file we could not parse.
+    """
     try:
-        return int(raw)
-    except (TypeError, ValueError):
+        data = json.loads(_stamp_path(config_path).read_text(encoding="utf-8"))
+        return int(data["version"])
+    except (OSError, ValueError, KeyError, TypeError):
         return 0
+
+
+def _write_migration_version(config_path: Path) -> None:
+    """Record that this config has been through the current migrations.
+
+    Written even when nothing needed changing -- this is our file, not the
+    user's, so stamping it costs the user nothing and buys the guarantee that
+    matters: from here on, a ``contextWindowTokens`` the user sets by hand is
+    never second-guessed, whatever its value.
+    """
+    stamp = _stamp_path(config_path)
+    try:
+        stamp.write_text(json.dumps({"version": CURRENT_CONFIG_VERSION}) + "\n", encoding="utf-8")
+    except OSError as exc:
+        logging.getLogger(__name__).debug("Could not write the migration stamp %s: %s", stamp, exc)
 
 
 def _migrate_legacy_context_window(data: dict[str, Any], *, notify: bool = False) -> bool:
     """Clear the retired 65536 context-window pin. True when ``data`` changed.
 
-    Gated on the stamp, and stamps in turn, because the value carries no
-    provenance: 65536 written by the old bootstrap and 65536 chosen by a user
-    are the same three bytes. Running once means we clear what we planted; from
-    then on the number is the user's, and the ladder in
+    Callers gate this on the watermark (see ``_migration_version``) because the
+    value carries no provenance: 65536 written by the old bootstrap and 65536
+    chosen by a user are the same three bytes. Running it once means we clear
+    what we planted; from then on the number is the user's, and the ladder in
     ``providers.rates.effective_context_window`` honours it like any other pin.
 
     ``notify`` is for the caller that has a user to tell -- the persist pass
     re-runs this on the raw file and must not double-announce.
-
-    Nothing found means nothing written: the stamp lands only on a file we
-    actually edited, so a config that never carried the fossil is left byte for
-    byte alone. The cost is a narrow hole -- someone who hand-sets 65536 on a
-    still-unstamped config has it cleared once, with the notice explaining why,
-    and their second attempt sticks (that first clear stamps the file). Paid
-    knowingly: touching every config on earth to close it is the worse trade.
     """
-    if _config_version(data) >= CURRENT_CONFIG_VERSION:
-        return False
-
     agents = data.get("agents")
     defaults = agents.get("defaults") if isinstance(agents, dict) else None
     if not isinstance(defaults, dict):
@@ -182,12 +212,11 @@ def _migrate_legacy_context_window(data: dict[str, Any], *, notify: bool = False
     # printed.
     if notify and notice not in _migration_notices:
         _migration_notices.append(notice)
-    data["configVersion"] = CURRENT_CONFIG_VERSION
     return True
 
 
-def _persist_migrated_config(path: Path) -> None:
-    """Apply the stamped migrations to the file itself. Best effort, once.
+def _persist_migrations(path: Path) -> None:
+    """Apply the stamped migrations to the file itself, then stamp. Best effort.
 
     Re-reads the raw file instead of reusing the mapping ``load_config`` already
     migrated: that one has the extension blocks popped (see
@@ -196,25 +225,42 @@ def _persist_migrated_config(path: Path) -> None:
     dumps every default (~8 KB), re-planting the very kind of fossil this
     migration exists to pull out. So: surgical edit, atomic replace.
 
-    Silent on failure (read-only home, a lost race with another process): the
-    in-memory migration already made this process correct, and the write only
-    serves to keep the file from disagreeing with it. Two processes racing here
-    write byte-identical content.
+    A config that needed no edit is left byte for byte alone; only the sidecar
+    stamp is written. Commands like ``provider use`` promise not to touch a
+    config they decided against changing, and that promise is theirs to keep,
+    not ours to spend.
+
+    Silent on failure (read-only home): the in-memory migration already made
+    this process correct, and the write only serves to keep the file from
+    disagreeing with it.
     """
     try:
         raw = read_raw_or_raise(path)
     except ConfigReadError:
         return
-    if not raw or not _migrate_legacy_context_window(raw):
-        return
 
-    tmp = path.with_name(path.name + ".migrating")
-    try:
-        tmp.write_text(json.dumps(raw, indent=2, ensure_ascii=False), encoding="utf-8")
-        os.replace(tmp, path)
-    except OSError as exc:
-        logging.getLogger(__name__).debug("Could not persist config migration to %s: %s", path, exc)
-        tmp.unlink(missing_ok=True)
+    if raw and _migrate_legacy_context_window(raw):
+        # PID in the name: two processes migrating at once would otherwise share
+        # one temp path, and the second's truncating write could be read as an
+        # empty config.json by anyone loading between it and the replace.
+        tmp = path.with_name(f"{path.name}.migrating.{os.getpid()}")
+        try:
+            tmp.write_text(json.dumps(raw, indent=2, ensure_ascii=False), encoding="utf-8")
+            # os.replace swaps the inode, so the original's mode is not carried
+            # over by anything: a config the user tightened to owner-only (it
+            # holds providers.*.apiKey) would come back world-readable. See
+            # config.paths.restrict_to_owner on why a replacing writer owns this.
+            try:
+                os.chmod(tmp, path.stat().st_mode & 0o7777)
+            except OSError:
+                pass
+            os.replace(tmp, path)
+        except OSError as exc:
+            logging.getLogger(__name__).debug("Could not persist config migration to %s: %s", path, exc)
+            tmp.unlink(missing_ok=True)
+            return
+
+    _write_migration_version(path)
 
 
 def load_config(config_path: Path | None = None) -> Config:
@@ -234,13 +280,11 @@ def load_config(config_path: Path | None = None) -> Config:
         try:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
-            # The stamp before and after: a migration only stamps a file it
-            # actually changed, so this pair is also the "did anything happen"
-            # signal -- and the reason an untouched config costs no extra file
-            # read per load (the TUI RPC server reloads every turn).
-            unstamped = _config_version(data) < CURRENT_CONFIG_VERSION
-            data = _migrate_config(data)
-            migrated = unstamped and _config_version(data) >= CURRENT_CONFIG_VERSION
+            # Read the watermark before the migrations run, and let it gate
+            # them: once stamped, this costs one small sidecar read per load
+            # (the TUI RPC server reloads every turn) and nothing else.
+            unstamped = _migration_version(path) < CURRENT_CONFIG_VERSION
+            data = _migrate_config(data, run_stamped=unstamped)
         except json.JSONDecodeError as e:
             # Boot on defaults for a malformed file (a transient mid-write race
             # shouldn't brick callers) but warn LOUDLY -- a persistent syntax
@@ -277,8 +321,8 @@ def load_config(config_path: Path | None = None) -> Config:
                 ) from e
             # Only once the migrated data is known to validate: a file we
             # cannot load is a file we have no business rewriting.
-            if migrated:
-                _persist_migrated_config(path)
+            if unstamped:
+                _persist_migrations(path)
 
     if config is None:
         config = Config()
@@ -303,22 +347,25 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 
-def _migrate_config(data: dict, *, pop_extension_keys: bool = True) -> dict:
+def _migrate_config(data: dict, *, pop_extension_keys: bool = True, run_stamped: bool = False) -> dict:
     """Migrate old config formats to current.
 
     ``pop_extension_keys``: when True (default, used by ``load_config``),
     strip extension block keys so the base ``Config(extra='forbid')``
     doesn't reject them. Set to False when the caller needs to read
     extension blocks from the migrated data (``load_raven_config``).
+
+    ``run_stamped``: also run the migrations that are meant to happen once per
+    config rather than on every load. Off by default so only the caller holding
+    the config path -- the one that can read the watermark and write it back --
+    opts in; the shims below are idempotent and always run.
     """
     import logging as _logging
 
     _log = _logging.getLogger(__name__)
 
-    # Stamped, run-once migrations first: they are the ones allowed to reach
-    # back out to disk (see _persist_migrated_config), and the stamp they set
-    # must not be confused by anything the shims below do.
-    _migrate_legacy_context_window(data, notify=True)
+    if run_stamped:
+        _migrate_legacy_context_window(data, notify=True)
 
     # Move tools.exec.restrictToWorkspace → tools.restrictToWorkspace
     tools = data.get("tools", {})

--- a/raven/config/schema.py
+++ b/raven/config/schema.py
@@ -9,12 +9,6 @@ from pydantic_settings import BaseSettings
 
 from raven.sandbox.config import SandboxConfig
 
-# Generation counter for the one-shot config migrations in
-# ``loader._migrate_config``. Bump it, and add the matching rule there, when a
-# migration must run exactly once per install rather than on every load -- the
-# stamp is what lets a user re-set by hand whatever a migration cleared.
-CURRENT_CONFIG_VERSION = 1
-
 
 class Base(BaseModel):
     """Base model that accepts both camelCase and snake_case keys."""
@@ -847,12 +841,6 @@ class CliConfig(Base):
 class Config(BaseSettings):
     """Root configuration for raven."""
 
-    # Which generation of one-shot config migrations this file already went
-    # through (see loader._migrate_config). Detection reads the RAW file, where
-    # an absent key means "generation 0", so this default is free to name the
-    # current generation -- and must, so a config written fresh today is never
-    # taken for a pre-migration one.
-    config_version: int = Field(default=CURRENT_CONFIG_VERSION, alias="configVersion")
     agents: AgentsConfig = Field(default_factory=AgentsConfig)
     cli: CliConfig = Field(default_factory=CliConfig)
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
@@ -1013,9 +1001,4 @@ class Config(BaseSettings):
         env_prefix="NANOBOT_",
         env_nested_delimiter="__",
         extra="forbid",
-        # This class is a BaseSettings, so it has no to_camel alias generator
-        # (unlike ``Base``): its fields carry explicit aliases instead, and
-        # snake_case has to stay accepted for callers constructing a Config in
-        # Python.
-        populate_by_name=True,
     )

--- a/raven/config/schema.py
+++ b/raven/config/schema.py
@@ -9,6 +9,12 @@ from pydantic_settings import BaseSettings
 
 from raven.sandbox.config import SandboxConfig
 
+# Generation counter for the one-shot config migrations in
+# ``loader._migrate_config``. Bump it, and add the matching rule there, when a
+# migration must run exactly once per install rather than on every load -- the
+# stamp is what lets a user re-set by hand whatever a migration cleared.
+CURRENT_CONFIG_VERSION = 1
+
 
 class Base(BaseModel):
     """Base model that accepts both camelCase and snake_case keys."""
@@ -841,6 +847,12 @@ class CliConfig(Base):
 class Config(BaseSettings):
     """Root configuration for raven."""
 
+    # Which generation of one-shot config migrations this file already went
+    # through (see loader._migrate_config). Detection reads the RAW file, where
+    # an absent key means "generation 0", so this default is free to name the
+    # current generation -- and must, so a config written fresh today is never
+    # taken for a pre-migration one.
+    config_version: int = Field(default=CURRENT_CONFIG_VERSION, alias="configVersion")
     agents: AgentsConfig = Field(default_factory=AgentsConfig)
     cli: CliConfig = Field(default_factory=CliConfig)
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
@@ -1001,4 +1013,9 @@ class Config(BaseSettings):
         env_prefix="NANOBOT_",
         env_nested_delimiter="__",
         extra="forbid",
+        # This class is a BaseSettings, so it has no to_camel alias generator
+        # (unlike ``Base``): its fields carry explicit aliases instead, and
+        # snake_case has to stay accepted for callers constructing a Config in
+        # Python.
+        populate_by_name=True,
     )

--- a/raven/tui_rpc/methods/session.py
+++ b/raven/tui_rpc/methods/session.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from loguru import logger
 
 from raven.cli.update_notice import update_notice
-from raven.config.loader import load_config
+from raven.config.loader import drain_migration_notices, load_config
 from raven.providers.rates import resolve_context_window
 from raven.session.export import default_export_path, write_transcript
 from raven.session.manager import SessionManager, new_chat_id
@@ -178,6 +178,14 @@ async def _default_session_info(
     notice = update_notice(_RAVEN_VERSION)
     if notice is not None:
         info["update_available"], info["update_command"] = notice
+
+    # Anything a config migration changed on the user's behalf while this
+    # backend booted. The CLI prints these itself; a TUI/served-page user never
+    # sees that terminal, so the first session of the launch carries them into
+    # the transcript instead. Drained, so a later resume does not repeat them.
+    migrated = drain_migration_notices()
+    if migrated:
+        info["config_notices"] = migrated
 
     return info
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -11,7 +11,8 @@ from pathlib import Path
 
 import pytest
 
-from raven.config.loader import load_config
+from raven.config.loader import drain_migration_notices, load_config
+from raven.config.schema import CURRENT_CONFIG_VERSION
 
 
 def _write(path: Path, body: dict) -> None:
@@ -252,3 +253,150 @@ def test_bad_config_warns_again_after_recovery(tmp_path: Path, capsys) -> None:
     load_config(p)
     captured = capsys.readouterr()
     assert (captured.out + captured.err).count("not valid JSON") == 2
+
+
+# ── The retired 65536 context-window pin ────────────────────────────────
+#
+# Pre-0.1.11 bootstraps dumped every schema default to disk, and back then
+# ``contextWindowTokens`` defaulted to 65536. A pin outranks the model's real
+# window by design, so on upgraded installs that fossil silently caps every
+# model at 64k. It is cleared once, under a ``configVersion`` stamp -- the
+# value itself carries no provenance, so the stamp is the only thing separating
+# "we planted this" from "the user chose this".
+
+
+def _defaults(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))["agents"]["defaults"]
+
+
+def test_legacy_context_window_pin_is_dropped_and_stamped(tmp_path: Path) -> None:
+    p = tmp_path / "config.json"
+    _write(p, {"agents": {"defaults": {"contextWindowTokens": 65536, "model": "anthropic/claude-opus-4-5"}}})
+
+    cfg = load_config(p)
+
+    assert cfg.agents.defaults.context_window_tokens is None
+    on_disk = json.loads(p.read_text(encoding="utf-8"))
+    assert "contextWindowTokens" not in on_disk["agents"]["defaults"]
+    assert on_disk["configVersion"] == CURRENT_CONFIG_VERSION
+    # Untouched neighbours: the write is surgical, not a re-dump of the model.
+    assert on_disk["agents"]["defaults"]["model"] == "anthropic/claude-opus-4-5"
+
+
+def test_legacy_context_window_pin_dropped_in_snake_case_too(tmp_path: Path) -> None:
+    """Configs in the wild use either casing; the schema accepts both."""
+    p = tmp_path / "config.json"
+    _write(p, {"agents": {"defaults": {"context_window_tokens": 65536}}})
+
+    assert load_config(p).agents.defaults.context_window_tokens is None
+    assert "context_window_tokens" not in _defaults(p)
+
+
+def test_context_window_pin_survives_once_stamped(tmp_path: Path) -> None:
+    """The user's own 65536 is theirs. Same value, same file -- but the stamp
+    says this config already had its one pass, so the pin stands."""
+    p = tmp_path / "config.json"
+    _write(p, {"configVersion": CURRENT_CONFIG_VERSION, "agents": {"defaults": {"contextWindowTokens": 65536}}})
+
+    assert load_config(p).agents.defaults.context_window_tokens == 65536
+    assert _defaults(p)["contextWindowTokens"] == 65536
+
+
+def test_other_context_window_pins_are_never_touched(tmp_path: Path) -> None:
+    """Only the one retired default is a fossil; every other number was typed
+    by someone."""
+    p = tmp_path / "config.json"
+    _write(p, {"agents": {"defaults": {"contextWindowTokens": 32768}}})
+
+    assert load_config(p).agents.defaults.context_window_tokens == 32768
+    assert _defaults(p)["contextWindowTokens"] == 32768
+
+
+def test_migration_write_back_keeps_extension_blocks(tmp_path: Path) -> None:
+    """The mapping ``load_config`` migrates has the extension blocks popped, so
+    writing *that* back would delete the user's memory / plugins / skillForge
+    sections. Guards the re-read the persist step does instead."""
+    p = tmp_path / "config.json"
+    _write(
+        p,
+        {
+            "agents": {"defaults": {"contextWindowTokens": 65536}},
+            "memory": {"backend": "everos"},
+            "plugins": {"enabled": ["demo"]},
+            "skillForge": {"detect_min_tool_calls": 3},
+        },
+    )
+
+    load_config(p)
+
+    on_disk = json.loads(p.read_text(encoding="utf-8"))
+    assert on_disk["memory"] == {"backend": "everos"}
+    assert on_disk["plugins"] == {"enabled": ["demo"]}
+    assert on_disk["skillForge"] == {"detect_min_tool_calls": 3}
+
+
+def test_migration_write_back_does_not_materialise_defaults(tmp_path: Path) -> None:
+    """``save_config`` dumps every default (~8 KB). Using it here would re-plant
+    exactly the kind of fossil this migration pulls out."""
+    p = tmp_path / "config.json"
+    _write(p, {"agents": {"defaults": {"contextWindowTokens": 65536, "model": "x/y"}}})
+
+    load_config(p)
+
+    on_disk = json.loads(p.read_text(encoding="utf-8"))
+    assert set(on_disk["agents"]["defaults"]) == {"model"}
+    assert "tools" not in on_disk
+
+
+def test_migration_is_correct_even_when_the_file_cannot_be_written(tmp_path: Path) -> None:
+    """A read-only home must not brick the boot: the in-memory migration is
+    what makes the process correct, the write only keeps the file honest."""
+    p = tmp_path / "config.json"
+    _write(p, {"agents": {"defaults": {"contextWindowTokens": 65536}}})
+    tmp_path.chmod(0o500)
+    try:
+        cfg = load_config(p)
+    finally:
+        tmp_path.chmod(0o700)
+
+    assert cfg.agents.defaults.context_window_tokens is None
+    assert _defaults(p)["contextWindowTokens"] == 65536
+
+
+def test_migration_notice_is_told_once_per_process(tmp_path: Path) -> None:
+    """Several loads per command (status and doctor do; the RPC server reloads
+    every turn) owe the user one telling."""
+    p = tmp_path / "config.json"
+    _write(p, {"agents": {"defaults": {"contextWindowTokens": 65536}}})
+
+    drain_migration_notices()
+    load_config(p)
+    load_config(p)
+    notices = drain_migration_notices()
+
+    assert len(notices) == 1
+    assert "contextWindowTokens" in notices[0]
+    assert drain_migration_notices() == []
+
+
+def test_no_notice_when_nothing_was_migrated(tmp_path: Path) -> None:
+    p = tmp_path / "config.json"
+    _write(p, {"agents": {"defaults": {"model": "x/y"}}})
+
+    drain_migration_notices()
+    load_config(p)
+
+    assert drain_migration_notices() == []
+
+
+def test_config_without_the_fossil_is_left_byte_identical(tmp_path: Path) -> None:
+    """The stamp lands only on a file we actually edited. Commands like
+    ``provider use`` promise to leave the config alone when they decide not to
+    act, and a load-time stamp would quietly break that promise for everyone."""
+    p = tmp_path / "config.json"
+    _write(p, {"agents": {"defaults": {"model": "x/y"}}})
+    before = p.read_bytes()
+
+    load_config(p)
+
+    assert p.read_bytes() == before

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -7,12 +7,12 @@ configs, plus the default-config fallback path.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
 
-from raven.config.loader import drain_migration_notices, load_config
-from raven.config.schema import CURRENT_CONFIG_VERSION
+from raven.config.loader import CURRENT_CONFIG_VERSION, _stamp_path, drain_migration_notices, load_config
 
 
 def _write(path: Path, body: dict) -> None:
@@ -278,9 +278,12 @@ def test_legacy_context_window_pin_is_dropped_and_stamped(tmp_path: Path) -> Non
     assert cfg.agents.defaults.context_window_tokens is None
     on_disk = json.loads(p.read_text(encoding="utf-8"))
     assert "contextWindowTokens" not in on_disk["agents"]["defaults"]
-    assert on_disk["configVersion"] == CURRENT_CONFIG_VERSION
     # Untouched neighbours: the write is surgical, not a re-dump of the model.
     assert on_disk["agents"]["defaults"]["model"] == "anthropic/claude-opus-4-5"
+    # And no key of ours lands in the user's file -- Config is extra='forbid',
+    # so a stamp in there is a hard boot failure for any build without it.
+    assert set(on_disk) == {"agents"}
+    assert json.loads(_stamp_path(p).read_text(encoding="utf-8")) == {"version": CURRENT_CONFIG_VERSION}
 
 
 def test_legacy_context_window_pin_dropped_in_snake_case_too(tmp_path: Path) -> None:
@@ -296,7 +299,8 @@ def test_context_window_pin_survives_once_stamped(tmp_path: Path) -> None:
     """The user's own 65536 is theirs. Same value, same file -- but the stamp
     says this config already had its one pass, so the pin stands."""
     p = tmp_path / "config.json"
-    _write(p, {"configVersion": CURRENT_CONFIG_VERSION, "agents": {"defaults": {"contextWindowTokens": 65536}}})
+    _write(p, {"agents": {"defaults": {"contextWindowTokens": 65536}}})
+    _stamp_path(p).write_text(json.dumps({"version": CURRENT_CONFIG_VERSION}), encoding="utf-8")
 
     assert load_config(p).agents.defaults.context_window_tokens == 65536
     assert _defaults(p)["contextWindowTokens"] == 65536
@@ -400,3 +404,80 @@ def test_config_without_the_fossil_is_left_byte_identical(tmp_path: Path) -> Non
     load_config(p)
 
     assert p.read_bytes() == before
+
+
+def test_the_stamp_never_lands_in_the_user_config(tmp_path: Path) -> None:
+    """``Config`` is ``extra='forbid'`` and ``load_config`` raises rather than
+    falling back, so a key this build knows and an older one does not is a hard
+    boot failure for the older build -- a reverted release, a pinned version, or
+    a second checkout sharing the same ~/.raven. The watermark is ours to keep in
+    a sidecar, not the user's file."""
+    p = tmp_path / "config.json"
+    _write(p, {"agents": {"defaults": {"contextWindowTokens": 65536}}})
+
+    load_config(p)
+
+    assert "configVersion" not in json.loads(p.read_text(encoding="utf-8"))
+    assert _stamp_path(p).exists()
+
+
+def test_a_clean_config_is_stamped_without_being_touched(tmp_path: Path) -> None:
+    """Nothing to remove still stamps: the sidecar is ours, so writing it costs
+    the user nothing and closes the hole where a 65536 they set by hand later
+    would be mistaken for the fossil."""
+    p = tmp_path / "config.json"
+    _write(p, {"agents": {"defaults": {"model": "x/y"}}})
+    before = p.read_bytes()
+
+    load_config(p)
+
+    assert p.read_bytes() == before
+    assert _stamp_path(p).exists()
+
+    # Their own 65536, set after the stamp, is theirs.
+    _write(p, {"agents": {"defaults": {"contextWindowTokens": 65536}}})
+    assert load_config(p).agents.defaults.context_window_tokens == 65536
+
+
+def test_migration_preserves_the_config_file_mode(tmp_path: Path) -> None:
+    """``os.replace`` swaps the inode, so a replacing writer owns the mode of
+    what it puts there. config.json holds providers.*.apiKey -- a user who
+    tightened it to owner-only must not have it widened behind their back."""
+    p = tmp_path / "config.json"
+    _write(
+        p,
+        {
+            "agents": {"defaults": {"contextWindowTokens": 65536}},
+            "providers": {"anthropic": {"apiKey": "sk-secret"}},
+        },
+    )
+    p.chmod(0o600)
+
+    load_config(p)
+
+    assert p.stat().st_mode & 0o777 == 0o600
+
+
+def test_migration_temp_file_is_process_scoped(tmp_path: Path) -> None:
+    """Two processes migrating at once must not share one temp path: the
+    second's truncating write would be visible as an empty config.json to
+    anyone loading between it and the replace."""
+    from raven.config import loader
+
+    p = tmp_path / "config.json"
+    _write(p, {"agents": {"defaults": {"contextWindowTokens": 65536}}})
+    seen: list[str] = []
+    original = Path.write_text
+
+    def _spy(self: Path, *args: object, **kwargs: object) -> int:
+        seen.append(self.name)
+
+        return original(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    loader.Path.write_text = _spy  # type: ignore[method-assign]
+    try:
+        load_config(p)
+    finally:
+        loader.Path.write_text = original  # type: ignore[method-assign]
+
+    assert any(name.startswith("config.json.migrating.") and name.endswith(str(os.getpid())) for name in seen)

--- a/tests/test_tui_rpc_session_init_bundle.py
+++ b/tests/test_tui_rpc_session_init_bundle.py
@@ -457,3 +457,32 @@ async def test_reading_the_banner_endpoint_does_not_rotate(config) -> None:
     loop.provider = _rotor(["eu", "us"], strategy="round_robin")
 
     assert [(await _default_session_info(loop, config))["endpoint"] for _ in range(3)] == ["eu", "eu", "eu"]
+
+
+# ---------------------------------------------------------------------------
+# Config-migration notices (the producer side; the TUI renders them as system
+# lines next to config_warning / credential_warning)
+# ---------------------------------------------------------------------------
+
+
+async def test_default_session_info_carries_config_migration_notices(fake_agent_loop, config, monkeypatch) -> None:
+    """A migration that edited the user's config must reach the user.
+
+    The CLI prints these itself, but a TUI or served-page user never sees that
+    terminal -- unpopulated here, a config Raven rewrote would be announced
+    nowhere.
+    """
+    monkeypatch.setattr(session_module, "drain_migration_notices", lambda: ["Removed the leftover line."])
+
+    info = await _default_session_info(fake_agent_loop, config)
+
+    assert info["config_notices"] == ["Removed the leftover line."]
+
+
+async def test_default_session_info_omits_config_notices_when_none(fake_agent_loop, config, monkeypatch) -> None:
+    """Nothing migrated means the key stays absent, not present-and-empty."""
+    monkeypatch.setattr(session_module, "drain_migration_notices", lambda: [])
+
+    info = await _default_session_info(fake_agent_loop, config)
+
+    assert "config_notices" not in info

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -269,6 +269,14 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
               const resumed = toTranscriptMessages(r.messages)
 
               setHistoryItems(r.info ? [introMsg(r.info), ...resumed] : resumed)
+
+              // session.resume drains the backend's migration notices exactly
+              // like session.create does, so resuming first (the picker, or
+              // --resume) would otherwise consume them and show nothing.
+              for (const notice of r.info?.config_notices ?? []) {
+                sys(notice)
+              }
+
               writeActiveSessionFile(r.resumed ?? r.session_id)
               patchUiState({
                 info: r.info ?? null,

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -201,6 +201,11 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
         sys(`warning: ${info.config_warning}`)
       }
 
+      // Not a warning: the backend already migrated the config line it names.
+      for (const notice of info?.config_notices ?? []) {
+        sys(notice)
+      }
+
       if (msg) {
         const bareId = r.session_id.includes(':') ? r.session_id.slice(r.session_id.indexOf(':') + 1) : r.session_id
         sys(`${msg}, new session id = ${bareId}`)

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -117,7 +117,7 @@ export interface SetupStatusResponse {
 // ── Session lifecycle ────────────────────────────────────────────────
 
 export interface SessionCreateResponse {
-  info?: SessionInfo & { config_warning?: string; credential_warning?: string }
+  info?: SessionInfo & { config_notices?: string[]; config_warning?: string; credential_warning?: string }
   session_id: string
 }
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -122,7 +122,7 @@ export interface SessionCreateResponse {
 }
 
 export interface SessionResumeResponse {
-  info?: SessionInfo
+  info?: SessionInfo & { config_notices?: string[] }
   message_count?: number
   messages: GatewayTranscriptMessage[]
   resumed?: string


### PR DESCRIPTION
## Summary

Every config written by 0.1.10 or earlier carries `contextWindowTokens: 65536` verbatim: that was the schema default back then, and the bootstrap dumped every default to disk. 0.1.11 (#287) started sizing the window from the model's own catalogue, but an explicit pin still wins over it -- correctly, that is what a pin means -- so **the fix reached new installs only**. Every upgraded install stayed capped at 64k on a 1M-token model, and `/model` could not shake it loose (`refresh_context_window` returns early for an explicit window, by design).

The blast radius is not cosmetic. The window sizes the per-turn history budget (`_make_token_budget`), the Curator's fast/slow path threshold (`available_history * 0.60`) and the memory consolidator's archive target (`window // 2`). An upgraded install therefore trimmed history early, paid for an extra Curator LLM call per turn, and consolidated at 32k instead of ~500k. The only existing signal was a `logger.warning` in a file nobody reads.

Key decisions:

- **Clear the pin once, under a watermark kept in a sidecar (`config.migrations.json`).** The value carries no provenance -- 65536 we planted and 65536 a user chose are the same three bytes -- so a watermark is the only thing that lets a re-set value stand for good. Without it, a user re-setting 65536 would have it stripped on every load, which is worse than the bug. The watermark deliberately does **not** live in config.json: `Config` is `extra='forbid'` and `load_config` raises rather than falling back, so a key this build knows and an older one does not is a hard boot failure for the older build -- a reverted release, a pinned version, or a second checkout sharing one `~/.raven`, which is already the case in this repo. A sidecar no published build reads is ignored instead of fatal. Because it is our file rather than the user's, it is also stamped unconditionally, which closes the one hole an in-file stamp had to accept: a `contextWindowTokens` the user sets by hand afterwards is never second-guessed, whatever its value.
- **Run it at config load, not in `raven upgrade`.** The upgrade helper is the outgoing version and cannot know a rule that ships with the incoming one; it `execve`s a bare Python bootstrap that never imports raven. And `install.sh` / `uv tool upgrade` never call `raven upgrade` at all. Config load is the one chokepoint every entry point shares, so the user experience is "upgraded, and it was already fixed".
- **A file we did not edit is left byte for byte alone.** config.json is rewritten only where the fossil was actually removed -- `provider use` and friends promise not to touch a config they decided against changing, and that promise is theirs to keep, not ours to spend (`test_use_leaves_the_config_alone_when_it_cannot_tell` caught an earlier draft that stamped unconditionally *in the config*).
- **The rewrite carries the file mode across.** `os.replace` swaps the inode, so a config tightened to 0600 -- it holds `providers.*.apiKey` -- came back 0644 in the first draft. The temp file is chmod-ed to the original's mode before the swap, and named per-PID so two processes migrating at once cannot have one truncate the file the other is about to move into place.
- **The write is surgical.** It re-reads the raw file, because the mapping `load_config` migrated has the extension blocks popped (`pop_extension_keys`) and writing that back would delete the user's `memory` / `plugins` / `skillForge` sections. It never goes through `save_config`, which dumps ~8 KB of defaults and would re-plant exactly this kind of fossil. A read-only home degrades to an in-memory-only migration rather than failing the boot.
- **The user is told where the user is looking, from every entry point.** The notice is drained in the `run()` wrapper, so all thirteen config-loading commands tell it, not the two that print eagerly (`agent`, `gateway`, which keep the early print because they hold the screen for a long time). This matters because the watermark suppresses the next run's notice: an unsaid notice is lost, not deferred, and `raven status` would otherwise migrate the file in silence forever. The TUI and the served page get a new `config_notices` field on the session init bundle, rendered as a system line on both `session.create` and `session.resume` -- resume drains the same one-shot list, so a picker-first user would otherwise see nothing. This also gives the client-side `config_warning` / `credential_warning` handlers their first server-side sibling that is actually populated -- both were dead wiring. The notice names the way back, because a window genuinely smaller than 65536 (a local model, an endpoint served with `--max-model-len`) is a real configuration this clears once.
- **The loop's 65536 warning is gone.** Post-migration, a pin that reaches the constructor is a deliberate choice, and warning about deliberate choices is noise.

Follow-ups, deliberately not in this PR: `raven doctor --fix` so the check can be run on demand rather than only at the next launch, and stopping the bootstrap from materialising defaults at all (`save_config(load_config())` in onboard) -- the root cause, and a change to every new user's config file shape, so it deserves its own review.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

```
pytest tests/test_config_loader.py                      31 passed (16 new migration cases, incl. the
                                                       sidecar watermark, mode preservation, per-PID temp)
pytest tests/test_tui_rpc_session_init_bundle.py         2 new cases, all green
pytest test_config_loader + test_config_schema + test_config_raven_loader \
     + test_cli_provider_commands + test_tui_rpc_session_init_bundle + test_cli_smoke
                                                       194 passed (re-run after rebasing on main)
pytest tests/ -k "config or agent_loop or provider or helpers or tui_rpc or usage_sink or onboard or gateway"
                                                       failure set identical with and without this branch
                                                       (56 -> 56, zero delta; pre-existing, a local config
                                                       block the schema on main does not accept)
ruff check raven/ tests/                               All checks passed
ruff format --check                                    already formatted
npm run type-check (ui-tui)                            clean
npx vitest run src/__tests__ (ui-tui)                  843 passed (70 files)
npx prettier --check / npx eslint on both changed .ts  0 errors (1 pre-existing warning at line 146)
```

End-to-end on a config shaped like an upgraded install (`contextWindowTokens: 65536`, plus `memory` and `skillForge` blocks):

```
first load    in-memory pin      -> None
              file               -> the line is gone, model/maxTokens/temperature untouched
              watermark          -> config.migrations.json, nothing added to config.json
              extension blocks   -> intact
              notice             -> surfaced once, then drained
user re-sets 65536 afterwards    -> honoured, no further notice
config with no fossil            -> file byte identical, no write
read-only home                   -> migration still correct in memory, no raise
0600 config with an apiKey        -> still 0600 after the migration
migrated config, older build     -> loads fine (the downgrade path the sidecar exists for)
raven status on a fossil config  -> prints the notice (it used to migrate in silence)
```

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

User-visible behaviour changes: on the first launch after this lands, an upgraded install loses the `contextWindowTokens: 65536` line from `~/.raven/config.json` and its context window jumps to whatever the model actually supports. Sessions get a longer history budget, the Curator drops back to its zero-LLM fast path far more often, and the status bar percentage falls accordingly. Users who genuinely need a 64k ceiling (a local model, a self-hosted endpoint with a smaller serving window) must re-add the line, which the notice tells them; those requests would fail loudly at the endpoint rather than silently, so the failure is self-announcing.

Rollback: revert the commits. Nothing of ours is left inside config.json, so an already-migrated config is byte-for-byte a config that simply has no pin -- exactly the state a fresh install has, loadable by every published build. The orphaned `config.migrations.json` sidecar is ignored by any build that does not look for it, and re-applying the change later just re-reads it. An earlier draft of this PR put the watermark in config.json and would have made a revert leave every migrated install unable to boot (`Config` is `extra='forbid'`); that is fixed, and the same reasoning covers pinning an older release or running a second checkout against the same `~/.raven`.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A