### PR TITLE
fix(*): close the follow-ups the model-binding review left open

### DIFF
--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -766,11 +766,13 @@ class AgentLoop:
     def clear_session_binding(self, session_key: str) -> None:
         """Drop a session's override so it follows the default again.
 
-        Counts as having consulted the record: without that, the next ask would
-        read the stored model straight back in and undo this.
+        Deliberately does not mark the key as consulted. The one caller is
+        ``session.delete``, which unlinks the record before this runs, so there
+        is nothing left for a later ask to read back in -- and a session that
+        somehow kept its record is better served by re-reading it than by a
+        marking that claims we looked when we did not.
         """
         self._session_bindings.pop(session_key, None)
-        self._restore_attempted.add(session_key)
 
     def _forget_transport_verdicts(self) -> None:
         """Drop the capability verdicts a new provider may answer differently.

--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -356,6 +356,9 @@ class AgentLoop:
         self._configured_window = context_window_tokens or None
         self._default_binding = ModelBinding(provider, model or provider.get_default_model(), self._configured_window)
         self._session_bindings: dict[str, ModelBinding] = {}
+        # Keys whose session record has been consulted for a stored model, hit
+        # or miss. See ``_restore_once``.
+        self._restore_attempted: set[str] = set()
         # Resolved lazily on the first tool result that carries an image. Keyed
         # by model, not a single flag: the loop is a long-lived singleton and
         # takes a per-call model (strategies rewrite it, and the model chain
@@ -666,8 +669,42 @@ class AgentLoop:
 
         A new session has no entry, so it starts on the configured default
         rather than on whatever the last session switched to.
+
+        A session whose choice is on disk but not yet in memory is restored here,
+        on first ask. That is what makes the choice outlive a restart on *every*
+        surface: the overrides live in this process, the session record is the
+        only place they survive, and hanging the read off a TUI-only resume call
+        meant a conversation on a channel came back on the default with its
+        choice sitting unread in its own record.
         """
+        binding = self._session_bindings.get(session_key)
+        if binding is not None:
+            return binding
+        self._restore_once(session_key)
         return self._session_bindings.get(session_key, self._default_binding)
+
+    def _restore_once(self, session_key: str) -> None:
+        """Read this session's stored model, at most once per key per process.
+
+        The negative answer is remembered too. Most sessions never switched, and
+        without that this would re-read a record on every turn to learn the same
+        nothing.
+        """
+        if session_key in self._restore_attempted:
+            return
+        self._restore_attempted.add(session_key)
+        sessions = getattr(self, "sessions", None)
+        if sessions is None or self._provider_pool is None:
+            return
+        try:
+            record = sessions.peek(session_key)
+        except Exception as exc:
+            logger.debug("cannot read session {!r} to restore its model: {}", session_key, exc)
+            return
+        metadata = getattr(record, "metadata", None) or {}
+        model = metadata.get("model")
+        if model:
+            self.restore_session_model(session_key, model, metadata.get("provider"))
 
     def session_model(self, session_key: str) -> str:
         """What to show this session's user, which is not the global default."""
@@ -679,19 +716,27 @@ class AgentLoop:
         ``session_model`` cannot answer that -- it falls back to the default,
         so it never returns None. Callers that must distinguish "chose this"
         from "inherited this" ask here.
+
+        Restores first, so a session that switched before a restart answers yes
+        rather than being reported as having inherited the default.
         """
+        if session_key not in self._session_bindings:
+            self._restore_once(session_key)
         return session_key in self._session_bindings
 
     def restore_session_model(self, session_key: str, model: str, provider_name: str | None = None) -> None:
-        """Put a resumed session back on the model it was last switched to.
+        """Put a session back on the model it was last switched to.
 
         Session overrides live in memory, so without this a restart moves every
-        switched session back to the default and the user's choice lasts
-        exactly as long as the process. The model comes from the session
-        record. A model that can no longer be built (a credential since
-        removed) leaves the session on the default rather than failing the
-        resume.
+        switched session back to the default and the user's choice lasts exactly
+        as long as the process. A model that can no longer be built (a credential
+        since removed) leaves the session on the default rather than failing the
+        turn that asked.
+
+        Normally reached through ``_restore_once``, which supplies the stored
+        pair; kept public for a caller that has the pair already.
         """
+        self._restore_attempted.add(session_key)
         pool = self._provider_pool
         if pool is None or not model:
             return
@@ -719,8 +764,13 @@ class AgentLoop:
         self._forget_transport_verdicts()
 
     def clear_session_binding(self, session_key: str) -> None:
-        """Drop a session's override so it follows the default again."""
+        """Drop a session's override so it follows the default again.
+
+        Counts as having consulted the record: without that, the next ask would
+        read the stored model straight back in and undo this.
+        """
         self._session_bindings.pop(session_key, None)
+        self._restore_attempted.add(session_key)
 
     def _forget_transport_verdicts(self) -> None:
         """Drop the capability verdicts a new provider may answer differently.

--- a/raven/cli/doctor_commands.py
+++ b/raven/cli/doctor_commands.py
@@ -162,6 +162,23 @@ class DoctorReport:
         return 0
 
 
+def _routes_anywhere(provider: str) -> bool:
+    """Is this a provider name anything can route to?
+
+    Deliberately generous: it accepts a vendor Raven carries no spec for as long
+    as LiteLLM knows the name -- mistral and xai are supported exactly that way,
+    and reporting them as broken would be worse than saying nothing. What it
+    catches is a name nothing has ever heard of, which is a typo.
+    """
+    from raven.config.update_providers import ensure_routable_provider
+
+    try:
+        ensure_routable_provider(provider)
+    except Exception:
+        return False
+    return True
+
+
 def _inspect_config_health(config: Any, *, fix: bool) -> ConfigHealth:
     """Ask the two questions the migrations refuse to answer for the user.
 
@@ -170,10 +187,12 @@ def _inspect_config_health(config: Any, *, fix: bool) -> ConfigHealth:
     configuration for a self-hosted endpoint served smaller than the catalogue
     thinks.
 
-    One check for now. The other candidate -- a config naming no provider --
-    reads differently before and after the explicit-provider rule lands, so it
-    belongs to that change rather than to this one; routing that resolves to
-    nothing is already reported above.
+    The provider checks are reported and never fixed, and that is not an
+    omission. Only the user knows which vendor they meant to pay: the load-time
+    migration already tried the derivation and wrote down its answer wherever it
+    had one, so a provider still blank here is one the derivation could not
+    resolve. Guessing again in a command called ``--fix`` would be the same
+    guess under a more confident name.
     """
     from raven.config.loader import get_config_path, read_raw_or_raise
     from raven.providers.rates import resolve_context_window
@@ -192,6 +211,23 @@ def _inspect_config_health(config: Any, *, fix: bool) -> ConfigHealth:
                 f"starts paying for a slow path, and when memory consolidation archives."
             )
             health.fixes.append("remove agents.defaults.contextWindowTokens so the window follows each model")
+
+    provider = (getattr(defaults, "provider", "") or "").strip()
+    if not provider:
+        health.findings.append(
+            "agents.defaults.provider is not set, so the vendor serving "
+            f"{model or 'your model'} is derived from its id. A model id does not name whose "
+            "credential answers for it, and the derivation walks a list -- with two vendors "
+            "configured, which one pays can come down to their order in it."
+        )
+        health.findings.append(f"  raven provider use {model or '<model>'} --provider <name>")
+    elif not _routes_anywhere(provider):
+        health.findings.append(
+            f"agents.defaults.provider is {provider!r}, which nothing routes to. "
+            "Every call resolves against a vendor that does not exist, so the credential "
+            "it would use is never found."
+        )
+        health.findings.append("  raven provider list  # the names this accepts")
 
     if fix and health.fixes:
         path = get_config_path()

--- a/raven/cli/doctor_commands.py
+++ b/raven/cli/doctor_commands.py
@@ -174,7 +174,11 @@ def _routes_anywhere(provider: str) -> bool:
 
     try:
         ensure_routable_provider(provider)
-    except Exception:
+    except KeyError:
+        # Only the answer this asks for. A broader catch would file a genuine
+        # fault in the lookup as an ordinary "unroutable" finding, which reads
+        # as the user's problem instead of ours -- and `provider use` catches
+        # exactly this one for the same reason.
         return False
     return True
 
@@ -213,13 +217,22 @@ def _inspect_config_health(config: Any, *, fix: bool) -> ConfigHealth:
             health.fixes.append("remove agents.defaults.contextWindowTokens so the window follows each model")
 
     provider = (getattr(defaults, "provider", "") or "").strip()
-    if not provider:
+    # ``auto`` counts as unset, the way ``Config._match_provider`` counts it. The
+    # migration leaves the literal in place when it cannot resolve a vendor, so
+    # this is a reachable state and precisely the legacy case this check is for.
+    # Read as a name instead, it is unroutable, and the user is told to fix a
+    # typo they did not make while the real advice goes unsaid.
+    if not provider or provider == "auto":
         health.findings.append(
             "agents.defaults.provider is not set, so the vendor serving "
             f"{model or 'your model'} is derived from its id. A model id does not name whose "
             "credential answers for it, and the derivation walks a list -- with two vendors "
             "configured, which one pays can come down to their order in it."
         )
+        if provider == "auto":
+            health.findings.append(
+                "  (your config says `auto`, which is the retired spelling of unset -- it never detected anything)"
+            )
         health.findings.append(f"  raven provider use {model or '<model>'} --provider <name>")
     elif not _routes_anywhere(provider):
         health.findings.append(

--- a/raven/cli/provider_commands.py
+++ b/raven/cli/provider_commands.py
@@ -570,6 +570,7 @@ def _register_config_commands(app: typer.Typer) -> None:
         provider -- so the three cannot disagree about what was chosen.
         """
         from raven.config.update import set_default_model
+        from raven.config.update_providers import ensure_routable_provider
         from raven.providers.auth import credential_status
         from raven.providers.catalog import describe
         from raven.providers.wire import stored_model_id
@@ -586,6 +587,25 @@ def _register_config_commands(app: typer.Typer) -> None:
             raise typer.Exit(1)
 
         name = provider
+
+        # Before the write, not after. A typo used to exit 0 with the config
+        # already changed, and the credential warning that followed suggested
+        # `raven provider set <typo> --api-key ...` -- advice that would have
+        # created an orphan section for a vendor nothing routes to. The TUI's
+        # `/model` builds the provider first and raises before it saves; this is
+        # the same order, with the same test `provider set` already applies.
+        #
+        # Only an unroutable *name* is refused. A known provider with no
+        # credentials yet is still reported and written: picking a model before
+        # configuring its key is a normal order to do things in, and that is the
+        # one place these two commands deliberately differ.
+        try:
+            ensure_routable_provider(name)
+        except KeyError as exc:
+            detail = exc.args[0] if exc.args else str(exc)
+            console.print(f"[red]x[/red] {detail}")
+            console.print("  [dim]raven provider list  # the ones you have configured[/dim]")
+            raise typer.Exit(1) from exc
 
         stored = stored_model_id(name, model) if name else model
         previous = set_default_model(stored, provider=name)

--- a/raven/cli/provider_commands.py
+++ b/raven/cli/provider_commands.py
@@ -603,7 +603,7 @@ def _register_config_commands(app: typer.Typer) -> None:
             ensure_routable_provider(name)
         except KeyError as exc:
             detail = exc.args[0] if exc.args else str(exc)
-            console.print(f"[red]x[/red] {detail}")
+            console.print(f"[red]✗[/red] {detail}")
             console.print("  [dim]raven provider list  # the ones you have configured[/dim]")
             raise typer.Exit(1) from exc
 

--- a/raven/config/update_providers.py
+++ b/raven/config/update_providers.py
@@ -187,6 +187,19 @@ def _provider_schema_cls(name: str, *, authoritative: bool = True) -> type[BaseM
     return ann
 
 
+def ensure_routable_provider(name: str) -> None:
+    """Raise ``KeyError`` unless something routes to ``name``.
+
+    The test ``provider set`` already applies before writing a section, exposed
+    so a command that writes ``agents.defaults.provider`` can refuse a typo
+    *before* touching the file. Accepts a vendor we carry no spec for as long as
+    LiteLLM knows the name -- mistral and xai are supported that way -- and
+    accepts a name it could not verify, since refusing on a failed check would
+    block a working provider.
+    """
+    _provider_schema_cls(name)
+
+
 def _provider_spec(name: str) -> ProviderSpec | None:
     """Look up ``ProviderSpec``, or None for a vendor we carry no spec for."""
     return find_by_name(name)

--- a/raven/providers/pool.py
+++ b/raven/providers/pool.py
@@ -43,29 +43,39 @@ class ProviderPool:
         return self._supplier()
 
     def _live_cache(self) -> dict[tuple[str, str], ModelBinding]:
-        """Drop cached providers when the credentials behind them changed.
+        """Drop cached bindings when anything they were built from changed.
 
         Not identity on the config object: a supplier that re-reads the file
         returns a new object every call, which would clear the cache every
-        time and defeat the pool. A fingerprint of what a provider is actually
+        time and defeat the pool. A fingerprint of what a binding is actually
         built from is the thing that has to match.
         """
-        fingerprint = self._credentials_fingerprint()
+        fingerprint = self._cache_fingerprint()
         if self._cache_key != fingerprint:
             self._cache_key = fingerprint
             self._cache = {}
         return self._cache
 
-    def _credentials_fingerprint(self) -> str:
-        """What a built provider depends on: the keys, bases and headers."""
+    def _cache_fingerprint(self) -> str:
+        """Everything a cached binding was built from.
+
+        The credentials, because that is what a provider is built out of -- and
+        also ``contextWindowTokens``, because ``bind`` copies it onto the binding.
+        A key that does not cover the value it caches means editing that number
+        leaves a stale binding serving the old one until a restart, which is
+        exactly the kind of "it did nothing" the pin ladder exists to avoid.
+        """
         import hashlib
         import json
 
         try:
-            providers = self.config.providers.model_dump(exclude_none=True)
+            material = {
+                "providers": self.config.providers.model_dump(exclude_none=True),
+                "window": self.config.agents.defaults.context_window_tokens,
+            }
         except Exception:
             return ""
-        return hashlib.sha256(json.dumps(providers, sort_keys=True, default=str).encode()).hexdigest()
+        return hashlib.sha256(json.dumps(material, sort_keys=True, default=str).encode()).hexdigest()
 
     def bind(self, model: str, provider_name: str | None = None) -> ModelBinding:
         """Build (or reuse) the provider that serves ``model``.

--- a/raven/providers/rates.py
+++ b/raven/providers/rates.py
@@ -196,6 +196,31 @@ def _try_litellm_rates(model: str, input_tokens: int, output_tokens: int) -> tup
     return None
 
 
+def _fresh_openrouter_models() -> dict[str, dict]:
+    """The gateway's own table, but only while it is still current.
+
+    Deliberately not :func:`_cache_only_openrouter_models`. That one answers with
+    a copy of any age, which is right for sizing a window -- a stale window is
+    still this model's window, roughly. It is wrong for the price tier that runs
+    ahead of LiteLLM: a copy old enough to have expired is not better evidence
+    than the router's table, and letting it answer would suppress the refetch
+    that the expiry exists to trigger.
+
+    Never fetches, for the same reason the any-age reader does not: this is read
+    after every completion, on the event loop.
+    """
+    global _OPENROUTER_CACHE, _OPENROUTER_CACHE_TIME
+
+    if not _OPENROUTER_CACHE:
+        disk = model_catalog_cache.load()
+        if disk is None:
+            return {}
+        _OPENROUTER_CACHE, _OPENROUTER_CACHE_TIME = disk
+    if _OPENROUTER_CACHE and (time.time() - _OPENROUTER_CACHE_TIME) < _OPENROUTER_CACHE_TTL:
+        return _OPENROUTER_CACHE
+    return {}
+
+
 def _cache_only_openrouter_models() -> dict[str, dict]:
     """Whatever OpenRouter table is already on hand, without a network call.
 
@@ -426,7 +451,7 @@ def _dotted_version_variants(key: str) -> list[str]:
     return variants
 
 
-def _lookup_openrouter_entry(model: str, *, allow_fetch: bool = True) -> dict | None:
+def _lookup_openrouter_entry(model: str, *, allow_fetch: bool = True, table: dict | None = None) -> dict | None:
     """This model's row in OpenRouter's catalogue, or None.
 
     Only for ids that name OpenRouter. The table was once consulted for every id,
@@ -445,7 +470,8 @@ def _lookup_openrouter_entry(model: str, *, allow_fetch: bool = True) -> dict | 
     if not model.startswith("openrouter/"):
         return None
     key = model.removeprefix("openrouter/")
-    table = _fetch_openrouter_models() if allow_fetch else _cache_only_openrouter_models()
+    if table is None:
+        table = _fetch_openrouter_models() if allow_fetch else _cache_only_openrouter_models()
     for candidate in (key, *_dotted_version_variants(key)):
         entry = table.get(candidate)
         if entry is None and "/" in candidate:
@@ -455,9 +481,15 @@ def _lookup_openrouter_entry(model: str, *, allow_fetch: bool = True) -> dict | 
     return None
 
 
-def _try_openrouter_rates(model: str) -> tuple[float, float] | None:
-    """Look up live OpenRouter per-token rates. Returns rates or None."""
-    entry = _lookup_openrouter_entry(model)
+def _try_openrouter_rates(model: str, *, table: dict | None = None) -> tuple[float, float] | None:
+    """Look up live OpenRouter per-token rates. Returns rates or None.
+
+    ``table`` supplies an already-resolved catalogue, which is what the ladder's
+    first tier passes: pricing runs after every completion, on the event loop, and
+    must not be the thing that blocks a turn on an HTTP round-trip. Omitted, this
+    fetches as before.
+    """
+    entry = _lookup_openrouter_entry(model, table=table)
     if not entry:
         return None
     pricing = entry.get("pricing") or {}
@@ -492,12 +524,21 @@ def token_rates(model: str, input_tokens: int = 0, output_tokens: int = 0) -> tu
 
     Ladder, most authoritative first:
 
+    0. OpenRouter's own catalogue while it is still current, and only for ids
+       that name OpenRouter. Ahead of LiteLLM because the two questions come
+       apart here: LiteLLM routes the request, but OpenRouter is the party
+       *billing* it, and who sends is not who charges. Measured, they disagree --
+       LiteLLM files ``openrouter/z-ai/glm-4.6`` at 0.40/1.75 per million where
+       OpenRouter's own current table says 0.50/2.00, so the ladder under-reported
+       a real bill by a fifth. Fresh-only and never fetching: an expired copy is
+       not better evidence than the router's table, and answering from one would
+       suppress the refetch the expiry exists to trigger -- while a blocking fetch
+       here would be paid by the turn;
     1. LiteLLM's own table -- it also routes the request, so its answer and the
        call agree by construction;
-    2. OpenRouter's live catalogue, and only for ids that name OpenRouter. Ahead
-       of the snapshot because for those ids OpenRouter is the party doing the
-       billing, and its table is current where a bundled copy is from whenever it
-       was refreshed;
+    2. OpenRouter's live catalogue, fetching if needed, and still only for ids
+       that name OpenRouter. Ahead of the snapshot for the tier-0 reason, behind
+       LiteLLM because reaching the network is worse than a slightly stale row;
     3. the bundled models.dev snapshot, keyed by provider, which reaches vendors
        LiteLLM has not indexed without reading another vendor's row;
     4. the manual table above, for a model too new for all three.
@@ -520,7 +561,8 @@ def token_rates(model: str, input_tokens: int = 0, output_tokens: int = 0) -> tu
     rate for a 200k-token prompt is not always the rate for a short one.
     """
     return (
-        _try_litellm_rates(model, input_tokens, output_tokens)
+        _try_openrouter_rates(model, table=_fresh_openrouter_models())
+        or _try_litellm_rates(model, input_tokens, output_tokens)
         or _try_openrouter_rates(model)
         or _try_snapshot_rates(model)
         or _FALLBACK_PRICING.get(model.removeprefix("openrouter/"))

--- a/raven/tui_rpc/methods/session.py
+++ b/raven/tui_rpc/methods/session.py
@@ -142,27 +142,6 @@ async def _baseline_usage(
     }
 
 
-def _restore_session_model(agent_loop: "AgentLoop", session_key: str) -> None:
-    """Re-apply the model this session was last switched to.
-
-    Overrides live in the loop's memory, so a restart would otherwise move
-    every switched session back to the default. The session record is the only
-    place that choice survives, and this is the only reader of it.
-    """
-    restore = getattr(agent_loop, "restore_session_model", None)
-    sessions = getattr(agent_loop, "sessions", None)
-    if not callable(restore) or sessions is None:
-        return
-    try:
-        record = sessions.peek(session_key)
-    except Exception:
-        return
-    metadata = getattr(record, "metadata", None) or {}
-    model = metadata.get("model")
-    if model:
-        restore(session_key, model, metadata.get("provider"))
-
-
 async def _default_session_info(
     agent_loop: "AgentLoop | None",
     config: "Config",
@@ -340,8 +319,10 @@ async def session_resume(
     agent_loop = _safe_invoke_factory(agent_loop_factory)
     config = load_config()
     session_key = params.get("session_id")
-    if isinstance(session_key, str) and session_key and agent_loop is not None:
-        _restore_session_model(agent_loop, session_key)
+    # No restore call here: ``_default_session_info`` asks the loop for this
+    # session's model, and the loop reads the stored one on first ask. Restoring
+    # from this handler covered only the surface that calls it -- a conversation
+    # arriving on a channel came back on the default with its choice unread.
     info = await _default_session_info(agent_loop, config, session_key if isinstance(session_key, str) else None)
 
     if session_key:

--- a/tests/test_agent_loop_session_model.py
+++ b/tests/test_agent_loop_session_model.py
@@ -588,8 +588,9 @@ def test_a_restored_session_stays_on_the_default_once_cleared(tmp_path) -> None:
 
     End to end, not a guard on one line: the key is marked both where the record
     is read and where a caller supplies the pair, so removing either alone still
-    leaves this green. ``test_the_stored_model_is_read_once_per_session`` is what
-    pins the marking itself.
+    leaves this green. ``test_the_stored_model_is_read_once_per_session`` pins
+    the marking in ``_restore_once``; the redundant one in
+    ``restore_session_model`` is unpinned, and deleting it passes the suite.
 
     Named for what it does show, and not for a guarantee
     ``clear_session_binding`` does not give: it deliberately does not mark, so a

--- a/tests/test_agent_loop_session_model.py
+++ b/tests/test_agent_loop_session_model.py
@@ -583,9 +583,19 @@ def test_the_stored_model_is_read_once_per_session(tmp_path) -> None:
     assert reads == ["tui:a", "tui:never-switched"]
 
 
-def test_clearing_an_override_is_not_undone_by_the_stored_model(tmp_path) -> None:
-    """Dropping a session back to the default has to stick. Re-reading the
-    record on the next ask would restore the very choice just cleared.
+def test_a_restored_session_stays_on_the_default_once_cleared(tmp_path) -> None:
+    """What makes clearing stick is that the read happens once per key.
+
+    End to end, not a guard on one line: the key is marked both where the record
+    is read and where a caller supplies the pair, so removing either alone still
+    leaves this green. ``test_the_stored_model_is_read_once_per_session`` is what
+    pins the marking itself.
+
+    Named for what it does show, and not for a guarantee
+    ``clear_session_binding`` does not give: it deliberately does not mark, so a
+    session cleared without ever having been read would be read afterwards. No
+    caller creates one -- ``session.delete`` unlinks the record first -- which is
+    why the marking lives in the read rather than in the clear.
     """
     loop = _restorable_loop(tmp_path, {"tui:a": {"model": "claude-sonnet-4-5", "provider": "anthropic"}})
 

--- a/tests/test_agent_loop_session_model.py
+++ b/tests/test_agent_loop_session_model.py
@@ -519,6 +519,95 @@ def test_a_stored_model_that_cannot_be_built_leaves_the_default(tmp_path) -> Non
     assert not loop.has_session_binding("tui:a")
 
 
+def _restorable_loop(tmp_path, stored: dict[str, dict[str, str]]) -> AgentLoop:
+    """A loop whose session store already holds someone's earlier choice."""
+    from raven.config.schema import Config
+    from raven.providers.pool import ProviderPool
+
+    cfg = Config()
+    cfg.agents.defaults.model = "claude-opus-4-5"
+    cfg.providers.anthropic.api_key = "sk-ant"
+    loop = AgentLoop(
+        provider=_Provider("boot"),
+        workspace=tmp_path,
+        model="boot/model",
+        context_config=ContextConfig(),
+        skill_forge_config=SkillForgeConfig(),
+        provider_pool=ProviderPool(cfg),
+    )
+    for key, metadata in stored.items():
+        record = loop.sessions.get_or_create(key)
+        record.metadata.update(metadata)
+        loop.sessions.save(record)
+    return loop
+
+
+async def test_a_channel_turn_restores_the_model_that_session_chose(tmp_path) -> None:
+    """The reason the read moved onto the loop. It used to hang off
+    ``session.resume``, so only the TUI got it: a conversation arriving from a
+    channel came back on the default after a restart, with its own choice
+    sitting unread in its own record. No resume call anywhere in this test.
+    """
+    loop = _restorable_loop(tmp_path, {"whatsapp:alice": {"model": "claude-sonnet-4-5", "provider": "anthropic"}})
+
+    seen: list[str] = []
+
+    async def body(*a, **k):
+        seen.append(loop.model)
+        return None
+
+    await _run(loop, "whatsapp:alice", body)
+
+    assert seen == ["claude-sonnet-4-5"]
+
+
+def test_the_stored_model_is_read_once_per_session(tmp_path) -> None:
+    """Most sessions never switched, and the miss has to be remembered too --
+    otherwise every turn of every unswitched conversation re-reads a record to
+    learn the same nothing.
+    """
+    loop = _restorable_loop(tmp_path, {"tui:a": {"model": "claude-sonnet-4-5", "provider": "anthropic"}})
+    reads: list[str] = []
+    real_peek = loop.sessions.peek
+
+    def counting_peek(key: str):
+        reads.append(key)
+        return real_peek(key)
+
+    loop.sessions.peek = counting_peek
+
+    for _ in range(3):
+        loop.session_model("tui:a")
+        loop.session_model("tui:never-switched")
+
+    assert reads == ["tui:a", "tui:never-switched"]
+
+
+def test_clearing_an_override_is_not_undone_by_the_stored_model(tmp_path) -> None:
+    """Dropping a session back to the default has to stick. Re-reading the
+    record on the next ask would restore the very choice just cleared.
+    """
+    loop = _restorable_loop(tmp_path, {"tui:a": {"model": "claude-sonnet-4-5", "provider": "anthropic"}})
+
+    assert loop.session_model("tui:a") == "claude-sonnet-4-5"
+    loop.clear_session_binding("tui:a")
+
+    assert loop.session_model("tui:a") == "boot/model"
+    assert not loop.has_session_binding("tui:a")
+
+
+def test_has_session_binding_sees_a_choice_that_only_exists_on_disk(tmp_path) -> None:
+    """``model.options`` asks this to decide whether to report the session's own
+    model or the configured default. Answered without the restore, a session
+    that switched before a restart is reported as having inherited the default,
+    and the picker stars the wrong row.
+    """
+    loop = _restorable_loop(tmp_path, {"tui:a": {"model": "claude-sonnet-4-5", "provider": "anthropic"}})
+
+    assert loop.has_session_binding("tui:a")
+    assert not loop.has_session_binding("tui:b")
+
+
 def test_has_session_binding_distinguishes_chosen_from_inherited(tmp_path) -> None:
     """``session_model`` falls back to the default, so it cannot answer this --
     and callers that override a forced provider need the difference.

--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -783,6 +783,74 @@ def test_the_fix_writer_survives_a_mode_it_cannot_read(tmp_path, monkeypatch) ->
     assert json.loads(cfg.read_text())["agents"]["defaults"]["model"] == "x/y"
 
 
+def test_doctor_reports_a_config_that_names_no_provider(tmp_path) -> None:
+    """The check that had to wait for the explicit-provider rule.
+
+    Before it, ``provider`` defaulted to ``auto`` and blank never happened. After
+    it, blank means the load-time migration could not resolve the vendor -- so
+    every call falls back to deriving it from the model id, which is the guess
+    the rule exists to end.
+
+    The fixture has to be genuinely unresolvable, which is the check's whole
+    scope: with a configured vendor that serves the model, the migration fills
+    the blank in during ``load_config`` and there is nothing left to report.
+    """
+    from raven.cli.doctor_commands import _inspect_config_health
+    from raven.config.loader import load_config
+
+    cfg = tmp_path / ".raven" / "config.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        json.dumps({"agents": {"defaults": {"model": "some/unclaimed-model", "provider": ""}}}),
+        encoding="utf-8",
+    )
+
+    health = _inspect_config_health(load_config(cfg), fix=False)
+
+    assert any("provider is not set" in f for f in health.findings)
+    assert any("raven provider use" in f for f in health.findings)
+    # Reported, never fixed: the migration already tried the derivation and had
+    # no answer, so only the user knows which vendor they meant to pay.
+    assert not health.fixes
+
+
+def test_doctor_reports_a_provider_nothing_routes_to(tmp_path) -> None:
+    """A typo written before `provider use` started checking the name. Every
+    call then resolves against a vendor that does not exist.
+    """
+    from raven.cli.doctor_commands import _inspect_config_health
+    from raven.config.loader import load_config
+
+    cfg = _pinned_config(tmp_path)
+    raw = json.loads(cfg.read_text())
+    raw["agents"]["defaults"]["provider"] = "antropic"
+    cfg.write_text(json.dumps(raw), encoding="utf-8")
+
+    health = _inspect_config_health(load_config(cfg), fix=False)
+
+    assert any("nothing routes to" in f for f in health.findings)
+    assert not health.fixes
+
+
+def test_doctor_accepts_a_vendor_only_litellm_knows(tmp_path) -> None:
+    """The counterweight. Raven carries no spec for mistral, so "no spec of
+    ours" cannot be the test -- reporting it as broken would be worse than
+    saying nothing.
+    """
+    from raven.cli.doctor_commands import _inspect_config_health
+    from raven.config.loader import load_config
+
+    cfg = _pinned_config(tmp_path)
+    raw = json.loads(cfg.read_text())
+    raw["agents"]["defaults"]["provider"] = "mistral"
+    raw["agents"]["defaults"]["model"] = "mistral/mistral-large-latest"
+    cfg.write_text(json.dumps(raw), encoding="utf-8")
+
+    health = _inspect_config_health(load_config(cfg), fix=False)
+
+    assert health.findings == []
+
+
 def test_doctor_prints_the_config_section_it_found(tmp_path, monkeypatch, capsys) -> None:
     """The renderer, not just the check: a finding nothing prints is a finding
     the user never gets."""

--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -814,6 +814,37 @@ def test_doctor_reports_a_config_that_names_no_provider(tmp_path) -> None:
     assert not health.fixes
 
 
+def test_doctor_reads_a_leftover_auto_as_unset_not_as_a_typo(tmp_path) -> None:
+    """`auto` is the state this check exists for, and it is reachable.
+
+    `_migrate_auto_provider` leaves the literal in place when it cannot resolve a
+    vendor, so a config can still say `auto` after `load_config` -- and
+    `Config._match_provider` already treats it as unset (`forced != "auto"`).
+    Read as a name instead, it is unroutable, and the user is told to fix a typo
+    they did not make while the advice that would help goes unsaid.
+
+    Neither of the checks around this one used a literal `auto`, which is how
+    the gap survived to review.
+    """
+    from raven.cli.doctor_commands import _inspect_config_health
+    from raven.config.loader import load_config
+
+    cfg = tmp_path / ".raven" / "config.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        json.dumps({"agents": {"defaults": {"model": "some/unclaimed-model", "provider": "auto"}}}),
+        encoding="utf-8",
+    )
+
+    health = _inspect_config_health(load_config(cfg), fix=False)
+
+    assert any("provider is not set" in f for f in health.findings)
+    assert any("raven provider use" in f for f in health.findings)
+    assert any("retired spelling of unset" in f for f in health.findings)
+    assert not any("nothing routes to" in f for f in health.findings)
+    assert not health.fixes
+
+
 def test_doctor_reports_a_provider_nothing_routes_to(tmp_path) -> None:
     """A typo written before `provider use` started checking the name. Every
     call then resolves against a vendor that does not exist.

--- a/tests/test_cli_provider_commands.py
+++ b/tests/test_cli_provider_commands.py
@@ -744,6 +744,32 @@ def test_use_refuses_an_id_that_names_no_provider(tmp_config: Path) -> None:
     assert not tmp_config.exists(), "a refused switch must not write a config"
 
 
+def test_use_refuses_a_misspelled_provider_before_it_writes(tmp_config: Path) -> None:
+    """A typo used to exit 0 with the config already changed, and the credential
+    warning that followed told the user to run
+    `raven provider set antropic --api-key ...` -- which would have created a
+    section for a vendor nothing routes to. The name is checked before the write,
+    the same test `provider set` already applies.
+    """
+    r = runner.invoke(app, ["provider", "use", "claude-opus-4-5", "--provider", "antropic"])
+
+    assert r.exit_code == 1, r.output
+    assert "antropic" in r.output
+    assert not tmp_config.exists(), "a refused switch must not write a config"
+
+
+def test_use_still_accepts_a_vendor_only_litellm_knows(tmp_config: Path) -> None:
+    """The counterweight to the check above. Raven carries no spec for mistral,
+    so "no spec" cannot be the typo test -- refusing on it would block every
+    passthrough vendor the config documents as supported.
+    """
+    r = runner.invoke(app, ["provider", "use", "mistral-large-latest", "--provider", "mistral"])
+
+    assert r.exit_code == 0, r.output
+    defaults = json.loads(tmp_config.read_text(encoding="utf-8"))["agents"]["defaults"]
+    assert defaults["provider"] == "mistral"
+
+
 def test_use_moves_the_pin_instead_of_reporting_that_it_is_stuck(tmp_config: Path) -> None:
     """A write that changes nothing must not report success and stop there.
 

--- a/tests/test_provider_pool.py
+++ b/tests/test_provider_pool.py
@@ -305,6 +305,35 @@ def test_a_re_reading_supplier_still_reuses_bindings() -> None:
     assert pool.bind("claude-opus-4-5") is first
 
 
+def test_an_edited_window_drops_the_binding_that_carried_the_old_one() -> None:
+    """The cache key has to cover the whole cached value, not just the credential.
+
+    ``bind`` copies ``contextWindowTokens`` onto the binding, so a key made only
+    of credentials leaves a stale binding answering with the old number until a
+    restart -- the "I changed it and nothing happened" shape the window ladder
+    exists to prevent, arriving through the cache instead.
+    """
+    from raven.providers.pool import ProviderPool
+
+    state = {"window": None}
+
+    def _fresh():
+        cfg = _config(anthropic="sk-ant")
+        cfg.agents.defaults.context_window_tokens = state["window"]
+        return cfg
+
+    pool = ProviderPool(_fresh)
+    first = pool.bind("claude-opus-4-5")
+    assert first.configured_window is None
+
+    state["window"] = 32768
+    second = pool.bind("claude-opus-4-5")
+
+    assert second is not first, "the stale binding was reused"
+    assert second.configured_window == 32768
+    assert second.context_window == 32768
+
+
 def test_a_gateway_pin_that_cannot_be_built_is_reported_not_raised(monkeypatch) -> None:
     """The gateway branch is reached from the factory at construction too, so
     it needs the same guard as the direct-vendor branch -- otherwise a missing

--- a/tests/test_provider_rates.py
+++ b/tests/test_provider_rates.py
@@ -177,6 +177,68 @@ def test_a_network_failure_falls_through_to_the_bundled_copy(monkeypatch):
     assert token_rates("openrouter/nobody/has-heard-of-this", 1000, 500) is None
 
 
+def test_the_gateway_price_wins_over_the_routers_copy(monkeypatch):
+    """Who sends the request is not who bills for it.
+
+    LiteLLM routes an ``openrouter/`` id and also carries a row for it, so its
+    answer used to win -- but OpenRouter is the party charging, and the two
+    disagree. Measured on the pinned LiteLLM: ``openrouter/z-ai/glm-4.6`` is
+    filed at 0.40/1.75 per million where OpenRouter's own table says 0.50/2.00,
+    so every such call was under-reported by a fifth.
+
+    A model LiteLLM knows is used deliberately: with one it does not, tier 1
+    misses and the old order would pass this too.
+    """
+    router = rates._try_litellm_rates("openrouter/openai/gpt-4.1", 1000, 500)
+    assert router, "fixture needs a model LiteLLM prices under its openrouter id"
+
+    gateway_prompt, gateway_completion = router[0] * 2, router[1] * 2
+    _patch_openrouter(
+        monkeypatch,
+        lambda req: _models_response(
+            [
+                {
+                    "id": "openai/gpt-4.1",
+                    "pricing": {"prompt": str(gateway_prompt), "completion": str(gateway_completion)},
+                }
+            ]
+        ),
+    )
+    rates._fetch_openrouter_models()  # tier 0 is cache-only; warm it as a real run does
+
+    assert token_rates("openrouter/openai/gpt-4.1", 1000, 500) == (gateway_prompt, gateway_completion)
+
+
+def test_a_direct_id_is_never_priced_from_the_gateways_table(monkeypatch):
+    """The other half. Reading OpenRouter's row for an id that does not name it
+    is what priced a self-hosted deployment at a hosted model's rate, and tier 0
+    must not reintroduce it.
+    """
+    _patch_openrouter(
+        monkeypatch,
+        lambda req: _models_response([{"id": "openai/gpt-4.1", "pricing": {"prompt": "999", "completion": "999"}}]),
+    )
+    rates._fetch_openrouter_models()
+
+    direct = token_rates("openai/gpt-4.1", 1000, 500)
+
+    assert direct is not None
+    assert direct != (999.0, 999.0)
+
+
+def test_the_price_ladder_never_fetches_on_its_first_tier(monkeypatch):
+    """Pricing runs after every call, inside the turn. Tier 0 reads a catalogue
+    already in hand; making it fetch would put an HTTP round-trip on the path of
+    every completion.
+    """
+    counter = _patch_openrouter(monkeypatch, lambda req: _models_response(_DEEPSEEK_MODELS))
+
+    # A model LiteLLM knows, so tier 1 answers and tiers 2+ never run.
+    assert token_rates("openrouter/openai/gpt-4.1", 1000, 500) is not None
+
+    assert counter["calls"] == 0
+
+
 def test_the_live_table_is_fetched_once_and_reused(monkeypatch):
     counter = _patch_openrouter(monkeypatch, lambda req: _models_response(_DEEPSEEK_MODELS))
 

--- a/tests/test_provider_resolution_invariants.py
+++ b/tests/test_provider_resolution_invariants.py
@@ -716,3 +716,75 @@ def test_a_lazy_provider_answers_with_its_inner_s_wire_id() -> None:
 
     assert lazy.wire_model_id("openai/gpt-4o") == inner.wire_model_id("openai/gpt-4o")
     assert lazy.wire_model_id("openai/gpt-4o") == "openrouter/openai/gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# The pair rule, enforced across every writer rather than at the one that broke
+# ---------------------------------------------------------------------------
+
+
+def test_no_surface_writes_the_default_model_without_naming_its_provider():
+    """The model and the provider serving it are written together, everywhere.
+
+    This guard used to live in ``tests/test_provider_pin.py`` and was deleted
+    with that file when ``providers/pin.py`` went away. Only half of its message
+    was obsolete -- "decide the pin with ``pin.resolve``" -- while the rule it
+    enforces became *more* central, not less: a provider is now a word the user
+    says, and this is the only place a machine checks that no surface writes the
+    model while leaving the provider to whatever it was.
+
+    That hole was real. It was fixed at one call site and stayed open at four
+    others: ``raven provider use`` was taught to write the provider, and the
+    warning about a stale one was deleted as impossible, while onboarding still
+    wrote the model through its own helper and left the provider alone -- so
+    finishing the wizard on Anthropic with DeepSeek configured sent Anthropic's
+    model to DeepSeek, with DeepSeek's key.
+
+    Scanned rather than asserted per call site, because the next writer is the
+    one nobody thought of -- and **both spellings count**. An earlier version
+    looked only for ``set_default_model`` and was therefore blind to
+    ``tui_rpc/methods/config.py``, which writes the same field through
+    ``_set_nested`` and happens to be correct.
+    """
+    import ast
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[1] / "raven"
+    definition = root / "config" / "update.py"
+    offenders: list[str] = []
+
+    for path in sorted(root.rglob("*.py")):
+        if path == definition:
+            continue  # the function itself
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        # A *write* of the provider, not a mention of it. Keying on the string
+        # alone was satisfied by the ``_get_nested(payload,
+        # "agents.defaults.provider")`` read two lines above the write, so it
+        # exempted the very file its docstring names -- deleting both writes
+        # there left it green.
+        writes_provider = any(
+            isinstance(call, ast.Call)
+            and any(isinstance(a, ast.Constant) and a.value == "agents.defaults.provider" for a in call.args)
+            and (call.func.attr if isinstance(call.func, ast.Attribute) else getattr(call.func, "id", ""))
+            in {"_set_nested", "set_nested"}
+            for call in ast.walk(tree)
+        )
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = node.func.attr if isinstance(node.func, ast.Attribute) else getattr(node.func, "id", "")
+
+            if name == "set_default_model":
+                if not any(kw.arg == "provider" for kw in node.keywords):
+                    offenders.append(f"{path.relative_to(root.parent)}:{node.lineno} (set_default_model)")
+                continue
+
+            targets = [a.value for a in node.args if isinstance(a, ast.Constant) and isinstance(a.value, str)]
+            if "agents.defaults.model" in targets and not writes_provider:
+                offenders.append(f"{path.relative_to(root.parent)}:{node.lineno} (raw key write)")
+
+    assert not offenders, (
+        "these write the model and leave the provider to whatever it was. A model id does not "
+        "name whose credential serves it, so write both -- pass provider= to set_default_model, "
+        "or write agents.defaults.provider alongside the raw key:\n" + "\n".join(offenders)
+    )

--- a/tests/test_tui_rpc_session.py
+++ b/tests/test_tui_rpc_session.py
@@ -1177,54 +1177,35 @@ async def test_session_info_without_a_session_reports_the_default() -> None:
     assert info["model"] == config.agents.defaults.model
 
 
-async def test_session_resume_puts_the_session_back_on_its_stored_model(tmp_path) -> None:
-    """The handler, not the helper: a resume that stops passing the session key
-    would leave every restored session on the default with the suite green.
+async def test_session_resume_reports_the_model_the_loop_restored(tmp_path) -> None:
+    """The handler no longer restores anything -- the loop reads the stored model
+    on first ask, which is what makes the choice survive on every surface and not
+    only on the one that calls this handler. What the handler still owes is
+    passing the session key down, so the bundle reports *this* session's model
+    instead of the configured default.
     """
-    from unittest.mock import MagicMock
-
     from raven.session.manager import SessionManager
     from raven.tui_rpc.methods.session import session_resume
 
     sessions = SessionManager(tmp_path)
     record = sessions.get_or_create("tui:a")
     record.metadata["model"] = "vendor-a/model"
-    record.metadata["provider"] = "anthropic"
     sessions.save(record)
 
-    restored: list[tuple[str, str, str | None]] = []
+    from unittest.mock import MagicMock
+
+    asked: list[str] = []
     loop = MagicMock()
     loop.sessions = sessions
     # A real id, not the MagicMock default: the init bundle resolves a window
     # from whatever the loop reports as its model.
     loop.model = "vendor-a/model"
-    loop.restore_session_model = lambda key, model, provider=None: restored.append((key, model, provider))
-    loop.session_model = lambda key: "vendor-a/model"
+    loop.session_model = lambda key: (asked.append(key), "vendor-a/model")[1]
 
-    await session_resume({"session_id": "tui:a"}, agent_loop_factory=lambda: loop)
+    result = await session_resume({"session_id": "tui:a"}, agent_loop_factory=lambda: loop)
 
-    assert restored == [("tui:a", "vendor-a/model", "anthropic")]
-
-
-async def test_session_resume_without_a_stored_model_restores_nothing(tmp_path) -> None:
-    from unittest.mock import MagicMock
-
-    from raven.session.manager import SessionManager
-    from raven.tui_rpc.methods.session import session_resume
-
-    sessions = SessionManager(tmp_path)
-    sessions.save(sessions.get_or_create("tui:a"))
-
-    restored: list[object] = []
-    loop = MagicMock()
-    loop.sessions = sessions
-    loop.model = "vendor-a/model"
-    loop.restore_session_model = lambda *a, **k: restored.append(a)
-    loop.session_model = lambda key: "boot/model"
-
-    await session_resume({"session_id": "tui:a"}, agent_loop_factory=lambda: loop)
-
-    assert restored == []
+    assert asked == ["tui:a"], "the handler stopped passing the session key down"
+    assert result["info"]["model"] == "vendor-a/model"
 
 
 async def test_session_branch_carries_the_parents_model_to_the_child(


### PR DESCRIPTION
## Summary

Six follow-ups from #284's review rounds. Five are defects in what that PR itself added or removed and were deliberately deferred rather than rushed into a diff already under review; the sixth is a check #346 wrote down as belonging here, because it only becomes a real state once the provider is explicit.

**A session's model now survives a restart on every surface, not only in the TUI.** The read half of the persistence hung off `session.resume`, so only the surface that calls that handler got it: a conversation arriving from a channel came back on the configured default with its own choice sitting unread in its own session record. The read moves onto the loop, where every entry point already goes, and the handler's duplicate copy is gone -- one reader instead of two. `has_session_binding` restores first as well, or a session that switched before a restart reports as having inherited the default and the picker stars the wrong row. `clear_session_binding` counts as having consulted the record, so returning a session to the default is not undone by the next read.

**`raven provider use` refuses an unroutable provider before it writes.** A typo exited 0 with the config already changed, then printed a credential warning suggesting `raven provider set <typo> --api-key ...` -- advice that would have created a section for a vendor nothing routes to. `provider set` already applied the right test before writing a section; it is exposed as `ensure_routable_provider` and called first, which is the order the TUI's `/model` already used. Only an unroutable *name* is refused: a known provider with no credentials yet is still written and reported, because picking a model before configuring its key is a normal order to do things in. "No spec of ours" cannot be the typo test either -- Raven carries none for mistral or xai, and refusing on it would block every passthrough vendor the config documents as supported.

**The guard that keeps a model and its provider paired has a home again.** A whole-repo AST scan failing any `set_default_model` without `provider=`, and any raw `agents.defaults.model` write not paired with a provider write, lived in `tests/test_provider_pin.py` and was deleted with that file. Only half its message was obsolete; the rule it enforces became more central, and it is the only place a machine checks it. `test_provider_resolution_invariants.py` is where the other source guards of this kind already live.

**The binding cache is keyed on everything it caches.** The fingerprint covered `config.providers`, but `bind` also copies `contextWindowTokens` onto the binding, so editing that number left a stale binding answering with the old one until a restart -- the "I changed it and nothing happened" shape the window ladder exists to prevent, arriving through the cache instead.

**A gateway call is priced from the gateway's own table.** Who routes a request is not who bills for it. LiteLLM answered first for every id, including one naming a gateway, and the two disagree: measured on the pinned LiteLLM, `openrouter/z-ai/glm-4.6` is filed at 0.40/1.75 per million where OpenRouter's own current table says 0.50/2.00, so every such call was reported a fifth under its real cost. OpenRouter's catalogue now answers ahead of LiteLLM for ids that name it, fresh-only and never fetching: an expired copy is not better evidence than the router's table and would suppress the refetch the expiry exists to trigger, while a blocking fetch would be paid by the turn this runs after. Unchanged for a direct id, which is what once priced a self-hosted deployment at a hosted model's rate.

**`raven doctor` can ask about a provider nothing resolved.** #346 deferred this with its reason: before the explicit-provider rule, the field defaulted to `auto` and blank never happened. Now blank means the load-time migration tried the derivation and had no answer. Two findings -- blank, and a name nothing routes to -- both report-only. Neither is offered to `--fix`, and that is not an omission: only the user knows which vendor they meant to pay, and the migration has already tried. Guessing again under the name `--fix` would be the same guess wearing more confidence.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

```
pytest tests/                     6477 passed, 43 skipped, 13 deselected   (TERM=dumb)
ruff check / format --check       clean, 832 files formatted
npx tsc --noEmit (ui-tui)         clean
npm test (ui-tui)                 998 passed (87 files)
commitlint + check_commit_messages.py    clean over github/main..HEAD
npm run lint:rpc                  generated.ts in sync
commitlint + check_commit_messages.py   clean over github/main..HEAD
```

Every fix is mutation-checked rather than assumed -- reverting it turns the new test red. That is worth naming for two of them, where writing the test taught something the fix alone did not:

- The doctor check's scope is narrower than it looks. With a configured vendor that serves the model, the migration fills the blank during `load_config` and there is nothing left to report, so the fixture has to be genuinely unresolvable -- which is exactly when the finding is real.
- The first attempt at the pricing tier read the any-age cache and made a stale disk copy outrank a refetch. `test_expired_disk_triggers_refetch` caught it, which is why the tier is fresh-only.

Three review rounds landed on this PR after it opened, each fixed and each verified rather than
taken from the report:

- **Blocking:** the doctor provider check read a leftover `auto` as an unroutable vendor name. That
  is the legacy state the check exists for -- `_migrate_auto_provider` leaves the literal in place
  when it cannot resolve one -- so the user was told to fix a typo they did not make. It now matches
  `Config._match_provider`'s own `forced != "auto"` test, and says the word is retired rather than
  merely ignoring it. Neither neighbouring test used a literal `auto`, which is how the branch
  between them went unentered.
- `_restore_attempted.add` in `clear_session_binding` was inert, and its stated reason did not hold
  for the only caller: `session.delete` unlinks the record before the clear runs. Dropped rather than
  relocated -- marking in `set_session_binding` would claim the record had been consulted when it had
  not. The test that was supposed to guard it is renamed and its docstring now scopes what it does
  and does not pin.
- `_routes_anywhere` caught `Exception` where the sibling check catches `KeyError`, and the new
  refusal printed a different failure marker from the eleven others in its file.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

Two user-visible changes, both deliberate:

`raven provider use` now exits 1 on a provider name nothing routes to, where it used to exit 0 with the config already written. A script passing a misspelled `--provider` starts failing; a script passing a real one is unaffected, including for a passthrough vendor.

Cost figures change for calls made through OpenRouter on ids where its catalogue and LiteLLM's copy disagree. The new number is the one the gateway bills, so this corrects a systematic under-report rather than introducing a new figure -- but a user comparing today's total to yesterday's will see the step.

Rollback: revert the commits. Nothing here writes a new field or changes a stored shape, so a revert needs no migration.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A -- follow-ups from the review of #284, which is merged.

