### PR TITLE
chore: bump version to 0.1.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raven"
-version = "0.1.11"
+version = "0.1.12"
 description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3003,7 +3003,7 @@ wheels = [
 
 [[package]]
 name = "raven"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Bump the package version from 0.1.11 to 0.1.12 for the next release. Only
pyproject.toml and uv.lock change.

Core changes since v0.1.11:

- Proactive reminders gained cron anti-runaway guards and notices for
  reminders missed while the TUI was closed.
- Skill installs now run behind a consent mode and a single safety policy gate.
- Sessions are auto-named, and a bare create persists.
- The interactive REPL and the CLI cron channel are retired; status output is
  folded and each turn reports its usage.
- Provider auth failures render real guidance with exit codes, and an old
  default no longer caps every model's context window.
- First-run onboarding, doctor, and channel commands gained clearer hints and
  non-tty guards.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

## Verification

- `uv lock` - resolved 193 packages, updated raven v0.1.11 -> v0.1.12
- `python3 -m scripts.check_commit_messages origin/main..HEAD` - exit 0
- `git diff --stat origin/main..HEAD` - 2 files changed, 2 insertions(+), 2
  deletions(-)

- [ ] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [ ] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Version-only bump; no code changes. Rollback: revert the squash commit.

## Related Issues

N/A
