### PR TITLE
fix(ui-tui): read a coalesced byte run as typing, not as a paste

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -29,7 +29,7 @@ import {
 import reconciler from '../reconciler.js'
 import { finishSelection, hasSelection, type SelectionState, startSelection } from '../selection.js'
 import { getTerminalFocused, setTerminalFocused } from '../terminal-focus-state.js'
-import { TerminalQuerier, xtversion } from '../terminal-querier.js'
+import { decrqm, TerminalQuerier, xtversion } from '../terminal-querier.js'
 import {
   isExtendedKeysCapableByXtversion,
   isXtermJs,
@@ -44,7 +44,7 @@ import {
   FOCUS_IN,
   FOCUS_OUT
 } from '../termio/csi.js'
-import { DBP, DFE, DISABLE_MOUSE_TRACKING, EBP, EFE, SHOW_CURSOR } from '../termio/dec.js'
+import { DBP, DEC, DFE, DISABLE_MOUSE_TRACKING, EBP, EFE, SHOW_CURSOR } from '../termio/dec.js'
 
 import AppContext from './AppContext.js'
 import { ClockProvider } from './ClockContext.js'
@@ -331,6 +331,12 @@ export default class App extends PureComponent<Props, State> {
         // init sequence completes — avoids interleaving with alt-screen/mouse
         // tracking enable writes that may happen in the same render cycle.
         setImmediate(() => {
+          // Rides the same batch as XTVERSION: the answer tells the key
+          // parser whether paste markers can be trusted, which decides
+          // whether an unmarked byte run is typing or an unmarkable paste.
+          // The reply is routed into keyParseState by the parser itself.
+          void this.querier.send(decrqm(DEC.BRACKETED_PASTE))
+
           void Promise.all([this.querier.send(xtversion()), this.querier.flush()]).then(([r]) => {
             let rePushed = false
 

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -363,6 +363,34 @@ describe('plain text run splitting', () => {
       expect(seqs(keys).slice(1)).toEqual(['a', 'b'])
     })
 
+    it('keeps raw alt+enter ESC+CR as one keypress', () => {
+      const [keys] = parseMultipleKeypresses(confirmed, '\x1b\r')
+
+      expect(keys).toHaveLength(1)
+      expect(keys[0]).toMatchObject({ kind: 'key', name: '', sequence: '\x1b\r' })
+    })
+
+    it('keeps raw alt+enter ESC+LF as one keypress', () => {
+      const [keys] = parseMultipleKeypresses(confirmed, '\x1b\n')
+
+      expect(keys).toHaveLength(1)
+      expect(keys[0]).toMatchObject({ kind: 'key', name: '', sequence: '\x1b\n' })
+    })
+
+    it('keeps raw meta+backspace ESC+DEL as one keypress', () => {
+      const [keys] = parseMultipleKeypresses(confirmed, '\x1b\x7f')
+
+      expect(keys).toHaveLength(1)
+      expect(keys[0]).toMatchObject({ name: 'backspace', sequence: '\x1b\x7f', meta: true })
+    })
+
+    it('keeps raw meta+backspace ESC+BS as one keypress', () => {
+      const [keys] = parseMultipleKeypresses(confirmed, '\x1b\b')
+
+      expect(keys).toHaveLength(1)
+      expect(keys[0]).toMatchObject({ name: 'backspace', sequence: '\x1b\b', meta: true })
+    })
+
     it('splits a run longer than a typing burst', () => {
       const [keys] = parseMultipleKeypresses(confirmed, 'x'.repeat(33))
 

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -9,6 +9,13 @@ import { describe, expect, it } from 'vitest'
 import { INITIAL_STATE, parseMultipleKeypresses } from './parse-keypress.js'
 import { PASTE_END, PASTE_START } from './termio/csi.js'
 
+const DECRPM_2004_SET = '\x1b[?2004;1$y'
+
+// A plain text run reaches the app as one keypress per code point, so text
+// assertions join the run back together instead of indexing a single key.
+const joinKeys = (events: ReturnType<typeof parseMultipleKeypresses>[0]) =>
+  events.map(e => (e.kind === 'key' ? e.sequence : '')).join('')
+
 describe('parseMultipleKeypresses bracketed paste recovery', () => {
   it('emits empty bracketed pastes when the terminal sends both markers', () => {
     const [keys, state] = parseMultipleKeypresses(INITIAL_STATE, PASTE_START + PASTE_END)
@@ -125,19 +132,23 @@ describe('fragmented SGR mouse recovery', () => {
       expect.objectContaining({ kind: 'mouse', button: 35, col: 124, row: 26 }),
       expect.objectContaining({ kind: 'mouse', button: 35, col: 119, row: 26 })
     ])
-    expect(events[4]).toMatchObject({ kind: 'key', sequence: 'typed' })
+    expect(joinKeys(events.slice(4))).toBe('typed')
   })
 
   it('keeps isolated semicolon text that only resembles a prefixless mouse report', () => {
-    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, 'see 1;2;3M for details')
+    const text = 'see 1;2;3M for details'
+    const [events] = parseMultipleKeypresses(INITIAL_STATE, text)
 
-    expect(key).toMatchObject({ kind: 'key', sequence: 'see 1;2;3M for details' })
+    expect(events.every(e => e.kind === 'key')).toBe(true)
+    expect(joinKeys(events)).toBe(text)
   })
 
   it('does not match prefixless fragments inside longer digit runs', () => {
-    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, '1234;56;78M9;10;11M')
+    const text = '1234;56;78M9;10;11M'
+    const [events] = parseMultipleKeypresses(INITIAL_STATE, text)
 
-    expect(key).toMatchObject({ kind: 'key', sequence: '1234;56;78M9;10;11M' })
+    expect(events.every(e => e.kind === 'key')).toBe(true)
+    expect(joinKeys(events)).toBe(text)
   })
 })
 
@@ -229,5 +240,147 @@ describe('modifier+enter parsing (tui-composer-multiline regression lock)', () =
     const [[key]] = parseMultipleKeypresses(INITIAL_STATE, '\x1b[13;1u')
 
     expect(key).toMatchObject({ name: 'return', ctrl: false, meta: false, shift: false })
+  })
+})
+
+// Typing and pasting are indistinguishable in the raw byte stream, so a run
+// of plain bytes is split into one keypress per code point instead of being
+// merged into a single nameless keypress. Bracketed paste (DEC 2004) is the
+// only reliable paste signal; when the terminal is confirmed to support it,
+// every unmarked run is typing. When it is not, short printable runs are
+// still typing but anything carrying control bytes or long enough to be a
+// paste stays whole for the paste path.
+describe('plain text run splitting', () => {
+  const seqs = (keys: ReturnType<typeof parseMultipleKeypresses>[0]) =>
+    keys.map(k => (k.kind === 'key' ? k.sequence : ''))
+
+  describe('bracketed paste unconfirmed (default)', () => {
+    it('splits a printable run into one keypress per character', () => {
+      const [keys] = parseMultipleKeypresses(INITIAL_STATE, 'abc')
+
+      expect(seqs(keys)).toEqual(['a', 'b', 'c'])
+      expect(keys.map(k => (k.kind === 'key' ? k.name : ''))).toEqual(['a', 'b', 'c'])
+    })
+
+    it('splits multi-byte characters without breaking them apart', () => {
+      const [keys] = parseMultipleKeypresses(INITIAL_STATE, '你好')
+
+      expect(seqs(keys)).toEqual(['你', '好'])
+    })
+
+    it('keeps a run carrying a control byte whole for the paste path', () => {
+      const [keys] = parseMultipleKeypresses(INITIAL_STATE, 'there\r')
+
+      expect(seqs(keys)).toEqual(['there\r'])
+    })
+
+    it('keeps an auto-repeated backspace burst whole', () => {
+      const [keys] = parseMultipleKeypresses(INITIAL_STATE, '\x7f\x7f\x7f')
+
+      expect(seqs(keys)).toEqual(['\x7f\x7f\x7f'])
+    })
+
+    it('keeps a run longer than a typing burst whole', () => {
+      const long = 'x'.repeat(33)
+      const [keys] = parseMultipleKeypresses(INITIAL_STATE, long)
+
+      expect(seqs(keys)).toEqual([long])
+    })
+
+    it('splits a run at the typing-burst limit', () => {
+      const [keys] = parseMultipleKeypresses(INITIAL_STATE, 'x'.repeat(32))
+
+      expect(keys).toHaveLength(32)
+    })
+  })
+
+  describe('bracketed paste confirmed', () => {
+    // The parser learns the capability from the terminal's own DECRPM answer,
+    // so every case here starts from the state that reply produced.
+    const confirmed = parseMultipleKeypresses(INITIAL_STATE, DECRPM_2004_SET)[1]
+
+    it('records the capability from the DECRQM answer', () => {
+      expect(confirmed.bracketedPaste).toBe('confirmed')
+    })
+
+    it('rejects an answer saying the mode is off - App enabled it before asking', () => {
+      const [, state] = parseMultipleKeypresses(INITIAL_STATE, '\x1b[?2004;2$y')
+
+      expect(state.bracketedPaste).toBe('unknown')
+    })
+
+    it('accepts an answer saying the mode is permanently on', () => {
+      const [, state] = parseMultipleKeypresses(INITIAL_STATE, '\x1b[?2004;3$y')
+
+      expect(state.bracketedPaste).toBe('confirmed')
+    })
+
+    it('rejects an answer saying the mode is unknown to the terminal', () => {
+      const [, state] = parseMultipleKeypresses(INITIAL_STATE, '\x1b[?2004;0$y')
+
+      expect(state.bracketedPaste).toBe('unknown')
+    })
+
+    it('rejects an answer saying the mode can never be turned on', () => {
+      const [, state] = parseMultipleKeypresses(INITIAL_STATE, '\x1b[?2004;4$y')
+
+      expect(state.bracketedPaste).toBe('unknown')
+    })
+
+    it('ignores a DECRQM answer for an unrelated mode', () => {
+      const [, state] = parseMultipleKeypresses(INITIAL_STATE, '\x1b[?2026;1$y')
+
+      expect(state.bracketedPaste).toBe('unknown')
+    })
+
+    it('keeps the capability across later reads', () => {
+      const [, next] = parseMultipleKeypresses(confirmed, 'ab')
+
+      expect(next.bracketedPaste).toBe('confirmed')
+    })
+
+    it('splits trailing control bytes into their own keypresses', () => {
+      const [keys] = parseMultipleKeypresses(confirmed, 'there\r')
+
+      expect(seqs(keys)).toEqual(['t', 'h', 'e', 'r', 'e', '\r'])
+      expect(keys[5]).toMatchObject({ name: 'return' })
+    })
+
+    it('splits an auto-repeated backspace burst into individual backspaces', () => {
+      const [keys] = parseMultipleKeypresses(confirmed, '\x7f\x7f\x7f')
+
+      expect(keys.map(k => (k.kind === 'key' ? k.name : ''))).toEqual([
+        'backspace',
+        'backspace',
+        'backspace'
+      ])
+    })
+
+    it('splits a leading control byte from the text that followed it', () => {
+      const [keys] = parseMultipleKeypresses(confirmed, '\x01ab')
+
+      expect(keys[0]).toMatchObject({ name: 'a', ctrl: true })
+      expect(seqs(keys).slice(1)).toEqual(['a', 'b'])
+    })
+
+    it('splits a run longer than a typing burst', () => {
+      const [keys] = parseMultipleKeypresses(confirmed, 'x'.repeat(33))
+
+      expect(keys).toHaveLength(33)
+    })
+
+    it('leaves bracketed paste content whole', () => {
+      const [keys] = parseMultipleKeypresses(confirmed, PASTE_START + 'ab' + PASTE_END)
+
+      expect(keys).toHaveLength(1)
+      expect(keys[0]).toMatchObject({ isPasted: true, raw: 'ab' })
+    })
+  })
+
+  it('leaves a single character alone in both modes', () => {
+    expect(parseMultipleKeypresses(INITIAL_STATE, 'a')[0]).toHaveLength(1)
+    expect(
+      parseMultipleKeypresses(parseMultipleKeypresses(INITIAL_STATE, DECRPM_2004_SET)[1], 'a')[0]
+    ).toHaveLength(1)
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -13,7 +13,17 @@
 import { Buffer } from 'buffer'
 
 import { PASTE_END, PASTE_START } from './termio/csi.js'
+import { DEC } from './termio/dec.js'
 import { createTokenizer, type Tokenizer } from './termio/tokenize.js'
+
+// Longest plain-byte run still read as typing while bracketed paste is
+// unconfirmed. Above it a run is far more likely to be a paste the terminal
+// could not mark, and staying whole keeps the paste path's placeholder
+// collapsing and dropped-path detection working.
+const MAX_TYPED_RUN = 32
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_BYTE_RE = /[\x00-\x1f\x7f]/
 
 // eslint-disable-next-line no-control-regex
 const META_KEY_CODE_RE = /^(?:\x1b)([a-zA-Z0-9])$/
@@ -191,10 +201,14 @@ function splitNumericParams(params: string): number[] {
   return params.split(';').map(p => parseInt(p, 10))
 }
 
+/** Whether this terminal is known to implement bracketed paste (DEC 2004). */
+export type BracketedPasteState = 'confirmed' | 'unknown'
+
 export type KeyParseState = {
   mode: 'NORMAL' | 'IN_PASTE'
   incomplete: string
   pasteBuffer: string
+  bracketedPaste: BracketedPasteState
   // Internal tokenizer instance
   _tokenizer?: Tokenizer
 }
@@ -202,7 +216,53 @@ export type KeyParseState = {
 export const INITIAL_STATE: KeyParseState = {
   mode: 'NORMAL',
   incomplete: '',
-  pasteBuffer: ''
+  pasteBuffer: '',
+  bracketedPaste: 'unknown'
+}
+
+/**
+ * Bracketed paste is trustworthy only once the terminal reports mode 2004 as
+ * actually on. App enables it (EBP) during raw-mode setup, before this query
+ * goes out, so an answer of RESET means the enable did not take and no paste
+ * marker will ever arrive -- the case where trusting markers would be worst.
+ */
+function confirmsBracketedPaste(response: TerminalResponse): boolean {
+  return (
+    response.type === 'decrpm' &&
+    response.mode === DEC.BRACKETED_PASTE &&
+    (response.status === DECRPM_STATUS.SET || response.status === DECRPM_STATUS.PERMANENTLY_SET)
+  )
+}
+
+/**
+ * Typing and pasting are the same bytes on stdin, so merging a run into one
+ * nameless keypress mis-reads a coalesced burst (SSH / tmux / a blocked event
+ * loop) as a paste. With bracketed paste confirmed, every unmarked run is
+ * typing and splits unconditionally. Without it, only runs that could not be
+ * a paste line -- short and free of control bytes -- are safe to split.
+ */
+function splitsIntoKeystrokes(text: string, bracketedPaste: BracketedPasteState): boolean {
+  if (text.length < 2) {
+    return false
+  }
+
+  if (bracketedPaste === 'confirmed') {
+    return true
+  }
+
+  return text.length <= MAX_TYPED_RUN && !CONTROL_BYTE_RE.test(text)
+}
+
+function pushTextKeys(out: ParsedInput[], text: string, bracketedPaste: BracketedPasteState): void {
+  if (!splitsIntoKeystrokes(text, bracketedPaste)) {
+    out.push(parseKeypress(text))
+
+    return
+  }
+
+  for (const codePoint of text) {
+    out.push(parseKeypress(codePoint))
+  }
 }
 
 function inputToString(input: Buffer | string): string {
@@ -227,6 +287,7 @@ export function parseMultipleKeypresses(
   prevState: KeyParseState,
   input: Buffer | string | null = ''
 ): [ParsedInput[], KeyParseState] {
+  let bracketedPaste = prevState.bracketedPaste
   const isFlush = input === null
   const inputString = isFlush ? '' : inputToString(input)
 
@@ -260,6 +321,10 @@ export function parseMultipleKeypresses(
         const response = parseTerminalResponse(token.value)
 
         if (response) {
+          if (confirmsBracketedPaste(response)) {
+            bracketedPaste = 'confirmed'
+          }
+
           keys.push({ kind: 'response', sequence: token.value, response })
         } else {
           const mouse = parseMouseEvent(token.value)
@@ -275,7 +340,7 @@ export function parseMultipleKeypresses(
       if (inPaste) {
         pasteBuffer += token.value
       } else {
-        const mouseFragments = parseTextWithSgrMouseFragments(token.value)
+        const mouseFragments = parseTextWithSgrMouseFragments(token.value, bracketedPaste)
 
         if (mouseFragments) {
           keys.push(...mouseFragments)
@@ -288,7 +353,7 @@ export function parseMultipleKeypresses(
           const resynthesized = '\x1b' + token.value
           keys.push(parseKeypress(resynthesized))
         } else {
-          keys.push(parseKeypress(token.value))
+          pushTextKeys(keys, token.value, bracketedPaste)
         }
       }
     }
@@ -311,6 +376,7 @@ export function parseMultipleKeypresses(
     mode: inPaste ? 'IN_PASTE' : 'NORMAL',
     incomplete: tokenizer.buffer(),
     pasteBuffer,
+    bracketedPaste,
     _tokenizer: tokenizer
   }
 
@@ -649,7 +715,10 @@ function parseSgrMouseFragment(fragment: string): ParsedInput {
   return parseMouseEvent(sequence) ?? parseKeypress(sequence)
 }
 
-function parseTextWithSgrMouseFragments(text: string): ParsedInput[] | null {
+function parseTextWithSgrMouseFragments(
+  text: string,
+  bracketedPaste: BracketedPasteState
+): ParsedInput[] | null {
   SGR_MOUSE_FRAGMENT_RE.lastIndex = 0
 
   const matches = [...text.matchAll(SGR_MOUSE_FRAGMENT_RE)]
@@ -682,7 +751,7 @@ function parseTextWithSgrMouseFragments(text: string): ParsedInput[] | null {
     }
 
     if (first.index! > cursor) {
-      parsed.push(parseKeypress(text.slice(cursor, first.index!)))
+      pushTextKeys(parsed, text.slice(cursor, first.index!), bracketedPaste)
     }
 
     for (const match of run) {
@@ -698,7 +767,7 @@ function parseTextWithSgrMouseFragments(text: string): ParsedInput[] | null {
   }
 
   if (cursor < text.length) {
-    parsed.push(parseKeypress(text.slice(cursor)))
+    pushTextKeys(parsed, text.slice(cursor), bracketedPaste)
   }
 
   return parsed

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -25,6 +25,8 @@ const MAX_TYPED_RUN = 32
 // eslint-disable-next-line no-control-regex
 const CONTROL_BYTE_RE = /[\x00-\x1f\x7f]/
 
+const RAW_ESCAPE_CONTROL_SUFFIXES = new Set(['\r', '\n', '\b', '\x7f'])
+
 // eslint-disable-next-line no-control-regex
 const META_KEY_CODE_RE = /^(?:\x1b)([a-zA-Z0-9])$/
 
@@ -260,7 +262,23 @@ function pushTextKeys(out: ParsedInput[], text: string, bracketedPaste: Brackete
     return
   }
 
-  for (const codePoint of text) {
+  const codePoints = [...text]
+
+  for (let index = 0; index < codePoints.length; index++) {
+    const codePoint = codePoints[index]!
+    const nextCodePoint = codePoints[index + 1]
+
+    if (
+      codePoint === '\x1b' &&
+      nextCodePoint !== undefined &&
+      RAW_ESCAPE_CONTROL_SUFFIXES.has(nextCodePoint)
+    ) {
+      out.push(parseKeypress(codePoint + nextCodePoint))
+      index++
+
+      continue
+    }
+
     out.push(parseKeypress(codePoint))
   }
 }

--- a/ui-tui/src/__tests__/textInputFastAppend.test.ts
+++ b/ui-tui/src/__tests__/textInputFastAppend.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// Portions Copyright (c) 2025 Nous Research (hermes-agent, MIT).
+// Modifications Copyright (c) 2026 EverMind.
+// See NOTICES.md and LICENSES/MIT-hermes-agent.txt.
+
+import { describe, expect, it } from 'vitest'
+
+import { fitsFastAppend } from '../components/textInput.js'
+
+// Fast append writes the character straight to the terminal and defers the
+// React update to the next frame, so a keystroke that takes it costs no
+// render. The guard only has to hold what the terminal itself does not: the
+// insert lands at the end of a single line, and the caret stays on that line.
+describe('fitsFastAppend', () => {
+  const COLS = 80
+
+  it('takes an ASCII character appended at the end of a line', () => {
+    expect(fitsFastAppend('abc', 3, 'd', 3, COLS)).toBe(true)
+  })
+
+  it('takes a wide character - the terminal advances two cells on its own', () => {
+    expect(fitsFastAppend('ab', 2, '你', 2, COLS)).toBe(true)
+  })
+
+  it('takes an emoji that occupies one grapheme', () => {
+    expect(fitsFastAppend('ab', 2, '🙂', 2, COLS)).toBe(true)
+  })
+
+  it('rejects an insert away from the end of the value', () => {
+    expect(fitsFastAppend('abc', 1, 'd', 3, COLS)).toBe(false)
+  })
+
+  it('rejects a value that already spans several lines', () => {
+    expect(fitsFastAppend('a\nb', 3, 'c', 1, COLS)).toBe(false)
+  })
+
+  it('rejects the first character of an empty value', () => {
+    expect(fitsFastAppend('', 0, 'a', 0, COLS)).toBe(false)
+  })
+
+  it('rejects a character that would reach the last column', () => {
+    expect(fitsFastAppend('x'.repeat(79), 79, 'y', 79, COLS)).toBe(false)
+  })
+
+  it('rejects a wide character with only one column left', () => {
+    expect(fitsFastAppend('x'.repeat(78), 78, '你', 78, COLS)).toBe(false)
+  })
+
+  it('rejects more than one grapheme', () => {
+    expect(fitsFastAppend('ab', 2, 'cd', 2, COLS)).toBe(false)
+  })
+
+  it('rejects a zero-width combining mark', () => {
+    expect(fitsFastAppend('ae', 2, '́', 2, COLS)).toBe(false)
+  })
+})

--- a/ui-tui/src/__tests__/textInputTypingBurst.test.tsx
+++ b/ui-tui/src/__tests__/textInputTypingBurst.test.tsx
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// Modifications Copyright (c) 2026 EverMind.
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { PassThrough } from 'stream'
+import { describe, expect, it } from 'vitest'
+
+import { TextInput } from '../components/textInput.js'
+
+// SSH, tmux and a blocked event loop all coalesce keystrokes, so a burst of
+// typed characters reaches stdin as one chunk. It has to land in the composer
+// as typing, not as a paste held back by the paste debounce.
+const flush = () => new Promise(resolve => setImmediate(resolve))
+
+const mount = () => {
+  const changes: string[] = []
+  const stdin = new PassThrough()
+  const stdout = new PassThrough()
+
+  // Non-TTY stdout keeps fast echo out of the picture, so every accepted
+  // character reaches onChange synchronously and the assertion needs no timer.
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+  Object.assign(stdin, { isTTY: true, ref: () => {}, setRawMode: () => {}, unref: () => {} })
+  stdout.resume()
+
+  const Harness = () => {
+    const [value, setValue] = React.useState('')
+
+    return React.createElement(TextInput, {
+      focus: true,
+      onChange: (next: string) => {
+        changes.push(next)
+        setValue(next)
+      },
+      value
+    })
+  }
+
+  const instance = renderSync(React.createElement(Harness), {
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  return {
+    changes,
+    type: async (s: string) => {
+      stdin.write(s)
+      await flush()
+    },
+    unmount: () => {
+      instance.unmount()
+      instance.cleanup()
+    }
+  }
+}
+
+describe('typing burst reaching the composer', () => {
+  it('accepts a coalesced run of characters without waiting on the paste debounce', async () => {
+    const h = mount()
+
+    try {
+      await h.type('hello')
+
+      expect(h.changes).toEqual(['h', 'he', 'hel', 'hell', 'hello'])
+    } finally {
+      h.unmount()
+    }
+  })
+
+  it('accepts a coalesced run of wide characters', async () => {
+    const h = mount()
+
+    try {
+      await h.type('你好')
+
+      expect(h.changes).toEqual(['你', '你好'])
+    } finally {
+      h.unmount()
+    }
+  })
+})

--- a/ui-tui/src/__tests__/virtualHistoryIdentity.test.tsx
+++ b/ui-tui/src/__tests__/virtualHistoryIdentity.test.tsx
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// Modifications Copyright (c) 2026 EverMind.
+
+import { render } from 'ink-testing-library'
+import React from 'react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { ScrollBoxHandle } from '../types/hermes-ink.js'
+
+import { useVirtualHistory } from '../hooks/useVirtualHistory.js'
+
+// useMainApp feeds this hook's return value straight into the appTranscript
+// memo, so a fresh object on every render invalidates the memo and re-renders
+// the whole transcript on each keystroke. Identity has to survive a render
+// that changed nothing the hook depends on.
+let results: unknown[] = []
+
+function IdentitySpy({ items }: { items: readonly { key: string }[] }) {
+  const scrollRef = React.useRef<ScrollBoxHandle | null>(null)
+
+  results.push(useVirtualHistory(scrollRef, items, 80))
+
+  return null
+}
+
+describe('useVirtualHistory return identity', () => {
+  beforeEach(() => {
+    results = []
+  })
+
+  it('returns the same object when a re-render changes none of its inputs', () => {
+    const items = [{ key: 'a' }, { key: 'b' }]
+    const { rerender } = render(React.createElement(IdentitySpy, { items }))
+
+    const settled = results.length
+
+    rerender(React.createElement(IdentitySpy, { items }))
+
+    expect(results.length).toBeGreaterThan(settled)
+    expect(results.at(-1)).toBe(results[settled - 1])
+  })
+
+  it('returns a new object once the item list changes', () => {
+    const items = [{ key: 'a' }]
+    const { rerender } = render(React.createElement(IdentitySpy, { items }))
+
+    const settled = results.length
+
+    rerender(React.createElement(IdentitySpy, { items: [{ key: 'a' }, { key: 'b' }] }))
+
+    expect(results.at(-1)).not.toBe(results[settled - 1])
+  })
+})

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -206,6 +206,43 @@ export function isLfReturn(sequence: string | undefined): boolean {
   return sequence === '\n'
 }
 
+/**
+ * Layout half of the fast-echo guard: whether writing `text` straight to the
+ * terminal leaves the caret where a re-render would have put it. Exported for
+ * unit testing; the component pairs it with focus / TTY state.
+ *
+ * A wide character is fine here — the terminal advances two cells for it on
+ * its own, and `sw` already carries that width into the column check. What
+ * the terminal cannot do for us is wrap or reflow, so the insert has to land
+ * at the end of a single line that still has room.
+ */
+export function fitsFastAppend(
+  current: string,
+  cursor: number,
+  text: string,
+  lineWidth: number,
+  columns: number
+): boolean {
+  const sw = stringWidth(text)
+
+  if (sw < 1 || sw > 2 || !isSingleGrapheme(text)) {
+    return false
+  }
+
+  return (
+    cursor === current.length &&
+    current.length > 0 &&
+    !current.includes('\n') &&
+    lineWidth + sw < Math.max(1, columns)
+  )
+}
+
+function isSingleGrapheme(text: string): boolean {
+  const it = seg().segment(text)[Symbol.iterator]()
+
+  return it.next().value?.segment === text
+}
+
 function renderWithCursor(value: string, cursor: number, cursorColor?: string) {
   const pos = Math.max(0, Math.min(cursor, value.length))
 
@@ -474,18 +511,8 @@ export function TextInput({
 
   const canFastEchoBase = () => focus && termFocus && !selected && !mask && !!stdout?.isTTY
 
-  const canFastAppend = (current: string, cursor: number, text: string) => {
-    const sw = stringWidth(text)
-
-    return (
-      canFastEchoBase() &&
-      cursor === current.length &&
-      current.length > 0 &&
-      !current.includes('\n') &&
-      sw === text.length &&
-      lineWidthRef.current + sw < Math.max(1, columns)
-    )
-  }
+  const canFastAppend = (current: string, cursor: number, text: string) =>
+    canFastEchoBase() && fitsFastAppend(current, cursor, text, lineWidthRef.current, columns)
 
   const canFastBackspace = (current: string, cursor: number) => {
     if (!canFastEchoBase() || cursor !== current.length || cursor <= 0 || current.includes('\n')) {

--- a/ui-tui/src/hooks/useVirtualHistory.ts
+++ b/ui-tui/src/hooks/useVirtualHistory.ts
@@ -11,6 +11,7 @@ import {
   useDeferredValue,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   useSyncExternalStore
@@ -516,14 +517,24 @@ export function useVirtualHistory(
     }
   }, [effEnd, effStart, items, liveTailActive, measuredHeightVersion, n, offsets, scrollRef, sticky, total, vp])
 
-  return {
-    bottomSpacer: Math.max(0, total - (offsets[effEnd] ?? total)),
-    end: effEnd,
-    measureRef,
-    offsets,
-    start: effStart,
-    topSpacer: offsets[effStart] ?? 0
-  }
+  const bottomSpacer = Math.max(0, total - (offsets[effEnd] ?? total))
+  const topSpacer = offsets[effStart] ?? 0
+
+  // Memoized because useMainApp passes this object into the appTranscript
+  // memo: a fresh identity on every render would re-render the transcript on
+  // every keystroke. offsets is a cached array and measureRef a stable
+  // callback, so the deps only move when the window actually moves.
+  return useMemo(
+    () => ({
+      bottomSpacer,
+      end: effEnd,
+      measureRef,
+      offsets,
+      start: effStart,
+      topSpacer
+    }),
+    [bottomSpacer, effEnd, effStart, measureRef, offsets, topSpacer]
+  )
 }
 
 interface MeasuredNode {


### PR DESCRIPTION
## Summary

A colleague reported the TUI composer feeling laggy while typing; it did not
reproduce on a fast local terminal with short English input. Two causes, and
they amplify each other.

**Typing was being read as a paste.** Typing and pasting are the same bytes on
stdin, so the parser merged any multi-character run into one nameless keypress
and the composer treated it as an unbracketed paste held behind a 50ms
debounce. SSH, tmux and a blocked event loop all coalesce keystrokes, so
continuous typing kept resetting that debounce and the input box stalled for
the whole burst. A CJK input method commits several characters at once, so it
took this path on almost every word.

The fix stops guessing from length. A plain byte run is split into one keypress
per code point, and bracketed paste (DEC 2004) becomes the paste signal it was
always meant to be. App asks the terminal with DECRQM whether the mode actually
took, riding the query batch that already carries XTVERSION, and the parser
records the answer in its own state. Confirmed: every unmarked run is typing.
Not confirmed: only runs that could not be a paste line - free of control bytes
and no longer than a typing burst (32 characters) - split, so multi-line paste
still stays whole on terminals without the markers.

Three input bugs shared that root cause and go away with it: an auto-repeated
backspace inserted literal DEL characters instead of deleting, a return
arriving in the same read as the text before it was swallowed without sending,
and a control key arriving alongside text inserted a literal control character.

**Wide characters could never take the fast-echo path.** Fast echo writes a
character straight to the terminal and defers the React update to the next
frame, so a keystroke that takes it costs no render. Its guard required display
width to equal string length, which a CJK character or an emoji can never
satisfy, so every wide character forced a full tree reconcile. The terminal
advances two cells for a wide character on its own, so the guard now only holds
what the terminal cannot: a single grapheme, at the end of a single line that
still has room.

The two halves ship together on purpose. Without the second, a two-character
IME commit would trade one delayed render for two immediate ones.

Also memoizes the `useVirtualHistory` return value. `useMainApp` feeds it into
the `appTranscript` memo, so a fresh object identity on every render
re-rendered the whole transcript on every keystroke - the amplifier that made
long sessions worse.

Note for review: this is the first change to the ink fork's implementation in
the repository's visible history (four earlier commits touched only its README,
export surface and lockfile). Its README asks for the same test and review bar
as first-party code, so `parse-keypress.ts` is the part worth reading closely.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

Run from `ui-tui/`, on this branch rebased onto `main` at 0e544ecb, after a
clean `npm ci`:

- `npm test` - 90 files, 1031 tests passed, 0 failed
- `npm run type-check` - clean
- `npm run lint` - 0 errors, 22 warnings, identical to the pre-change baseline
  (compared warning-by-warning against a clean checkout of `main`; only line
  numbers moved)

Three load-bearing new tests were mutation-checked: the implementation was
broken on purpose and each test was confirmed to fail, then restored. One of
them silently passed on the first attempt because component tests load the
bundled `packages/hermes-ink/dist` rather than its source; it was re-checked
after rebuilding.

Manual, in `raven tui --dev` after rebuilding the ink bundle: holding backspace
deletes instead of inserting `^?`; typing a sentence and pressing return
immediately sends it; CJK input keeps up with typing; a several-hundred-line
paste still collapses into a single placeholder; a dropped file path is still
recognised.

New coverage:

| File | Tests | Covers |
| --- | --- | --- |
| `parse-keypress.test.ts` | 28 -> 47 | split rules in both modes, five DECRQM reply statuses, paste content untouched |
| `textInputFastAppend.test.ts` | 10 | wide characters and emoji accepted; line end, newline, column limit, multi-grapheme and zero-width rejected |
| `textInputTypingBurst.test.tsx` | 2 | end to end, a coalesced run from real stdin through the parser into the composer |
| `virtualHistoryIdentity.test.tsx` | 2 | identity survives an unrelated re-render, changes when the item list does |

Three existing tests in `parse-keypress.test.ts` were updated. They asserted
that a text run arrives as a single key, which is the shape this change
replaces; they now assert the intent instead - every event is a key and their
sequences join back to the original text. That also checks each event's kind,
which the old form did not.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

## Risk

User-visible behaviour changes, all in the composer:

- typing no longer stalls behind the paste debounce;
- CJK and emoji no longer force a full re-render per character;
- backspace auto-repeat, return-after-typing and control-key-with-text now do
  what they say instead of inserting literal control characters.

The regression surface is paste. On a terminal that confirms DEC 2004 nothing
about paste handling changes: markers still delimit it and the parser already
reassembled marked pastes across reads. On a terminal that does not confirm it,
short printable runs now arrive as typing, which is why the 32-character
threshold is there - it keeps long single-line pastes whole so placeholder
collapsing and dropped-path detection still work. A paste of a short
single-line string on such a terminal is the one case that changes: it inserts
character by character instead of going through the paste handler.

Rollback is a revert of the two commits; they touch no state, no protocol and
no persisted format.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A