### PR TITLE
docs: point the release notes template at bare raven

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -28,8 +28,11 @@ irm https://raw.githubusercontent.com/EverMind-AI/Raven/refs/heads/main/install.
 Open a new terminal, then run:
 
 ```bash
-raven onboard
+raven
 ```
+
+That sets you up on first run and then opens the TUI. `raven onboard` stays
+the explicit way to reconfigure later.
 
 ## Upgrade
 


### PR DESCRIPTION
## Summary

The release notes Install block still told a new user to run `raven onboard`.
Since #342 the first-run entry is bare `raven`: both installers close with it,
and the wizard runs through the startup gate before continuing into the TUI.

CI prefills this template into every release draft, so the stale command comes
back each release; the v0.1.12 notes had to be corrected by hand. `raven
onboard` stays documented as the explicit way to reconfigure later.

## Type

- [ ] Fix
- [ ] Feature
- [x] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `git diff origin/main..HEAD --stat` - 1 file changed, 4 insertions(+), 1 deletion(-)
- `git grep -n "sets you up on first run" -- install.sh install.ps1` - both
  installers close a first run with bare `raven` (install.sh:305,
  install.ps1:363)

- [ ] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

- [ ] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Documentation-only; it changes what the next release draft is prefilled with.
Rollback: revert the squash commit.

## Related Issues

N/A
