### PR TITLE
docs: position Raven as the Harness of Harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,9 @@
 
 # Raven
 
-Raven is **The Self-Improving Agent Harness**, built on [EverOS](https://github.com/EverMind-AI/EverOS), with opt-in Deep Research for multi-source investigation.
+Raven is **The Self-Improving Agent Harness** for terminal-first, long-running AI work. It treats the model and harness not as a static pair, but as a system that can improve through a continuous loop of execution, tracing, memory, evaluation, and feedback.
 
-Raven helps agents improve across runs by continuously refining the systems around them: tools, skills, memory, code execution, policies, and working environment. EverOS provides durable user memory, agent memory, and world knowledge across sessions, so successful workflows can evolve into reusable Agent Templates and digital workers.
-
-**Update:** Raven added Deep Research. Enable it with `raven deep-research enable`
-to give the agent access to MiroThinker-backed, multi-source research when a
-task needs deeper investigation.
+Built on [EverOS](https://github.com/EverMind-AI/EverOS), Raven carries user memory, agent experience, and world knowledge across sessions. Every run can refine the tools, skills, context, policies, and workflows around the model, allowing proven work to evolve into reusable Agent Templates and digital workers.
 
 > Raven is pre-alpha. Interfaces and configuration may change quickly.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center" id="readme-top">
 
-![RavenX banner](https://github.com/user-attachments/assets/67523656-1750-4890-8871-fe0cdfb1dda4)
+![Raven banner](https://github.com/user-attachments/assets/d56804e5-5d4b-4493-bc70-71bd38833806)
 
 <p align="center">
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>
@@ -19,21 +19,21 @@
 
 Raven is the open-source, **self-improving Agent Harness** you can run today. It brings terminal-first execution, local tracing, long-term memory, skills, evaluation, and reusable workflows into one system for long-running AI work.
 
-## RavenX: The Harness of Harnesses
+## The Harness of Harnesses
 
 As AI agents move from narrow tasks toward long-running, cross-domain work, manually designing a single, ever-larger harness stops scaling. A harness optimized for one model or domain also cannot provide every capability needed for general intelligence.
 
-**RavenX** is the broader research and ecosystem direction behind this work: **The Harness of Harnesses**. It aims to automatically build and improve Agent Harnesses for specific models and domains, then compose their heterogeneous execution capabilities into an **All-Domain Collaboration Network**.
+**Raven** also names the broader research and ecosystem direction behind this work: **The Harness of Harnesses**. It aims to automatically build and improve Agent Harnesses for specific models and domains, then compose their heterogeneous execution capabilities into an **All-Domain Collaboration Network**.
 
 | **Trusted** | **Persistent** | **Evolving** |
 | --- | --- | --- |
 | Capability is earned through verified performance, not self-declared labels. | Verified results, task state, and long-term memory carry across executors. | Every real run improves capability profiles, skills, routing, and the network itself. |
 
-RavenX does not treat a model and its harness as a fixed pair. Through a continuous **evaluation -> execution -> verification -> memory -> feedback** loop, it discovers, composes, and improves the right capabilities for each task. Validated work becomes reusable experience, allowing both individual agents and the wider capability network to evolve.
+Raven does not treat a model and its harness as a fixed pair. Through a continuous **evaluation -> execution -> verification -> memory -> feedback** loop, it discovers, composes, and improves the right capabilities for each task. Validated work becomes reusable experience, allowing both individual agents and the wider capability network to evolve.
 
-The RavenX evaluation spans **22 Agent benchmark tasks** across task quality, cost, and key mechanism gains. The reported results show broad performance and efficiency improvements over existing agent systems while advancing the **quality-cost Pareto frontier**.
+The Raven evaluation spans **22 Agent benchmark tasks** across task quality, cost, and key mechanism gains. The reported results show broad performance and efficiency improvements over existing agent systems while advancing the **quality-cost Pareto frontier**.
 
-> **Today:** Raven is the runnable open-source harness in this repository. **Direction:** RavenX is the broader multi-agent research and ecosystem vision described above.
+> Raven names both the runnable open-source harness in this repository and the broader multi-agent research and ecosystem direction described above.
 
 > Raven is pre-alpha. Interfaces and configuration may change quickly.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center" id="readme-top">
 
-![Raven banner](https://github.com/user-attachments/assets/118d2bba-342f-4435-b446-2edafc33a38c)
+![RavenX banner](https://github.com/user-attachments/assets/67523656-1750-4890-8871-fe0cdfb1dda4)
 
 <p align="center">
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>
@@ -17,9 +17,23 @@
 
 # Raven
 
-Raven is **The Self-Improving Agent Harness** for terminal-first, long-running AI work. It treats the model and harness not as a static pair, but as a system that can improve through a continuous loop of execution, tracing, memory, evaluation, and feedback.
+Raven is the open-source, **self-improving Agent Harness** you can run today. It brings terminal-first execution, local tracing, long-term memory, skills, evaluation, and reusable workflows into one system for long-running AI work.
 
-Built on [EverOS](https://github.com/EverMind-AI/EverOS), Raven carries user memory, agent experience, and world knowledge across sessions. Every run can refine the tools, skills, context, policies, and workflows around the model, allowing proven work to evolve into reusable Agent Templates and digital workers.
+## RavenX: The Harness of Harnesses
+
+As AI agents move from narrow tasks toward long-running, cross-domain work, manually designing a single, ever-larger harness stops scaling. A harness optimized for one model or domain also cannot provide every capability needed for general intelligence.
+
+**RavenX** is the broader research and ecosystem direction behind this work: **The Harness of Harnesses**. It aims to automatically build and improve Agent Harnesses for specific models and domains, then compose their heterogeneous execution capabilities into an **All-Domain Collaboration Network**.
+
+| **Trusted** | **Persistent** | **Evolving** |
+| --- | --- | --- |
+| Capability is earned through verified performance, not self-declared labels. | Verified results, task state, and long-term memory carry across executors. | Every real run improves capability profiles, skills, routing, and the network itself. |
+
+RavenX does not treat a model and its harness as a fixed pair. Through a continuous **evaluation -> execution -> verification -> memory -> feedback** loop, it discovers, composes, and improves the right capabilities for each task. Validated work becomes reusable experience, allowing both individual agents and the wider capability network to evolve.
+
+The RavenX evaluation spans **22 Agent benchmark tasks** across task quality, cost, and key mechanism gains. The reported results show broad performance and efficiency improvements over existing agent systems while advancing the **quality-cost Pareto frontier**.
+
+> **Today:** Raven is the runnable open-source harness in this repository. **Direction:** RavenX is the broader multi-agent research and ecosystem vision described above.
 
 > Raven is pre-alpha. Interfaces and configuration may change quickly.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center" id="readme-top">
 
-![Raven banner](https://github.com/user-attachments/assets/6c6f585a-21b6-4e7b-9187-acffe59d0c10)
+![Raven banner](https://github.com/user-attachments/assets/118d2bba-342f-4435-b446-2edafc33a38c)
 
 <p align="center">
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,16 +17,9 @@
 
 # Raven
 
-Raven 是构建在 [EverOS](https://github.com/EverMind-AI/EverOS) 之上的
-**The Self-Improving Agent Harness**，并内置可选 Deep Research，用于多来源深度研究。
+Raven 是面向终端与长程任务的 **The Self-Improving Agent Harness**。它不再把模型与 harness 视为静态组合，而是将每次真实执行纳入“执行—追踪—记忆—评测—反馈”的持续闭环。
 
-Raven 会持续迭代支撑 Agent 的 harness：tools、skills、memory、code execution
-runtime、policies 和工作环境。EverOS 为这个 harness 提供跨会话持久存在的用户
-记忆、Agent 记忆和世界知识，让每一次运行都能改进 Agent 的行动方式、知识状态，
-并把可重复工作流沉淀成可复用 Agent Templates 和 digital workers。
-
-**Update：** Raven 新增 Deep Research。运行 `raven deep-research enable` 后，
-Agent 可以在需要深度调查的任务中使用 MiroThinker-backed、多来源 research tool。
+Raven 构建于 [EverOS](https://github.com/EverMind-AI/EverOS) 之上，让用户记忆、Agent 经验与世界知识跨会话延续。每次运行都可以持续改进模型周围的 tools、skills、context、policies 与 workflows，让经过验证的工作沉淀为可复用的 Agent Templates 和 digital workers。
 
 > Raven 目前处于 pre-alpha 阶段，接口和配置可能快速变化。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center" id="readme-top">
 
-![Raven banner](https://github.com/user-attachments/assets/118d2bba-342f-4435-b446-2edafc33a38c)
+![RavenX banner](https://github.com/user-attachments/assets/67523656-1750-4890-8871-fe0cdfb1dda4)
 
 <p align="center">
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>
@@ -17,9 +17,23 @@
 
 # Raven
 
-Raven 是面向终端与长程任务的 **The Self-Improving Agent Harness**。它不再把模型与 harness 视为静态组合，而是将每次真实执行纳入“执行—追踪—记忆—评测—反馈”的持续闭环。
+Raven 是今天即可运行的开源 **自我进化 Agent Harness**。它将终端执行、本地 Tracing、长期记忆、Skills、评测与可复用工作流整合进同一套系统，面向长程 AI 任务持续学习与改进。
 
-Raven 构建于 [EverOS](https://github.com/EverMind-AI/EverOS) 之上，让用户记忆、Agent 经验与世界知识跨会话延续。每次运行都可以持续改进模型周围的 tools、skills、context、policies 与 workflows，让经过验证的工作沉淀为可复用的 Agent Templates 和 digital workers。
+## RavenX：The Harness of Harnesses
+
+随着 AI Agent 从单一任务走向长程、多领域协作，依赖人工设计一个不断膨胀的 harness 已经难以持续扩展；而与特定模型和领域深度绑定的单一 harness，也无法覆盖通用智能所需的全部能力。
+
+**RavenX** 是这一工作的更广阔研究与生态方向，其核心定义是 **The Harness of Harnesses**。它旨在自动构建和提升适配特定模型与领域的 Agent Harness，并将不同 Harness 的异构执行能力汇聚为统一的 **全领域协作网络（All-Domain Collaboration Network）**。
+
+| **可信** | **可延续** | **可进化** |
+| --- | --- | --- |
+| 能力由真实、可验证的表现决定，而非自我声明。 | 经过验证的结果、任务状态与长期记忆能够跨执行者延续。 | 每次真实执行都会改进能力档案、Skills、调度与整个协作网络。 |
+
+RavenX 不再把模型与 harness 视为静态组合，而是通过持续的 **评测 → 执行 → 验证 → 记忆 → 反馈** 闭环，发现、编排并优化每项任务所需的能力。经过验证的工作会沉淀为可复用经验，使 Agent 个体与更广泛的能力网络共同进化。
+
+RavenX 的评测覆盖 **22 个 Agent 基准任务**，从任务质量、成本与关键机制收益等维度进行验证。报告结果显示，其在性能与效率上相较现有 Agent 系统实现了全面提升，并进一步推进了 **质量—成本帕累托前沿**。
+
+> **当前产品：** Raven 是本仓库中可运行的开源 harness。**长期方向：** RavenX 是上述 Multi-Agent 研究与生态愿景。
 
 > Raven 目前处于 pre-alpha 阶段，接口和配置可能快速变化。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center" id="readme-top">
 
-![RavenX banner](https://github.com/user-attachments/assets/67523656-1750-4890-8871-fe0cdfb1dda4)
+![Raven banner](https://github.com/user-attachments/assets/d56804e5-5d4b-4493-bc70-71bd38833806)
 
 <p align="center">
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>
@@ -19,21 +19,21 @@
 
 Raven 是今天即可运行的开源 **自我进化 Agent Harness**。它将终端执行、本地 Tracing、长期记忆、Skills、评测与可复用工作流整合进同一套系统，面向长程 AI 任务持续学习与改进。
 
-## RavenX：The Harness of Harnesses
+## The Harness of Harnesses
 
 随着 AI Agent 从单一任务走向长程、多领域协作，依赖人工设计一个不断膨胀的 harness 已经难以持续扩展；而与特定模型和领域深度绑定的单一 harness，也无法覆盖通用智能所需的全部能力。
 
-**RavenX** 是这一工作的更广阔研究与生态方向，其核心定义是 **The Harness of Harnesses**。它旨在自动构建和提升适配特定模型与领域的 Agent Harness，并将不同 Harness 的异构执行能力汇聚为统一的 **全领域协作网络（All-Domain Collaboration Network）**。
+**Raven** 同时代表这一工作的更广阔研究与生态方向，其核心定义是 **The Harness of Harnesses**。它旨在自动构建和提升适配特定模型与领域的 Agent Harness，并将不同 Harness 的异构执行能力汇聚为统一的 **全领域协作网络（All-Domain Collaboration Network）**。
 
 | **可信** | **可延续** | **可进化** |
 | --- | --- | --- |
 | 能力由真实、可验证的表现决定，而非自我声明。 | 经过验证的结果、任务状态与长期记忆能够跨执行者延续。 | 每次真实执行都会改进能力档案、Skills、调度与整个协作网络。 |
 
-RavenX 不再把模型与 harness 视为静态组合，而是通过持续的 **评测 → 执行 → 验证 → 记忆 → 反馈** 闭环，发现、编排并优化每项任务所需的能力。经过验证的工作会沉淀为可复用经验，使 Agent 个体与更广泛的能力网络共同进化。
+Raven 不再把模型与 harness 视为静态组合，而是通过持续的 **评测 → 执行 → 验证 → 记忆 → 反馈** 闭环，发现、编排并优化每项任务所需的能力。经过验证的工作会沉淀为可复用经验，使 Agent 个体与更广泛的能力网络共同进化。
 
-RavenX 的评测覆盖 **22 个 Agent 基准任务**，从任务质量、成本与关键机制收益等维度进行验证。报告结果显示，其在性能与效率上相较现有 Agent 系统实现了全面提升，并进一步推进了 **质量—成本帕累托前沿**。
+Raven 的评测覆盖 **22 个 Agent 基准任务**，从任务质量、成本与关键机制收益等维度进行验证。报告结果显示，其在性能与效率上相较现有 Agent 系统实现了全面提升，并进一步推进了 **质量—成本帕累托前沿**。
 
-> **当前产品：** Raven 是本仓库中可运行的开源 harness。**长期方向：** RavenX 是上述 Multi-Agent 研究与生态愿景。
+> Raven 既指本仓库中可运行的开源 harness，也指上述更广阔的 Multi-Agent 研究与生态方向。
 
 > Raven 目前处于 pre-alpha 阶段，接口和配置可能快速变化。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center" id="readme-top">
 
-![Raven banner](https://github.com/user-attachments/assets/6c6f585a-21b6-4e7b-9187-acffe59d0c10)
+![Raven banner](https://github.com/user-attachments/assets/118d2bba-342f-4435-b446-2edafc33a38c)
 
 <p align="center">
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>


### PR DESCRIPTION
## Summary

- Position Raven as both the runnable open-source harness and the broader research and ecosystem direction.
- Define Raven as The Harness of Harnesses and explain the All-Domain Collaboration Network.
- Highlight Trusted, Persistent, and Evolving behavior plus the evaluation, execution, verification, memory, and feedback loop in English and Chinese.
- Surface the 22-task evaluation and quality-cost Pareto-frontier positioning before the published benchmark table.
- Replace the old banner with a 129 KB GitHub-hosted Raven visual.

## Type

- [ ] Fix
- [ ] Feature
- [x] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `.venv/bin/pre-commit run --files README.md README.zh-CN.md` - passed
- `env UV_CACHE_DIR=/private/tmp/raven-uv-cache make check-large-files` - passed
- `git diff --check origin/main...HEAD` - passed
- `git merge-tree --write-tree HEAD origin/main` - clean
- No runtime tests were run because this change only updates documentation and externally hosted artwork.

- [ ] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

The change affects repository messaging only. Rollback is a revert of the documentation commit and restoration of the previous banner URL.

## Related Issues

N/A
