### PR TITLE
chore: bump version to 0.1.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raven"
-version = "0.1.12"
+version = "0.1.13"
 description = "Raven — AI-native command line agent with memory, proactivity, context control, and skill evolution"
 requires-python = ">=3.12"
 license =  "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3003,7 +3003,7 @@ wheels = [
 
 [[package]]
 name = "raven"
-version = "0.1.12"
+version = "0.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Bump the package version from 0.1.12 to 0.1.13 for the next release. Only
pyproject.toml and uv.lock change.

Core changes since v0.1.12:

- Conversations now keep their selected model, with the follow-up lifecycle
  and recovery paths aligned to that ownership.
- The TUI handles fast typing, prompt layout, and cross-platform copy-on-select
  behavior more reliably.
- ask_user now keeps its timeout, validation, and delivery contracts aligned
  across runtime paths.
- End-to-end trajectory debugging and regression workflows are available.
- Configuration and Skill Hub failures now surface clearer, bounded errors,
  and EverOS is updated from 1.2.1 to 1.2.3.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

## Verification

- `uv lock` - resolved 193 packages and updated raven v0.1.12 to v0.1.13
- `uv lock --check` - resolved 193 packages successfully
- `uv export --locked --all-extras --no-hashes --no-emit-project -o /tmp/raven-0.1.13-constraints.txt` - resolved 193 packages and wrote 624 lines
- `uv run pytest tests/test_package_skeleton.py::test_package_imports tests/test_cli_smoke.py::test_version_flag_matches_installed_metadata -x` - 2 passed
- `uv run raven --version` - reported Raven v0.1.13
- `git diff github/main...HEAD --check` - passed with no output

- [x] Relevant tests pass locally
- [ ] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

No lint, type, documentation, or screenshot changes are needed for this
version-only bump.

## Risk

- [ ] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

This changes package metadata only. Rollback by reverting the version bump.

## Related Issues

N/A
