### PR TITLE
fix(*): report an invalid memory identity as the config error it is

### DIFF
--- a/raven/cli/import_commands.py
+++ b/raven/cli/import_commands.py
@@ -115,6 +115,12 @@ def _require_memory_service_ready(backend: object) -> None:
 
     if state is ServiceState.READY:
         return
+    if state is ServiceState.BAD_IDENTITY:
+        # A config error, not an outage: the server log holds nothing about it,
+        # and start() has already printed the key to edit.
+        console.print("[red]Memory identity is invalid; nothing would be imported.[/red]")
+        console.print("[dim]Fix memory.userId / memory.agentId in your config.json, then: raven import run[/dim]")
+        raise typer.Exit(1)
     from raven.plugin.memory.everos._server import server_log_path
 
     console.print(f"[red]Memory service is not available ({state.value}); nothing would be imported.[/red]")

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -137,9 +137,10 @@ class ServiceState(Enum):
 
     Two axes are folded into one enum because callers only ever act on the
     combination: may I send a request, and is it worth probing again. The
-    states that answer "no" to both -- ``UNCONFIGURED`` and ``NO_BINARY`` --
-    describe the installation rather than the process, so no amount of probing
-    resolves them and a stray success must not clear them.
+    states that answer "no" to both -- ``UNCONFIGURED``, ``NO_BINARY`` and
+    ``BAD_IDENTITY`` -- describe the installation and its config rather than
+    the process, so no amount of probing resolves them and a stray success must
+    not clear them.
     """
 
     UNKNOWN = "unknown"
@@ -149,13 +150,14 @@ class ServiceState(Enum):
     UNRESPONSIVE = "unresponsive"
     UNCONFIGURED = "unconfigured"
     NO_BINARY = "no_binary"
+    BAD_IDENTITY = "bad_identity"
     FOREIGN = "foreign"
 
 
 # Probing cannot change these: they are facts about the install, not the
 # process. Letting a probe promote out of them would hide a missing binary
 # behind somebody else's server answering on the same port.
-_TERMINAL_STATES = frozenset({ServiceState.UNCONFIGURED, ServiceState.NO_BINARY})
+_TERMINAL_STATES = frozenset({ServiceState.UNCONFIGURED, ServiceState.NO_BINARY, ServiceState.BAD_IDENTITY})
 
 # Only the opening state may spawn. Every other non-ready state has already
 # either spawned once (STARTING / FAILED), found the data occupied
@@ -169,7 +171,7 @@ _PROBE_MIN_INTERVAL_S: float = 2.0
 # States where no write was ever going to land, so nothing was lost. Reporting
 # a loss here would tell an install that never configured a memory LLM that it
 # dropped turns of memory it never had.
-_NEVER_HAD_MEMORY = frozenset({ServiceState.UNCONFIGURED, ServiceState.NO_BINARY})
+_NEVER_HAD_MEMORY = frozenset({ServiceState.UNCONFIGURED, ServiceState.NO_BINARY, ServiceState.BAD_IDENTITY})
 
 
 class _HttpEverosAdapter:
@@ -548,7 +550,29 @@ class EverosBackend:
     # ── Lifecycle ───────────────────────────────────────────────────
 
     async def start(self) -> None:
-        self._validate_identity()
+        try:
+            self._validate_identity()
+        except ValueError as e:
+            # Caught here rather than left to the callers: all four of them fold
+            # it into ``logger.exception``, and a one-shot CLI run writes no log
+            # file, so the one message that names the key to edit reached nobody.
+            # Leaving ``_state`` unset was the other half -- ``store`` then filed
+            # a config error under the dropped-write counter and told the user
+            # the service was unavailable, which sent them to a server that was
+            # never broken.
+            from rich.console import Console
+            from rich.markup import escape
+
+            self._state = ServiceState.BAD_IDENTITY
+            # Escaped: the message quotes the accepted-character class, and rich
+            # reads "[a-zA-Z0-9_.@+-]" as a markup tag and eats it -- leaving the
+            # user the pattern "^+$" to match their id against.
+            Console(stderr=True).print(
+                f"[yellow]Long-term memory is off: {escape(str(e))}[/yellow]\n"
+                "[dim]Fix memory.userId / memory.agentId in your config.json, "
+                "then start a new session.[/dim]"
+            )
+            return
         self._logger.info(
             "EverosBackend.start (adapter=%s)",
             type(self._adapter).__name__,

--- a/tests/test_cli_import_commands.py
+++ b/tests/test_cli_import_commands.py
@@ -998,6 +998,24 @@ class TestImportRefusesToRunWithoutMemory:
         with pytest.raises(typer.Exit):
             _require_memory_service_ready(_NotReady())
 
+    def test_a_bad_identity_does_not_send_the_user_to_the_server_log(self, capsys: pytest.CaptureFixture) -> None:
+        """The service is fine; the config is not. Its log holds nothing about
+        this, and start() already printed the key to edit."""
+        import typer
+
+        from raven.cli.import_commands import _require_memory_service_ready
+        from raven.plugin.memory.everos.backend import ServiceState
+
+        class _BadIdentity:
+            _state = ServiceState.BAD_IDENTITY
+
+        with pytest.raises(typer.Exit):
+            _require_memory_service_ready(_BadIdentity())
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "server log" not in out
+        assert "memory.userId" in out
+
     def test_a_ready_backend_passes(self) -> None:
         from raven.cli.import_commands import _require_memory_service_ready
         from raven.plugin.memory.everos.backend import ServiceState

--- a/tests/test_everos_backend.py
+++ b/tests/test_everos_backend.py
@@ -1037,16 +1037,47 @@ class TestIdentityFromServices:
         assert not [r for r in caplog.records if r.levelname == "WARNING"]
 
     @pytest.mark.parametrize("bad", ["agent:default", "a/b", "..", "."])
-    async def test_illegal_identity_rejected_on_start(self, tmp_path: Path, bad: str) -> None:
+    async def test_illegal_identity_is_reported_as_a_config_error(
+        self, tmp_path: Path, bad: str, capsys: pytest.CaptureFixture
+    ) -> None:
+        from raven.plugin.memory.everos.backend import ServiceState
+
         ctx = PluginContext(
             config={},
             services=ServiceLocator(workspace=tmp_path, user_id=bad, agent_id="default"),
         )
         backend = make_backend(ctx)
+        await backend.start()
+
         # The message must name the on-disk camelCase key so the user can grep
-        # for it in config.json.
-        with pytest.raises(ValueError, match="memory.userId"):
-            await backend.start()
+        # for it in config.json, and it must reach the terminal: the callers all
+        # swallow a raise into logger.exception, and a one-shot CLI run writes no
+        # log file for it to land in.
+        err = " ".join(capsys.readouterr().err.split())
+        assert "memory.userId" in err
+        # The accepted-character class must survive rich's markup parser: it
+        # looks exactly like a tag, and a swallowed one leaves the user matching
+        # their id against "^+$".
+        assert "[a-zA-Z0-9_.@+-]" in err
+        assert backend._state is ServiceState.BAD_IDENTITY
+
+    async def test_illegal_identity_does_not_report_a_service_outage(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """The service is fine; the config is not. Counting the turn as a dropped
+        write sends the user to look at a server that never broke."""
+        ctx = PluginContext(
+            config={},
+            services=ServiceLocator(workspace=tmp_path, user_id="a/b", agent_id="default"),
+        )
+        backend = make_backend(ctx)
+        await backend.start()
+        capsys.readouterr()
+
+        assert await backend.store("s1", [{"role": "user", "content": "hi"}]) is False
+        assert backend._dropped_writes == 0
+        await backend.stop()
+        assert "unavailable" not in capsys.readouterr().err
 
 
 class TestServiceStateMachine:
@@ -1158,12 +1189,13 @@ class TestServiceStateMachine:
             assert b._state is ServiceState.READY, start
 
     def test_terminal_states_ignore_probes(self) -> None:
-        """UNCONFIGURED and NO_BINARY describe the install, not the process.
-        Probing cannot fix either, so a stray OK must not paper over them."""
+        """UNCONFIGURED, NO_BINARY and BAD_IDENTITY describe the install and its
+        config, not the process. Probing cannot fix any of them, so a stray OK
+        must not paper over them."""
         from raven.plugin.memory.everos._server import ProbeResult
         from raven.plugin.memory.everos.backend import ServiceState
 
-        for terminal in (ServiceState.UNCONFIGURED, ServiceState.NO_BINARY):
+        for terminal in (ServiceState.UNCONFIGURED, ServiceState.NO_BINARY, ServiceState.BAD_IDENTITY):
             b = self._backend()
             b._state = terminal
             b._apply_probe(ProbeResult.OK)


### PR DESCRIPTION
## Summary

An identity EverOS cannot accept becomes a directory segment on its write path, so `EverosBackend.start()` rejects it. The rejection carried the one message a user can act on -- it names the key and the accepted pattern -- and no surface delivered it as one. Three of the four call sites fold the raise into `logger.exception`; under the TUI loguru is file-only, so there an invalid identity turned memory off with nothing on screen. The fourth, in `import_commands._build_and_run`, is not wrapped at all, so the `ValueError` escaped as a bare traceback. Where it was visible it was a traceback, which is not a thing a user reads as "edit this key".

The state machine then told the user the opposite of the truth. `start()` died before assigning a state, so `_state` stayed `UNKNOWN`, which is not in `_NEVER_HAD_MEMORY`; every `store()` after it counted a dropped write, and the session ended with:

```
1 turn(s) were not written to long-term memory because the memory service was
unavailable.
```

The service was fine. That sends the user to debug a server that never broke.

**The change.** Catch the `ValueError` in `start()`, give it a `BAD_IDENTITY` state, and file that state with the other two the user must fix themselves:

- terminal, so a stray probe cannot promote it to `READY`;
- never-had-memory, so no dropped-write count and no outage wording;
- the message goes to stderr, matching what the unconfigured-LLM and missing-binary paths beside it already do.

Two things came out of running it rather than reading it:

1. **The message needs escaping.** It quotes the accepted-character class, and rich reads `[a-zA-Z0-9_.@+-]` as a markup tag and eats it, leaving the user the pattern `^+$` to match their id against. The test now pins the full class.
2. **`raven import` had the same defect on its own gate.** It kept the outage wording and pointed at the server log, which holds nothing about a config error. It now names the config keys instead.

Before / after, same config (`memory.userId: "bad/id"`), same command:

```
- 1 turn(s) were not written to long-term memory because the memory service was
- unavailable.

+ Long-term memory is off: memory.userId='bad/id' is not accepted by EverOS: it
+ becomes a directory segment on the write path, so it must match
+ ^[a-zA-Z0-9_.@+-]+$ and must not be '.' or '..'.
+ Fix memory.userId / memory.agentId in your config.json, then start a new session.
```

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

Re-run after rebasing onto `d35e398c`, the current `main`.

```
uv run pytest tests/test_everos_backend.py tests/test_cli_import_commands.py \
              tests/test_everos_plugin_discovery.py -q
162 passed

uv run pytest -q
1 failed, 6478 passed, 43 skipped, 13 deselected

uv run ruff check <the four touched files>            All checks passed
uv run ruff format --check <the four touched files>   4 files already formatted
```

The one failure is `tests/test_cli_theme.py::test_bold_accent_renders_styled_not_bare`. It is pre-existing on this base: checked out `d35e398c` in a clean worktree and ran `uv run pytest tests/test_cli_theme.py` there, same failure, 1 failed / 44 passed. It passes in isolation and fails when the file runs as a whole, so it is order-dependent, and it is unrelated to anything here. That file is untouched by this change.

Manual check, sandbox `RAVEN_HOME`, `memory.userId: "bad/id"`, `raven agent -m "hi"`: prints the block quoted above, and the session no longer ends with the dropped-write line.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

Terminal-only wording plus one new enum member. No config, schema, or protocol change; an identity that was accepted before is accepted now, on the same code path. The only behaviour change for a valid setup is none.

For an invalid identity the turn behaves as it did -- memory off, turn completes -- and only what the user is told changes. Rollback is reverting the single commit.

`ServiceState.BAD_IDENTITY` is new. Every consumer was checked: `raven/cli/import_commands.py` (handled here) and `tests/test_everos_plugin_discovery.py` (reads `READY` only). `_may_spawn` allowlists `UNKNOWN` via `_SPAWNABLE_STATES`, so a new member is non-spawnable without a change.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

Fixes #271

