### PR TITLE
test: read LiteLLM's price table offline, not from the network

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,19 @@ declaration.
 
 from __future__ import annotations
 
+import os
+
 import pytest
+
+# LiteLLM fetches its price and context table over the network at import unless
+# this is set, and setting it before first use is too late -- the remote table is
+# already loaded by then. The suite reads that table as a fixed input, the same
+# reason `_no_openrouter_network` keeps raven's own catalogue fetch off the wire,
+# so leaving it remote makes assertions depend on what a vendor published that
+# morning: a newly added row answered a lookup several tests had arranged to
+# miss, and they failed on numbers nobody in this repo had touched.
+# `setdefault`, so a developer can still point a run at the live table.
+os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
 
 
 def pytest_unconfigure(config: pytest.Config) -> None:

--- a/tests/test_provider_rates.py
+++ b/tests/test_provider_rates.py
@@ -8,6 +8,7 @@ arithmetic on top of it stays with the module that does the arithmetic.
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 
@@ -39,6 +40,23 @@ def _reset_catalog_state():
     rates._OPENROUTER_CACHE.clear()
     yield
     rates._OPENROUTER_CACHE.clear()
+
+
+@pytest.fixture
+def minimax_row(monkeypatch):
+    """Pin the one row the assertions below need and the offline table lacks.
+
+    LiteLLM's bundled table carries no `minimax/MiniMax-M3` -- only the
+    bedrock-prefixed MiniMax models -- so the figure these two read was coming
+    from the table LiteLLM fetches remotely. Pinned here, what they exercise is
+    the resolution ladder rather than what MiniMax published this morning.
+    `minimax/` and not `minimax-global/`: `_candidates` maps the plan-billed
+    prefix onto the direct one before the table is consulted.
+    """
+    litellm = import_litellm()
+    monkeypatch.setattr(
+        litellm, "model_cost", {**litellm.model_cost, "minimax/MiniMax-M3": {"max_input_tokens": 1_000_000}}
+    )
 
 
 def _patch_openrouter(monkeypatch, handler):
@@ -87,6 +105,18 @@ _DEEPSEEK_MODELS = [
 
 
 # --- The tier LiteLLM answers (see `rates.token_rates` for the order) ---
+
+
+def test_the_suite_reads_litellms_table_offline():
+    """The table has to be a fixed input, not whatever a vendor published today.
+
+    LiteLLM fetches it at import unless this is set, and setting it after the
+    import is too late, so the value is published from `conftest` before any test
+    module loads. Asserted rather than assumed: without it a row appearing
+    upstream answers a lookup the tests below arrange to miss, and they fail on
+    numbers no commit here touched.
+    """
+    assert os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP") == "True"
 
 
 def test_a_litellm_mapped_model_is_priced_without_touching_the_network(monkeypatch):
@@ -588,7 +618,7 @@ def test_plan_billing_is_declared_not_inferred_from_oauth():
     assert plan_billed == {"openai_codex", "github_copilot", "minimax_global", "minimax_cn"}
 
 
-def test_a_plan_billed_provider_still_reports_a_window():
+def test_a_plan_billed_provider_still_reports_a_window(minimax_row):
     """Occupancy is the measure that means something on a subscription, so the
     window resolves even where no per-token figure describes the call."""
     for model in ("github_copilot/gpt-4o", "openai-codex/gpt-5.3-codex", "minimax-global/MiniMax-M3"):
@@ -606,7 +636,7 @@ def test_a_directly_routed_model_is_priced_as_the_vendor_prices_it():
     assert resolve_context_window("openrouter/deepseek/deepseek-chat") == 65_536
 
 
-def test_the_window_those_families_report_is_the_vendors_own():
+def test_the_window_those_families_report_is_the_vendors_own(minimax_row):
     """Read from LiteLLM's table offline, so this is the number, not a default."""
     assert rates._try_litellm_context_window("openai-codex/gpt-5.3-codex") == 128_000
     assert rates._try_litellm_context_window("minimax-global/MiniMax-M3") == 1_000_000


### PR DESCRIPTION
## Summary

LiteLLM fetches its price and context table over the network at import unless
`LITELLM_LOCAL_MODEL_COST_MAP` is set beforehand. Nothing in this repo sets it, so the
unit suite reads a remote file as a fixed input. A `deepseek/deepseek-v4-pro` row
appeared upstream and turned 19 tests red on `main`, on bytes no commit here had
touched, minutes after the same bytes had passed.

`token_rates` and `resolve_context_window` consult LiteLLM's table first and only then
the OpenRouter catalogue, which the autouse `_no_openrouter_network` fixture already
keeps off the wire for exactly this reason. Several tests mock an OpenRouter catalogue
and arrange for the LiteLLM tier to miss, so the mocked number is the one under test.
When the new row started answering that lookup first, the mock was never reached: the
counting transport recorded 0 calls, no disk cache was written, and the assertions read
live figures instead (a window of 1048576 where the mock said 163840, a cost of 0.0033
where the mock said 0.00125). The fixture's promise to keep the suite off the network
covered one of the two doors.

The change is three small parts:

- `conftest` publishes `LITELLM_LOCAL_MODEL_COST_MAP` at module scope, before any test
  module imports LiteLLM. Setting it before first *use* is too late, because the remote
  table is loaded at import. `setdefault`, so a run can still be pointed at the live
  table deliberately.
- Two assertions genuinely needed a row that exists only remotely. `minimax/MiniMax-M3`
  is the one MiniMax row absent from the bundled table, which does carry the other
  direct `minimax/` models. Both now pin the row, so what they exercise is the
  resolution ladder rather than what MiniMax published this morning. The key is
  `minimax/` and not `minimax-global/` because `_candidates` maps the plan-billed prefix
  onto the direct one before the table is consulted.
- A third test asserts the offline guarantee itself. Nothing else in the suite would
  notice it being lost, which is how it was lost in the first place.

Checked and deliberately not changed:

- **`_litellm_price_table` and `_try_litellm_context_window` describe that table as
  "static" and "offline"** (four places in `raven/providers/rates.py`). Both are wrong
  in production, where the flag is never set and the import does reach the network, and
  they are the reason the tests were written believing it. Correcting them means
  touching the provider hot path, and whether production should read a pinned table
  instead of a fetched one is a behaviour question with its own trade-offs: a bundled
  table is reproducible but goes stale, and it lacks rows the fetched one has, which is
  the same gap the MiniMax pin works around. Left for a change that can weigh it
  properly, because `main` is red right now and this is the smallest surface that clears
  it.
- **The `allow_fetch=False` tier is still order-dependent.**
  `_try_litellm_context_window` returns early only while LiteLLM is absent from
  `sys.modules`, so whether that tier is shut depends on which test imported LiteLLM
  first. Pinning the table makes those cases deterministic, which is what this change is
  for, but it does not make the contract they assert true.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other -- tests only

## Verification

Full suite on the base commit and on this branch, same machine, failing test IDs
diffed rather than counts compared:

```
base   (0e544ecb):  100 failed, 6379 passed, 46 skipped, 13 deselected
branch:              81 failed, 6399 passed, 46 skipped, 13 deselected

introduced: 0
fixed:     19   (exactly the set that went red on main)
```

The two files that exercise the ladder, with no flag on the command line, which is what
proves the `conftest` placement is early enough:

```
pytest tests/test_provider_rates.py tests/test_agent_loop_usage_sink.py -q
-> 71 passed
```

Not vacuous: the same two files with `LITELLM_LOCAL_MODEL_COST_MAP=False`, which
pre-empts the `setdefault` and so removes the guarantee:

```
-> 20 failed, 51 passed
```

Twenty are the nineteen original failures plus the new test that exists to notice
exactly this.

Repo gate and lint:

```
python scripts/check_commit_messages.py 0e544ecb..HEAD   -> exit 0
ruff check raven tests scripts                           -> All checks passed!
ruff format --check raven tests scripts                  -> 844 files already formatted
```

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

Disclosed gaps. The 81 failures that remain are present on the base commit too and are
unrelated to this change (58 in `test_tui_rpc_session.py`, the rest across the CLI cron,
import, onboard and TUI command suites); they are environment-dependent on this machine
and CI does not reproduce them, which is why the red count on CI was 19 and not 100. The
full suite segfaults at interpreter finalization on base and branch alike, before and
after. `make lint` also runs `lint-tui` and `lint-bridge`, which could not run here
because their Node toolchains are not installed in this checkout; this change adds no
TypeScript. No docs changed: nothing outside `tests/` mentions this flag, which is the
same grep that confirms production never sets it.

## Risk

Test-only. No file under `raven/` changes, so no runtime behaviour moves: in production
LiteLLM still fetches its table exactly as before, and this only stops the suite from
asserting against it.

The trade-off is that the suite now reads a table pinned to whatever LiteLLM bundles, so
a genuine upstream correction to a window or a price no longer reaches these assertions.
That is the intended direction -- a unit test should fail because the code changed -- but
it means the numbers in them describe LiteLLM's bundled data rather than a live vendor
claim, and a LiteLLM upgrade can still move them.

Two existing tests changed meaning and are worth a reviewer's eye:
`test_a_plan_billed_provider_still_reports_a_window` and
`test_the_window_those_families_report_is_the_vendors_own` previously passed by reading a
live row, and now pass by reading a pinned one.

Rollback is reverting the commit; the suite returns to reading the live table, with the
failure mode described above.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues\n\nFixes #358