### PR TITLE
chore(deps): upgrade everos 1.2.1 to 1.2.3

### DIFF
--- a/docs/memory-plugin-architecture.md
+++ b/docs/memory-plugin-architecture.md
@@ -293,7 +293,7 @@ imported.
 
 ## 7. EverOS version pinning & upgrade SOP
 
-### 7.1 Exact pin is mandatory **[DONE: `everos[multimodal]==1.2.1`]**
+### 7.1 Exact pin is mandatory **[DONE: `everos[multimodal]==1.2.3`]**
 
 The adapter is written against EverOS **internal** APIs, not a stable
 public surface:
@@ -321,7 +321,7 @@ place (raven's `pyproject.toml`). The upgrade surface is one line.
    (`~/.everos/.index/` sqlite + lancedb) changed.
 1. **Bump the pin (uv only — never hand-edit pyproject/lock)**:
    ```bash
-   uv add 'everos[multimodal]==1.2.1' && uv sync
+   uv add 'everos[multimodal]==1.2.3' && uv sync
    ```
    Always keep the `[multimodal]` extra. Skip `1.2.0`: it shipped a
    path-traversal regression fixed in `1.2.1`.
@@ -348,9 +348,53 @@ place (raven's `pyproject.toml`). The upgrade surface is one line.
    notes for any bump whose migration behaves this way. An upgrade whose
    only record is a pull-request description is known to whoever read
    that description.
-5. **Finalize**: bump the manifest `version`; commit `pyproject.toml` +
-   `uv.lock` + adapter changes. Rollback = `git revert` (plus data
-   restore if the schema changed — see step 4).
+5. **Finalize**: bump the manifest `version`. Two tests assert it as a
+   literal and must be updated with it —
+   `test_everos_plugin_discovery.py::test_bundled_shadows_lower_priority_source`
+   and `test_plugin_command.py::TestActiveBackend::test_lists_everos_memory`.
+   Then commit
+   `pyproject.toml` + `uv.lock` + adapter changes. Rollback =
+   `git revert` (plus data restore if the schema changed — see step 4).
+
+### 7.3 Record: `1.2.1` -> `1.2.3`
+
+Four packages moved: `everos`, `everalgo-agent-memory` `0.3.1` ->
+`0.4.0`, `everalgo-user-memory` `0.3.2` -> `0.4.0`, and `lancedb`
+`0.33.0` -> `0.34.0`.
+
+**No data migration.** No LanceDB table schema changed: `user_profile`
+and `knowledge_topic` are byte-identical between the two releases, and
+the five files that differ at all (`episode`, `atomic_fact`,
+`agent_case`, `agent_skill`, `foresight`) differ only in docstrings. So
+the startup schema check that `1.2.2` extended to column *types* does
+not fire on an index this upgrade produced. `0.33` and `0.34` were
+verified compatible in both directions — each writes Lance file format
+`v2.1`, and a table written by either opens, searches (over the other's
+IVF and FTS indexes), upserts and prunes under the other — so reverting
+the pin can still read the index. Step 4's backup is cheap insurance,
+not a precondition.
+
+**The Linux floor moved to glibc 2.28.** `lancedb 0.34.0` ships no
+`manylinux_2_17` wheel and no sdist, so CentOS/RHEL 7, Ubuntu 18.04 and
+Amazon Linux 2 can no longer install. `install.sh` hands the exported
+lockfile to the user's `uv` as constraints, which makes this an
+install-time hard failure rather than a slow source build.
+
+**Two behaviour changes.** `extract_foresight` now ships disabled, and
+because the default moved in code rather than in `default_ome.toml` an
+existing `~/.everos/ome.toml` does not opt out of the change; re-enable
+it per install. Agent-skill extraction works for the first time —
+before `1.2.3` a cascade race meant it produced zero `SKILL.md` files —
+so `EverosSkillSource` starts contributing real skills to the prompt
+instead of nothing.
+
+**Two known gaps, not addressed here.** On exhausting a supervised
+loop's restart budget the server now `SIGTERM`s itself, expecting a
+process supervisor; raven spawns it once per session and
+`_SPAWNABLE_STATES` deliberately excludes `FAILED`, so memory stays off
+until the session restarts. And `everos cascade rebuild`, now the
+supported index recovery, refuses to run while a server holds the OME
+lock — while raven exposes no way to stop the server it started.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tiktoken>=0.7.0,<1.0.0",
     "questionary>=2.0.0,<3.0.0",
     "watchfiles>=0.21,<2.0",
-    "everos[multimodal]==1.2.1",
+    "everos[multimodal]==1.2.3",
     "tomli-w>=1.2.0",
     "portalocker>=3.2.0",
     "mcp>=1.27.0",

--- a/raven/plugin/memory/everos/backend.py
+++ b/raven/plugin/memory/everos/backend.py
@@ -903,7 +903,7 @@ class EverosBackend:
 
         The host already collects ``skill_usage`` signals (which everos
         skills were injected / used in a turn) and dispatches them here.
-        everos 1.2.1's HTTP surface still exposes no endpoint to consume
+        everos 1.2.3's HTTP surface still exposes no endpoint to consume
         them — its routes are get / health / knowledge / memorize /
         metrics / ome / search, and ``agent_skill.confidence`` lives in
         the persistence internals with no service-level write path — so

--- a/raven/plugin/memory/everos/raven-plugin.toml
+++ b/raven/plugin/memory/everos/raven-plugin.toml
@@ -1,6 +1,6 @@
 [plugin]
 id                 = "everos-memory"
-version            = "1.1.0"
+version            = "1.2.0"
 display_name       = "EverOS memory"
 raven           = ">=0.1"
 bundled            = true

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -67,7 +67,7 @@ _STRATEGY_SINGLETONS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("everos.memory.strategies.extract_foresight", ("_writer",)),
     ("everos.memory.strategies.extract_user_profile", ("_writer", "_reader")),
     ("everos.memory.strategies.extract_agent_case", ("_writer",)),
-    ("everos.memory.strategies.extract_agent_skill", ("_writer",)),
+    ("everos.memory.strategies.extract_agent_skill", ("_writer", "_reader")),
 )
 
 

--- a/tests/test_everos_plugin_discovery.py
+++ b/tests/test_everos_plugin_discovery.py
@@ -107,9 +107,9 @@ class TestBundledDiscovery:
         d = PluginDiscovery(bundled_dir=_BUNDLED, user_dir=user_dir)
         out = d.discover()
         record = next(p for p in out if p.manifest.id == "everos-memory")
-        # Bundled (version 1.1.0) wins; user-dir version (9.9.9) is shadowed.
+        # Bundled (version 1.2.0) wins; user-dir version (9.9.9) is shadowed.
         assert record.source == Source.BUNDLED
-        assert record.manifest.version == "1.1.0"
+        assert record.manifest.version == "1.2.0"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugin_command.py
+++ b/tests/test_plugin_command.py
@@ -57,7 +57,7 @@ class TestActiveBackend:
         )
         assert result.exit_code == 0, result.stdout
         assert "everos-memory" in result.stdout
-        assert "1.1.0" in result.stdout
+        assert "1.2.0" in result.stdout
         assert "bundled" in result.stdout
 
     def test_shows_active_backend_with_track_ids(

--- a/uv.lock
+++ b/uv.lock
@@ -768,16 +768,17 @@ wheels = [
 
 [[package]]
 name = "everalgo-agent-memory"
-version = "0.3.1"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "asgiref" },
     { name = "everalgo-boundary" },
     { name = "everalgo-clustering" },
     { name = "everalgo-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/94/6eead80b95d0c26e750563e18b097c710ae29467d14f719efb2d72ed12df/everalgo_agent_memory-0.3.1.tar.gz", hash = "sha256:ff89fd0608530440bb21123eb76b9b5ade4d171c9c04f6407cf038b84eb6df15", size = 71944, upload-time = "2026-06-15T07:09:24.532Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/d1/c8f4eba92d3d9fbdcbfae9eccf887650a22ae92b16a5b791b0feaf07f8dc/everalgo_agent_memory-0.4.0.tar.gz", hash = "sha256:58364d4c78b39b91d1eb93489c7d37fa9343e696987ac0c21631a8bb1099ec57", size = 86143, upload-time = "2026-07-30T07:10:30.002Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/2e/3d892f31ecfbac8f127f4664877bed6a5ad74bd8c101e106ab583a5e5ca2/everalgo_agent_memory-0.3.1-py3-none-any.whl", hash = "sha256:4e8c2cf06ec4699199de5c769aa7c5ac30fdf61086526edbbd0b68bee5ec9219", size = 54895, upload-time = "2026-06-15T07:09:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7c/98632538a43a1b9a14310e95dd3400c1768b0a15b89072a49ce87e06ba46/everalgo_agent_memory-0.4.0-py3-none-any.whl", hash = "sha256:9b11d066a620df8cc3e6d2fa6cd088c44d9aa32eef30bc55b3c8e792efee6b4b", size = 62380, upload-time = "2026-07-30T07:10:29.105Z" },
 ]
 
 [[package]]
@@ -871,21 +872,22 @@ wheels = [
 
 [[package]]
 name = "everalgo-user-memory"
-version = "0.3.2"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "everalgo-boundary" },
     { name = "everalgo-core" },
+    { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/1f/f3f3f264083f8253b1ffdd87f9f3edc4c8f22790112fe2fae93f5c01457a/everalgo_user_memory-0.3.2.tar.gz", hash = "sha256:9aa66a29dbd53176fe99a6482ca4d428158e085d146e14830e44cdd7a67840d6", size = 56591, upload-time = "2026-07-21T09:17:09.018Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/dc/e28a9901c13b5399ebba2033fca4e152206528d20b1b8168d53ccf6a6da0/everalgo_user_memory-0.4.0.tar.gz", hash = "sha256:68dca5d49a8586caa734f862ae64ad63178f32c6b9d10341ba69c0a2f58b43b9", size = 74997, upload-time = "2026-07-30T07:02:34.204Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/55/e22d6dff61fb766b33677ff68a64cd2edd78502f5feb2a3eb19ed82f7588/everalgo_user_memory-0.3.2-py3-none-any.whl", hash = "sha256:958fef976dff6961ff62858b73c867131ca3f511b5f515b1610e4818bdf2d024", size = 54128, upload-time = "2026-07-21T09:17:07.952Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/ba/5c7e65281efae449b01b92f37181c39445f763a31b32f798da740413f17a/everalgo_user_memory-0.4.0-py3-none-any.whl", hash = "sha256:a40cc3ba8aa8062942572ed50e3434887fbb9e73e31d31885124506534d9dc3e", size = 65307, upload-time = "2026-07-30T07:02:33.263Z" },
 ]
 
 [[package]]
 name = "everos"
-version = "1.2.1"
+version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -916,9 +918,9 @@ dependencies = [
     { name = "watchdog" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/23/135f48195411fecee6a7df387071d0140d55e096e1601db64328d28bad33/everos-1.2.1.tar.gz", hash = "sha256:2ea75f30856715916059de9f3ed9356694da1a573139f6e7ee144b13e5421d03", size = 1392168, upload-time = "2026-07-29T06:26:37.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/da/964c03d1c45a1279a6e0a2764b4e4ab77722c59537ec9be1b91dd0667673/everos-1.2.3.tar.gz", hash = "sha256:10675665c7e55f09378e9e3cf5dd3e326509810a031f7b5879c1a33f18079c3a", size = 1681463, upload-time = "2026-08-07T11:50:07.573Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/87/d8a6a4fe4bca1ba4b28b7f4b3a9b198b14588b00f6c6845d82d249d5e29c/everos-1.2.1-py3-none-any.whl", hash = "sha256:cdf56e07c0ac91da038f8f3fd69ebb9a4c1a39773ef92b6edd67e0f1830b6b09", size = 560696, upload-time = "2026-07-29T06:26:35.582Z" },
+    { url = "https://files.pythonhosted.org/packages/58/2b/5271c47296191b77b699be681110c59898a3a495a16d10221bc514538331/everos-1.2.3-py3-none-any.whl", hash = "sha256:f818bc61fefa35029b1066f0fce5579f4151ed932cfc35c3dd9d7362bcb1f89f", size = 604149, upload-time = "2026-08-07T11:50:06.123Z" },
 ]
 
 [package.optional-dependencies]
@@ -1521,7 +1523,7 @@ wheels = [
 
 [[package]]
 name = "lancedb"
-version = "0.33.0"
+version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecation" },
@@ -1533,12 +1535,10 @@ dependencies = [
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/2f/d5a4b2a5bb1f800936c76a6d8a4daf127a86fcab621eeb70b574a5adc774/lancedb-0.33.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d4eaf6fa7c2eac619208f1d396f4de635ee0f535673067118a31c1181575c48b", size = 48338115, upload-time = "2026-05-28T20:37:55.88Z" },
-    { url = "https://files.pythonhosted.org/packages/07/12/31787b93a856b2c31382c7771dc22fb05575b70b87c9efe454269f4f0948/lancedb-0.33.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c6c2402ed2744245ae76c4167c0461da0a7a80f1608e0ec491c1548ea2b4302", size = 51162262, upload-time = "2026-05-28T20:37:59.101Z" },
-    { url = "https://files.pythonhosted.org/packages/49/b7/081cc29f8e06bf12191b99ab3fe702aceebdb0914476b821a8c0445cacc8/lancedb-0.33.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ebf1ffad811e6254a93931a79489ba1f21f48564bdfa06abae846f5fcaaf3e8", size = 54381368, upload-time = "2026-05-28T20:38:02.2Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/bd/e0f4bd621f10ecf96a801b0166e87799ed7ca5a9dbabcef9a6c766a58ef3/lancedb-0.33.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:13da39f80adfea59e5831fe64e4166b2d70a2f843e6507bf644c4fe4c350087c", size = 51188986, upload-time = "2026-05-28T20:38:05.375Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/1a/a8647a432ac6aa59cdce1fc061a7050ea4278bcab364539b78af2ecf72d2/lancedb-0.33.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:21b712825f0a00225e8974a41352c4ea84b0899ef8c23b17f672fadc38bd8346", size = 54440958, upload-time = "2026-05-28T20:38:08.474Z" },
-    { url = "https://files.pythonhosted.org/packages/08/6c/d0cc8da784cd7ed3b4940a5d1f3e7702e2d99a0a348ba81a376eed782810/lancedb-0.33.0-cp39-abi3-win_amd64.whl", hash = "sha256:4ba78c6202b0f6c2ce8edc7aa470e550d2da56271c7cbdd10428613f1f7126f9", size = 58751944, upload-time = "2026-05-28T20:38:11.549Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f7/5262b9aa593f790757163c0165ab0da1dda054758901bea7e4f02c9cb633/lancedb-0.34.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c462f2e6f933cad659fd0179394eaab578acbc9151fe2ef41bc29b36ecca5058", size = 52654213, upload-time = "2026-07-02T17:13:31.102Z" },
+    { url = "https://files.pythonhosted.org/packages/69/99/05ea0d32229ebea695193ff20c15d6ecae25785ad82a9d4723d98832a284/lancedb-0.34.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:48829e88e708947d0520454ab9e4f8efa35f3e3626469eadd3a6e061b89cb223", size = 55434501, upload-time = "2026-07-02T17:13:34.81Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4e/4325c13d5afa93c466428a5a0f168ad4d96f5eb4a77bbe7c5100d39c9897/lancedb-0.34.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:05ba8a5b58e064edfbe5be71b1abf2e411b4eaf295d1a173dcb1a55c5bfb5285", size = 58659359, upload-time = "2026-07-02T17:13:38.424Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/8ca165f1386caf6c4d1c515afd52f345b66432264eecfdfb7fd33eefd9af/lancedb-0.34.0-cp39-abi3-win_amd64.whl", hash = "sha256:51cbc11808f9e3332819b9367c975b3a888541447a8e7bea09c57c852a279153", size = 63530726, upload-time = "2026-07-02T17:13:41.612Z" },
 ]
 
 [[package]]
@@ -3123,7 +3123,7 @@ requires-dist = [
     { name = "boxlite", marker = "sys_platform != 'win32' and extra == 'sandbox'", specifier = "==0.9.5" },
     { name = "croniter", specifier = ">=6.0.0,<7.0.0" },
     { name = "dingtalk-stream", marker = "extra == 'channel-dingtalk'", specifier = ">=0.24.0,<1.0.0" },
-    { name = "everos", extras = ["multimodal"], specifier = "==1.2.1" },
+    { name = "everos", extras = ["multimodal"], specifier = "==1.2.3" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "huggingface-hub", marker = "extra == 'eval'", specifier = ">=1.11.0" },
     { name = "json-repair", specifier = ">=0.30.0" },


### PR DESCRIPTION
## Summary

Upgrades the pinned EverOS from `1.2.1` to `1.2.3`, per the SOP in
`docs/memory-plugin-architecture.md` section 7.2. Four packages move:
`everos`, `everalgo-agent-memory` `0.3.1` to `0.4.0`,
`everalgo-user-memory` `0.3.2` to `0.4.0`, and `lancedb` `0.33.0` to `0.34.0`.

**The adapter needs no change.** Every EverOS symbol it imports still exists
with an identical signature (12 call sites checked), and `memory/search/dto.py`
plus the `search` / `memorize` / `get` route modules are byte-identical between
the two releases, so the HTTP contract is untouched.

**No data migration.** No LanceDB table schema changed: `user_profile` and
`knowledge_topic` are byte-identical between the two releases, and the five
files that differ at all (`episode`, `atomic_fact`, `agent_case`,
`agent_skill`, `foresight`) differ only in docstrings. So the column-type
startup check that `1.2.2` added does not fire on an index this upgrade
produces. `lancedb` `0.33` and `0.34` were verified interchangeable in both
directions - each writes Lance file format `v2.1`, and a table written by
either opens, searches over the other's IVF and FTS indexes, upserts and
prunes under the other - so reverting the pin can still read the index.

Three things reviewers should know, all recorded in the new SOP section 7.3
rather than only here:

1. **`extract_foresight` now ships disabled.** The default moved in code, not
   in `default_ome.toml`, so an existing `~/.everos/ome.toml` does not opt out
   of the change. Any deployment relying on foresight entries must set
   `enabled = true` per install.
2. **Agent-skill extraction works for the first time.** Before `1.2.3` a
   cascade race meant it produced zero `SKILL.md` files, so
   `EverosSkillSource` has been contributing nothing; it now contributes real
   skills to the prompt.
3. **The Linux install floor moves to glibc 2.28.** `lancedb 0.34.0` ships no
   `manylinux_2_17` wheel and no sdist, and `install.sh` hands the exported
   lockfile to the user's `uv` as constraints, so CentOS or RHEL 7,
   Ubuntu 18.04 and Amazon Linux 2 fail at install time rather than falling
   back to a source build.

Two smaller changes are consequences, not choices. `1.2.3` gives
`extract_agent_skill` a module-level `_reader` singleton beside `_writer`, and
the integration conftest reset only the writers it knew about. And the bundled
plugin manifest version moves to `1.2.0`, which two tests assert as a literal;
SOP step 5 now names both so the next bump does not rediscover them.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

Dependency upgrade. `chore` has no box of its own.

## Verification

```
uv run pytest tests/test_everos_plugin_discovery.py tests/test_everos_backend.py \
  tests/test_everos_http_adapter.py tests/test_memory_backend_protocol.py \
  tests/test_memory_backend_contract.py -q
=> 158 passed

uv run pytest <all unit files that mention everos> \
  tests/test_memory_backend_protocol.py tests/test_memory_backend_contract.py \
  -q -p no:randomly
=> 1336 passed, 30 skipped

uv run ruff check <the four changed .py files>          => All checks passed
uv run ruff format --check <the four changed .py files> => 4 files already formatted
make check-large-files                                  => pass
```

`make lint-python` on this branch only covers the nine CI-tooling files in
`PYTHON_LINT_TARGETS`, so ruff was run directly against the files this change
touches instead of relying on that target.

The 30 skips are parametrized cases in
`test_provider_resolution_invariants.py` ("not a gateway" and similar); they
are structural, unrelated to EverOS, and skip identically on the baseline.

Beyond the suites above, the upgrade was exercised end to end through Raven's
own entrypoints on an isolated `RAVEN_HOME`: `raven plugins` reports the new
manifest version, `raven doctor` still parses the capability matrix from a
`/health` that `1.2.3` extended with a `cascade` block, and a real
`raven agent -m` turn recalls memories that `1.2.1` wrote - including after
rolling the pin back, with the index having been written by `lancedb 0.34` in
between. The `extract_foresight` change is visible in the OME `run_record`
table: every other strategy advances by one dispatch per turn while
`extract_foresight` stops being dispatched at all.

**The `real_llm` layer of SOP step 3 could not be validated, and this PR does
not claim it passes.** All three tests in
`tests/integration/test_everos_backend_e2e.py` fail with
`no such table: md_change_state`, and they fail identically on the baseline,
checked by re-syncing to the old pin and running the same command. The cause is
pre-existing and independent of the upgrade: `everos_env` isolates the test by
monkeypatching `EVEROS_ROOT` to a tmp dir (`conftest.py:126`), but the
backend's start path calls `configure_everos_env()`, which deliberately assigns
rather than defaults that variable (`update_everos.py:228`), so the spawned
server serves the recorded root while the test's drain helper reads the tmp
root's sqlite. Worth fixing, but not here.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

## Risk

Two user-visible behaviour changes, both upstream defaults rather than choices
made here: foresight extraction stops running unless an install opts in, and
agent-skill extraction starts running for the first time, which changes prompt
content and token usage. The `ome.db` `run_record` ring buffer for
`skill_cluster_updated` also grows from roughly 0.8 KB to 14 KB per row because
`SkillClusterUpdated` now carries a 1024-dim embedding, about 14 MB instead of
0.8 MB at the default 1000-record cap.

Rollback is `git revert` of this commit plus `uv sync`. The index does not need
restoring: the schemas are unchanged and `lancedb` `0.33` reads what `0.34`
wrote, both verified. Installs on glibc below 2.28 are the one case a revert is
required rather than optional.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A