### PR TITLE
fix(*): close the gaps between what ask_user promises and what it does

### DIFF
--- a/docs/Proactivity-Implementation.md
+++ b/docs/Proactivity-Implementation.md
@@ -631,7 +631,15 @@ leave a free slot; only four conversations blocked at once exhaust the pool.
 The default timeout bounds the worst case, so a forgotten question cannot wedge
 the gateway indefinitely.
 
-The `ask_user` tool schema accepts `multiple` / `custom` per question, but the
-`clarify.request` wire payload carries only `{question, choices}`, so the
-frontend ClarifyPrompt renders a single-select prompt — multi-select and
-free-form answers degrade to a single choice for now.
+The `clarify.request` wire payload carries `{question, choices, header,
+recommended, timeout_s, index, total, batch}`. `header` is a short chip label,
+`recommended` names the option the agent would pick, and `index` / `total` /
+`batch` place the question in its call so a surface can show the whole set and
+its progress while still collecting one answer at a time. ClarifyPrompt renders
+a single-select prompt, marks the recommended option, counts the budget down,
+and takes a free-form answer or a note alongside a selection; multi-select is
+not offered.
+
+One `ask_user` call shares one budget (`tools.ask_user.timeout`, 600s by
+default) across every question in it, so the paragraph above holds for a batch
+too -- a three-question call cannot hold a lane for three timeouts.

--- a/raven/agent/loop/main.py
+++ b/raven/agent/loop/main.py
@@ -100,7 +100,7 @@ if TYPE_CHECKING:
         RuntimeConfig,
         SkillForgeRouterConfig,
     )
-    from raven.config.schema import ChannelsConfig, DeepResearchToolConfig, ExecToolConfig
+    from raven.config.schema import AskUserToolConfig, ChannelsConfig, DeepResearchToolConfig, ExecToolConfig
     from raven.context_engine import ContextEngine
     from raven.memory_engine.backend import MemoryBackend
     from raven.proactive_engine.schedulers.cron.service import CronService
@@ -269,6 +269,7 @@ class AgentLoop:
         brave_api_key: str | None = None,
         web_proxy: str | None = None,
         exec_config: ExecToolConfig | None = None,
+        ask_user_config: AskUserToolConfig | None = None,
         cron_service: CronService | None = None,
         restrict_to_workspace: bool = False,
         session_manager: SessionManager | None = None,
@@ -319,7 +320,7 @@ class AgentLoop:
             OnUserInboundAdapter,
             ResponseModifierAdapter,
         )
-        from raven.config.schema import ExecToolConfig
+        from raven.config.schema import AskUserToolConfig, ExecToolConfig
         from raven.token_wise.registry import StrategyRegistry
 
         # Optional transform applied to the final assistant content right
@@ -379,6 +380,7 @@ class AgentLoop:
         self.media_config = media_config or MediaGenConfig()
         self.deep_research_config = deep_research_config or DeepResearchToolConfig()
         self.exec_config = exec_config or ExecToolConfig()
+        self.ask_user_config = ask_user_config or AskUserToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
         # TokenWise strategies — empty registry acts as pure pass-through.
@@ -889,7 +891,7 @@ class AgentLoop:
         self.tools.register(SpawnTool(manager=self.subagents))
         # The QuestionBroker is a per-transport singleton, late-bound via
         # set_broker once the transport (TUI RPC server / gateway hub) exists.
-        self.tools.register(AskUserTool())
+        self.tools.register(AskUserTool(timeout_s=self.ask_user_config.timeout))
         if self.cron_service:
             # Lazy import: CronTool lives under raven.proactive_engine.schedulers.cron.tool
             # which (a) imports raven.agent.tools.base, triggering raven.agent.__init__,

--- a/raven/agent/tools/ask_user.py
+++ b/raven/agent/tools/ask_user.py
@@ -6,13 +6,88 @@ conversation_id and the prompt to the broker, which emits a ``clarify.request``
 notification and blocks until an inbound answer arrives (or the broker's
 fail-safe default fires). The returned answer is rendered as a natural-language
 tool result; the loop never sees an exception.
+
+A batch shares one deadline rather than one per question, and a call whose
+shape would waste the user's time -- a single-option question, a repeated
+question, more questions than the cap -- is rejected before anything is
+rendered, with a message that steers the next attempt.
 """
 
+import asyncio
 from contextvars import ContextVar
+from dataclasses import dataclass
 from typing import Any
 
 from raven.agent.tools.base import Tool, ToolResult
-from raven.tui_rpc.question_broker import QuestionBroker
+from raven.tui_rpc.question_broker import DEFAULT_TIMEOUT_S, QuestionBroker
+
+MAX_QUESTIONS = 4
+"""Cap on one call. Each question is its own round-trip, so an uncapped
+batch is an uncapped number of prompts in front of one user."""
+
+_MAX_HEADER_CHARS = 12
+
+
+@dataclass(frozen=True)
+class _Question:
+    """One validated question: what to ask, and what to fall back on."""
+
+    question: str
+    header: str
+    options: list[str]
+    recommended: str
+
+
+def _dedup(labels: list[str]) -> list[str]:
+    seen: set[str] = set()
+    return [label for label in labels if not (label in seen or seen.add(label))]
+
+
+def _prepare(entries: list[dict[str, Any]]) -> tuple[list["_Question"], str]:
+    """Validate and normalize the questions, or return why to reject the call.
+
+    Rejection happens before any question reaches a human, so a malformed
+    call costs the user nothing and the message is what steers the retry.
+    """
+    if len(entries) > MAX_QUESTIONS:
+        return [], (
+            f"Error: ask_user accepts at most {MAX_QUESTIONS} questions per call "
+            f"(got {len(entries)}); split them across calls."
+        )
+    prepared: list[_Question] = []
+    seen: set[str] = set()
+    for entry in entries:
+        question = str(entry.get("question", "")).strip()
+        if not question:
+            continue
+        if question in seen:
+            return [], (
+                f'Error: ask_user rejected the call -- duplicate question text "{question}". Ask each question once.'
+            )
+        seen.add(question)
+        # A repeated label is a typo with one obvious reading, so drop it; a
+        # repeated question would prompt the same human twice, so reject that.
+        options = _dedup([str(option) for option in entry.get("options") or []])
+        if len(options) == 1:
+            return [], (
+                f'Error: ask_user rejected the call -- question "{question}" has exactly one '
+                "option, which is not a decision. Do not retry with a filler second option: "
+                "state that single path as the approach you are taking and continue. A question "
+                "needs two or more options, or none at all for a free-form answer."
+            )
+        pick = entry.get("recommended")
+        recommended = (
+            options[pick] if isinstance(pick, int) and not isinstance(pick, bool) and 0 <= pick < len(options) else ""
+        )
+        prepared.append(
+            _Question(
+                question=question,
+                header=str(entry.get("header", "")).strip()[:_MAX_HEADER_CHARS],
+                options=options,
+                recommended=recommended,
+            )
+        )
+    return prepared, ""
 
 
 class AskUserTool(Tool):
@@ -30,6 +105,7 @@ class AskUserTool(Tool):
         self,
         broker: QuestionBroker | None = None,
         conversation_id: str = "",
+        timeout_s: float | None = None,
     ) -> None:
         # The broker is the shared transport singleton (not per-turn). The
         # conversation_id is per-turn, so it lives in a ContextVar — a turn runs
@@ -37,6 +113,11 @@ class AskUserTool(Tool):
         # immutable, so a plain set/get is task-isolated without copy-on-write.
         self._broker = broker
         self._cid: ContextVar[str] = ContextVar("ask_user_cid", default=conversation_id)
+        # Configured budget for one whole call. It arrives here rather than at
+        # the broker because the broker is built before any config is loaded on
+        # the TUI transport, and re-reading config there would put a schema
+        # failure in the path of the RPC server coming up.
+        self._timeout_s = timeout_s
 
     def set_broker(self, broker: QuestionBroker | None) -> None:
         """Set the QuestionBroker. ``None`` disables the round-trip."""
@@ -57,9 +138,10 @@ class AskUserTool(Tool):
             "a preference, clarify an ambiguous request, or decide a choice with real "
             "trade-offs. Reach for it when the answer genuinely depends on the user; "
             "for low-stakes or reversible choices, pick a sensible default instead. "
-            "When you can name a few likely answers, pass them as 'options' (the user "
-            "can always type a free-form answer instead); if you recommend one, list "
-            "it first with '(Recommended)'. Batch related questions into one call."
+            "When you can name a few likely answers, pass them as 'options' -- two or "
+            "more, or none at all for a free-form question (the user can always type an "
+            "answer instead). Point at the one you would pick with 'recommended'. Batch "
+            f"related questions into one call, up to {MAX_QUESTIONS}; they share one deadline."
         )
 
     @property
@@ -80,23 +162,35 @@ class AskUserTool(Tool):
                                     "it in a separate title."
                                 ),
                             },
+                            "header": {
+                                "type": "string",
+                                "description": (
+                                    f"Very short label ({_MAX_HEADER_CHARS} chars or fewer) shown "
+                                    "as a chip beside the question, e.g. 'Base branch'. Optional."
+                                ),
+                            },
                             "options": {
                                 "type": "array",
                                 "items": {"type": "string"},
-                                "description": "Optional list of suggested answers",
+                                "description": (
+                                    "Suggested answers: give two or more, or none at all for a "
+                                    "free-form question. One option is not a decision and is "
+                                    "rejected. Do not add an 'Other' entry -- the user always "
+                                    "has a free-form answer."
+                                ),
                             },
-                            "multiple": {
-                                "type": "boolean",
-                                "description": "Whether multiple options may be chosen",
-                            },
-                            "custom": {
-                                "type": "boolean",
-                                "description": "Whether a free-form answer is allowed",
+                            "recommended": {
+                                "type": "integer",
+                                "description": (
+                                    "0-based index into 'options' of the option you recommend. "
+                                    "Omit when you have no preference."
+                                ),
                             },
                         },
                         "required": ["question"],
                     },
-                    "description": "One or more questions to ask the user",
+                    "maxItems": MAX_QUESTIONS,
+                    "description": f"One to {MAX_QUESTIONS} questions to ask the user",
                 }
             },
             "required": ["questions"],
@@ -123,31 +217,54 @@ class AskUserTool(Tool):
         if not questions:
             return "Error: ask_user requires at least one question"
 
+        prepared, rejection = _prepare(questions)
+        if rejection:
+            return rejection
+        if not prepared:
+            return "Error: ask_user requires at least one non-empty question"
+
+        # One budget for the whole batch, not one per question: each question is
+        # its own round-trip, so a per-question timeout let three questions hold
+        # a turn open for three times the surface's wait.
+        budget = float(self._timeout_s or getattr(self._broker, "default_timeout_s", DEFAULT_TIMEOUT_S))
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + budget
+        batch = [{"question": item.question, "header": item.header} for item in prepared]
+
         told: list[str] = []  # model-facing
         # Human-facing display: one "question -> answer" line per question, so a
         # batch shows which answer belongs to which question. The UI renders each
         # line as its own row.
         picks: list[str] = []
-        for entry in questions:
-            question = str(entry.get("question", "")).strip()
-            if not question:
-                continue
-            options = entry.get("options") or []
-
-            answer = await self._broker.await_question(
-                cid,
-                prompt=question,
-                choices=[str(o) for o in options],
+        for index, item in enumerate(prepared):
+            remaining = deadline - loop.time()
+            # A spent budget stops the batch rather than opening a fresh wait on
+            # every question that is left.
+            answer = (
+                await self._broker.await_question(
+                    cid,
+                    prompt=item.question,
+                    choices=item.options,
+                    timeout_s=remaining,
+                    header=item.header,
+                    recommended=item.recommended,
+                    index=index,
+                    total=len(prepared),
+                    batch=batch,
+                )
+                if remaining > 0
+                else ""
             )
             if answer:
-                told.append(f'User answered: "{question}" -> "{answer}".')
-                picks.append(f"{question} -> {answer}" if len(questions) > 1 else str(answer))
+                told.append(f'User answered: "{item.question}" -> "{answer}".')
+                picks.append(f"{item.question} -> {answer}" if len(prepared) > 1 else str(answer))
             else:
-                told.append(f'For "{question}": (user did not answer; proceed with best judgment).')
-                picks.append(f"{question} -> (no answer)" if len(questions) > 1 else "(no answer)")
+                # Naming the option the model recommended is what lets it carry on
+                # the way it intended; without it the only signal is "no answer".
+                hint = f' recommended option was "{item.recommended}";' if item.recommended else ""
+                told.append(f'For "{item.question}": (user did not answer;{hint} proceed with best judgment).')
+                picks.append(f"{item.question} -> (no answer)" if len(prepared) > 1 else "(no answer)")
 
-        if not told:
-            return "Error: ask_user requires at least one non-empty question"
         return ToolResult(
             model_text=" ".join(told) + " Continue.",
             display_text="\n".join(picks) if len(picks) > 1 else f"answered: {picks[0]}",

--- a/raven/agent/tools/ask_user.py
+++ b/raven/agent/tools/ask_user.py
@@ -67,7 +67,8 @@ def _prepare(entries: list[dict[str, Any]]) -> tuple[list["_Question"], str]:
         seen.add(question)
         # A repeated label is a typo with one obvious reading, so drop it; a
         # repeated question would prompt the same human twice, so reject that.
-        options = _dedup([str(option) for option in entry.get("options") or []])
+        submitted = [str(option) for option in entry.get("options") or []]
+        options = _dedup(submitted)
         if len(options) == 1:
             return [], (
                 f'Error: ask_user rejected the call -- question "{question}" has exactly one '
@@ -76,8 +77,13 @@ def _prepare(entries: list[dict[str, Any]]) -> tuple[list["_Question"], str]:
                 "needs two or more options, or none at all for a free-form answer."
             )
         pick = entry.get("recommended")
+        # The index counts the options as submitted, so resolve it before dedup
+        # narrows the list. Dedup keeps every distinct label, so the label this
+        # resolves to is still one of the choices the surface can mark.
         recommended = (
-            options[pick] if isinstance(pick, int) and not isinstance(pick, bool) and 0 <= pick < len(options) else ""
+            submitted[pick]
+            if isinstance(pick, int) and not isinstance(pick, bool) and 0 <= pick < len(submitted)
+            else ""
         )
         prepared.append(
             _Question(

--- a/raven/cli/agent_commands.py
+++ b/raven/cli/agent_commands.py
@@ -256,6 +256,7 @@ def register(app: typer.Typer) -> None:
             media_config=config.effective_media_config(),
             deep_research_config=config.tools.deep_research,
             exec_config=config.tools.exec,
+            ask_user_config=config.tools.ask_user,
             restrict_to_workspace=config.tools.restrict_to_workspace,
             session_manager=session_manager,
             mcp_servers=config.tools.mcp_servers,

--- a/raven/cli/gateway_commands.py
+++ b/raven/cli/gateway_commands.py
@@ -110,6 +110,45 @@ def _build_gateway_channels(config) -> set[str]:
     return config.channels.enabled_channel_names()
 
 
+def _format_question_body(params: dict) -> str:
+    """Render one ``clarify.request`` as chat text.
+
+    A chat channel has no dialog to hold a batch, so the question's position in
+    it has to ride in the message body or the user cannot tell how many more are
+    coming.
+    """
+    body = str(params.get("question", ""))
+    total = int(params.get("total", 1) or 1)
+    if total > 1:
+        body = f"({int(params.get('index', 0)) + 1}/{total}) {body}"
+    choices = params.get("choices") or []
+    if choices:
+        body += "\n" + "\n".join(f"{i + 1}. {c}" for i, c in enumerate(choices))
+    return body
+
+
+async def _deliver_question_to_channel(frame: dict, *, sources: dict, hub) -> None:
+    """Put a question on its conversation's channel, or say it cannot be put.
+
+    The live turn's real inbound Source is still in ``sources`` (keyed by
+    conversation id), so reuse it -- a topic / thread address is exact that way,
+    where one reconstructed from the conversation id is not.
+
+    Raises :class:`QuestionUndeliverableError` rather than returning when there is no
+    live source: a silent drop left the broker waiting out its whole budget on a
+    question that was never rendered.
+    """
+    from raven.spine import Text
+    from raven.tui_rpc.question_broker import QuestionUndeliverableError
+
+    params = frame.get("params", {})
+    qcid = params.get("conversation_id", "")
+    source = sources.get(qcid)
+    if source is None:
+        raise QuestionUndeliverableError(f"conversation {qcid!r} has no live source")
+    await hub.dispatch(Text(content=_format_question_body(params), source=source))
+
+
 async def _health_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
     """Answer any request with a 200 ``{"status":"ok"}`` liveness body."""
     try:
@@ -266,6 +305,7 @@ def register(app: typer.Typer) -> None:
             media_config=config.effective_media_config(),
             deep_research_config=config.tools.deep_research,
             exec_config=config.tools.exec,
+            ask_user_config=config.tools.ask_user,
             cron_service=cron,
             restrict_to_workspace=config.tools.restrict_to_workspace,
             session_manager=session_manager,
@@ -497,26 +537,15 @@ def register(app: typer.Typer) -> None:
                 # so the live turn's real inbound Source is still in gw_sources
                 # (keyed by conversation id) — reuse it so a topic / thread address
                 # is exact, rather than reconstructing it from the conversation id.
-                from raven.spine import Text as _Text
                 from raven.tui_rpc.question_broker import QuestionBroker
 
                 async def _question_to_channel(frame: dict) -> None:
-                    params = frame.get("params", {})
-                    qcid = params.get("conversation_id", "")
-                    source = gw_sources.get(qcid)
-                    if source is None:
-                        logger.warning(
-                            "ask_user question for {} has no live source — dropping",
-                            qcid,
-                        )
-                        return
-                    body = params.get("question", "")
-                    choices = params.get("choices") or []
-                    if choices:
-                        body += "\n" + "\n".join(f"{i + 1}. {c}" for i, c in enumerate(choices))
-                    await gw_hub.dispatch(_Text(content=body, source=source))
+                    await _deliver_question_to_channel(frame, sources=gw_sources, hub=gw_hub)
 
-                question_broker = QuestionBroker(send_frame=_question_to_channel)
+                question_broker = QuestionBroker(
+                    send_frame=_question_to_channel,
+                    timeout_s=config.tools.ask_user.timeout,
+                )
                 # Wire the broker into the mid-turn askers. deep_research goes
                 # through the loop so a tool built later by promotion (a mid-session
                 # enable) inherits the broker too, not just the startup one.

--- a/raven/cli/tui_commands.py
+++ b/raven/cli/tui_commands.py
@@ -486,6 +486,7 @@ def _build_tui_agent_loop():
             media_config=config.effective_media_config(),
             deep_research_config=config.tools.deep_research,
             exec_config=config.tools.exec,
+            ask_user_config=config.tools.ask_user,
             cron_service=cron,
             restrict_to_workspace=config.tools.restrict_to_workspace,
             session_manager=session_manager,

--- a/raven/config/schema.py
+++ b/raven/config/schema.py
@@ -751,6 +751,17 @@ class ExecToolConfig(Base):
     extra_deny_patterns: list[str] = Field(default_factory=list)
 
 
+class AskUserToolConfig(Base):
+    """ask_user tool configuration.
+
+    ``timeout`` is the budget for one whole ask_user call, shared across every
+    question in the batch. It belongs to the surface rather than to the tool:
+    a chat channel and a rendered page sit out a silent user very differently.
+    """
+
+    timeout: int = Field(default=600, gt=0)  # seconds, per call not per question
+
+
 class MediaToolConfig(Base):
     """Config for a media-generation tool (key + base + model).
 
@@ -831,6 +842,7 @@ class ToolsConfig(Base):
 
     web: WebToolsConfig = Field(default_factory=WebToolsConfig)
     exec: ExecToolConfig = Field(default_factory=ExecToolConfig)
+    ask_user: AskUserToolConfig = Field(default_factory=AskUserToolConfig)
     media: MediaGenConfig = Field(default_factory=MediaGenConfig)
     deep_research: DeepResearchToolConfig = Field(default_factory=DeepResearchToolConfig)
     restrict_to_workspace: bool = False  # If true, restrict all tool access to workspace directory

--- a/raven/tui_rpc/question_broker.py
+++ b/raven/tui_rpc/question_broker.py
@@ -10,8 +10,9 @@ the notification so a frontend that prefers to answer by request_id can.
 Like ConfirmBroker it is transport-agnostic: constructed with a notification
 emit callable (bound to ``RpcServer.send_frame`` in production), and every
 fail-safe path (timeout, cancel, internal error, connection EOF via
-:meth:`cancel_all`) resolves to the prompt's ``default`` rather than raising —
-the agent loop must always get a string back.
+:meth:`cancel_all`, and a surface that reports the question as undeliverable)
+resolves to the prompt's ``default`` rather than raising — the agent loop must
+always get a string back.
 """
 
 from __future__ import annotations
@@ -25,6 +26,18 @@ from uuid import uuid4
 from loguru import logger
 
 SendFrame = Callable[[dict[str, Any]], Awaitable[None]]
+
+DEFAULT_TIMEOUT_S = 600.0
+
+
+class QuestionUndeliverableError(Exception):
+    """A ``send_frame`` adapter could not put the question in front of anyone.
+
+    Raised rather than returned so the broker can tell "the surface refused
+    it" apart from "nobody has answered yet": an adapter that swallowed the
+    drop left the round-trip waiting out its whole budget on a question that
+    was never rendered.
+    """
 
 
 @dataclass
@@ -42,8 +55,13 @@ class QuestionBroker:
     concurrently.
     """
 
-    def __init__(self, send_frame: SendFrame) -> None:
+    def __init__(self, send_frame: SendFrame, *, timeout_s: float = DEFAULT_TIMEOUT_S) -> None:
         self._send_frame = send_frame
+        # The budget belongs to the surface, not to the caller: a chat channel
+        # and a rendered page wait out a silent user very differently. Callers
+        # may still override per question, which is what lets one batch share
+        # a single deadline across several round-trips.
+        self.default_timeout_s = timeout_s
         self._pending: dict[str, _PendingQuestion] = {}
         # Reverse index request_id -> conversation_id so :meth:`reply` can
         # accept either handle.
@@ -56,12 +74,25 @@ class QuestionBroker:
         prompt: str,
         choices: list[str] | None = None,
         default: str = "",
-        timeout_s: float = 600.0,
+        timeout_s: float | None = None,
+        header: str = "",
+        recommended: str = "",
+        index: int = 0,
+        total: int = 1,
+        batch: list[dict[str, Any]] | None = None,
     ) -> str:
         """Emit a ``clarify.request`` and await the matching answer.
 
         Returns ``default`` on timeout, cancellation, EOF
-        (:meth:`cancel_all`), or any internal error — never raises.
+        (:meth:`cancel_all`), an undeliverable question, or any internal
+        error — never raises.
+
+        ``timeout_s`` of ``None`` takes :attr:`default_timeout_s`, and is echoed
+        in the notification so a surface can show how long the question
+        stands. ``recommended`` is the option label to mark. ``header``,
+        ``index``, ``total`` and ``batch`` describe the question's place in a
+        batch so a surface can render the whole set and its progress while
+        still collecting one answer at a time.
 
         A turn is serial, so a second pending question for the same
         conversation is a programming error: we drop the stale one (fail-safe
@@ -82,6 +113,8 @@ class QuestionBroker:
         future: asyncio.Future = loop.create_future()
         self._pending[conversation_id] = _PendingQuestion(future=future, request_id=request_id, default=default)
         self._by_request[request_id] = conversation_id
+        if timeout_s is None:
+            timeout_s = self.default_timeout_s
         try:
             # ``clarify.request`` is the ui-tui frontend's existing multi-choice
             # prompt contract ({question, choices, request_id} -> ClarifyPrompt ->
@@ -96,11 +129,26 @@ class QuestionBroker:
                         "request_id": request_id,
                         "question": prompt,
                         "choices": choices or [],
+                        "header": header,
+                        "recommended": recommended,
+                        "timeout_s": timeout_s,
+                        "index": index,
+                        "total": total,
+                        "batch": batch if batch is not None else [{"question": prompt, "header": header}],
                     },
                 }
             )
             return await asyncio.wait_for(future, timeout_s)
         except (asyncio.TimeoutError, asyncio.CancelledError):
+            return default
+        except QuestionUndeliverableError as exc:
+            # Expected, not exceptional: the conversation has no live surface.
+            # warning, not exception, so a routine drop leaves no stack trace.
+            logger.warning(
+                "question_broker: question for {} is undeliverable ({}); failing safe to the default",
+                conversation_id,
+                exc,
+            )
             return default
         except Exception:  # noqa: BLE001 — fail-safe: the loop needs a string back
             logger.exception("question_broker: await_question failed for {}", conversation_id)
@@ -139,4 +187,4 @@ class QuestionBroker:
                 pending.future.set_result(pending.default)
 
 
-__all__ = ["QuestionBroker", "SendFrame"]
+__all__ = ["DEFAULT_TIMEOUT_S", "QuestionBroker", "QuestionUndeliverableError", "SendFrame"]

--- a/tests/test_ask_user_tool.py
+++ b/tests/test_ask_user_tool.py
@@ -228,6 +228,29 @@ async def test_unanswered_question_names_the_recommended_option():
 
 
 @pytest.mark.asyncio
+async def test_recommendation_survives_a_duplicate_earlier_in_the_options():
+    """The index counts the options as submitted, so a duplicate ahead of it must
+    not shift which label the recommendation resolves to."""
+    tool, broker = _tool({"Ship?": "ship"})
+
+    await tool.execute(questions=[{"question": "Ship?", "options": ["a", "a", "b", "c"], "recommended": 2}])
+
+    assert broker.calls[0]["choices"] == ["a", "b", "c"]
+    assert broker.calls[0]["recommended"] == "b"
+
+
+@pytest.mark.asyncio
+async def test_recommendation_past_the_deduped_length_still_resolves():
+    """Dedup shortens the list, so an index valid against the submitted options
+    can fall outside it -- that must not silently drop the recommendation."""
+    tool, broker = _tool({"Ship?": "ship"})
+
+    await tool.execute(questions=[{"question": "Ship?", "options": ["a", "a", "b", "c"], "recommended": 3}])
+
+    assert broker.calls[0]["recommended"] == "c"
+
+
+@pytest.mark.asyncio
 async def test_out_of_range_recommended_index_is_ignored():
     tool, _ = _tool({})
 

--- a/tests/test_ask_user_tool.py
+++ b/tests/test_ask_user_tool.py
@@ -351,3 +351,47 @@ async def test_round_trip_through_the_real_broker():
     assert params["recommended"] == "uv"
     assert params["total"] == 1
     assert params["timeout_s"] <= 5.0
+
+
+@pytest.mark.asyncio
+async def test_registry_dispatch_and_the_real_clarify_respond_route():
+    """The production entry point is the registry, not ``execute`` directly, and
+    the answer arrives over the real ``clarify.respond`` handler. Neither layer
+    is exercised by the tests above, and both can reject a call the tool would
+    have accepted -- the schema validator runs in between.
+    """
+    from raven.agent.tools.registry import ToolRegistry
+    from raven.tui_rpc.dispatcher import Dispatcher
+    from raven.tui_rpc.methods.question import register_question_methods
+    from raven.tui_rpc.question_broker import QuestionBroker
+
+    dispatcher = Dispatcher()
+
+    async def send_frame(frame: dict) -> None:
+        params = frame["params"]
+        reply = await dispatcher.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "clarify.respond",
+                "params": {"request_id": params["request_id"], "answer": "uv"},
+            }
+        )
+        assert reply["result"]["ok"] is True
+
+    broker = QuestionBroker(send_frame, timeout_s=5.0)
+    register_question_methods(dispatcher, question_broker=broker)
+    registry = ToolRegistry()
+    registry.register(AskUserTool(broker=broker, conversation_id="tui:test"))
+
+    answered = await registry.execute(
+        "ask_user",
+        {"questions": [{"question": "Which?", "header": "Pkg", "options": ["uv", "pip"], "recommended": 0}]},
+    )
+    assert 'User answered: "Which?" -> "uv".' in answered
+
+    # A rejection has to survive the registry intact -- it is the steer the model
+    # reads, and the registry appends to it rather than replacing it.
+    rejected = await registry.execute("ask_user", {"questions": [{"question": "Ship?", "options": ["yes"]}]})
+    assert "exactly one option" in rejected
+    assert "filler" in rejected

--- a/tests/test_ask_user_tool.py
+++ b/tests/test_ask_user_tool.py
@@ -9,6 +9,8 @@ raw arguments blob.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from raven.agent.tools.ask_user import AskUserTool
@@ -18,17 +20,24 @@ from raven.agent.tools.base import ToolResult
 class _StubBroker:
     """Stands in for QuestionBroker: replies from a scripted answer map."""
 
-    def __init__(self, answers: dict[str, str]) -> None:
+    default_timeout_s = 600.0
+
+    def __init__(self, answers: dict[str, str], *, delay_s: float = 0.0) -> None:
         self.answers = answers
         self.asked: list[tuple[str, list[str]]] = []
+        self.calls: list[dict] = []
+        self._delay_s = delay_s
 
-    async def await_question(self, cid: str, *, prompt: str, choices: list[str]) -> str:
+    async def await_question(self, cid: str, *, prompt: str, choices: list[str], **kwargs) -> str:
         self.asked.append((prompt, choices))
+        self.calls.append({"prompt": prompt, "choices": choices, **kwargs})
+        if self._delay_s:
+            await asyncio.sleep(self._delay_s)
         return self.answers.get(prompt, "")
 
 
-def _tool(answers: dict[str, str]) -> tuple[AskUserTool, _StubBroker]:
-    broker = _StubBroker(answers)
+def _tool(answers: dict[str, str], **kw) -> tuple[AskUserTool, _StubBroker]:
+    broker = _StubBroker(answers, **kw)
     tool = AskUserTool(broker=broker, conversation_id="tui:test")  # type: ignore[arg-type]
     return tool, broker
 
@@ -97,3 +106,248 @@ def test_display_call_labels_the_row_with_the_question():
     assert tool.display_call({"questions": []}) is None
     assert tool.display_call({"questions": [{"question": "  "}]}) is None
     assert tool.display_call({}) is None
+
+
+def test_schema_advertises_only_fields_the_tool_reads():
+    """Every declared field must reach the broker; a decorative one misleads.
+
+    ``multiple`` and ``custom`` were declared and never read, so a model that
+    asked for a multi-select got a single-select and never learned why.
+    """
+    tool, _ = _tool({})
+    entry = tool.parameters["properties"]["questions"]["items"]["properties"]
+
+    assert "multiple" not in entry
+    assert "custom" not in entry
+    assert set(entry) == {"question", "header", "options", "recommended"}
+    assert tool.parameters["properties"]["questions"]["maxItems"] == 4
+
+
+@pytest.mark.asyncio
+async def test_header_and_batch_position_reach_the_broker():
+    tool, broker = _tool({"Base?": "main", "Squash?": "yes"})
+
+    await tool.execute(
+        questions=[
+            {"question": "Base?", "header": "Base"},
+            {"question": "Squash?", "header": "Squash"},
+        ]
+    )
+
+    assert [c["header"] for c in broker.calls] == ["Base", "Squash"]
+    assert [c["index"] for c in broker.calls] == [0, 1]
+    assert [c["total"] for c in broker.calls] == [2, 2]
+    # Every round-trip carries the whole batch so a surface can render the set
+    # and its progress while still collecting one answer at a time.
+    assert broker.calls[0]["batch"] == [
+        {"question": "Base?", "header": "Base"},
+        {"question": "Squash?", "header": "Squash"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_batch_shares_one_deadline_instead_of_one_each():
+    """N questions must not cost N full timeouts."""
+    tool, broker = _tool({"a?": "1", "b?": "2"}, delay_s=0.05)
+    broker.default_timeout_s = 1.0
+
+    await tool.execute(questions=[{"question": "a?"}, {"question": "b?"}])
+
+    first, second = broker.calls[0]["timeout_s"], broker.calls[1]["timeout_s"]
+    assert first <= 1.0
+    assert second < first, "the second question must inherit what the first left"
+    assert second > 0
+
+
+@pytest.mark.asyncio
+async def test_single_option_question_is_rejected_without_asking_anyone():
+    tool, broker = _tool({})
+
+    result = await tool.execute(questions=[{"question": "Ship it?", "options": ["yes"]}])
+
+    assert isinstance(result, str)
+    assert "exactly one option" in result
+    assert "filler" in result
+    assert broker.asked == [], "a rejected call must not reach the user"
+
+
+@pytest.mark.asyncio
+async def test_free_form_question_with_no_options_is_still_allowed():
+    tool, broker = _tool({"Why?": "because"})
+
+    result = await tool.execute(questions=[{"question": "Why?"}])
+
+    assert isinstance(result, ToolResult)
+    assert broker.asked == [("Why?", [])]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_question_text_is_rejected_before_prompting():
+    tool, broker = _tool({})
+
+    result = await tool.execute(questions=[{"question": "Ship it?"}, {"question": "Ship it?"}])
+
+    assert isinstance(result, str)
+    assert "duplicate question" in result
+    assert broker.asked == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_option_labels_are_deduped_rather_than_rejected():
+    """A repeated label is a typo with one obvious reading; dropping it costs
+    the model nothing, whereas rejecting the call costs a whole turn."""
+    tool, broker = _tool({"Which?": "uv"})
+
+    result = await tool.execute(questions=[{"question": "Which?", "options": ["uv", "pip", "uv"]}])
+
+    assert isinstance(result, ToolResult)
+    assert broker.asked == [("Which?", ["uv", "pip"])]
+
+
+@pytest.mark.asyncio
+async def test_batch_over_the_cap_is_rejected_with_the_cap_named():
+    tool, broker = _tool({})
+
+    result = await tool.execute(questions=[{"question": f"q{i}?"} for i in range(5)])
+
+    assert isinstance(result, str)
+    assert "at most 4" in result
+    assert broker.asked == []
+
+
+@pytest.mark.asyncio
+async def test_unanswered_question_names_the_recommended_option():
+    """Without a default the model only learns that nobody answered; naming the
+    option it recommended is what lets it proceed the way it intended to."""
+    tool, _ = _tool({})
+
+    result = await tool.execute(questions=[{"question": "Ship it?", "options": ["hold", "ship"], "recommended": 1}])
+
+    assert isinstance(result, ToolResult)
+    assert 'recommended option was "ship"' in result.model_text
+
+
+@pytest.mark.asyncio
+async def test_out_of_range_recommended_index_is_ignored():
+    tool, _ = _tool({})
+
+    result = await tool.execute(questions=[{"question": "Ship it?", "options": ["a", "b"], "recommended": 9}])
+
+    assert isinstance(result, ToolResult)
+    assert "recommended option" not in result.model_text
+    assert "did not answer" in result.model_text
+
+
+@pytest.mark.asyncio
+async def test_exhausted_budget_stops_asking_instead_of_starting_a_fresh_wait():
+    """Once the shared deadline is spent, the remaining questions must not each
+    open a new wait -- that is the per-question timeout this replaces."""
+    tool, broker = _tool({"a?": "1", "b?": "2"}, delay_s=0.05)
+    broker.default_timeout_s = 0.01
+
+    result = await tool.execute(questions=[{"question": "a?"}, {"question": "b?"}])
+
+    assert isinstance(result, ToolResult)
+    assert [c["prompt"] for c in broker.calls] == ["a?"], "the second question must not be asked"
+    assert "did not answer" in result.model_text
+
+
+@pytest.mark.asyncio
+async def test_overlong_header_is_truncated_rather_than_breaking_the_chip():
+    tool, broker = _tool({"Which?": "uv"})
+
+    await tool.execute(questions=[{"question": "Which?", "header": "a-very-long-header-label"}])
+
+    assert broker.calls[0]["header"] == "a-very-long-"
+
+
+@pytest.mark.asyncio
+async def test_recommended_option_reaches_the_broker_for_the_surface_to_mark():
+    tool, broker = _tool({"Ship?": "ship"})
+
+    await tool.execute(questions=[{"question": "Ship?", "options": ["hold", "ship"], "recommended": 1}])
+
+    assert broker.calls[0]["recommended"] == "ship"
+
+
+@pytest.mark.asyncio
+async def test_tool_budget_overrides_whatever_the_surface_defaults_to():
+    """The batch budget is configuration, so it has to reach the tool without
+    the tool re-reading config from under a transport that never had one."""
+    broker = _StubBroker({"a?": "1"})
+    broker.default_timeout_s = 600.0
+    tool = AskUserTool(broker=broker, conversation_id="tui:test", timeout_s=1.5)  # type: ignore[arg-type]
+
+    await tool.execute(questions=[{"question": "a?"}])
+
+    assert broker.calls[0]["timeout_s"] <= 1.5
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_hands_the_configured_budget_to_the_tool(tmp_path):
+    """The loop is where the config already is, so it is where the budget has
+    to be handed over -- the transports that wire the broker do not all have a
+    config to read."""
+    from raven.agent.loop.main import AgentLoop
+    from raven.config.schema import AskUserToolConfig
+
+    class _Provider:
+        """AgentLoop construction reads the default model; no turn is run here."""
+
+        def get_default_model(self) -> str:
+            return "stub-model"
+
+        async def chat_with_retry(self, **kwargs):  # pragma: no cover - never invoked
+            raise NotImplementedError
+
+    loop = AgentLoop(provider=_Provider(), workspace=tmp_path, ask_user_config=AskUserToolConfig(timeout=42))
+    tool = loop.tools.get("ask_user")
+    assert tool is not None
+
+    broker = _StubBroker({"a?": "1"})
+    broker.default_timeout_s = 600.0
+    tool.set_broker(broker)
+    tool.set_context("tui:test")
+
+    await tool.execute(questions=[{"question": "a?"}])
+
+    assert broker.calls[0]["timeout_s"] <= 42
+
+
+def test_description_states_the_cap_the_code_enforces():
+    """The description is prompt text the model reads, so a cap named there and
+    a cap enforced here are two statements of one rule and will drift apart."""
+    from raven.agent.tools.ask_user import MAX_QUESTIONS
+
+    tool, _ = _tool({})
+
+    assert f"up to {MAX_QUESTIONS}" in tool.description
+    assert tool.parameters["properties"]["questions"]["maxItems"] == MAX_QUESTIONS
+
+
+@pytest.mark.asyncio
+async def test_round_trip_through_the_real_broker():
+    """Every other test here drives a stand-in, which cannot catch the tool and
+    the broker disagreeing about the keyword names they pass between them."""
+    from raven.tui_rpc.question_broker import QuestionBroker
+
+    frames: list[dict] = []
+
+    async def send_frame(frame: dict) -> None:
+        frames.append(frame)
+        broker.reply(frame["params"]["conversation_id"], "uv")
+
+    broker = QuestionBroker(send_frame, timeout_s=5.0)
+    tool = AskUserTool(broker=broker, conversation_id="tui:test")
+
+    result = await tool.execute(
+        questions=[{"question": "Which?", "header": "Pkg", "options": ["uv", "pip"], "recommended": 0}]
+    )
+
+    assert isinstance(result, ToolResult)
+    assert 'User answered: "Which?" -> "uv".' in result.model_text
+    params = frames[0]["params"]
+    assert params["header"] == "Pkg"
+    assert params["recommended"] == "uv"
+    assert params["total"] == 1
+    assert params["timeout_s"] <= 5.0

--- a/tests/test_cli_gateway_commands.py
+++ b/tests/test_cli_gateway_commands.py
@@ -336,3 +336,32 @@ def test_risk_banner_silent_when_sandboxed_or_restricted() -> None:
     assert _risk_banner(_config_with(backend="boxlite", telegram_enabled=True, allow_from=["*"])) is None
     assert _risk_banner(_config_with(backend="none", telegram_enabled=True, allow_from=["u1"])) is None
     assert _risk_banner(_config_with(backend="none", telegram_enabled=False, allow_from=["*"])) is None
+
+
+def test_question_body_numbers_choices_and_shows_batch_progress() -> None:
+    """On a chat channel the batch has no dialog to show progress in, so the
+    position has to ride in the message text itself."""
+    from raven.cli.gateway_commands import _format_question_body
+
+    body = _format_question_body(
+        {"question": "Squash?", "choices": ["yes", "no"], "index": 1, "total": 3, "header": "Squash"}
+    )
+
+    assert body.splitlines() == ["(2/3) Squash?", "1. yes", "2. no"]
+
+
+def test_lone_question_carries_no_progress_prefix() -> None:
+    from raven.cli.gateway_commands import _format_question_body
+
+    assert _format_question_body({"question": "Which?", "choices": [], "index": 0, "total": 1}) == "Which?"
+
+
+@pytest.mark.asyncio
+async def test_question_for_a_dead_conversation_is_reported_not_swallowed() -> None:
+    """Swallowing the drop left the broker waiting out its whole budget on a
+    question nobody would ever see."""
+    from raven.cli.gateway_commands import _deliver_question_to_channel
+    from raven.tui_rpc.question_broker import QuestionUndeliverableError
+
+    with pytest.raises(QuestionUndeliverableError):
+        await _deliver_question_to_channel({"params": {"conversation_id": "gone"}}, sources={}, hub=None)

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -103,3 +103,19 @@ def test_distinct_endpoint_labels_are_accepted() -> None:
         {"endpoints": [{"label": "primary", "apiKey": "sk-1"}, {"label": "backup", "apiKey": "sk-2"}]}
     )
     assert [e.label for e in section.endpoints] == ["primary", "backup"]
+
+
+def test_ask_user_timeout_is_configurable_per_surface() -> None:
+    """The wait belongs to the surface: a chat channel and a rendered page sit
+    out a silent user very differently, and 600s was hardcoded for both."""
+    from raven.config.schema import AskUserToolConfig, ToolsConfig
+
+    assert ToolsConfig().ask_user.timeout == 600
+    assert AskUserToolConfig(timeout=90).timeout == 90
+
+
+def test_ask_user_timeout_must_be_positive() -> None:
+    from raven.config.schema import AskUserToolConfig
+
+    with pytest.raises(ValidationError):
+        AskUserToolConfig(timeout=0)

--- a/tests/test_question_broker.py
+++ b/tests/test_question_broker.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 
 from raven.tui_rpc.methods.question import question_respond, register_question_methods
-from raven.tui_rpc.question_broker import QuestionBroker
+from raven.tui_rpc.question_broker import QuestionBroker, QuestionUndeliverableError
 
 CID = "telegram:123"
 
@@ -182,3 +182,89 @@ async def test_register_question_methods_adds_respond() -> None:
     register_question_methods(dispatcher, question_broker=broker)
 
     assert "clarify.respond" in dispatcher.methods()
+
+
+async def test_undeliverable_question_fails_fast_to_default() -> None:
+    """A surface that cannot render the question must not cost the full budget.
+
+    The gateway drops a question whose conversation has no live source. Before,
+    the drop was invisible to the broker, which then waited out the whole
+    timeout on a question nobody would ever see.
+    """
+
+    async def send_frame(frame: dict) -> None:
+        raise QuestionUndeliverableError("no live source")
+
+    broker = QuestionBroker(send_frame, timeout_s=30.0)
+    started = asyncio.get_running_loop().time()
+
+    answer = await broker.await_question(CID, prompt="?", default="fallback")
+
+    assert answer == "fallback"
+    assert asyncio.get_running_loop().time() - started < 1.0
+    assert broker.pending_req(CID) is None
+
+
+async def test_construction_timeout_is_the_default_budget() -> None:
+    _frames, send_frame = _frame_collector()
+    broker = QuestionBroker(send_frame, timeout_s=0.05)
+
+    assert await broker.await_question(CID, prompt="?", default="d") == "d"
+
+
+async def test_per_call_timeout_overrides_the_construction_default() -> None:
+    _frames, send_frame = _frame_collector()
+    broker = QuestionBroker(send_frame, timeout_s=30.0)
+
+    assert await broker.await_question(CID, prompt="?", default="d", timeout_s=0.05) == "d"
+
+
+async def test_clarify_request_carries_header_and_batch_progress() -> None:
+    frames, send_frame = _frame_collector()
+    broker = QuestionBroker(send_frame)
+    batch = [{"question": "Base?", "header": "Base"}, {"question": "Squash?", "header": "Squash"}]
+
+    task = asyncio.create_task(
+        broker.await_question(CID, prompt="Squash?", header="Squash", index=1, total=2, batch=batch)
+    )
+    params = (await _wait_for_frame(frames))["params"]
+
+    assert params["header"] == "Squash"
+    assert params["index"] == 1
+    assert params["total"] == 2
+    assert params["batch"] == batch
+
+    broker.reply(CID, "yes")
+    await task
+
+
+async def test_single_question_still_carries_a_one_item_batch() -> None:
+    frames, send_frame = _frame_collector()
+    broker = QuestionBroker(send_frame)
+
+    task = asyncio.create_task(broker.await_question(CID, prompt="Which?"))
+    params = (await _wait_for_frame(frames))["params"]
+
+    assert params["header"] == ""
+    assert params["index"] == 0
+    assert params["total"] == 1
+    assert params["batch"] == [{"question": "Which?", "header": ""}]
+
+    broker.reply(CID, "a")
+    await task
+
+
+async def test_clarify_request_carries_the_recommended_option_and_the_budget() -> None:
+    """The surface needs both to do its half: mark the recommended choice, and
+    tell the user how long the question will stand."""
+    frames, send_frame = _frame_collector()
+    broker = QuestionBroker(send_frame, timeout_s=45.0)
+
+    task = asyncio.create_task(broker.await_question(CID, prompt="Ship?", choices=["hold", "ship"], recommended="ship"))
+    params = (await _wait_for_frame(frames))["params"]
+
+    assert params["recommended"] == "ship"
+    assert params["timeout_s"] == 45.0
+
+    broker.reply(CID, "ship")
+    await task

--- a/ui-tui/src/__tests__/clarifyPrompt.test.tsx
+++ b/ui-tui/src/__tests__/clarifyPrompt.test.tsx
@@ -146,4 +146,35 @@ describe('ClarifyPrompt', () => {
 
     expect(onAnswer).toHaveBeenCalledWith('hold')
   })
+
+  it('quick-picks the Other row by its own number', async () => {
+    const onAnswer = vi.fn()
+    const h = driven(onAnswer)
+
+    // The Other row is rendered as "3." beside two choices, so 3 has to reach
+    // it -- otherwise the list numbers a row the keyboard cannot select.
+    await h.key('3')
+    await h.type('something else entirely')
+    await h.key(ENTER)
+    h.unmount()
+
+    expect(onAnswer).toHaveBeenCalledWith('something else entirely')
+  })
+
+  it('names a quick-pick range that covers every row it draws', () => {
+    const frame = frameOf(<ClarifyPrompt onAnswer={noop} onCancel={noop} req={req()} t={DEFAULT_THEME} />)
+
+    // Two choices plus Other is three rows, so the hint has to say 1-3.
+    expect(frame).toContain('1-3 quick pick')
+  })
+
+  it('ignores a number past the last row', async () => {
+    const onAnswer = vi.fn()
+    const h = driven(onAnswer)
+
+    await h.key('9')
+    h.unmount()
+
+    expect(onAnswer).not.toHaveBeenCalled()
+  })
 })

--- a/ui-tui/src/__tests__/clarifyPrompt.test.tsx
+++ b/ui-tui/src/__tests__/clarifyPrompt.test.tsx
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 EverMind.
+// See NOTICES.md.
+
+import { renderSync } from '@hermes/ink'
+import { render } from 'ink-testing-library'
+import React from 'react'
+import { PassThrough } from 'stream'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ClarifyReq } from '../types.js'
+
+import { ClarifyPrompt } from '../components/prompts.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+const req = (over: Partial<ClarifyReq> = {}): ClarifyReq => ({
+  choices: ['hold', 'ship'],
+  question: 'Ship it?',
+  requestId: 'r1',
+  ...over
+})
+
+const noop = () => {}
+
+const frameOf = (node: React.ReactElement): string => stripAnsi(render(node).lastFrame() ?? '')
+
+// ink only routes keystrokes through useInput when stdin looks like a raw-mode
+// TTY, which ink-testing-library's stub stdin is not -- so the typing tests get
+// the same PassThrough harness the model-picker tests use.
+const driven = (onAnswer: (s: string) => void, over: Partial<ClarifyReq> = {}) => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+
+  Object.assign(stdout, { columns: 80, isTTY: true, rows: 24 })
+  Object.assign(stdin, { isTTY: true, ref: noop, setRawMode: noop, unref: noop })
+  Object.assign(stderr, { isTTY: true })
+
+  const instance = renderSync(
+    <ClarifyPrompt onAnswer={onAnswer} onCancel={noop} req={req(over)} t={DEFAULT_THEME} />,
+    {
+      patchConsole: false,
+      stderr: stderr as NodeJS.WriteStream,
+      stdin: stdin as NodeJS.ReadStream,
+      stdout: stdout as NodeJS.WriteStream
+    }
+  )
+
+  return {
+    // One keystroke per write: ink's input parser reads a multi-character write
+    // as a single burst, which the text input does not treat as typing.
+    key: async (s: string) => {
+      stdin.write(s)
+      await delay(30)
+    },
+    type: async (s: string) => {
+      for (const ch of s) {
+        stdin.write(ch)
+        await delay(15)
+      }
+      await delay(20)
+    },
+    unmount: () => {
+      instance.unmount()
+      instance.cleanup()
+    }
+  }
+}
+
+const DOWN = "\u001B[B"
+const TAB = '\t'
+const ENTER = '\r'
+
+describe('ClarifyPrompt', () => {
+  it('shows the short header beside the question', () => {
+    const frame = frameOf(
+      <ClarifyPrompt onAnswer={noop} onCancel={noop} req={req({ header: 'Release' })} t={DEFAULT_THEME} />
+    )
+
+    expect(frame).toContain('Release')
+    expect(frame).toContain('Ship it?')
+  })
+
+  it('shows the batch position and the rest of the set', () => {
+    const frame = frameOf(
+      <ClarifyPrompt
+        onAnswer={noop}
+        onCancel={noop}
+        req={req({
+          batch: [
+            { header: 'Base', question: 'Base branch?' },
+            { header: 'Release', question: 'Ship it?' },
+            { header: 'Squash', question: 'Squash?' }
+          ],
+          index: 1,
+          total: 3
+        })}
+        t={DEFAULT_THEME}
+      />
+    )
+
+    expect(frame).toContain('2/3')
+    // Seeing the whole set is what tells the user how much is still coming.
+    expect(frame).toContain('Base branch?')
+    expect(frame).toContain('Squash?')
+  })
+
+  it('marks the option the agent recommends', () => {
+    const frame = frameOf(
+      <ClarifyPrompt onAnswer={noop} onCancel={noop} req={req({ recommended: 'ship' })} t={DEFAULT_THEME} />
+    )
+
+    expect(frame).toMatch(/ship.*recommended/i)
+  })
+
+  it('shows how long the question will stand', () => {
+    const frame = frameOf(
+      <ClarifyPrompt onAnswer={noop} onCancel={noop} req={req({ timeoutS: 90 })} t={DEFAULT_THEME} />
+    )
+
+    expect(frame).toMatch(/1m 30s/)
+  })
+
+  it('sends the selected option together with the note the user added', async () => {
+    const onAnswer = vi.fn()
+    const h = driven(onAnswer)
+
+    await h.key(DOWN)
+    await h.key(TAB)
+    await h.type('needs a changelog entry')
+    await h.key(ENTER)
+    h.unmount()
+
+    expect(onAnswer).toHaveBeenCalledWith('ship (note: needs a changelog entry)')
+  })
+
+  it('still sends a bare option when no note is added', async () => {
+    const onAnswer = vi.fn()
+    const h = driven(onAnswer)
+
+    await h.key(ENTER)
+    h.unmount()
+
+    expect(onAnswer).toHaveBeenCalledWith('hold')
+  })
+})

--- a/ui-tui/src/__tests__/clarifyPrompt.test.tsx
+++ b/ui-tui/src/__tests__/clarifyPrompt.test.tsx
@@ -124,6 +124,29 @@ describe('ClarifyPrompt', () => {
     expect(frame).toMatch(/1m 30s/)
   })
 
+  it('renders a whole-second countdown from the fractional payload', () => {
+    // The runtime sends `deadline - loop.time()`, so a 90-second budget arrives
+    // as 89.99999912502244 and the raw value would widen the line to
+    // "1m 29.99999912502244s" on every tick, not just the first frame.
+    const frame = frameOf(
+      <ClarifyPrompt onAnswer={noop} onCancel={noop} req={req({ timeoutS: 89.99999912502244 })} t={DEFAULT_THEME} />
+    )
+
+    expect(frame).toMatch(/1m 30s/)
+    expect(frame).not.toMatch(/\d\.\d/)
+  })
+
+  it('carries a rounded-up sub-minute value into the minutes shape', () => {
+    // Ceiling 59.7 crosses the minute boundary, so the branch has to be chosen
+    // after the rounding or the line reads "60s".
+    const frame = frameOf(
+      <ClarifyPrompt onAnswer={noop} onCancel={noop} req={req({ timeoutS: 59.7 })} t={DEFAULT_THEME} />
+    )
+
+    expect(frame).toMatch(/1m 00s/)
+    expect(frame).not.toMatch(/60s/)
+  })
+
   it('sends the selected option together with the note the user added', async () => {
     const onAnswer = vi.fn()
     const h = driven(onAnswer)

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -516,7 +516,17 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
       case 'clarify.request':
         patchOverlayState({
-          clarify: { choices: ev.payload.choices, question: ev.payload.question, requestId: ev.payload.request_id }
+          clarify: {
+            batch: ev.payload.batch,
+            choices: ev.payload.choices,
+            header: ev.payload.header,
+            index: ev.payload.index,
+            question: ev.payload.question,
+            recommended: ev.payload.recommended,
+            requestId: ev.payload.request_id,
+            timeoutS: ev.payload.timeout_s,
+            total: ev.payload.total
+          }
         })
         setStatus('waiting for input…')
 

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -16,6 +16,11 @@ import { TextInput } from './textInput.js'
 
 const CMD_PREVIEW_LINES = 10
 
+// 90 -> "1m 30s", 45 -> "45s". Seconds are padded so the line keeps its
+// width as the countdown runs and the prompt below it does not jitter.
+const clarifyRemainingText = (secs: number): string =>
+  secs < 60 ? `${secs}s` : `${Math.floor(secs / 60)}m ${String(secs % 60).padStart(2, '0')}s`
+
 export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
   const [sel, setSel] = useState(0)
   const [remainingSeconds, setRemainingSeconds] = useState(() => approvalRemainingSeconds(req.expiresAt))
@@ -112,23 +117,63 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
   const [sel, setSel] = useState(0)
   const [custom, setCustom] = useState('')
   const [typing, setTyping] = useState(false)
+  // The option a note is being attached to. Distinct from `typing`, which
+  // replaces the selection with free text rather than annotating it.
+  const [noting, setNoting] = useState<null | string>(null)
+  const [note, setNote] = useState('')
+  const [remaining, setRemaining] = useState(req.timeoutS ?? 0)
   const choices = req.choices ?? []
+  const total = req.total ?? 1
+  const position = (req.index ?? 0) + 1
+  const others = (req.batch ?? []).filter((_, i) => i !== (req.index ?? 0))
+
+  useEffect(() => {
+    if (!req.timeoutS) {
+      return
+    }
+
+    setRemaining(req.timeoutS)
+    const timer = setInterval(() => setRemaining(s => (s > 0 ? s - 1 : 0)), 1000)
+
+    return () => clearInterval(timer)
+  }, [req.requestId, req.timeoutS])
 
   const heading = (
     <Text bold>
       <Text color={t.color.accent}>ask</Text>
+      {total > 1 ? <Text color={t.color.muted}> ({position}/{total})</Text> : null}
+      {req.header ? <Text color={t.color.label}> [{req.header}]</Text> : null}
       <Text color={t.color.text}> {req.question}</Text>
     </Text>
   )
 
+  // The rest of the batch, so the user can see how much is still coming rather
+  // than discovering it one prompt at a time.
+  const rest =
+    others.length > 0 ? (
+      <Box flexDirection="column" paddingLeft={1}>
+        <Text color={t.color.muted} dimColor>
+          also asking: {others.map(q => q.question).join(' · ')}
+        </Text>
+      </Box>
+    ) : null
+
+  const budget = req.timeoutS ? `${clarifyRemainingText(remaining)} left · ` : ''
+
   useInput((ch, key) => {
     if (key.escape) {
+      if (noting !== null) {
+        setNoting(null)
+
+        return
+      }
+
       typing && choices.length ? setTyping(false) : onCancel()
 
       return
     }
 
-    if (typing || !choices.length) {
+    if (typing || noting !== null || !choices.length) {
       return
     }
 
@@ -138,6 +183,13 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
 
     if (key.downArrow && sel < choices.length) {
       setSel(s => s + 1)
+    }
+
+    if (key.tab && sel < choices.length && choices[sel]) {
+      setNote('')
+      setNoting(choices[sel]!)
+
+      return
     }
 
     if (key.return) {
@@ -151,10 +203,37 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
     }
   })
 
+  if (noting !== null) {
+    return (
+      <Box flexDirection="column">
+        {heading}
+
+        <Text color={t.color.label}>
+          {'  '}note for {noting}
+        </Text>
+
+        <Box>
+          <Text color={t.color.label}>{'> '}</Text>
+          <TextInput
+            columns={Math.max(20, cols - 6)}
+            onChange={setNote}
+            onSubmit={v => onAnswer(v.trim() ? `${noting} (note: ${v.trim()})` : noting)}
+            value={note}
+          />
+        </Box>
+
+        <Text color={t.color.muted}>
+          {budget}Enter send · Esc back
+        </Text>
+      </Box>
+    )
+  }
+
   if (typing || !choices.length) {
     return (
       <Box flexDirection="column">
         {heading}
+        {rest}
 
         <Box>
           <Text color={t.color.label}>{'> '}</Text>
@@ -162,7 +241,7 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
         </Box>
 
         <Text color={t.color.muted}>
-          Enter send · Esc {choices.length ? 'back' : 'cancel'} ·{' '}
+          {budget}Enter send · Esc {choices.length ? 'back' : 'cancel'} ·{' '}
           {isMac ? 'Cmd+C copy · Cmd+V paste · Ctrl+C cancel' : 'Ctrl+C cancel'}
         </Text>
       </Box>
@@ -172,17 +251,21 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
   return (
     <Box flexDirection="column">
       {heading}
+      {rest}
 
       {[...choices, 'Other (type your answer)'].map((c, i) => (
         <Text key={i}>
           <Text bold={sel === i} color={sel === i ? t.color.label : t.color.muted} inverse={sel === i}>
             {sel === i ? '▸ ' : '  '}
             {i + 1}. {c}
+            {req.recommended && c === req.recommended ? ' (recommended)' : ''}
           </Text>
         </Text>
       ))}
 
-      <Text color={t.color.muted}>↑/↓ select · Enter confirm · 1-{choices.length} quick pick · Esc/Ctrl+C cancel</Text>
+      <Text color={t.color.muted}>
+        {budget}↑/↓ select · Enter confirm · Tab add note · 1-{choices.length} quick pick · Esc/Ctrl+C cancel
+      </Text>
     </Box>
   )
 }

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -200,6 +200,10 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
 
     if (n >= 1 && n <= choices.length) {
       onAnswer(choices[n - 1]!)
+    } else if (n === choices.length + 1) {
+      // The Other row is drawn with a number like every other row, so its
+      // number has to reach it too; Enter on the row already does.
+      setTyping(true)
     }
   })
 
@@ -264,7 +268,7 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
       ))}
 
       <Text color={t.color.muted}>
-        {budget}↑/↓ select · Enter confirm · Tab add note · 1-{choices.length} quick pick · Esc/Ctrl+C cancel
+        {budget}↑/↓ select · Enter confirm · Tab add note · 1-{choices.length + 1} quick pick · Esc/Ctrl+C cancel
       </Text>
     </Box>
   )

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -18,8 +18,17 @@ const CMD_PREVIEW_LINES = 10
 
 // 90 -> "1m 30s", 45 -> "45s". Seconds are padded so the line keeps its
 // width as the countdown runs and the prompt below it does not jitter.
-const clarifyRemainingText = (secs: number): string =>
-  secs < 60 ? `${secs}s` : `${Math.floor(secs / 60)}m ${String(secs % 60).padStart(2, '0')}s`
+//
+// The payload is a remaining-time subtraction, so it arrives fractional: a
+// 90-second budget shows up as 89.99999912502244. Ceil before the branch, not
+// inside it -- 59.7 belongs to the minutes shape, and rounding after the test
+// would render it as "60s". Ceil rather than round keeps the last second on
+// screen until the deadline has actually passed.
+const clarifyRemainingText = (secs: number): string => {
+  const whole = Math.ceil(secs)
+
+  return whole < 60 ? `${whole}s` : `${Math.floor(whole / 60)}m ${String(whole % 60).padStart(2, '0')}s`
+}
 
 export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
   const [sel, setSel] = useState(0)

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -552,7 +552,17 @@ export type GatewayEvent =
       type: 'tool.complete'
     }
   | {
-      payload: { choices: string[] | null; question: string; request_id: string }
+      payload: {
+        batch?: { header?: string; question: string }[]
+        choices: string[] | null
+        header?: string
+        index?: number
+        question: string
+        recommended?: string
+        request_id: string
+        timeout_s?: number
+        total?: number
+      }
       session_id?: string
       type: 'clarify.request'
     }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -112,10 +112,23 @@ export interface ConfirmReq {
   title?: string
 }
 
-export interface ClarifyReq {
-  choices: string[] | null
+// One entry of an ask_user batch, carried on every question in it so the
+// prompt can show the whole set while answering one at a time.
+export interface ClarifyBatchItem {
+  header?: string
   question: string
+}
+
+export interface ClarifyReq {
+  batch?: ClarifyBatchItem[]
+  choices: string[] | null
+  header?: string
+  index?: number
+  question: string
+  recommended?: string
   requestId: string
+  timeoutS?: number
+  total?: number
 }
 
 // One tool invocation inside an episode. `summary` is a target-string ("ls


### PR DESCRIPTION
## Summary

`ask_user` advertised things it did not do, and a batch cost the user more than
one wait. This closes both, and gives the prompt the fields it needs to render a
batch honestly.

- **Two schema fields nothing read.** `multiple` and `custom` were declared per
  question and never passed to the broker, so a model asking for a multi-select
  got a single-select and never learned why. Both are removed. Multi-select is
  deliberately not implemented here: it would need a new answer syntax on the
  chat-channel surface, which has no dialog to hold a multi-select, and that is
  a larger decision than removing a field that never worked.
- **One deadline per call, not per question.** A batch was N round-trips with N
  independent timeouts, so a three-question call could hold a lane for three
  times the surface's wait. The call now shares one budget, and a spent budget
  stops the batch instead of opening a fresh wait on every question left.
- **The budget is configuration.** `tools.ask_user.timeout` (600s, must be
  positive) reaches the tool through `AgentLoop`, which is where the config
  already is. It deliberately does not read config at the transport: the TUI
  builds its broker before any config is loaded, and reading it there put a
  schema-validation failure in the path of the RPC server coming up.
- **Calls that would waste the user's time are rejected before rendering**, with
  a message that steers the retry: more than four questions, a duplicate
  question text, or a question with exactly one option, which is not a decision.
  A duplicate option label is a typo with one obvious reading, so it is deduped
  rather than rejected. Zero options remains a free-form question.
- **`header` and `recommended`.** A short chip label, and a 0-based index into
  `options` naming the option the agent would pick. When nobody answers, the
  text the model reads now names that option; before, the only signal was that
  no answer arrived.
- **A recommendation is resolved against the options as submitted.** The index
  counts what the caller sent, but the list was deduplicated before the index was
  resolved against it. With `["a","a","b","c"]` and `recommended: 2` the caller
  means `"b"` while the broker was handed `"c"`, so the surface marked the wrong
  row and a timeout told the model the wrong intended fallback; an index past the
  deduped length (`3` on that list) failed the range check and the recommendation
  was dropped without a word. The label is now resolved before dedup narrows the
  list. Dedup keeps every distinct label, so the resolved label is always still
  one of the choices the surface can mark.
- **An undeliverable question is reported, not dropped.** A question for a
  conversation with no live source was dropped with a log line the broker could
  not see, so the round-trip waited out its whole budget on a question nobody
  would ever see. The channel adapter now raises `QuestionUndeliverableError`
  and the broker fails safe at once.
- **The prompt renders the batch.** Position in the call, the questions still to
  come, the recommended option marked, and the remaining budget counting down.
  Tab attaches a note to a selection, so an answer no longer has to be either a
  choice or free text. On a chat channel the position rides in the message text.
- **The countdown renders whole seconds.** `timeout_s` is a remaining-time
  subtraction, so a 90-second budget arrives as `89.99999912502244` and the
  prompt decrements that same fractional value once a second. The formatter
  passed it straight through, so the line read `1m 29.99999912502244s` on every
  tick and widened the prompt that the padding exists to keep steady. The value
  is now ceiled before the branch is chosen, since ceiling inside the branches
  renders a ceiled `59.7` as `60s` rather than `1m 00s`.
- **The `Other` row answers to its own number.** This one predates the rest of
  the branch. The options list draws `Other` as one more numbered row, but the
  quick-pick handler bounded itself at the number of real choices, so the last
  row was numbered and unreachable -- and worse than inert: the keystrokes that
  followed were swallowed by the options handler, so the next Enter submitted
  whichever option was still highlighted. Someone who thought they were typing a
  free-form answer sent a selection they never made. Its number now opens the
  text input, which is what Enter on that row already did, and the hint names
  the range it can take.

The wire payload gains `header`, `recommended`, `timeout_s`, `index`, `total`
and `batch`. `clarify.request` is a notification and is not part of
`rpc-schema/openrpc.json`, so no generated artifact changes; `npm run lint:rpc`
confirms `generated.ts` is still in sync. `deep_research` shares the same broker
and passes none of the new fields, so its prompt is unchanged except that it now
shows the countdown, which was always the real deadline.

`timeout_s` stays fractional on the wire deliberately: it is also what the model
is told about the budget, and rounding it at the source would change that value
to serve a display concern. The formatter is the layer with a width to protect.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

Mostly fixes; the prompt affordances and the config field are additive.

## Verification

Every new test was watched failing before the code that makes it pass.

Rebased onto `22b71765`, which collapsed the earlier `Merge branch 'main'` commit
into a linear six-commit history. The base gained #361 and #362; the only file
this branch and those commits both touch is `raven/agent/loop/main.py`, and the
replay was clean. `git merge-tree --write-tree` needs git 2.38 and this box has
2.34.1, so the pre-push check was that file-overlap table plus a full re-run at
the new head rather than a dry-run merge. Everything below is from the new head,
not carried forward.

```
python -m pytest tests/ -q
  82 failed, 6576 passed, 47 skipped, 13 deselected

# same suite on the new base 22b71765, in a separate worktree:
  82 failed, 6545 passed, 47 skipped, 13 deselected

# full failing-ID lists from both runs, sorted and diffed:
diff branch_fail.txt base_fail.txt   -> identical (0 introduced, 0 fixed)
```

The 82 failures are inherited: the base fails the same 82 IDs on this box, and the
sets are identical rather than merely the same size. They are
`test_tui_rpc_session.py` (58), `test_cli_cron_commands.py` (7),
`test_cli_import_commands.py` (5), `test_tui_commands_error_codes.py` (3),
`test_cli_onboard_commands.py` (3), and 6 more spread across 5 files. The +31
passing tests are the ones added here.

Suites that exercise the changed code directly:

```
python -m pytest tests/test_ask_user_tool.py tests/test_question_broker.py \
                 tests/test_cli_gateway_commands.py tests/test_config_schema.py -q
  81 passed

npm run test -- --run src/__tests__/clarifyPrompt.test.tsx
  11 passed

npm run type-check   -> clean
npm run lint:rpc     -> OK: generated.ts in sync

python -m ruff check raven tests           -> All checks passed!
python -m ruff format --check raven tests   -> 849 files already formatted
python -m scripts.check_commit_messages github/main..HEAD -> exit 0
scripts/check_large_files.py                -> exit 0
```

Beyond the suites, the tool was exercised over the real path -- a real
`ToolRegistry` (so `cast_params` and the schema validator run), a real
`QuestionBroker`, and answers delivered through the real `clarify.respond`
handler on a real `Dispatcher`:

- the three rejections emit **zero** prompts, so a malformed call costs the user
  nothing, and the steer text reaches the model intact through the registry;
- a batch answered by a responder taking 0.25s per question is handed
  `10.0000s`, `9.7495s`, `9.4991s` -- each question inherits what the last one
  left;
- a batch whose budget is spent emits **one** prompt, not one per question;
- an undeliverable question returns in `0.001s` against a 30s budget.

`test_registry_dispatch_and_the_real_clarify_respond_route` was added from that
exercise, because no committed test drove the registry before. It was proved
non-vacuous by renaming the `recommended` keyword the tool passes the broker and
watching it go red.

The two review fixes were each proved the same way:

- The recommendation cases were run against the deduped resolution and failed
  with `assert 'c' == 'b'` (wrong label) and `assert '' == 'c'` (recommendation
  dropped), then passed once the resolution moved ahead of dedup.
  `test_out_of_range_recommended_index_is_ignored` passes unchanged -- it has no
  duplicates, so it never encoded this.
- The countdown cases were run against the pass-through formatter and failed on
  `expected ... to match /1m 30s/` and `/1m 00s/`, covering both the fractional
  payload and the `59.7` boundary that ceiling creates.

`prompts.tsx` and `clarifyPrompt.test.tsx` are reported by Prettier, and were
before this branch touched them: the hunks it wants are at lines this branch does
not change (a JSX ternary and a `renderSync` call), so they are left alone rather
than reformatted into this diff.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

`docs/Proactivity-Implementation.md` documented the two removed fields and the
old narrow payload, so that paragraph is rewritten. `ui-tui/dist/entry.js` is
gitignored, so testing the prompt by hand needs
`npm run build --prefix ui-tui` first.

## Risk

User-visible changes:

- A model sending five questions, a duplicate question, or a one-option question
  now gets an error instead of prompting the user. The error text tells it what
  to do instead.
- A batch that used to get a fresh timeout per question now shares one. A slow
  user answering question 3 of 4 past the budget gets the rest recorded as
  unanswered rather than being asked.
- The prompt shows a countdown where it showed none, including for
  `deep_research`, and that countdown now reads in whole seconds.
- A recommendation sent as an index past the deduped option count used to be
  dropped silently and now resolves. That is what the schema promises, but it is
  a real change for a caller that had been sending such an index.
- Typing the `Other` row's number now opens the text input instead of doing
  nothing.

Rollback is the six commits; nothing is persisted and no format changes on disk.
The config field defaults to the previous 600s, so an untouched config behaves
as before.

Checked and deliberately not fixed, to keep this diff to one subject:

- `QuestionBroker.await_question` still returns its default on
  `asyncio.CancelledError`, which swallows an outer cancellation. It sits beside
  the handler added here, but changing it means auditing how the agent loop
  reacts to a cancelled turn.
- The gateway's inbound gate calls `pending_req(cid)` and then `reply(...)`. If
  the question times out between the two, the message answers nothing and starts
  no turn. `reply` already returns a bool, so using it as the condition would
  close this.
- The registry's schema validator does not implement `maxItems`, so the cap in
  the schema is advisory to the model and `_prepare` is what enforces it. That
  is deliberate -- the model gets the steer text rather than a generic
  validation error -- and a test pins the two statements of the cap together so
  they cannot drift.
- `ApprovalPrompt` in the same file hardcodes `1-2 quick pick`, which is correct
  for its two fixed options and has no `Other` row, so it is not the same bug.
- `approvalRemainingSeconds()` feeds the approval countdown in the same file and
  is already `Math.max(0, Math.ceil(...))`, so it needs nothing here. It is also
  where the `ceil` convention comes from: the clarify countdown now rounds the
  same direction as the approval one rather than inventing a second rule. The two
  are still not made to share a formatter -- one takes an absolute deadline and
  the other a remaining duration.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

No new secret, no new surface, and no asset moved onto an unauthenticated one.
The new config field is a timeout.

## Related Issues

N/A
