### PR TITLE
fix(*): first-run flow, channel install hints, and default-model pricing

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -156,6 +156,15 @@ _Avoid_: reintroducing fire-time channel selection (the retired
 channel value is retired with the REPL; stored `cli`-bound jobs migrate to
 `tui` at load time.
 
+**Fixed-delay interval**:
+The scheduling contract for `--every` jobs: the next run is computed from the
+moment the previous fire **completed**, not from the moment it was due. A job
+that takes 15s to run therefore repeats every `interval + 15s`, and its clock
+drifts by design — the property being bought is that a slow run can never
+overlap itself or leave a backlog to catch up on.
+_Avoid_: calling this fixed-rate, or reading `--every 2m` as a promise to fire
+on the two-minute mark; calendar-anchored schedules are what `--cron` is for.
+
 **Predictor**:
 The Sentinel pipeline stage that turns signals into predicted user needs (the
 proactive side of prediction).

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ irm https://raw.githubusercontent.com/EverMind-AI/Raven/refs/heads/main/install.
 ### Onboard and run
 
 ```bash
-raven onboard
 raven
 ```
+
+That is the whole first run: with nothing configured yet, `raven` walks you through setup and then opens the TUI in the same session. To reconfigure later, run `raven onboard` explicitly.
 
 The bilingual onboarding wizard configures six areas without requiring manual edits to `~/.raven/config.json`:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,9 +67,10 @@ irm https://raw.githubusercontent.com/EverMind-AI/Raven/refs/heads/main/install.
 ### 完成引导并运行
 
 ```bash
-raven onboard
 raven
 ```
+
+首次运行只需这一条：尚未配置时，`raven` 会先带你走完引导，然后在同一次会话里直接进入 TUI。之后想重新配置，再显式运行 `raven onboard`。
 
 双语 onboarding 向导会配置六个方面，无需手动编辑 `~/.raven/config.json`：
 

--- a/install.ps1
+++ b/install.ps1
@@ -317,6 +317,10 @@ function Install-Raven([string]$UvPath, [string]$NodePath) {
 }
 
 function Main {
+    # Read before installing so the closing hint can tell a first run from an
+    # upgrade; the install itself never writes config.json (the wizard does).
+    $hadConfig = Test-Path (Join-Path $RavenHome "config.json")
+
     $uv = Ensure-Uv
     $node = Ensure-Node
     Install-Raven $uv $node
@@ -325,11 +329,19 @@ function Main {
     Add-ProcessPath $toolBin
 
     Write-Host ""
-    Write-Ok "All set. Open a new PowerShell window, or continue in this one, then run:"
-    Write-Host ""
-    Write-Host "    raven            # enter the TUI"
-    Write-Host "    raven agent -m `"hello`""
-    Write-Host ""
+    if ($hadConfig) {
+        Write-Ok "Raven updated. Your config in $RavenHome is unchanged."
+        Write-Host ""
+        Write-Host "    raven    # continue where you left off"
+        Write-Host ""
+        Write-Host "  tip: next time you can upgrade in place with 'raven upgrade'"
+        Write-Host ""
+    } else {
+        Write-Ok "All set. Open a new PowerShell window, or continue in this one, then run:"
+        Write-Host ""
+        Write-Host "    raven    # sets you up on first run, then opens the TUI"
+        Write-Host ""
+    }
     if (($env:PATH -split ';') -notcontains $toolBin) {
         Write-Warn "Current PATH does not include $toolBin. Restart PowerShell if 'raven' is not found."
     }

--- a/install.sh
+++ b/install.sh
@@ -259,16 +259,27 @@ install_raven() {
 # --- main ------------------------------------------------------------------
 main() {
   have curl || die "curl is required; please install it first"
+  # Read before installing so the closing hint can tell a first run from an
+  # upgrade; the install itself never writes config.json (the wizard does).
+  if [ -f "$RAVEN_HOME/config.json" ]; then
+    had_config=1
+  else
+    had_config=0
+  fi
   detect_platform
   ensure_uv
   ensure_node
   install_raven
 
   printf '\n'
-  ok "All set! Open a new terminal (or source your shell profile), then run:"
-  printf '\n    \033[1mraven onboard\033[0m    # first-time setup\n'
-  printf '    \033[1mraven\033[0m            # enter the TUI\n'
-  printf '    \033[1mraven agent\033[0m -m "hello"\n\n'
+  if [ "$had_config" = 1 ]; then
+    ok "Raven updated. Your config in $RAVEN_HOME is unchanged."
+    printf '\n    \033[1mraven\033[0m    # continue where you left off\n\n'
+    printf '  tip: next time you can upgrade in place with \033[1mraven upgrade\033[0m\n\n'
+  else
+    ok "All set! Open a new terminal (or source your shell profile), then run:"
+    printf '\n    \033[1mraven\033[0m    # sets you up on first run, then opens the TUI\n\n'
+  fi
   if ! printf '%s' "$PATH" | grep -q "$HOME/.local/bin"; then
     warn "Your current PATH does not include ~/.local/bin yet -- open a new terminal, or run: export PATH=\"\$HOME/.local/bin:\$PATH\""
   fi

--- a/raven/channels/manager.py
+++ b/raven/channels/manager.py
@@ -19,8 +19,8 @@ from raven.channels.contract import Channel
 from raven.config.schema import Config
 
 
-def _missing_dep_hint(modname: str) -> str:
-    """How to install a channel's missing SDK, tailored to the install mode.
+def _missing_dep_hint() -> str:
+    """How to install missing channel SDKs, tailored to the install mode.
 
     An editable (dev) checkout uses ``uv sync``; a wheel/tool install has no
     source tree, so it must re-run the installer instead. PEP 610
@@ -28,6 +28,10 @@ def _missing_dep_hint(modname: str) -> str:
     ``archive_info`` (no ``dir_info`` key), so ``.get`` chaining avoids a
     KeyError when it is absent. This runs while a channel is already failing,
     so a missing/corrupt file must degrade to the installer hint, never raise.
+
+    The dev hint names the umbrella ``channels`` extra and passes
+    ``--inexact`` on purpose: ``uv sync`` is an exact sync, so syncing one
+    channel's extra uninstalls every other channel's SDK on the way in.
     """
     editable = False
     try:
@@ -38,10 +42,37 @@ def _missing_dep_hint(modname: str) -> str:
         pass
 
     if editable:
-        return f"Run: uv sync --extra channel-{modname}"
+        return "Run: uv sync --inexact --extra channels"
     if sys.platform == "win32":
         return "Re-run the installer to add channels: irm https://raw.githubusercontent.com/EverMind-AI/Raven/refs/heads/main/install.ps1 | iex"
     return "Re-run the installer to add channels: curl -fsSL https://raven.evermind.ai/install.sh | bash"
+
+
+def missing_dependency_channels(config: Config) -> list[str]:
+    """Enabled channels whose SDK is not installed, in registry order.
+
+    Runs the same probe as :meth:`ChannelManager._init_channels` -- build via
+    the spec factory, catch ImportError -- so a channel reported here is
+    exactly one the gateway would disable at start. Every other construction
+    failure is somebody else's diagnosis, not a missing dependency.
+
+    Read-only callers (``channels status``, ``doctor``) use this so an enabled
+    channel that can never start is visible before the gateway is run.
+    """
+    from raven.channels.registry import discover_specs
+
+    missing: list[str] = []
+    for modname, spec in discover_specs().items():
+        section = getattr(config.channels, modname, None)
+        if not section or not getattr(section, "enabled", False):
+            continue
+        try:
+            spec.factory(section)
+        except ImportError:
+            missing.append(modname)
+        except Exception:
+            continue
+    return missing
 
 
 class ChannelManager:
@@ -79,7 +110,7 @@ class ChannelManager:
                     "{} channel disabled: missing dependency ({}). {}",
                     modname,
                     e,
-                    _missing_dep_hint(modname),
+                    _missing_dep_hint(),
                 )
 
         self._validate_allow_from()

--- a/raven/cli/_helpers.py
+++ b/raven/cli/_helpers.py
@@ -76,10 +76,15 @@ def check_provider_credentials(config: Config) -> None:
     # so answer the wizard instead. Both halves are required -- a user who picked
     # this model, or who has some other provider working, gets the specific
     # verdict, which for the OAuth families names a sign-in rather than a key.
+    # Names come from the declared fields *and* the extras: an undeclared
+    # provider key is a supported shape, and `ProvidersConfig.get` is the only
+    # place allowed to resolve either kind, so route both through it rather than
+    # reading `__dict__` -- which sees no extras and would call a user whose one
+    # working credential lives there unconfigured.
     chose_a_model = config.agents.defaults.model != type(config.agents.defaults)().model
+    configured = (*config.providers.__dict__, *(config.providers.model_extra or {}))
     if not chose_a_model and not any(
-        credential_status(name, section, include_external=True).ok
-        for name, section in config.providers.__dict__.items()
+        credential_status(name, config.providers.get(name), include_external=True).ok for name in configured
     ):
         raise MissingCredentialsError(
             "no provider is configured yet -- run `raven onboard` for guided setup",

--- a/raven/cli/_helpers.py
+++ b/raven/cli/_helpers.py
@@ -66,12 +66,31 @@ def check_provider_credentials(config: Config) -> None:
         )
 
     status = credential_status(provider_name, config.providers.get(provider_name), include_external=True)
-    if not status.ok:
+    if status.ok:
+        return
+
+    # A first run fails this check while naming a provider the user never chose:
+    # with nothing configured, routing falls back to the schema's default model,
+    # whose vendor then gets reported as the thing to go fix. Sending someone who
+    # only has an OpenRouter key to `provider set anthropic` is the wrong errand,
+    # so answer the wizard instead. Both halves are required -- a user who picked
+    # this model, or who has some other provider working, gets the specific
+    # verdict, which for the OAuth families names a sign-in rather than a key.
+    chose_a_model = config.agents.defaults.model != type(config.agents.defaults)().model
+    if not chose_a_model and not any(
+        credential_status(name, section, include_external=True).ok
+        for name, section in config.providers.__dict__.items()
+    ):
         raise MissingCredentialsError(
-            status.summary,
-            provider=provider_name,
-            remedy="Run `raven onboard` for guided setup.",
+            "no provider is configured yet -- run `raven onboard` for guided setup",
+            remedy="Already have a key? raven provider set <name> --api-key <key>",
         )
+
+    raise MissingCredentialsError(
+        status.summary,
+        provider=provider_name,
+        remedy="Run `raven onboard` for guided setup.",
+    )
 
 
 def make_provider(config: Config):

--- a/raven/cli/channel_commands.py
+++ b/raven/cli/channel_commands.py
@@ -482,10 +482,12 @@ def _display_name(name: str) -> str:
 @channels_app.command("status")
 def channels_status():
     """Show channel status."""
+    from raven.channels.manager import _missing_dep_hint, missing_dependency_channels
     from raven.channels.registry import discover_channel_names
     from raven.config.loader import load_config
 
     config = load_config()
+    missing = set(missing_dependency_channels(config))
 
     table = Table(title="Channel Status")
     table.add_column("Channel", style="cyan")
@@ -495,12 +497,19 @@ def channels_status():
         section = getattr(config.channels, modname, None)
         enabled = section and getattr(section, "enabled", False)
         display = _display_name(modname)
-        table.add_row(
-            display,
-            "[green]✓[/green]" if enabled else "[dim]✗[/dim]",
-        )
+        state = "[green]✓[/green]" if enabled else "[dim]✗[/dim]"
+        if modname in missing:
+            state = "[yellow]⚠ SDK missing[/yellow]"
+        table.add_row(display, state)
 
     console.print(table)
+    if missing:
+        names = ", ".join(sorted(missing))
+        console.print(
+            f"\n[yellow]⚠ Enabled but cannot start: {names}[/yellow] "
+            "[dim](dependency not installed; the gateway disables these at startup)[/dim]"
+        )
+        console.print(f"  {_missing_dep_hint()}")
 
 
 @channels_app.command("login")

--- a/raven/cli/cron_commands.py
+++ b/raven/cli/cron_commands.py
@@ -668,7 +668,11 @@ def cron_add(
     every: str = typer.Option(
         None,
         "--every",
-        help="Interval duration for fixed-interval recurring jobs (e.g. '7s', '5m', '1h30m', '7d'; units s/m/h/d)",
+        help=(
+            "Interval duration for fixed-interval recurring jobs (e.g. '7s', '5m', '1h30m', '7d'; "
+            "units s/m/h/d). Measured from the end of the previous run, so runs never overlap "
+            "and the clock drifts by the run's duration; use --cron for clock-anchored schedules"
+        ),
     ),
     tz: str = typer.Option(
         None,

--- a/raven/cli/doctor_commands.py
+++ b/raven/cli/doctor_commands.py
@@ -50,6 +50,7 @@ class RoutingInfo:
 @dataclass
 class FeaturesInfo:
     channels_enabled: list[str] = field(default_factory=list)
+    channels_missing_deps: list[str] = field(default_factory=list)
     skill_forge_enabled: bool = False
 
 
@@ -196,8 +197,11 @@ def _gather_static_checks() -> DoctorReport:
     except Exception:
         skill_forge_on = False
 
+    from raven.channels.manager import missing_dependency_channels
+
     report.features = FeaturesInfo(
         channels_enabled=enabled,
+        channels_missing_deps=missing_dependency_channels(config),
         skill_forge_enabled=skill_forge_on,
     )
 
@@ -373,6 +377,11 @@ def _render_human_output(report: DoctorReport) -> None:
             console.print(f"  Channels:    {count} enabled  ({', '.join(features.channels_enabled)})")
         else:
             console.print("  Channels:    [dim]none enabled[/dim]")
+        if features.channels_missing_deps:
+            from raven.channels.manager import _missing_dep_hint
+
+            names = ", ".join(features.channels_missing_deps)
+            console.print(f"               [yellow]⚠ SDK missing: {names}[/yellow]  [dim]{_missing_dep_hint()}[/dim]")
         sf_label = "enabled" if features.skill_forge_enabled else "[dim]disabled[/dim]"
         console.print(f"  Skill forge: {sf_label}")
 

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -2179,7 +2179,7 @@ def _step2_sandbox(*, skip: bool, non_interactive: bool) -> object:
 # ---------------------------------------------------------------------------
 
 
-def _print_next_steps(*, warnings: list[str]) -> None:
+def _print_next_steps(*, warnings: list[str], show_next_steps: bool = True) -> None:
     from rich.table import Table
 
     console.print()
@@ -2247,6 +2247,17 @@ def _print_next_steps(*, warnings: list[str]) -> None:
             padding=(1, 2),
         )
     )
+
+    if not show_next_steps:
+        # The startup gate runs the wizard with the TUI already on its way in,
+        # so a list of commands to try next is answered before it is read.
+        console.print(
+            _t(
+                "  [dim]Setup complete - starting the TUI...[/dim]",
+                "  [dim]配置完成,正在进入 TUI...[/dim]",
+            )
+        )
+        return
 
     table = Table(show_header=False, box=None, padding=(0, 3, 0, 0))
     table.add_column(style="accent", no_wrap=True)
@@ -2774,6 +2785,7 @@ def run_wizard(
     yes: bool = False,
     reset: bool = False,
     skip_test: bool = False,
+    show_next_steps: bool = True,
 ) -> None:
     """Run the 6-step onboarding wizard end-to-end.
 
@@ -2804,6 +2816,7 @@ def run_wizard(
             yes=yes,
             reset=reset,
             skip_test=skip_test,
+            show_next_steps=show_next_steps,
         )
     finally:
         _logger.enable("raven")
@@ -2848,6 +2861,7 @@ def _run_wizard_body(
     yes: bool = False,
     reset: bool = False,
     skip_test: bool = False,
+    show_next_steps: bool = True,
 ) -> None:
     global _LANG
     _check_tty_or_die(non_interactive)
@@ -2936,11 +2950,14 @@ def _run_wizard_body(
         else:
             index += 1
 
-    _print_next_steps(warnings=warnings)
+    _print_next_steps(warnings=warnings, show_next_steps=show_next_steps)
 
 
 # ---------------------------------------------------------------------------
-# Startup gate — invoked by bare `raven` / `raven agent` / TUI entry points
+# Startup gate — invoked by bare `raven` and `raven tui` (the same callback).
+# One-shot `raven agent` deliberately stays out: launching a six-step wizard
+# from a scriptable command would be a surprise, so it reports the missing
+# credentials through `check_provider_credentials` instead.
 # ---------------------------------------------------------------------------
 
 
@@ -2961,7 +2978,7 @@ def ensure_ready_to_start(*, non_interactive: bool = False) -> None:
         return
 
     if not _configured_providers():
-        run_wizard(non_interactive=non_interactive)
+        run_wizard(non_interactive=non_interactive, show_next_steps=False)
         return
 
     model = (_load_raw_config().get("agents", {}) or {}).get("defaults", {}).get("model")

--- a/raven/providers/rates.py
+++ b/raven/providers/rates.py
@@ -20,6 +20,7 @@ Two questions, deliberately answered from different places:
 from __future__ import annotations
 
 import pathlib
+import re
 import sys
 import threading
 import time
@@ -392,6 +393,29 @@ def openrouter_input_modalities(model: str) -> tuple[str, ...] | None:
     return tuple(mods) if isinstance(mods, list) and mods else None
 
 
+_DIGIT_HYPHEN_DIGIT = re.compile(r"(?<=\d)-(?=\d)")
+
+
+def _dotted_version_variants(key: str) -> list[str]:
+    """Dotted spellings of a hyphenated version number, most likely first.
+
+    Vendors and OpenRouter disagree on the separator: the id Raven routes with
+    is Anthropic's ``claude-sonnet-4-5``, while OpenRouter files the same model
+    as ``claude-sonnet-4.5``. Exact-key lookup therefore missed the default
+    model Raven itself recommends, and every turn reported a cost of None.
+
+    One variant per digit-hyphen-digit boundary (``llama-3-3-70b`` must become
+    ``llama-3.3-70b``, not ``llama-3.3.70b``), then the all-boundaries form for
+    ids that really do carry two dots. Only ever consulted after the exact key
+    misses, so a wrong guess degrades to the same None it replaces.
+    """
+    spots = [m.start() for m in _DIGIT_HYPHEN_DIGIT.finditer(key)]
+    variants = [key[:i] + "." + key[i + 1 :] for i in spots]
+    if len(spots) > 1:
+        variants.append(_DIGIT_HYPHEN_DIGIT.sub(".", key))
+    return variants
+
+
 def _lookup_openrouter_entry(model: str, *, allow_fetch: bool = True) -> dict | None:
     """This model's row in OpenRouter's catalogue, or None.
 
@@ -412,10 +436,13 @@ def _lookup_openrouter_entry(model: str, *, allow_fetch: bool = True) -> dict | 
         return None
     key = model.removeprefix("openrouter/")
     table = _fetch_openrouter_models() if allow_fetch else _cache_only_openrouter_models()
-    entry = table.get(key)
-    if entry is None and "/" in key:
-        entry = table.get(key.split("/", 1)[1])
-    return entry
+    for candidate in (key, *_dotted_version_variants(key)):
+        entry = table.get(candidate)
+        if entry is None and "/" in candidate:
+            entry = table.get(candidate.split("/", 1)[1])
+        if entry is not None:
+            return entry
+    return None
 
 
 def _try_openrouter_rates(model: str) -> tuple[float, float] | None:

--- a/raven/skill_hub/client.py
+++ b/raven/skill_hub/client.py
@@ -24,6 +24,7 @@ import uuid
 import zipfile
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -146,10 +147,20 @@ class SkillHubClient:
         result = self._result(r.json() or {})
         return list(result.get("items", []))
 
+    @staticmethod
+    def _id_segment(skill_id: str) -> str:
+        """A skill id as one path segment.
+
+        Hub ids carry slashes (``openclaw/skills/tag-memory``), which
+        interpolate into a URL as extra path segments and reach the server as a
+        different route than the one intended.
+        """
+        return quote(str(skill_id), safe="")
+
     # ── Read body (skill_md) — no download ──────────────────────────
     async def get(self, skill_id: str) -> dict[str, Any]:
         r = await self._client.get(
-            f"{self._base}/openapi/v1/skills/{skill_id}",
+            f"{self._base}/openapi/v1/skills/{self._id_segment(skill_id)}",
             headers=self._headers(),
         )
         r.raise_for_status()
@@ -158,7 +169,7 @@ class SkillHubClient:
     # ── Bundle (zip with scripts/assets) ────────────────────────────
     async def download(self, skill_id: str) -> bytes:
         r = await self._client.get(
-            f"{self._base}/openapi/v1/skills/{skill_id}/download",
+            f"{self._base}/openapi/v1/skills/{self._id_segment(skill_id)}/download",
             params={"source": self._source},
             headers=self._headers(),
         )

--- a/tests/test_channels_manager.py
+++ b/tests/test_channels_manager.py
@@ -115,11 +115,13 @@ def _patch_direct_url(monkeypatch, read_text_result):
     monkeypatch.setattr("raven.channels.manager.distribution", lambda pkg: _Dist())
 
 
-@pytest.mark.parametrize("modname", ["feishu", "weixin", "qq", "telegram", "dingtalk"])
-def test_hint_editable_names_the_channel_extra(monkeypatch, modname):
-    """Editable checkout -> `uv sync --extra channel-<name>`, name interpolated."""
+def test_hint_editable_syncs_the_umbrella_extra_inexactly(monkeypatch):
+    """Editable checkout -> the umbrella extra, and --inexact so syncing one
+    channel's SDK in does not uninstall every other channel's."""
     _patch_direct_url(monkeypatch, _EDITABLE_JSON)
-    assert _missing_dep_hint(modname) == f"Run: uv sync --extra channel-{modname}"
+    hint = _missing_dep_hint()
+    assert hint == "Run: uv sync --inexact --extra channels"
+    assert "--extra channel-" not in hint
 
 
 @pytest.mark.parametrize(
@@ -137,7 +139,7 @@ def test_hint_non_editable_points_to_installer(monkeypatch, raw):
     """Any non-editable / malformed direct_url.json -> installer hint, never raises."""
     _patch_direct_url(monkeypatch, raw)
     monkeypatch.setattr("raven.channels.manager.sys.platform", "linux")
-    hint = _missing_dep_hint("weixin")
+    hint = _missing_dep_hint()
     assert "uv sync" not in hint
     assert "install.sh" in hint
 
@@ -150,7 +152,7 @@ def test_hint_package_not_found_points_to_installer(monkeypatch):
 
     monkeypatch.setattr("raven.channels.manager.distribution", _raise)
     monkeypatch.setattr("raven.channels.manager.sys.platform", "darwin")
-    assert "install.sh" in _missing_dep_hint("qq")
+    assert "install.sh" in _missing_dep_hint()
 
 
 @pytest.mark.parametrize(
@@ -161,13 +163,13 @@ def test_hint_installer_matches_os(monkeypatch, platform, marker):
     """Wheel install picks the installer for the running OS (irm vs curl)."""
     _patch_direct_url(monkeypatch, _WHEEL_JSON)
     monkeypatch.setattr("raven.channels.manager.sys.platform", platform)
-    assert marker in _missing_dep_hint("slack")
+    assert marker in _missing_dep_hint()
 
 
 @pytest.mark.parametrize(
     "direct_url, platform, expected",
     [
-        (_EDITABLE_JSON, "linux", "uv sync --extra channel-feishu"),
+        (_EDITABLE_JSON, "linux", "uv sync --inexact --extra channels"),
         (_WHEEL_JSON, "linux", "install.sh"),
         (_WHEEL_JSON, "win32", "raw.githubusercontent.com"),
     ],
@@ -212,3 +214,37 @@ def test_get_status_and_get_channel(monkeypatch):
     assert mgr.get_status() == {"fake": {"enabled": True, "running": True}}
     assert mgr.get_channel("fake") is mgr.channels["fake"]
     assert mgr.get_channel("nope") is None
+
+
+# ── missing_dependency_channels (read-only probe for status / doctor) ──
+
+
+def test_missing_dependency_channels_reports_only_enabled_import_failures(monkeypatch):
+    """An enabled channel whose SDK is absent is reported; a disabled one is not,
+    and neither is a channel that fails to build for some other reason -- that is
+    a different diagnosis than "install the dependency"."""
+    from raven.channels.manager import missing_dependency_channels
+
+    def no_sdk(config):
+        raise ImportError("No module named 'telegram'")
+
+    def other_failure(config):
+        raise ValueError("bad token")
+
+    monkeypatch.setattr(
+        "raven.channels.registry.discover_specs",
+        lambda: {
+            "telegram": _spec(no_sdk),
+            "discord": _spec(no_sdk),
+            "slack": _spec(other_failure),
+        },
+    )
+    config = _config(
+        {
+            "telegram": SimpleNamespace(enabled=True, allow_from=["*"]),
+            "discord": SimpleNamespace(enabled=False, allow_from=["*"]),
+            "slack": SimpleNamespace(enabled=True, allow_from=["*"]),
+        }
+    )
+
+    assert missing_dependency_channels(config) == ["telegram"]

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -503,3 +503,49 @@ def test_azure_missing_key_same_onboard_guidance(tmp_path: Path) -> None:
         _helpers.check_provider_credentials(load_config(cfg))
 
     assert "raven onboard" in f"{excinfo.value.summary} {excinfo.value.remedy}"
+
+
+# ── the first-run verdict vs. a provider Raven carries no field for ──
+
+
+def test_a_working_extra_provider_is_not_a_first_run(tmp_path: Path) -> None:
+    """A credential under an undeclared provider key still counts as configured.
+
+    ``ProvidersConfig`` allows extra keys and serves them from ``get`` -- a
+    provider LiteLLM supports but Raven carries no field for is a supported
+    shape. Deciding "is anything configured" from ``__dict__`` sees only the
+    declared fields, so such a user was told nothing was configured yet and
+    sent to the wizard. The model is left at the schema default here, which is
+    the only case that reaches this branch at all.
+    """
+    from raven.config.loader import load_config
+    from raven.providers.auth import MissingCredentialsError
+
+    cfg = tmp_path / "config.json"
+    cfg.write_text(
+        json.dumps({"providers": {"my-private-vllm": {"apiKey": "sk-real", "apiBase": "http://x/v1"}}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(MissingCredentialsError) as excinfo:
+        _helpers.check_provider_credentials(load_config(cfg))
+
+    # The specific verdict for the model's own vendor, not the first-run one.
+    assert "no provider is configured yet" not in excinfo.value.summary
+    assert "API key" in excinfo.value.summary
+
+
+def test_nothing_configured_at_all_names_the_wizard(tmp_path: Path) -> None:
+    """With no credential anywhere and no model chosen, the default model's
+    vendor is not the thing to go fix -- the wizard is."""
+    from raven.config.loader import load_config
+    from raven.providers.auth import MissingCredentialsError
+
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"providers": {}}), encoding="utf-8")
+
+    with pytest.raises(MissingCredentialsError) as excinfo:
+        _helpers.check_provider_credentials(load_config(cfg))
+
+    assert "no provider is configured yet" in excinfo.value.summary
+    assert "raven onboard" in excinfo.value.summary

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -4516,12 +4516,46 @@ def test_each_provider_sits_in_the_group_its_credentials_put_it_in() -> None:
 # --------------------------------------------------------------------------- first-run hints
 
 
-def test_install_sh_all_set_mentions_onboard() -> None:
-    """The install.sh closing hints must point first-time users at ``raven onboard``
-    (README already does; the installer's "All set" block must match)."""
-    text = (Path(__file__).resolve().parents[1] / "install.sh").read_text()
-    tail = text[text.index("All set") :]
-    assert "raven onboard" in tail
+def test_installers_send_first_run_to_bare_raven() -> None:
+    """Both installers' first-run block names bare ``raven``, not the wizard.
+
+    The startup gate runs the wizard from bare ``raven`` and continues into the
+    TUI in the same process, so naming ``raven onboard`` here would present one
+    continuous flow as two commands to run in sequence.
+    """
+    root = Path(__file__).resolve().parents[1]
+    for name in ("install.sh", "install.ps1"):
+        first_run = (root / name).read_text()
+        first_run = first_run[first_run.index("All set") :]
+        assert "sets you up on first run" in first_run, name
+        assert "raven onboard" not in first_run, name
+
+
+def test_installers_tell_an_upgrade_apart_from_a_first_run() -> None:
+    """A re-run over an existing config is an upgrade: say so instead of
+    repeating first-time-setup wording, and name the in-place path (which keeps
+    the channel extras rather than re-downloading everything)."""
+    root = Path(__file__).resolve().parents[1]
+    for name in ("install.sh", "install.ps1"):
+        text = (root / name).read_text()
+        assert "config.json" in text, name
+        assert "Raven updated" in text, name
+        assert "raven upgrade" in text, name
+
+
+def test_readme_quickstart_matches_the_installer_hint() -> None:
+    """The README's first step and the installer's first-run hint must name the
+    same command. They drifted once -- the installer said nothing about setup
+    while the README opened with ``raven onboard`` -- and a first-time user who
+    followed the terminal hit the missing-credentials error instead."""
+    root = Path(__file__).resolve().parents[1]
+    for name, heading in (
+        ("README.md", "### Onboard and run"),
+        ("README.zh-CN.md", "### 完成引导并运行"),
+    ):
+        text = (root / name).read_text()
+        block = text[text.index(heading) :][:200]
+        assert "```bash\nraven\n```" in block, name
 
 
 def test_pick_model_shows_default_positioning_line(

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -1091,6 +1091,36 @@ def test_a_first_run_gets_the_wizard(tmp_env: Path, monkeypatch: pytest.MonkeyPa
     assert ran == [True]
 
 
+def test_the_gate_starts_the_wizard_without_its_outro(tmp_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """On the gate path the TUI takes the terminal as soon as the wizard
+    returns, so the closing list of commands to try next is answered before it
+    can be read. Pinned on the call itself: a stub that swallows kwargs left
+    this wiring free to regress silently."""
+    calls: list[dict] = []
+    monkeypatch.setattr(onboard_commands, "run_wizard", lambda **kw: calls.append(kw))
+
+    onboard_commands.ensure_ready_to_start()
+
+    assert [c.get("show_next_steps") for c in calls] == [False]
+
+
+def test_the_outro_flag_swaps_the_panel_for_one_line(
+    tmp_env: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The suppressed outro still confirms the setup finished -- it drops only
+    the command table, which is what the TUI is about to replace."""
+    onboard_commands._print_next_steps(warnings=[], show_next_steps=False)
+    suppressed = capsys.readouterr().out
+    assert "Get started" not in suppressed
+    assert "starting the TUI" in suppressed
+
+    onboard_commands._print_next_steps(warnings=[], show_next_steps=True)
+    full = capsys.readouterr().out
+    assert "Get started" in full
+    assert "starting the TUI" not in full
+
+
 # --------------------------------------------------------------------------- entry-point gate wiring
 
 

--- a/tests/test_provider_rates.py
+++ b/tests/test_provider_rates.py
@@ -827,3 +827,53 @@ def test_allow_fetch_false_never_calls_fetch_with_a_keyword_it_may_not_accept(mo
         rates.effective_context_window("openrouter/deepseek/deepseek-v4-pro", None, allow_fetch=False)
         == rates.DEFAULT_CONTEXT_WINDOW_TOKENS
     )
+
+
+# --- Hyphen/dot version spellings (OpenRouter files what vendors hyphenate) ---
+
+
+_DOTTED_MODELS = [
+    {
+        "id": "anthropic/claude-sonnet-4.5",
+        "context_length": 200000,
+        "pricing": {"prompt": "0.000003", "completion": "0.000015"},
+    },
+    {
+        "id": "meta-llama/llama-3.3-70b-instruct",
+        "context_length": 131072,
+        "pricing": {"prompt": "0.00000004", "completion": "0.00000012"},
+    },
+]
+
+
+def test_a_hyphenated_version_finds_the_dotted_openrouter_row(monkeypatch):
+    """Raven routes Anthropic's ``claude-sonnet-4-5``; OpenRouter files the same
+    model as ``claude-sonnet-4.5``. Exact-key lookup missed, so the default model
+    Raven itself recommends reported a cost of None on every turn."""
+    _patch_openrouter(monkeypatch, lambda req: _models_response(_DOTTED_MODELS))
+
+    entry = rates._lookup_openrouter_entry("openrouter/anthropic/claude-sonnet-4-5")
+    assert entry is not None
+    assert entry["pricing"]["prompt"] == "0.000003"
+    assert _rate_cost("openrouter/anthropic/claude-sonnet-4-5", 1000, 100) is not None
+
+
+def test_only_one_boundary_is_dotted_at_a_time(monkeypatch):
+    """``llama-3-3-70b`` is ``llama-3.3-70b``, never ``llama-3.3.70b`` -- so the
+    variants are tried one digit boundary at a time rather than all at once."""
+    _patch_openrouter(monkeypatch, lambda req: _models_response(_DOTTED_MODELS))
+
+    entry = rates._lookup_openrouter_entry("openrouter/meta-llama/llama-3-3-70b-instruct")
+    assert entry is not None
+    assert entry["pricing"]["prompt"] == "0.00000004"
+    assert rates._lookup_openrouter_entry("openrouter/meta-llama/llama-3-3-70b-nope") is None
+
+
+def test_dotted_variants_are_a_fallback_not_a_rewrite():
+    """No digit boundary, nothing to try; and the exact key is always preferred,
+    so a wrong guess can only ever degrade to the None it replaced."""
+    assert rates._dotted_version_variants("openai/gpt-4o-mini") == []
+    assert rates._dotted_version_variants("anthropic/claude-sonnet-4-5") == ["anthropic/claude-sonnet-4.5"]
+    # Only digit-to-digit boundaries count: the hyphen in "x-1" joins a letter
+    # to a digit and is left alone.
+    assert rates._dotted_version_variants("x-1-2-3") == ["x-1.2-3", "x-1-2.3", "x-1.2.3"]


### PR DESCRIPTION
## Summary

Follow-ups found while running a real-machine regression pass over the fixes in #321-#334. Five independent defects, each verified by reproducing it and then reproducing the fix on this machine rather than only in tests.

**First run is one command again.** The installer's closing block told a new user to run `raven onboard`, then `raven`, then `raven agent -m hello`. Bare `raven` already runs the wizard through the startup gate and continues into the TUI in the same process, so the list presented one continuous flow as three commands -- and the third one cannot work on a fresh install, because `raven agent` never consults the gate. Both installers now branch on an existing `config.json`: a first run is sent to bare `raven`; a re-run over an existing config is told its config is untouched and pointed at `raven upgrade` for the in-place path. `install.ps1` had never carried the onboard line at all, so the two scripts had disagreed since they were written; they now say the same thing. README (both languages) opens with bare `raven`, keeping `raven onboard` in the command tables as the explicit reconfigure entry. On the gate path the wizard also stops printing its "Get started" command list, which the TUI answers a second later by taking the terminal.

**A zero-provider install no longer names a vendor the user never chose.** With nothing configured, routing falls back to the schema default model, and its vendor was reported as the thing to go fix -- sending someone who only holds an OpenRouter key to `provider set anthropic`. The first-run verdict now requires both halves (the model is still the schema default, and no provider anywhere holds credentials), so a user who chose this model, or who has another provider working, keeps the specific message; for the OAuth families that message still names a sign-in rather than a key.

**`uv sync --extra channel-telegram` was uninstalling other channels.** `uv sync` is an exact sync, so the dev hint for one missing channel SDK removed every other channel's SDK on the way in. It now names the umbrella `channels` extra with `--inexact`, matching what the installer puts on an end user's machine. Separately, an enabled channel whose SDK is absent was visible only as a single WARNING line in the gateway log; `channels status` and `doctor` now report it through the same probe the gateway performs.

**The recommended default model could not be priced.** Raven routes Anthropic's `claude-sonnet-4-5`; OpenRouter files the same model as `claude-sonnet-4.5`. Exact-key lookup missed, so the model the wizard itself recommends reported a cost of None on every turn, with an unknown-model warning beside it. The catalog lookup now tries dotted spellings after the exact key misses, one digit boundary at a time so `llama-3-3-70b` resolves as `llama-3.3-70b` rather than `llama-3.3.70b`. It is a fallback only, so a wrong guess degrades to the same None it replaces.

**Two smaller items.** Hub skill ids carry slashes (`openclaw/skills/tag-memory`) and were interpolated into the request URL as extra path segments; they are now escaped into one segment. And the `--every` scheduling contract is written down: it measures from the moment the previous fire completed, so a job that takes 15s repeats every interval + 15s and its clock drifts by design, which is what buys the guarantee that a slow run never overlaps itself or leaves a backlog. That was never stated anywhere, so the drift read as a defect; CONTEXT.md now carries the term and `cron add --every` states it where the schedule is chosen.

Two decisions were taken deliberately and are **not** changed here: `skillForge.autoInstall` stays `auto` (the disclosure line, the two install-path audit records, `skill remove` and `skill block` together already give the user visibility and control), and cron stays fixed-delay (documented rather than converted to fixed-rate, which would need a catch-up policy and would interact with the anti-runaway counter from #333).

Out of scope, reported rather than fixed: the published `tag-memory` bundle on the Hub still ships the upstream author's runtime data at `data/pending_summary.json`, including personal content. That is server-side; the client-side install policy from #327 already refuses the skill over its `~/.openclaw` references, which is what keeps it off users' machines today.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

Commands run on macOS against this branch:

- `uv run pytest tests/ -q` -> 6080 passed, 43 skipped, 2 failed locally: `test_cli_theme.py::test_bold_accent_renders_styled_not_bare` (terminal color-depth detection, tracked as #309) and `test_read_file_image.py::test_image_block_is_the_only_place_the_shape_is_written`. Both reproduce on unmodified `main` on this machine, and both pass in CI on this branch, so they are artifacts of the local terminal environment rather than anything this branch does.
- `uv run ruff check raven/ tests/` -> All checks passed
- `uv run ruff format --check raven/ tests/` -> 821 files already formatted
- `sh -n install.sh` -> syntax OK. `install.ps1` was not parse-checked (no PowerShell on this machine); its closing block is covered by a text assertion in `tests/test_cli_onboard_commands.py`, and its braces balance.
- `make check-large-files` -> no findings

Behaviour reproduced by hand, each against an isolated `HOME`:

- Installer closing block, driven with the heavy steps stubbed: no `config.json` prints the bare-`raven` first-run hint; an existing `config.json` prints `Raven updated ... raven upgrade`.
- `raven agent -m hi` with nothing configured -> `Error: no provider is configured yet -- run `raven onboard` for guided setup.`, exit code 1.
- `raven agent -m "say ok"` with a working provider -> `5k in / 4 out tokens - $0.0184 - 4.0s` (the cost figure was absent before this branch).
- `raven channels status` and `raven doctor` with telegram enabled and its SDK absent -> both report the missing SDK plus `Run: uv sync --inexact --extra channels`; with no channels enabled, neither prints anything extra.
- The wizard driven through a pseudo-terminal to step 4, confirming the model picker's default line, the host-run `(y/N)` confirmation, and the memory-embedding prompt.

Regression checks over the areas this touches, on the same machine: a cron job under a real `raven gateway` fired four times at its interval; the Skill Hub install policy refused a blocklisted skill at runtime (verified against a control run where the same prompt installed it); `autoInstall` `off` and `prompt` both installed nothing on a non-interactive run.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

## Risk

User-visible changes:

- The installer prints a different closing block, and a re-run over an existing config now says "Raven updated" instead of first-time-setup wording.
- A first run with nothing configured gets a different error sentence from `raven agent`. Any script matching on the old `anthropic needs an API key` text for the zero-config case would need updating; the per-provider message is unchanged for every configured case.
- The wizard prints no "Get started" panel when it was started by the gate. Running `raven onboard` explicitly still prints it.
- Turn-level cost figures appear for OpenRouter models whose ids are hyphenated where the catalog is dotted. This changes reported numbers from absent to present; no billing behaviour changes.

Rollback: each concern is a separate commit, so any one can be reverted alone. Nothing here writes to `~/.raven`, changes a config default, or alters an on-disk format, so a revert needs no migration.

Security: `--inexact` only stops `uv sync` from removing packages, and the umbrella extra is the same set the installer already installs. Escaping the Hub skill id narrows what a hub-supplied id can address in a request URL. The install-policy and blocklist behaviour from #327 and #328 is unchanged; this branch only verifies it.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

Nothing on the tracker covers these five defects; they surfaced while regression-testing #321-#334, so this PR closes no issue.

Referenced for context only:

- #88 is where the missing-dependency hint got its editable-vs-wheel split. This PR refines the editable branch it added; the wheel branch is unchanged.
- #309 tracks `test_bold_accent_renders_styled_not_bare`, one of the two suite failures listed under Verification. The other, `test_read_file_image.py::test_image_block_is_the_only_place_the_shape_is_written`, has no issue open against it; both fail the same way on unmodified `main`.