### PR TITLE
fix(*): keep migration notices off stdout, and stop planting defaults

### DIFF
--- a/raven/cli/_helpers.py
+++ b/raven/cli/_helpers.py
@@ -356,11 +356,25 @@ def print_config_migration_notices() -> None:
     The migrations run inside the loader, which has no terminal; this is the
     place that does. Call it after the config is loaded and before the command
     takes over the screen -- once printed, the notices are gone.
+
+    On stderr, because stdout is a command's answer and this is not part of it:
+    ``raven doctor --json`` and ``raven import --json`` are documented for
+    automation, and a line appended to their output is not a cosmetic problem
+    but an unparseable document. That is also where the rest of this class of
+    message already goes -- ``commands.run``'s own ConfigReadError branch and
+    the loader's malformed-config warning both use stderr -- so a future
+    ``--json`` command inherits the right behaviour without knowing about this.
     """
+    from rich.console import Console
+
     from raven.config.loader import drain_migration_notices
 
-    for notice in drain_migration_notices():
-        console.print(f"[yellow]Config updated:[/yellow] {notice}")
+    notices = drain_migration_notices()
+    if not notices:
+        return
+    err = Console(stderr=True)
+    for notice in notices:
+        err.print(f"[yellow]Config updated:[/yellow] {notice}")
 
 
 __all__ = [

--- a/raven/cli/doctor_commands.py
+++ b/raven/cli/doctor_commands.py
@@ -15,7 +15,7 @@ import json
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import typer
 from rich.console import Console
@@ -24,6 +24,8 @@ from raven import __logo__
 from raven.cli._helpers import print_probe_troubleshooting, send_probe
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from raven.config.raven import RavenConfig
 
 console = Console()
@@ -113,6 +115,24 @@ class ProbeResult:
 
 
 @dataclass
+class ConfigHealth:
+    """What the config says that the migrations deliberately did not change.
+
+    The migrations run at load, so by the time this command looks there is
+    nothing pending -- they already happened, silently, one launch ago. What is
+    left for a person to ask about is the set of things Raven will not decide
+    on their behalf: a window they pinned that is smaller than the model can
+    hold, and a provider nothing could resolve. Both are legitimate
+    configurations and both are common mistakes, which is exactly why they need
+    somewhere to be asked rather than a rule that guesses.
+    """
+
+    findings: list[str] = field(default_factory=list)
+    fixes: list[str] = field(default_factory=list)
+    applied: list[str] = field(default_factory=list)
+
+
+@dataclass
 class DoctorReport:
     version: int = 1
     config_loaded: bool = False
@@ -122,6 +142,7 @@ class DoctorReport:
     gateway: Optional[GatewayInfo] = None
     memory: Optional[MemoryInfo] = None
     probe: Optional[ProbeResult] = None
+    config_health: Optional[ConfigHealth] = None
 
     def exit_code(self) -> int:
         if self.paths is None or not self.paths.config_exists:
@@ -139,6 +160,73 @@ class DoctorReport:
         if self.memory is not None and self.memory.broken:
             return 2
         return 0
+
+
+def _inspect_config_health(config: Any, *, fix: bool) -> ConfigHealth:
+    """Ask the two questions the migrations refuse to answer for the user.
+
+    ``fix`` is the consent: without it this only reports, because the finding is
+    a value someone may have meant -- a window pinned below the model is a real
+    configuration for a self-hosted endpoint served smaller than the catalogue
+    thinks.
+
+    One check for now. The other candidate -- a config naming no provider --
+    reads differently before and after the explicit-provider rule lands, so it
+    belongs to that change rather than to this one; routing that resolves to
+    nothing is already reported above.
+    """
+    from raven.config.loader import get_config_path, read_raw_or_raise
+    from raven.providers.rates import resolve_context_window
+
+    health = ConfigHealth()
+    defaults = config.agents.defaults
+    pinned = defaults.context_window_tokens
+    model = defaults.model
+
+    if pinned and model:
+        real = resolve_context_window(model)
+        if real and pinned < real:
+            health.findings.append(
+                f"contextWindowTokens is pinned to {pinned:,}, but {model} holds {real:,}. "
+                f"Everything is sized against the pin: the history budget, when the Curator "
+                f"starts paying for a slow path, and when memory consolidation archives."
+            )
+            health.fixes.append("remove agents.defaults.contextWindowTokens so the window follows each model")
+
+    if fix and health.fixes:
+        path = get_config_path()
+        try:
+            raw = read_raw_or_raise(path)
+            raw.get("agents", {}).get("defaults", {}).pop("contextWindowTokens", None)
+            raw.get("agents", {}).get("defaults", {}).pop("context_window_tokens", None)
+            _write_config_preserving_mode(path, raw)
+        except Exception as exc:  # noqa: BLE001 -- reported, never fatal
+            health.findings.append(f"could not write the fix: {exc}")
+        else:
+            health.applied = list(health.fixes)
+            health.fixes = []
+
+    return health
+
+
+def _write_config_preserving_mode(path: "Path", raw: dict) -> None:
+    """Atomic replace that carries the original's mode across.
+
+    ``os.replace`` swaps the inode, so the mode of what lands is the temp
+    file's: a config the user tightened to owner-only (it holds
+    ``providers.*.apiKey``) would come back world-readable. Same rule the
+    loader's migration writer follows.
+    """
+    import json as _json
+    import os as _os
+
+    tmp = path.with_name(f"{path.name}.doctorfix.{_os.getpid()}")
+    tmp.write_text(_json.dumps(raw, indent=2, ensure_ascii=False), encoding="utf-8")
+    try:
+        _os.chmod(tmp, path.stat().st_mode & 0o7777)
+    except OSError:
+        pass
+    _os.replace(tmp, path)
 
 
 def _gather_static_checks() -> DoctorReport:
@@ -488,12 +576,27 @@ def _render_human_output(report: DoctorReport) -> None:
         )
         console.print("Run [cyan]raven provider list[/cyan] / [cyan]raven provider set[/cyan] to fix routing.")
 
+    health = report.config_health
+    if health and (health.findings or health.applied):
+        console.print("\n[bold]Config[/bold]")
+        for line in health.findings:
+            console.print(
+                f"  [yellow]![/yellow] {line}" if not line.startswith("  ") else f"  [dim]{line.strip()}[/dim]"
+            )
+        for line in health.applied:
+            console.print(f"  [green]fixed[/green] {line}")
+        if health.fixes:
+            console.print("  [dim]Run [cyan]raven doctor --fix[/cyan] to apply:[/dim]")
+            for line in health.fixes:
+                console.print(f"    [dim]- {line}[/dim]")
+
 
 def register(app: typer.Typer) -> None:
     @app.command()
     def doctor(
         probe: bool = typer.Option(False, "--probe", help="Send a test message to verify the LLM responds."),
         json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON (CI-friendly)."),
+        fix: bool = typer.Option(False, "--fix", help="Apply the config fixes this reports, where one exists."),
         timeout: int = typer.Option(
             15,
             "--timeout",
@@ -501,13 +604,20 @@ def register(app: typer.Typer) -> None:
             min=1,
         ),
     ) -> None:
-        """Health-check Raven config, routing, and (optionally) the LLM."""
+        """Health-check Raven config, routing, and (optionally) the LLM.
+
+        ``--fix`` is consent, not a mode: without it the config findings are
+        reported and nothing is written, because each one is a value somebody
+        may have meant.
+        """
         report = _gather_static_checks()
 
         if report.config_loaded:
+            from raven.config.loader import load_config
             from raven.config.raven import load_raven_config
 
             report.memory = _probe_memory(load_raven_config())
+            report.config_health = _inspect_config_health(load_config(), fix=fix)
 
         if probe and report.routing is not None and report.routing.provider is not None:
             report.probe = _run_llm_probe(timeout_s=timeout)

--- a/raven/config/loader.py
+++ b/raven/config/loader.py
@@ -334,6 +334,18 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
     """
     Save configuration to file.
 
+    Only what differs from the defaults is written. A dump of everything is
+    lossless on reload either way -- a value equal to its default reloads as
+    that default -- but it freezes today's defaults into the user's file, and
+    then a default we change later never reaches anyone who already has one.
+    That is not hypothetical: ``contextWindowTokens: 65536`` was written this
+    way, and every upgraded install stayed capped at 64k on a 1M model until a
+    migration went and took it out again. Writing less means the next default
+    we improve simply applies.
+
+    It also leaves a file a person can read: the handful of lines they chose,
+    rather than eight kilobytes of settings they have never heard of.
+
     Args:
         config: Configuration to save.
         config_path: Optional path to save to. Uses default if not provided.
@@ -341,7 +353,7 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
     path = config_path or get_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    data = config.model_dump(by_alias=True)
+    data = config.model_dump(by_alias=True, exclude_defaults=True)
 
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)

--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -744,3 +744,79 @@ def test_doctor_says_nothing_about_a_pin_that_matches_the_model(tmp_path, monkey
     monkeypatch.setattr(rates, "resolve_context_window", lambda *a, **k: 1_000_000)
 
     assert _inspect_config_health(load_config(cfg), fix=False).findings == []
+
+
+def test_doctor_fix_reports_a_write_it_could_not_make(tmp_path, monkeypatch) -> None:
+    """A read-only home is a reason to say so, not to crash the health check --
+    the rest of the report is still worth printing."""
+    from raven.cli.doctor_commands import _inspect_config_health
+    from raven.config import loader
+    from raven.config.loader import load_config
+    from raven.providers import rates
+
+    cfg = _pinned_config(tmp_path, contextWindowTokens=32768)
+    monkeypatch.setattr(rates, "resolve_context_window", lambda *a, **k: 1_000_000)
+    monkeypatch.setattr(loader, "get_config_path", lambda: cfg)
+    monkeypatch.setattr(
+        "raven.cli.doctor_commands._write_config_preserving_mode",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("read-only file system")),
+    )
+
+    health = _inspect_config_health(load_config(cfg), fix=True)
+
+    assert any("could not write the fix" in f for f in health.findings)
+    assert health.applied == []
+    assert json.loads(cfg.read_text())["agents"]["defaults"]["contextWindowTokens"] == 32768
+
+
+def test_the_fix_writer_survives_a_mode_it_cannot_read(tmp_path, monkeypatch) -> None:
+    """Preserving the mode is best-effort: a filesystem that will not answer
+    `stat` is not a reason to leave the fix unwritten."""
+    from raven.cli.doctor_commands import _write_config_preserving_mode
+
+    cfg = tmp_path / "config.json"
+    cfg.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr("os.chmod", lambda *a, **k: (_ for _ in ()).throw(OSError("no")))
+
+    _write_config_preserving_mode(cfg, {"agents": {"defaults": {"model": "x/y"}}})
+
+    assert json.loads(cfg.read_text())["agents"]["defaults"]["model"] == "x/y"
+
+
+def test_doctor_prints_the_config_section_it_found(tmp_path, monkeypatch, capsys) -> None:
+    """The renderer, not just the check: a finding nothing prints is a finding
+    the user never gets."""
+    from raven.cli.doctor_commands import ConfigHealth, DoctorReport, PathsInfo, _render_human_output
+
+    report = DoctorReport(
+        config_loaded=True,
+        paths=PathsInfo(config_path=str(tmp_path / "config.json"), config_exists=True, config_valid=True),
+        config_health=ConfigHealth(
+            findings=["contextWindowTokens is pinned to 32,768"],
+            fixes=["remove agents.defaults.contextWindowTokens"],
+        ),
+    )
+
+    _render_human_output(report)
+
+    out = capsys.readouterr().out
+    assert "Config" in out
+    assert "pinned to 32,768" in out
+    assert "raven doctor --fix" in out
+    assert "remove agents.defaults.contextWindowTokens" in out
+
+
+def test_doctor_prints_what_the_fix_applied(tmp_path, capsys) -> None:
+    from raven.cli.doctor_commands import ConfigHealth, DoctorReport, PathsInfo, _render_human_output
+
+    report = DoctorReport(
+        config_loaded=True,
+        paths=PathsInfo(config_path=str(tmp_path / "config.json"), config_exists=True, config_valid=True),
+        config_health=ConfigHealth(applied=["remove agents.defaults.contextWindowTokens"]),
+    )
+
+    _render_human_output(report)
+
+    out = capsys.readouterr().out
+    assert "fixed" in out
+    assert "raven doctor --fix" not in out, "nothing left to apply, so nothing to advertise"

--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -664,3 +664,83 @@ class TestASelfManagedServerCanStillBeBroken:
 
         assert "rerank" not in info.configured
         assert "rerank" not in info.unbuilt
+
+
+# ── raven doctor --fix ──────────────────────────────────────────────────
+#
+# The migrations run at load, so nothing is ever "pending" by the time this
+# command looks. What is left to ask about is what they deliberately do not
+# decide: a window the user pinned below what the model holds, and a provider
+# nothing could resolve. Both are legitimate configurations, which is why they
+# are reported and only written with --fix.
+
+
+def _pinned_config(home: Path, **defaults: object) -> Path:
+    cfg = home / ".raven" / "config.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        json.dumps(
+            {
+                "providers": {"anthropic": {"apiKey": "sk-a"}},
+                "agents": {
+                    "defaults": {
+                        "model": "anthropic/claude-opus-4-5",
+                        "provider": "anthropic",
+                        **defaults,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+def test_doctor_reports_a_pin_that_caps_the_model(tmp_path, monkeypatch) -> None:
+    from raven.cli.doctor_commands import _inspect_config_health
+    from raven.config.loader import load_config
+    from raven.providers import rates
+
+    # Not 65536: that is the retired default the loader clears on its own, so a
+    # fixture using it would be testing the migration instead of this check.
+    cfg = _pinned_config(tmp_path, contextWindowTokens=32768)
+    monkeypatch.setattr(rates, "resolve_context_window", lambda *a, **k: 1_000_000)
+
+    health = _inspect_config_health(load_config(cfg), fix=False)
+
+    assert any("32,768" in f and "1,000,000" in f for f in health.findings)
+    assert health.fixes and not health.applied
+    # Reported only: no consent, no write.
+    assert json.loads(cfg.read_text())["agents"]["defaults"]["contextWindowTokens"] == 32768
+
+
+def test_doctor_fix_removes_the_pin_and_keeps_the_file_mode(tmp_path, monkeypatch) -> None:
+    from raven.cli.doctor_commands import _inspect_config_health
+    from raven.config import loader
+    from raven.config.loader import load_config
+    from raven.providers import rates
+
+    # Not 65536: that is the retired default the loader clears on its own, so a
+    # fixture using it would be testing the migration instead of this check.
+    cfg = _pinned_config(tmp_path, contextWindowTokens=32768)
+    cfg.chmod(0o600)
+    monkeypatch.setattr(rates, "resolve_context_window", lambda *a, **k: 1_000_000)
+    monkeypatch.setattr(loader, "get_config_path", lambda: cfg)
+
+    health = _inspect_config_health(load_config(cfg), fix=True)
+
+    assert health.applied and not health.fixes
+    assert "contextWindowTokens" not in json.loads(cfg.read_text())["agents"]["defaults"]
+    # config.json holds providers.*.apiKey, so a replacing writer owns the mode.
+    assert cfg.stat().st_mode & 0o777 == 0o600
+
+
+def test_doctor_says_nothing_about_a_pin_that_matches_the_model(tmp_path, monkeypatch) -> None:
+    from raven.cli.doctor_commands import _inspect_config_health
+    from raven.config.loader import load_config
+    from raven.providers import rates
+
+    cfg = _pinned_config(tmp_path, contextWindowTokens=1_000_000)
+    monkeypatch.setattr(rates, "resolve_context_window", lambda *a, **k: 1_000_000)
+
+    assert _inspect_config_health(load_config(cfg), fix=False).findings == []

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -549,3 +549,35 @@ def test_nothing_configured_at_all_names_the_wizard(tmp_path: Path) -> None:
 
     assert "no provider is configured yet" in excinfo.value.summary
     assert "raven onboard" in excinfo.value.summary
+
+
+def test_migration_notices_go_to_stderr_not_stdout(tmp_path, capsys, monkeypatch) -> None:
+    """stdout is a command's answer; this is not part of it.
+
+    ``raven doctor --json`` and ``raven import --json`` are documented for
+    automation, so a notice appended to their output is not a cosmetic problem
+    but an unparseable document -- and the migration only fires once, which is
+    exactly the run a CI job would be unlucky enough to hit.
+    """
+    from raven.cli._helpers import print_config_migration_notices
+    from raven.config import loader
+
+    monkeypatch.setattr(loader, "_migration_notices", ["something was rewritten"])
+
+    print_config_migration_notices()
+
+    captured = capsys.readouterr()
+    assert "something was rewritten" in captured.err
+    assert captured.out == ""
+
+
+def test_no_notice_prints_nothing_at_all(capsys, monkeypatch) -> None:
+    from raven.cli._helpers import print_config_migration_notices
+    from raven.config import loader
+
+    monkeypatch.setattr(loader, "_migration_notices", [])
+
+    print_config_migration_notices()
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err) == ("", "")

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -797,16 +797,19 @@ def test_step1_picker_uses_catalog_when_available(tmp_env: Path, monkeypatch: py
     r = runner.invoke(app, ["onboard"])
     assert r.exit_code == 0, r.stdout
 
-    # Catalog feeds the picker, every id carrying the provider's route prefix.
-    # The schema's pre-existing default (``anthropic/claude-opus-4-5``) is one of
-    # them rather than a fourth entry: while bare and prefixed spellings coexisted
-    # the same model appeared twice, once in each form.
+    # Catalog feeds the picker, every id carrying the provider's route prefix,
+    # with the provider's own recommended default at the head when the catalog
+    # does not already carry it. It used to be the schema default that led here,
+    # because the bootstrap wrote every default into the config and the wizard
+    # read it back as "the current model" -- a value nobody had chosen, offered
+    # as though somebody had.
     assert captured_choices["choices"] == [
+        "anthropic/claude-sonnet-5",
         "anthropic/claude-haiku-4-5",
         "anthropic/claude-sonnet-4-5",
         "anthropic/claude-opus-4-5",
     ]
-    assert captured_choices["default"] == "anthropic/claude-opus-4-5"
+    assert captured_choices["default"] == "anthropic/claude-sonnet-5"
     # The pick made it into config, carrying the route prefix. The user may type
     # a bare id -- autocomplete accepts free text -- and a bare id is routed by
     # keyword and fallback rather than to the provider just configured, so the

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -482,3 +482,38 @@ def test_migration_temp_file_is_process_scoped(tmp_path: Path) -> None:
         loader.Path.write_text = original  # type: ignore[method-assign]
 
     assert any(name.startswith("config.json.migrating.") and name.endswith(str(os.getpid())) for name in seen)
+
+
+def test_save_config_writes_only_what_differs_from_the_defaults(tmp_path: Path) -> None:
+    """A dump of everything is lossless on reload, but it freezes today's
+    defaults into the user's file -- and then a default we improve later never
+    reaches anyone who already has one. `contextWindowTokens: 65536` got there
+    exactly this way."""
+    from raven.config.loader import save_config
+    from raven.config.schema import Config
+
+    p = tmp_path / "config.json"
+    save_config(Config(), p)
+
+    assert json.loads(p.read_text(encoding="utf-8")) == {}
+    assert p.stat().st_size < 100
+
+
+def test_save_config_keeps_every_value_the_user_chose(tmp_path: Path) -> None:
+    from raven.config.loader import save_config
+    from raven.config.schema import Config
+
+    p = tmp_path / "config.json"
+    chosen = Config.model_validate(
+        {"agents": {"defaults": {"model": "x/y"}}, "providers": {"anthropic": {"apiKey": "sk-a"}}}
+    )
+    save_config(chosen, p)
+
+    written = json.loads(p.read_text(encoding="utf-8"))
+    assert written == {"agents": {"defaults": {"model": "x/y"}}, "providers": {"anthropic": {"apiKey": "sk-a"}}}
+    # And it reloads to the same config: dropping a value equal to its default
+    # is what makes this lossless.
+    reloaded = load_config(p)
+    assert reloaded.agents.defaults.model == "x/y"
+    assert reloaded.providers.get("anthropic").api_key == "sk-a"
+    assert reloaded.agents.defaults.max_tool_iterations == Config().agents.defaults.max_tool_iterations

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -260,9 +260,10 @@ def test_bad_config_warns_again_after_recovery(tmp_path: Path, capsys) -> None:
 # Pre-0.1.11 bootstraps dumped every schema default to disk, and back then
 # ``contextWindowTokens`` defaulted to 65536. A pin outranks the model's real
 # window by design, so on upgraded installs that fossil silently caps every
-# model at 64k. It is cleared once, under a ``configVersion`` stamp -- the
-# value itself carries no provenance, so the stamp is the only thing separating
-# "we planted this" from "the user chose this".
+# model at 64k. It is cleared once, under a watermark kept in a sidecar next to
+# the config (see ``_stamp_path``) -- the value itself carries no provenance, so
+# the watermark is the only thing separating "we planted this" from "the user
+# chose this".
 
 
 def _defaults(path: Path) -> dict:


### PR DESCRIPTION
## Summary

Three follow-ups from #341, which fixed a retired `contextWindowTokens: 65536` capping every upgraded install at 64k. Two are its loose ends; the third is the reason it happened at all.

**The notice no longer prints on stdout.** #341 drains config-migration notices in the `run()` wrapper so every command tells the user, which caught the two whose stdout is a machine-readable document: `raven doctor --json` and `raven import --json`, both advertised for automation. Reproduced -- a config still carrying the retired pin makes `doctor --json` emit JSON with a sentence after it, and `jq` refuses the result. Moved to stderr, where the rest of this class of message already goes (the `ConfigReadError` branch a few lines up in the same wrapper, and the loader's malformed-config warning). That fixes any future `--json` command without it having to know this exists, which allow-listing the two would not. The window is narrow -- the migration fires once per install -- but the run it can spoil is a first run after upgrading, and a CI job is exactly the caller not watching.

**`raven doctor` gains a Config section and a `--fix`.** The premise changed while building it: the migrations run at load, so by the time this command looks, nothing is pending -- they already happened, silently, one launch ago. What is left for a person to ask about is what Raven deliberately will not decide for them. So it reports a `contextWindowTokens` pinned below what the configured model holds, and names what rides on it: the per-turn history budget, when the Curator starts paying for a slow path, and when memory consolidation archives. `--fix` removes the pin.

Reported without `--fix`, never written: that pin is a real configuration for a local model or an endpoint served smaller than the catalogue thinks, and the flag is the user saying which case theirs is. The write carries the file mode across (config.json holds `providers.*.apiKey`) and uses a per-PID temp name -- the same rules the loader's migration writer follows.

One check rather than two. A config naming no provider is the other thing worth asking about, but it reads differently on either side of the explicit-provider rule in #284, so it belongs to that change; a model that routes to nothing is already reported above it.

**The bootstrap stops writing every default into the user's config.** This is the cause of the bug #341 cured. `save_config` dumped the whole `Config()`, so a new install started life with eight kilobytes of settings its owner had never heard of and, worse, with that day's defaults frozen into their file -- after which a default we improve never reaches anyone who already has one. `contextWindowTokens: 65536` got onto disk exactly this way.

It now writes only what differs from the defaults. Lossless on reload, since a value equal to its default reloads as that default. A fresh config drops from 7,985 bytes to 2, and to 634 once the extension blocks are seeded -- what is left is the handful of lines someone actually chose, which is also a config they can read.

That third one is the only change here with a broad blast radius, and it has one visible consequence, which is an improvement: the onboarding picker used to lead with the schema's default model, because the bootstrap had written it into the config and the wizard read it back as "the current model" -- a value nobody had chosen, offered as though somebody had. With nothing written, the wizard leads with the provider's own recommendation instead. The test that pinned the old list now pins the new one and says why.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

```
pytest tests/                       6650 passed, 1 failed, 33 skipped
                                    (tests/test_cli_theme.py::test_bold_accent_renders_styled_not_bare,
                                    which fails identically on github/main when its file runs
                                    together and passes alone on both)
ruff check raven/ tests/            All checks passed
ruff format                         clean
```

Driven by hand as well as by tests, each against a throwaway home:

```
doctor --json on a fossil config   stdout parses as JSON again; the notice is on stderr
doctor    (pin 65536, model 1M)    reports the pin and what is sized against it
doctor --fix                       pin removed, file still 0600, a second run reports nothing
save_config on a fresh Config()    2 bytes; 634 after the extension blocks are seeded
```

New cases cover the stderr split, both doctor paths including the mode preservation, and the save round-trip keeping every value the user chose.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

The bootstrap change alters what every new install's config file looks like: nearly empty instead of a full dump. Existing configs are untouched -- nothing rewrites them -- and both shapes load identically, so the risk is confined to anyone reading `config.json` as documentation of what can be set. `raven doctor` and the schema remain the answer to that question.

The onboarding picker's default moves from the schema default to the provider's recommendation, as described above.

`doctor --fix` writes only when asked, and only removes a key. Everything else here is output routing.

Rollback: revert the commits. Nothing persists a new format, so a reverted build reads every config written under this one.

## Related Issues

N/A