### PR TITLE
feat: interactive trajectory browser with attempt merge and split

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -576,10 +576,11 @@ writes completed/failed (never unknown) into `HISTORY.md`.
 
 **Attempt**:
 One task try, possibly spanning several turns — the stable address of a trajectory.
-Every span carries `attempt.id` (`raven/tracing/spans.py`); without an explicitly
-opened attempt (`trace.begin_attempt(session_key)`) each turn is its own single-turn
-attempt whose id equals the trace id, so every trace is addressable as an attempt.
-At read time an Attempt Definition takes precedence over the span attribute.
+At read time an attempt id equals the trace id unless an Attempt Definition in
+`attempts.json` groups several traces under one minted id, so every trace is
+addressable as an attempt. Legacy logs may carry a span-level `attempt.id`
+attribute, which read paths keep resolving; new spans never carry it
+(`attempt.id` is a reserved attribute key stripped by `raven/tracing/spans.py`).
 _Avoid_: "run id" / "task id" — neither is bound to span records.
 
 **Attempt Definition** (`raven/trajectory/store.py`):

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -579,7 +579,19 @@ One task try, possibly spanning several turns — the stable address of a trajec
 Every span carries `attempt.id` (`raven/tracing/spans.py`); without an explicitly
 opened attempt (`trace.begin_attempt(session_key)`) each turn is its own single-turn
 attempt whose id equals the trace id, so every trace is addressable as an attempt.
+At read time an Attempt Definition takes precedence over the span attribute.
 _Avoid_: "run id" / "task id" — neither is bound to span records.
+
+**Attempt Definition** (`raven/trajectory/store.py`):
+The mutable sidecar record in `attempts.json` (trace state dir) mapping a minted
+`att-*` id to its member trace ids plus the historical ids it absorbed (`aliases`),
+so attempt grouping stays editable while span logs stay append-only. `merge_attempts`
+creates one (absorbing prior definitions and legacy groups into `aliases`, migrating
+member pins up); `split_attempt` deletes one (migrating its pin down to the members,
+merged verdicts do not transfer). A legacy attempt (span-attribute grouping) can be
+merged but not split. Read paths resolve definition, alias, or member to the
+definition id; verdicts/pins recorded under absorbed ids stay visible through it.
+_Avoid_: "attempt group" — the canonical term is Attempt Definition.
 
 **Trajectory Verdict** (`raven/trajectory/verdict.py`):
 The task-outcome label for one Attempt: `pass` / `fail` (agent failure) / `infra`

--- a/raven/cli/trajectory_browse.py
+++ b/raven/cli/trajectory_browse.py
@@ -1,0 +1,461 @@
+"""Interactive trajectory browser — the human face of ``raven trajectory``.
+
+A bare ``raven trajectory`` on a TTY opens a three-screen questionary flow:
+session list -> attempt list -> action menu (save / report / minimize /
+verdict / pin|unpin / split, plus a multi-select merge entry). The machine
+face (id-taking subcommands) lives in :mod:`raven.cli.trajectory_commands`;
+this module never shows a session key, trace id, or attempt id in menus,
+labels, or action messages — only artifact paths may carry ids.
+
+Control flow contracts:
+
+- Every ``.ask()`` goes through :func:`_ask`; a ``None`` answer (Ctrl+C/EOF)
+  raises :class:`_CancelledError`, caught only at the top level for a clean exit.
+- Once an action runs — normally, refused, or failing controlled — the
+  browser rescans everything (``_REFRESH``): actions like report bundle
+  before confirming, so even an aborted one may have pinned the attempt.
+- Action errors are presented as fixed, id-free messages; the original
+  exception goes to the debug log (data-layer messages embed ids).
+- Aggregation works on one snapshot per refresh: definitions, pins, and
+  verdicts are each read once, and log records are deduplicated into logical
+  spans keyed by ``(traceId, spanId)`` (a root turn's checkpoint and final
+  record share both; the last write wins).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.markup import escape
+
+from raven.cli import trajectory_commands as tcmd
+from raven.cli._theme import POINTER, QMARK
+from raven.session.manager import SessionManager
+from raven.tracing import config as tracing_config
+from raven.trajectory import store as tstore
+from raven.trajectory.bundle import _default_workspace, collect_bundle
+from raven.trajectory.cassette import minimize_bundle
+from raven.trajectory.verdict import VERDICT_STATUSES, read_verdicts, record_verdict
+
+console = Console()
+_log = logging.getLogger("raven.cli.trajectory_browse")
+
+_BACK = object()
+_MERGE = object()
+_REFRESH = object()
+_UNSET = object()
+
+_TITLE_LIMIT = 48
+_PREVIEW_LIMIT = 32
+_STALE_MESSAGE = "The action was rejected or the selected attempt is no longer available; the list was refreshed."
+
+_QUESTIONARY_INSTALL_HINT = (
+    "[red]The interactive browser needs the questionary package.[/red]"
+    " Install it with [cyan]uv add questionary[/cyan], or use the subcommands"
+    " ([cyan]raven trajectory list[/cyan], ...)."
+)
+
+
+class _CancelledError(Exception):
+    """A prompt was cancelled (Ctrl+C / EOF); unwinds to the browser top."""
+
+
+def _require_questionary() -> Any:
+    """Lazy-import :mod:`questionary` so missing-package errors stay scoped here."""
+    try:
+        import questionary
+    except ModuleNotFoundError:
+        console.print(_QUESTIONARY_INSTALL_HINT)
+        raise typer.Exit(1)
+    return questionary
+
+
+def _ask(prompt: Any) -> Any:
+    value = prompt.ask()
+    if value is None:
+        raise _CancelledError()
+    return value
+
+
+def _str(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _label_text(value: Any, limit: int) -> str | None:
+    """Normalize an untrusted value into one plain menu-safe line.
+
+    questionary renders plain text (no Rich markup, so no escaping), but the
+    value may carry newlines or control characters that would break the
+    one-item-one-line layout — collapse them, then truncate."""
+    s = _str(value)
+    if s is None:
+        return None
+    collapsed = " ".join("".join(ch if ch.isprintable() else " " for ch in s).split())
+    if not collapsed:
+        return None
+    return collapsed if len(collapsed) <= limit else collapsed[: limit - 1] + "…"
+
+
+def _fmt_ts(ts: str | None) -> str:
+    # Timestamps are unvalidated record strings too: normalize the slice so a
+    # newline or control character cannot break the one-line menu layout.
+    return _label_text((ts or "")[5:16].replace("T", " "), 16) or "?"
+
+
+@dataclass
+class AttemptRow:
+    key: str
+    traces: tuple[str, ...]
+    session_key: str | None
+    start: str | None
+    end: str | None
+    spans: int
+    turns: int
+    verdict: str | None
+    pinned: bool
+    preview: str | None
+    merged: bool
+
+
+@dataclass
+class SessionRow:
+    key: str | None
+    title: str
+    attempts: list[AttemptRow]
+    end: str | None
+
+
+def _session_titles(workspace: Path) -> dict[str, str]:
+    """session key -> human title; defective entries and read failures degrade
+    to an empty mapping (every session falls back to a derived label)."""
+    try:
+        entries = SessionManager(workspace).list_sessions()
+    except Exception:
+        _log.debug("session title scan failed", exc_info=True)
+        return {}
+    titles: dict[str, str] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        key = _str(entry.get("key"))
+        meta = entry.get("metadata")
+        title = _str(meta.get("title")) if isinstance(meta, dict) else None
+        if key and title:
+            titles[key] = title
+    return titles
+
+
+def _fallback_title(session_key: str | None, start: str | None, channel: str | None = None) -> str:
+    if session_key is None:
+        return "(no session)"
+    # The span's own channel attribute is the primary source; only a
+    # well-formed "<channel>:<chat>" key yields a prefix fallback — a
+    # malformed key must not surface whole (menus never show session ids).
+    label = _label_text(channel, 16)
+    if label is None and ":" in session_key:
+        label = _label_text(session_key.split(":", 1)[0], 16)
+    stamp = _label_text((start or "")[:16].replace("T", " "), 16)
+    head = f"{label} session" if label else "unknown session"
+    return f"{head} · {stamp}" if stamp else head
+
+
+def scan_sessions(workspace: Path, state_dir: Path | None = None) -> list[SessionRow]:
+    """One snapshot of every addressable attempt, grouped by session.
+
+    Single-read discipline: definitions, pins, and verdicts are read exactly
+    once; grouping and alias sets are built locally from that snapshot (no
+    per-row re-reads). Records first collapse into logical spans keyed by
+    ``(traceId, spanId)`` with last-write-wins; records missing either key
+    stay separate.
+    """
+    state = state_dir if state_dir is not None else tracing_config.state_dir()
+    defs = tstore.definitions(state)
+    registry = tstore.pins(state)
+    verdict_rows = read_verdicts(state)
+    owner_by_trace = {t: def_id for def_id, entry in defs.items() for t in entry["traces"]}
+
+    logical: dict[Any, dict[str, Any]] = {}
+    bogus = 0
+    for span in tstore.iter_spans(state):
+        trace_id, span_id = _str(span.get("traceId")), _str(span.get("spanId"))
+        if trace_id and span_id:
+            logical[(trace_id, span_id)] = span
+        else:
+            logical[("?", bogus)] = span
+            bogus += 1
+
+    groups: dict[str, dict[str, Any]] = {}
+    for span in logical.values():
+        attrs = span.get("attributes")
+        attrs = attrs if isinstance(attrs, dict) else {}
+        trace_id = _str(span.get("traceId"))
+        aid = owner_by_trace.get(trace_id) or _str(attrs.get("attempt.id")) or trace_id
+        if not aid:
+            continue
+        g = groups.setdefault(
+            aid,
+            {
+                "traces": [],
+                "session": None,
+                "channel": None,
+                "start": None,
+                "end": None,
+                "spans": 0,
+                "turns": 0,
+                "preview": None,
+            },
+        )
+        g["spans"] += 1
+        if trace_id and trace_id not in g["traces"]:
+            g["traces"].append(trace_id)
+        if g["session"] is None:
+            g["session"] = _str(attrs.get("session.key"))
+        if g["channel"] is None:
+            g["channel"] = _str(attrs.get("channel"))
+        start, end = _str(span.get("startTime")), _str(span.get("endTime"))
+        if start and (g["start"] is None or start < g["start"]):
+            g["start"] = start
+        if end and (g["end"] is None or end > g["end"]):
+            g["end"] = end
+        if span.get("name") == "session.turn":
+            g["turns"] += 1
+            if g["preview"] is None:
+                g["preview"] = _label_text(attrs.get("turn.input_preview"), _PREVIEW_LIMIT)
+
+    latest: dict[str, tuple[int, str]] = {}
+    for idx, v in enumerate(verdict_rows):
+        latest[v.attempt_id] = (idx, v.status)
+
+    def _verdict_of(aid: str) -> str | None:
+        entry = defs.get(aid)
+        ids = (aid, *(entry.get("aliases") or []), *entry["traces"]) if entry else (aid,)
+        hits = [latest[x] for x in ids if x in latest]
+        return max(hits)[1] if hits else None
+
+    def _pinned(aid: str, traces: list[str]) -> bool:
+        if aid in registry:
+            return True
+        entry = defs.get(aid)
+        if entry and any(alias in registry for alias in entry.get("aliases") or []):
+            return True
+        return any(t in registry for t in traces)
+
+    by_session: dict[str | None, list[AttemptRow]] = {}
+    channel_by_session: dict[str | None, str] = {}
+    for aid, g in groups.items():
+        row = AttemptRow(
+            key=aid,
+            traces=tuple(g["traces"]),
+            session_key=g["session"],
+            start=g["start"],
+            end=g["end"],
+            spans=g["spans"],
+            turns=g["turns"],
+            verdict=_verdict_of(aid),
+            pinned=_pinned(aid, g["traces"]),
+            preview=g["preview"],
+            merged=aid in defs,
+        )
+        by_session.setdefault(row.session_key, []).append(row)
+        if g["channel"] and row.session_key not in channel_by_session:
+            channel_by_session[row.session_key] = g["channel"]
+
+    titles = _session_titles(workspace)
+    sessions: list[SessionRow] = []
+    for key, rows in by_session.items():
+        rows.sort(key=lambda r: r.start or "")
+        title = _label_text(titles.get(key) if key else None, _TITLE_LIMIT) or _fallback_title(
+            key, rows[0].start, channel_by_session.get(key)
+        )
+        sessions.append(SessionRow(key=key, title=title, attempts=rows, end=max((r.end or "" for r in rows))))
+    sessions.sort(key=lambda s: s.end or "", reverse=True)
+    return sessions
+
+
+def session_label(row: SessionRow) -> str:
+    return f"{row.title} · {len(row.attempts)} attempt(s)"
+
+
+def attempt_label(index: int, row: AttemptRow) -> str:
+    parts = [f"#{index}", _fmt_ts(row.start), f"{row.turns} turn(s)", f"{row.spans} span(s)"]
+    if row.verdict:
+        parts.append(_label_text(row.verdict, 12) or "?")
+    if row.pinned:
+        parts.append("pinned")
+    if row.merged:
+        parts.append("merged")
+    if row.preview:
+        parts.append(f'"{row.preview}"')
+    return " · ".join(parts)
+
+
+def _action_error(exc: Exception) -> None:
+    _log.debug("browser action failed", exc_info=exc)
+    console.print(f"[red]{_STALE_MESSAGE}[/red]")
+
+
+def _run_action(action: str, row: AttemptRow, workspace: Path, questionary: Any, style: Any) -> None:
+    """Run one action against the data layer; every outcome is id-free.
+
+    Success wording is gated on the data layer's sentinel protocol: split
+    returns None and unpin returns False for already-gone state (a normal
+    concurrent race, not an exception) — those must not read as success."""
+
+    def _confirm(message: str) -> bool:
+        return bool(_ask(questionary.confirm(message, style=style, qmark=QMARK)))
+
+    try:
+        if action == "save":
+            with console.status("Packing the bundle...", spinner="dots"):
+                bundle_dir = collect_bundle(row.key, workspace=workspace)
+            console.print(f"[green]✓[/green] Bundled to [cyan]{escape(str(bundle_dir))}[/cyan]")
+        elif action == "report":
+            tcmd._report_attempt(
+                row.key,
+                out=None,
+                yes=False,
+                workspace=workspace,
+                config=None,
+                confirm=_confirm,
+                on_bundled=lambda _aid: console.print(
+                    "Bundled the selected attempt (re-packed to pick up the latest data)"
+                ),
+            )
+        elif action == "minimize":
+            with console.status("Packing and minimizing...", spinner="dots"):
+                bundle_dir = collect_bundle(row.key, workspace=workspace)
+                report = minimize_bundle(bundle_dir, tcmd._default_cassette_dir(bundle_dir.name), config_path=None)
+            console.print(f"[green]✓[/green] Cassette written to [cyan]{escape(str(report.cassette_dir))}[/cyan]")
+            console.print(f"  spans kept: {report.span_count}/{report.source_span_count}")
+        elif action == "verdict":
+            status = _ask(
+                questionary.select(
+                    "Verdict:", choices=list(VERDICT_STATUSES), style=style, qmark=QMARK, pointer=POINTER
+                )
+            )
+            why = _ask(questionary.text("Why (optional):", style=style, qmark=QMARK))
+            notes = _ask(questionary.text("Notes (optional):", style=style, qmark=QMARK))
+            record_verdict(row.key, status, source="user", why=why or None, notes=notes or None)
+            console.print(f"[green]✓[/green] Recorded verdict [cyan]{escape(status)}[/cyan]")
+        elif action == "pin":
+            reason = _ask(questionary.text("Reason (optional):", style=style, qmark=QMARK))
+            tstore.pin_attempt(row.key, reason=reason)
+            console.print("[green]✓[/green] Pinned the selected attempt")
+        elif action == "unpin":
+            if _confirm("Remove protection (member-level pins are cleared too)?"):
+                if tstore.unpin_attempt(row.key):
+                    console.print("[green]✓[/green] Unpinned the selected attempt")
+                else:
+                    console.print("Nothing was pinned; the list was refreshed.")
+        elif action == "split":
+            if _confirm(
+                "Split this merged attempt (pins migrate to members, merged verdicts do not"
+                " transfer, legacy members revert to their original grouping)?"
+            ):
+                members = tstore.split_attempt(row.key)
+                if members is None:
+                    console.print("The attempt is no longer merged; the list was refreshed.")
+                else:
+                    console.print(f"[green]✓[/green] Split into {len(members)} member trace(s)")
+    except (ValueError, LookupError) as exc:
+        _action_error(exc)
+    except typer.Exit:
+        pass
+
+
+def _merge_action(session_row: SessionRow, questionary: Any, style: Any) -> None:
+    choices = [
+        questionary.Choice(attempt_label(i, row), value=row.key) for i, row in enumerate(session_row.attempts, start=1)
+    ]
+    picked = _ask(
+        questionary.checkbox(
+            "Select 2+ attempts to merge:",
+            choices=choices,
+            style=style,
+            qmark=QMARK,
+            pointer=POINTER,
+            validate=lambda picked: len(picked) >= 2 or "Select at least two attempts",
+        )
+    )
+    try:
+        tstore.merge_attempts(list(picked))
+        console.print(f"[green]✓[/green] Merged {len(picked)} attempts into one")
+    except (ValueError, LookupError) as exc:
+        _action_error(exc)
+    except typer.Exit:
+        pass
+
+
+def _attempt_screen(session_row: SessionRow, workspace: Path, questionary: Any, style: Any) -> object:
+    """Pick an attempt and run one action. Returns _BACK or _REFRESH."""
+    while True:
+        choices = [
+            questionary.Choice(attempt_label(i, row), value=row) for i, row in enumerate(session_row.attempts, start=1)
+        ]
+        if len(session_row.attempts) >= 2:
+            choices.append(questionary.Choice("Merge attempts…", value=_MERGE))
+        choices.append(questionary.Choice("Back", value=_BACK))
+        picked = _ask(questionary.select("Attempt:", choices=choices, style=style, qmark=QMARK, pointer=POINTER))
+        if picked is _BACK:
+            return _BACK
+        if picked is _MERGE:
+            _merge_action(session_row, questionary, style)
+            return _REFRESH
+
+        row = picked
+        actions = [
+            questionary.Choice("Save (bundle)", value="save"),
+            questionary.Choice("Report (redact + tarball)", value="report"),
+            questionary.Choice("Minimize (cassette)", value="minimize"),
+            questionary.Choice("Verdict", value="verdict"),
+            questionary.Choice("Unpin" if row.pinned else "Pin", value="unpin" if row.pinned else "pin"),
+        ]
+        if row.merged:
+            actions.append(questionary.Choice("Split", value="split"))
+        actions.append(questionary.Choice("Back", value=_BACK))
+        action = _ask(questionary.select("Action:", choices=actions, style=style, qmark=QMARK, pointer=POINTER))
+        if action is _BACK:
+            continue
+        _run_action(action, row, workspace, questionary, style)
+        return _REFRESH
+
+
+def browse_trajectories(workspace: Path | None = None) -> None:
+    """Run the interactive browser until the user exits."""
+    questionary = _require_questionary()
+    from raven.cli._styles import RAVEN_STYLE
+
+    ws = workspace or _default_workspace()
+    current_key: Any = _UNSET
+    try:
+        while True:
+            with console.status("Scanning trajectories...", spinner="dots"):
+                sessions = scan_sessions(ws)
+            if not sessions:
+                console.print("[dim]No trajectories found.[/dim]")
+                return
+            selected = next((s for s in sessions if current_key is not _UNSET and s.key == current_key), None)
+            if selected is None:
+                current_key = _UNSET
+                choices = [questionary.Choice(session_label(s), value=s) for s in sessions]
+                choices.append(questionary.Choice("Exit", value=_BACK))
+                picked = _ask(
+                    questionary.select("Session:", choices=choices, style=RAVEN_STYLE, qmark=QMARK, pointer=POINTER)
+                )
+                if picked is _BACK:
+                    return
+                selected = picked
+                current_key = selected.key
+            outcome = _attempt_screen(selected, ws, questionary, RAVEN_STYLE)
+            if outcome is _BACK:
+                current_key = _UNSET
+    except _CancelledError:
+        console.print("[dim]Cancelled.[/dim]")
+
+
+__all__ = ["AttemptRow", "SessionRow", "attempt_label", "browse_trajectories", "scan_sessions", "session_label"]

--- a/raven/cli/trajectory_commands.py
+++ b/raven/cli/trajectory_commands.py
@@ -342,8 +342,15 @@ def trajectory_pin(
     reason: str = typer.Option("", "--reason", "-r", help="Why this trajectory is kept"),
 ) -> None:
     """Protect a trajectory from any future purge."""
-    attempt_id = _resolve_or_exit(id_)
-    tstore.pin(attempt_id, reason=reason)
+    # pin_attempt resolves and pins under the attempts lock, so a concurrent
+    # merge/split cannot leave this pin on an id that no longer owns anything.
+    try:
+        attempt_id = tstore.pin_attempt(id_, reason=reason)
+    except LookupError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1)
+    if attempt_id != id_:
+        console.print(f"[dim]{id_} is one turn of attempt {attempt_id}[/dim]")
     console.print(f"[green]✓[/green] Pinned {attempt_id}")
 
 

--- a/raven/cli/trajectory_commands.py
+++ b/raven/cli/trajectory_commands.py
@@ -38,12 +38,14 @@ import shutil
 import tempfile
 from collections import Counter
 from pathlib import Path
+from typing import Callable
 
 import typer
 from rich.console import Console
 from rich.markup import escape
 from rich.table import Table
 
+from raven.cli._tty_guard import die_if_not_tty
 from raven.tracing import config as tracing_config
 from raven.trajectory import store as tstore
 from raven.trajectory.bundle import collect_bundle
@@ -53,10 +55,44 @@ from raven.trajectory.verdict import VERDICT_STATUSES, read_verdicts, record_ver
 
 console = Console()
 
-trajectory_app = typer.Typer(
-    help="Package, label, and protect agent trajectories.",
-    no_args_is_help=True,
-)
+trajectory_app = typer.Typer(help="Package, label, and protect agent trajectories.")
+
+
+@trajectory_app.callback(invoke_without_command=True)
+def trajectory_main(
+    ctx: typer.Context,
+    workspace: Path | None = typer.Option(
+        None,
+        "--workspace",
+        "-w",
+        help="Workspace holding the session records (default: the configured workspace)",
+    ),
+) -> None:
+    """Package, label, and protect agent trajectories (bare invocation opens
+    the interactive browser)."""
+    # Subcommands must pass through before the TTY gate, or non-interactive
+    # scripts running `trajectory save/list/...` would die on the check.
+    if ctx.invoked_subcommand is not None:
+        return
+    die_if_not_tty("raven trajectory list")
+    # Local import: the browser (and its questionary dependency) loads only
+    # when actually entered, and the module cycle commands <-> browse breaks.
+    from raven.cli.trajectory_browse import browse_trajectories
+
+    browse_trajectories(workspace=workspace)
+
+
+def _default_cassette_dir(attempt_id: str) -> Path:
+    """Default cassette directory for ``attempt_id`` under the cassettes root.
+
+    The id is recorded data; one that would name a path outside the cassettes
+    directory raises ``ValueError`` (shared by the CLI and the browser so the
+    escape check cannot drift)."""
+    out_root = (tracing_config.state_dir() / "cassettes").resolve()
+    out_dir = (out_root / attempt_id).resolve()
+    if out_dir.parent != out_root:
+        raise ValueError(f"id {attempt_id!r} cannot be used as a cassette directory name")
+    return out_dir
 
 
 def _bundle_dir_or_exit(target: str) -> Path:
@@ -149,6 +185,35 @@ def trajectory_report(
     ),
 ) -> None:
     """Redact a trajectory and pack it into a shareable .tar.gz (the original bundle is untouched)."""
+    try:
+        _report_attempt(id_, out=out, yes=yes, workspace=workspace, config=config, confirm=typer.confirm)
+    except (LookupError, ValueError) as exc:
+        console.print(f"[red]{escape(str(exc))}[/red]")
+        raise typer.Exit(code=1)
+
+
+def _cli_bundled_note(attempt_id: str) -> None:
+    console.print(f"Bundled [cyan]{escape(attempt_id)}[/cyan] (re-packed to pick up the latest data)")
+
+
+def _report_attempt(
+    id_: str,
+    *,
+    out: Path | None,
+    yes: bool,
+    workspace: Path | None,
+    config: Path | None,
+    confirm: Callable[[str], bool],
+    on_bundled: Callable[[str], None] = _cli_bundled_note,
+) -> None:
+    """The report workflow with injectable presentation seams.
+
+    ``confirm`` carries only yes/no (a cancelled prompt must be raised by the
+    injector, not folded into False); ``on_bundled`` renders the re-pack
+    progress note (the browser injects an id-free variant). Collection errors
+    (``LookupError`` / ``ValueError``) propagate to the caller — each frontend
+    presents them within its own output boundary.
+    """
     if workspace is None and config is not None:
         # The traced agent's session records live in that config's workspace;
         # without this the bundle silently omits session.jsonl. An unloadable
@@ -160,13 +225,9 @@ def trajectory_report(
             workspace = load_config(config).workspace_path
         except Exception:
             pass
-    try:
-        bundle_dir = collect_bundle(id_, workspace=workspace)
-    except (LookupError, ValueError) as exc:
-        console.print(f"[red]{escape(str(exc))}[/red]")
-        raise typer.Exit(code=1)
+    bundle_dir = collect_bundle(id_, workspace=workspace)
     attempt_id = bundle_dir.name
-    console.print(f"Bundled [cyan]{escape(attempt_id)}[/cyan] (re-packed to pick up the latest data)")
+    on_bundled(attempt_id)
 
     staging = Path(tempfile.mkdtemp(prefix=f"raven-report-{attempt_id}-"))
     try:
@@ -203,7 +264,7 @@ def trajectory_report(
         else:
             console.print("[green]Residual scan: clean[/green]")
 
-        if not yes and not typer.confirm("Produce the report tarball?"):
+        if not yes and not confirm("Produce the report tarball?"):
             console.print("Aborted — no tarball was produced.")
             raise typer.Exit(code=1)
 
@@ -301,12 +362,10 @@ def trajectory_minimize(
     attempt_id = manifest_id if isinstance(manifest_id, str) and manifest_id else bundle_dir.name
     out_dir = out
     if out_dir is None:
-        # The manifest's attempt id is recorded data; refuse one that would
-        # name a default path outside the cassettes directory.
-        out_root = (tracing_config.state_dir() / "cassettes").resolve()
-        out_dir = (out_root / attempt_id).resolve()
-        if out_dir.parent != out_root:
-            console.print(f"[red]id {escape(repr(attempt_id))} cannot be used as a cassette directory name[/red]")
+        try:
+            out_dir = _default_cassette_dir(attempt_id)
+        except ValueError as exc:
+            console.print(f"[red]{escape(str(exc))}[/red]")
             raise typer.Exit(code=1)
     try:
         report = minimize_bundle(bundle_dir, out_dir, config_path=config)

--- a/raven/cli/trajectory_commands.py
+++ b/raven/cli/trajectory_commands.py
@@ -16,9 +16,18 @@ wrappers over the trajectory layer:
 - ``minimize`` — shrink a bundle to a redacted Trajectory Cassette fit for
   the regression suite (:func:`raven.trajectory.cassette.minimize_bundle`).
 - ``verdict`` — record a task-outcome label (source fixed to ``user``).
-- ``pin`` / ``unpin`` — grant / revoke the never-purge retention promise.
+- ``pin`` / ``unpin`` — grant / revoke the never-purge retention promise
+  (``unpin`` also clears absorbed aliases and member-level pins).
+- ``merge``   — combine attempts into one definition in ``attempts.json``
+  (:func:`raven.trajectory.store.merge_attempts`; pins migrate up).
+- ``split``   — delete a merged attempt's definition; pins migrate down to
+  the member traces (:func:`raven.trajectory.store.split_attempt`).
 - ``list``    — aggregate addressable attempts from the trace logs so users
-  can find the id they want to bundle.
+  can find the id they want to bundle; definition members fold into one row.
+
+Ids echoed in output may come from user input, spans, or bundle manifests —
+none are trusted: every dynamic value rendered through Rich is escaped first
+(an id like ``x[/red]y`` is legal and would otherwise crash markup parsing).
 """
 
 from __future__ import annotations
@@ -59,7 +68,10 @@ def _bundle_dir_or_exit(target: str) -> Path:
     bundle_dir = tracing_config.state_dir() / "bundles" / target
     if (bundle_dir / "manifest.json").is_file():
         return bundle_dir
-    console.print(f"[red]no bundle found for {target!r}[/red] — run [cyan]raven trajectory save {target}[/cyan] first")
+    console.print(
+        f"[red]no bundle found for {escape(repr(target))}[/red]"
+        f" — run [cyan]raven trajectory save {escape(target)}[/cyan] first"
+    )
     raise typer.Exit(code=1)
 
 
@@ -72,10 +84,10 @@ def _resolve_or_exit(id_: str) -> str:
     """
     resolved = tstore.resolve_attempt_id(id_)
     if resolved is None:
-        console.print(f"[red]no spans found for id {id_!r}[/red]")
+        console.print(f"[red]no spans found for id {escape(repr(id_))}[/red]")
         raise typer.Exit(code=1)
     if resolved != id_:
-        console.print(f"[dim]{id_} is one turn of attempt {resolved}[/dim]")
+        console.print(f"[dim]{escape(id_)} is one turn of attempt {escape(resolved)}[/dim]")
     return resolved
 
 
@@ -94,13 +106,14 @@ def trajectory_save(
     try:
         bundle_dir = collect_bundle(id_, out_dir=out, workspace=workspace)
     except (LookupError, ValueError) as exc:
-        console.print(f"[red]{exc}[/red]")
+        console.print(f"[red]{escape(str(exc))}[/red]")
         raise typer.Exit(code=1)
     manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
-    console.print(f"[green]✓[/green] Bundled to [cyan]{bundle_dir}[/cyan]")
+    console.print(f"[green]✓[/green] Bundled to [cyan]{escape(str(bundle_dir))}[/cyan]")
     if manifest.get("attempt_id") != id_:
         console.print(
-            f"  [dim]{id_} is one turn of attempt {manifest.get('attempt_id')}; bundled the whole attempt[/dim]"
+            f"  [dim]{escape(id_)} is one turn of attempt {escape(str(manifest.get('attempt_id')))};"
+            f" bundled the whole attempt[/dim]"
         )
     session_note = "included" if manifest.get("session_included") else "not found (omitted)"
     console.print(
@@ -150,10 +163,10 @@ def trajectory_report(
     try:
         bundle_dir = collect_bundle(id_, workspace=workspace)
     except (LookupError, ValueError) as exc:
-        console.print(f"[red]{exc}[/red]")
+        console.print(f"[red]{escape(str(exc))}[/red]")
         raise typer.Exit(code=1)
     attempt_id = bundle_dir.name
-    console.print(f"Bundled [cyan]{attempt_id}[/cyan] (re-packed to pick up the latest data)")
+    console.print(f"Bundled [cyan]{escape(attempt_id)}[/cyan] (re-packed to pick up the latest data)")
 
     staging = Path(tempfile.mkdtemp(prefix=f"raven-report-{attempt_id}-"))
     try:
@@ -197,7 +210,7 @@ def trajectory_report(
         out_file = out or tracing_config.state_dir() / "reports" / f"{attempt_id}.tar.gz"
         tarball = pack_report(staging / attempt_id, out_file)
         destination = get_uploader("local").upload(tarball, metadata=report.metadata())
-        console.print(f"[green]✓[/green] Report ready at [cyan]{destination}[/cyan]")
+        console.print(f"[green]✓[/green] Report ready at [cyan]{escape(str(destination))}[/cyan]")
         console.print("  [dim]local backend: nothing was uploaded — hand the file over yourself[/dim]")
     finally:
         shutil.rmtree(staging, ignore_errors=True)
@@ -225,11 +238,11 @@ def trajectory_replay(
     try:
         report = asyncio.run(run_replay(bundle_dir, mode=mode))
     except ValueError as exc:
-        console.print(f"[red]{exc}[/red]")
+        console.print(f"[red]{escape(str(exc))}[/red]")
         raise typer.Exit(code=1)
 
     streamed = f" ({report.llm_calls_streamed} streamed)" if report.llm_calls_streamed else ""
-    console.print(f"Replayed [cyan]{bundle_dir.name}[/cyan] ({mode} mode)")
+    console.print(f"Replayed [cyan]{escape(bundle_dir.name)}[/cyan] ({mode} mode)")
     console.print(
         f"  turns: {report.turns_replayed}/{report.turns_recorded}"
         f"  model calls: {report.llm_calls_replayed}/{report.llm_calls_recorded}{streamed}"
@@ -284,15 +297,15 @@ def trajectory_minimize(
         out_root = (tracing_config.state_dir() / "cassettes").resolve()
         out_dir = (out_root / attempt_id).resolve()
         if out_dir.parent != out_root:
-            console.print(f"[red]id {attempt_id!r} cannot be used as a cassette directory name[/red]")
+            console.print(f"[red]id {escape(repr(attempt_id))} cannot be used as a cassette directory name[/red]")
             raise typer.Exit(code=1)
     try:
         report = minimize_bundle(bundle_dir, out_dir, config_path=config)
     except ValueError as exc:
-        console.print(f"[red]{exc}[/red]")
+        console.print(f"[red]{escape(str(exc))}[/red]")
         raise typer.Exit(code=1)
 
-    console.print(f"[green]✓[/green] Cassette written to [cyan]{report.cassette_dir}[/cyan]")
+    console.print(f"[green]✓[/green] Cassette written to [cyan]{escape(str(report.cassette_dir))}[/cyan]")
     console.print(f"  size: {_fmt_bytes(report.original_bytes)} -> {_fmt_bytes(report.cassette_bytes)}")
     console.print(
         f"  spans: {report.span_count}/{report.source_span_count} kept"
@@ -333,7 +346,7 @@ def trajectory_verdict(
         raise typer.BadParameter(f"status must be one of {', '.join(VERDICT_STATUSES)}; got {status!r}")
     attempt_id = _resolve_or_exit(id_)
     record_verdict(attempt_id, status, source="user", why=why, notes=notes)
-    console.print(f"[green]✓[/green] Recorded verdict [cyan]{status}[/cyan] for {attempt_id}")
+    console.print(f"[green]✓[/green] Recorded verdict [cyan]{status}[/cyan] for {escape(attempt_id)}")
 
 
 @trajectory_app.command("pin")
@@ -347,58 +360,122 @@ def trajectory_pin(
     try:
         attempt_id = tstore.pin_attempt(id_, reason=reason)
     except LookupError as exc:
-        console.print(f"[red]{exc}[/red]")
+        console.print(f"[red]{escape(str(exc))}[/red]")
         raise typer.Exit(code=1)
     if attempt_id != id_:
-        console.print(f"[dim]{id_} is one turn of attempt {attempt_id}[/dim]")
-    console.print(f"[green]✓[/green] Pinned {attempt_id}")
+        console.print(f"[dim]{escape(id_)} is one turn of attempt {escape(attempt_id)}[/dim]")
+    console.print(f"[green]✓[/green] Pinned {escape(attempt_id)}")
 
 
 @trajectory_app.command("unpin")
 def trajectory_unpin(
     id_: str = typer.Argument(..., metavar="ID", help="Attempt id or trace id"),
 ) -> None:
-    """Remove a trajectory's purge protection."""
-    # Best-effort resolution (a stale pin may outlive its spans), and drop the
-    # literal id too so pins written before canonical resolution still clear.
-    resolved = tstore.resolve_attempt_id(id_) or id_
-    removed = [x for x in dict.fromkeys((resolved, id_)) if tstore.unpin(x)]
-    if removed:
-        console.print(f"[green]✓[/green] Unpinned {' and '.join(removed)}")
+    """Remove a trajectory's purge protection (clears the definition id,
+    absorbed aliases, and all member-level pins)."""
+    if tstore.unpin_attempt(id_):
+        console.print(f"[green]✓[/green] Unpinned {escape(id_)}")
     else:
-        console.print(f"{id_} was not pinned.")
+        console.print(f"{escape(id_)} was not pinned.")
+
+
+@trajectory_app.command("merge")
+def trajectory_merge(
+    ids: list[str] = typer.Argument(
+        ...,
+        metavar="IDS...",
+        help="Two or more attempt/trace ids to combine (any mix of definition, alias, legacy, or trace ids)",
+    ),
+) -> None:
+    """Merge attempts into one definition; pins migrate up, verdicts and pins
+    recorded under the absorbed ids stay visible through it.
+
+    Attempts made of adjacent turns replay best; gaps between merged turns
+    surface as replay divergences.
+    """
+    try:
+        new_id = tstore.merge_attempts(ids)
+    except ValueError as exc:
+        console.print(f"[red]{escape(str(exc))}[/red]")
+        raise typer.Exit(code=1)
+    console.print(f"[green]✓[/green] Merged into {escape(new_id)}")
+
+
+@trajectory_app.command("split")
+def trajectory_split(
+    id_: str = typer.Argument(..., metavar="ID", help="Definition id, alias, or member trace id"),
+) -> None:
+    """Split a merged attempt back into its member traces.
+
+    Deletes the definition: pins migrate down to the members, merged-attempt
+    verdicts do not transfer, and members carrying a legacy span-level
+    grouping revert to that original legacy attempt.
+    """
+    members = tstore.split_attempt(id_)
+    if members is None:
+        console.print(
+            f"[red]no attempt definition owns {escape(repr(id_))}[/red] — only merged attempts can be split"
+            " (a legacy attempt's grouping is recorded in its spans and cannot be removed)"
+        )
+        raise typer.Exit(code=1)
+    console.print(
+        f"[green]✓[/green] Split the merged attempt addressed by {escape(id_)}; restored {len(members)} member trace(s)"
+    )
+    for member in members:
+        console.print(f"  [dim]{escape(member)}[/dim]")
 
 
 @trajectory_app.command("list")
 def trajectory_list(
     session: str | None = typer.Option(None, "--session", help="Only attempts of this session key"),
 ) -> None:
-    """List addressable attempts aggregated from the trace logs."""
+    """List addressable attempts aggregated from the trace logs (traces merged
+    into one definition fold into a single row under the definition id)."""
     state = tracing_config.state_dir()
+    # One definitions read up front (owning_attempt would re-read the file per
+    # span). Definition ownership must win over a member's legacy attempt.id,
+    # or merged legacy members would surface as a second row.
+    defs = tstore.definitions(state)
+    owner_by_trace = {t: def_id for def_id, entry in defs.items() for t in entry["traces"]}
+
+    def _str(value) -> str | None:
+        return value if isinstance(value, str) and value else None
+
     attempts: dict[str, dict] = {}
     for span in tstore.iter_spans(state, session_key=session):
+        # Span attributes are unvalidated history: a JSON-legal record with a
+        # non-string id/key/timestamp must degrade per-field, never kill list.
         attrs = span.get("attributes") or {}
-        aid = attrs.get("attempt.id") or span.get("traceId")
+        trace_id = _str(span.get("traceId"))
+        aid = owner_by_trace.get(trace_id) or _str(attrs.get("attempt.id")) or trace_id
         if not aid:
             continue
         entry = attempts.setdefault(aid, {"session": None, "spans": 0, "start": None, "end": None})
         entry["spans"] += 1
-        if entry["session"] is None and attrs.get("session.key"):
+        if entry["session"] is None and _str(attrs.get("session.key")):
             entry["session"] = attrs["session.key"]
-        span_start, span_end = span.get("startTime"), span.get("endTime")
+        span_start, span_end = _str(span.get("startTime")), _str(span.get("endTime"))
         if span_start and (entry["start"] is None or span_start < entry["start"]):
             entry["start"] = span_start
         if span_end and (entry["end"] is None or span_end > entry["end"]):
             entry["end"] = span_end
 
     if not attempts:
-        scope = f"session {session!r}" if session else "the trace logs"
+        scope = f"session {escape(repr(session))}" if session else "the trace logs"
         console.print(f"[dim]No attempts found in {scope}.[/dim]")
         return
 
-    latest: dict[str, str] = {}
-    for v in read_verdicts(state):
-        latest[v.attempt_id] = v.status
+    # verdicts.jsonl is append-only, so file order is time order: the highest
+    # index per id is that id's latest word.
+    latest: dict[str, tuple[int, str]] = {}
+    for idx, v in enumerate(read_verdicts(state)):
+        latest[v.attempt_id] = (idx, v.status)
+
+    def _latest_status(aid: str) -> str:
+        entry = defs.get(aid)
+        ids = (aid, *(entry.get("aliases") or []), *entry["traces"]) if entry else (aid,)
+        hits = [latest[x] for x in ids if x in latest]
+        return max(hits)[1] if hits else "-"
 
     table = Table()
     # Fold, never truncate: the id must stay copy-pastable into `save`.
@@ -414,12 +491,12 @@ def trajectory_list(
 
     for aid, entry in sorted(attempts.items(), key=lambda kv: kv[1]["end"] or "", reverse=True):
         table.add_row(
-            aid,
-            entry["session"] or "-",
+            escape(str(aid)),
+            escape(str(entry["session"] or "-")),
             str(entry["spans"]),
             _fmt(entry["start"]),
             _fmt(entry["end"]),
-            latest.get(aid, "-"),
+            escape(str(_latest_status(aid))),
         )
     console.print(table)
 

--- a/raven/cli/trajectory_commands.py
+++ b/raven/cli/trajectory_commands.py
@@ -287,9 +287,18 @@ def trajectory_minimize(
     from raven.trajectory.cassette import minimize_bundle
 
     bundle_dir = _bundle_dir_or_exit(target)
-    attempt_id = (
-        json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8")).get("attempt_id") or bundle_dir.name
-    )
+    # The manifest is recorded data: broken JSON, a non-object top level, or a
+    # non-string attempt_id must fail controlled (or fall back to the
+    # directory name), never leak a parse/path-join traceback.
+    try:
+        manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        manifest = None
+    if not isinstance(manifest, dict):
+        console.print(f"[red]{escape(str(bundle_dir / 'manifest.json'))} is not a valid bundle manifest[/red]")
+        raise typer.Exit(code=1)
+    manifest_id = manifest.get("attempt_id")
+    attempt_id = manifest_id if isinstance(manifest_id, str) and manifest_id else bundle_dir.name
     out_dir = out
     if out_dir is None:
         # The manifest's attempt id is recorded data; refuse one that would
@@ -444,8 +453,10 @@ def trajectory_list(
     attempts: dict[str, dict] = {}
     for span in tstore.iter_spans(state, session_key=session):
         # Span attributes are unvalidated history: a JSON-legal record with a
-        # non-string id/key/timestamp must degrade per-field, never kill list.
-        attrs = span.get("attributes") or {}
+        # non-object attributes value or a non-string id/key/timestamp must
+        # degrade per-field, never kill list.
+        raw_attrs = span.get("attributes")
+        attrs = raw_attrs if isinstance(raw_attrs, dict) else {}
         trace_id = _str(span.get("traceId"))
         aid = owner_by_trace.get(trace_id) or _str(attrs.get("attempt.id")) or trace_id
         if not aid:

--- a/raven/tracing/context.py
+++ b/raven/tracing/context.py
@@ -28,19 +28,9 @@ class TraceCtx:
     # ``llm.call`` can self-label without walking the tree. Generic: no adopter
     # names are hard-coded here.
     source: str | None = None
-    # Stable trajectory address for this span tree. Defaults to the trace id
-    # (every turn is a single-turn attempt); an explicit attempt opened via
-    # begin_attempt() groups multiple turns of one session under one id.
-    attempt_id: str | None = None
 
 
 _CTX: contextvars.ContextVar[TraceCtx | None] = contextvars.ContextVar("raven_tracing_ctx", default=None)
-
-# session_key -> open attempt id. Plain module state (not a contextvar): an
-# attempt outlives any single turn's task, so it must be visible to the fresh
-# context each new turn starts in. In-memory only — a process restart closes
-# all attempts (spans after restart fall back to single-turn attempt ids).
-_ATTEMPTS: dict[str, str] = {}
 
 
 def current() -> TraceCtx | None:
@@ -55,57 +45,6 @@ def new_span_id() -> str:
     return f"span-{int(time.time() * 1000):x}-{secrets.token_hex(3)}"
 
 
-def new_attempt_id() -> str:
-    return f"att-{int(time.time() * 1000):x}-{secrets.token_hex(4)}"
-
-
-def begin_attempt(session_key: str, attempt_id: str | None = None) -> str:
-    """Open an attempt for ``session_key``; subsequent turns carry its id.
-
-    Re-entrant by replacement: beginning while one is open replaces it (the
-    old attempt is implicitly ended). Returns the attempt id in effect.
-    """
-    aid = attempt_id or new_attempt_id()
-    _ATTEMPTS[session_key] = aid
-    return aid
-
-
-def end_attempt(session_key: str) -> str | None:
-    """Close the open attempt for ``session_key`` (returns its id, or None)."""
-    return _ATTEMPTS.pop(session_key, None)
-
-
-def current_attempt(session_key: str | None) -> str | None:
-    if session_key is None:
-        return None
-    return _ATTEMPTS.get(session_key)
-
-
-@contextlib.contextmanager
-def turn_scope(
-    *,
-    session_key: str | None,
-    channel: str | None,
-    chat_id: str | None,
-    root_span_id: str,
-) -> Iterator[TraceCtx]:
-    """Open a fresh trace for one turn; child spans parent onto ``root_span_id``."""
-    trace_id = new_trace_id()
-    ctx = TraceCtx(
-        trace_id=trace_id,
-        session_key=session_key,
-        channel=channel,
-        chat_id=chat_id,
-        parent_span_id=root_span_id,
-        attempt_id=current_attempt(session_key) or trace_id,
-    )
-    token = _CTX.set(ctx)
-    try:
-        yield ctx
-    finally:
-        _CTX.reset(token)
-
-
 def push(
     *,
     trace_id: str,
@@ -115,7 +54,6 @@ def push(
     session_key: str | None = None,
     channel: str | None = None,
     chat_id: str | None = None,
-    attempt_id: str | None = None,
 ):
     """Set the active ctx so descendants parent onto ``span_id``; returns a reset token.
 
@@ -137,7 +75,6 @@ def push(
             chat_id=chat_id,
             parent_span_id=span_id,
             source=source,
-            attempt_id=attempt_id,
         )
     )
 

--- a/raven/tracing/spans.py
+++ b/raven/tracing/spans.py
@@ -40,7 +40,6 @@ def build_span(
     session_key: str | None = None,
     channel: str | None = None,
     chat_id: str | None = None,
-    attempt_id: str | None = None,
     start_time: str,
     end_time: str | None = None,
     status_code: str = "OK",
@@ -48,6 +47,12 @@ def build_span(
     attributes: dict[str, Any] | None = None,
     events: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    """Assemble one audit.span.v1 record.
+
+    ``attempt.id`` is a reserved attribute key: caller-supplied values are
+    silently dropped (attempt grouping lives in ``attempts.json``, see
+    :mod:`raven.trajectory.store`).
+    """
     attrs: dict[str, Any] = {
         "span.type": span_type,
         "framework": FRAMEWORK,
@@ -59,13 +64,14 @@ def build_span(
         "channel": channel,
         "channel.id": channel,
         "chat_id": chat_id,
-        # Stable trajectory address: equals the trace id for a single-turn
-        # attempt; an explicit attempt groups several turns under one id.
-        "attempt.id": attempt_id or trace_id,
         "audit.schema_version": SCHEMA_VERSION,
     }
     if attributes:
         attrs.update(attributes)
+        # "attempt.id" is reserved: attempts.json is the sole source of attempt
+        # grouping, and an injected value could collide with a definition id.
+        # Legacy logs already carrying the attribute stay readable as-is.
+        attrs.pop("attempt.id", None)
     return {
         "schemaVersion": SCHEMA_VERSION,
         "traceId": trace_id,

--- a/raven/tracing/trace.py
+++ b/raven/tracing/trace.py
@@ -50,7 +50,6 @@ class Span:
         "kind",
         "trace_id",
         "span_id",
-        "attempt_id",
         "_parent",
         "_start",
         "_attrs",
@@ -78,13 +77,11 @@ class Span:
         chat_id,
         start,
         source=None,
-        attempt_id=None,
     ):
         self.name = name
         self.kind = kind
         self.trace_id = trace_id
         self.span_id = span_id
-        self.attempt_id = attempt_id
         self._parent = parent
         self._session_key = session_key
         self._channel = channel
@@ -177,7 +174,6 @@ class Span:
                     session_key=self._session_key,
                     channel=self._channel,
                     chat_id=self._chat_id,
-                    attempt_id=self.attempt_id,
                     start_time=self._start,
                     end_time=_spans.now_iso(),
                     status_code=self._status_code,
@@ -197,7 +193,6 @@ class _NoopSpan:
     trace_id = ""
     span_id = ""
     name = ""
-    attempt_id = ""
     invocation_source = None
 
     def set(self, *_a, **_k):
@@ -257,9 +252,6 @@ def span(
         session_key = session_key if session_key is not None else (cur.session_key if cur else None)
         channel = channel if channel is not None else (cur.channel if cur else None)
         chat_id = chat_id if chat_id is not None else (cur.chat_id if cur else None)
-        # Children inherit the tree's attempt id; a root span resolves it from
-        # the session's open attempt, else this trace is a single-turn attempt.
-        attempt_id = (cur.attempt_id if cur else None) or _ctx.current_attempt(session_key) or trace_id
         span_id = _ctx.new_span_id()
         handle = Span(
             name,
@@ -272,7 +264,6 @@ def span(
             chat_id=chat_id,
             start=_spans.now_iso(),
             source=cur.source if cur else None,
-            attempt_id=attempt_id,
         )
         handle.set(attributes, **kw)
         # A detached span is a leaf marker: it does NOT become the active parent,
@@ -290,7 +281,6 @@ def span(
                 session_key=session_key,
                 channel=channel,
                 chat_id=chat_id,
-                attempt_id=attempt_id,
             )
         )
     except Exception:  # noqa: BLE001 — open must never break the host
@@ -318,7 +308,6 @@ def span(
                         session_key=handle._session_key,
                         channel=handle._channel,
                         chat_id=handle._chat_id,
-                        attempt_id=handle.attempt_id,
                         start_time=handle._start,
                         end_time=_spans.now_iso(),
                         status_code=handle._status_code,
@@ -432,38 +421,6 @@ def instrument(name: str, *, kind: str | None = None, detached: bool = False, se
 def current() -> Any | None:
     """The active trace context (or None). Exposed for adopters that need it."""
     return _ctx.current()
-
-
-def begin_attempt(session_key: str, attempt_id: str | None = None) -> str:
-    """Open a multi-turn attempt for ``session_key``.
-
-    Every span of every turn opened while the attempt is active carries its id
-    as ``attempt.id`` — the stable trajectory address a task spanning several
-    turns groups under. Without an open attempt each turn is its own
-    single-turn attempt (``attempt.id`` = trace id). No-throw; returns the id.
-    """
-    try:
-        return _ctx.begin_attempt(session_key, attempt_id)
-    except Exception:  # noqa: BLE001 — tracing must never break the host
-        _log.debug("tracing: begin_attempt failed", exc_info=True)
-        return attempt_id or ""
-
-
-def end_attempt(session_key: str) -> str | None:
-    """Close the open attempt for ``session_key`` (no-op if none). No-throw."""
-    try:
-        return _ctx.end_attempt(session_key)
-    except Exception:  # noqa: BLE001
-        _log.debug("tracing: end_attempt failed", exc_info=True)
-        return None
-
-
-def current_attempt(session_key: str | None) -> str | None:
-    """The open attempt id for ``session_key``, or None. No-throw."""
-    try:
-        return _ctx.current_attempt(session_key)
-    except Exception:  # noqa: BLE001
-        return None
 
 
 def enabled() -> bool:

--- a/raven/trajectory/__init__.py
+++ b/raven/trajectory/__init__.py
@@ -7,7 +7,7 @@ into trajectories — addressable, labeled, retained units of agent work:
 - ``verdict``  — the label sidecar. Task success/failure is not tracing's
   business (``status.code`` answers "did the code crash", not "did the task
   succeed"), so verdicts live in a separate append-only file keyed by
-  ``attempt.id``, written by whoever can judge (user command, eval judge).
+  attempt id, written by whoever can judge (user command, eval judge).
 - ``store``    — pin registry, attempt definitions, and the rotation-
   transparent span reader. A pinned attempt is corpus, not diagnostics: any
   purge tooling must consult :func:`store.pins` before deleting spans or the
@@ -33,11 +33,11 @@ into trajectories — addressable, labeled, retained units of agent work:
   (where the replay must diverge, what the live side must do there) evaluated
   against a cassette replay, driving ``tests/trajectories/``.
 
-The address unit is the **attempt** (``attempt.id`` on every span): one task
-try, possibly spanning several turns. Without an explicitly opened attempt
-(:func:`raven.tracing.trace.begin_attempt`) each turn is its own single-turn
-attempt whose id equals the trace id — so every trace is addressable as an
-attempt with zero ceremony.
+The address unit is the **attempt**: one task try, possibly spanning several
+turns. At read time an attempt id equals the trace id unless a definition in
+``attempts.json`` groups several traces under one minted id — so every trace
+is addressable as an attempt with zero ceremony. Old logs may carry a legacy
+span-level ``attempt.id`` attribute, which read paths keep resolving.
 """
 
 from __future__ import annotations

--- a/raven/trajectory/__init__.py
+++ b/raven/trajectory/__init__.py
@@ -8,9 +8,12 @@ into trajectories — addressable, labeled, retained units of agent work:
   business (``status.code`` answers "did the code crash", not "did the task
   succeed"), so verdicts live in a separate append-only file keyed by
   ``attempt.id``, written by whoever can judge (user command, eval judge).
-- ``store``    — pin registry + rotation-transparent span reader. A pinned
-  attempt is corpus, not diagnostics: any purge tooling must consult
-  :func:`store.pins` before deleting spans or the artifacts they reference.
+- ``store``    — pin registry, attempt definitions, and the rotation-
+  transparent span reader. A pinned attempt is corpus, not diagnostics: any
+  purge tooling must consult :func:`store.pins` before deleting spans or the
+  artifacts they reference. Attempt definitions (``attempts.json``) are the
+  mutable merge/split sidecar: an attempt id equals the trace id unless a
+  definition groups several traces under one minted id.
 - ``bundle``   — the bundle collector. Packs one attempt's spans, artifacts,
   session record, and verdicts into a self-contained offline directory (and
   pins the id, since bundling declares the trajectory corpus).
@@ -70,13 +73,22 @@ from raven.trajectory.replay import (
 )
 from raven.trajectory.report import LocalTarballUploader, Uploader, get_uploader, pack_report
 from raven.trajectory.store import (
+    attempt_alias_ids,
+    attempt_members,
+    definitions,
     is_pinned,
     iter_spans,
+    merge_attempts,
+    new_attempt_id,
+    owning_attempt,
     pin,
+    pin_attempt,
     pins,
     resolve_attempt_id,
     span_log_paths,
+    split_attempt,
     unpin,
+    unpin_attempt,
 )
 from raven.trajectory.verdict import (
     VERDICT_STATUSES,
@@ -106,18 +118,25 @@ __all__ = [
     "ResidualFinding",
     "Uploader",
     "Verdict",
+    "attempt_alias_ids",
+    "attempt_members",
     "check_report",
     "collect_bundle",
     "collect_known_secrets",
+    "definitions",
     "get_uploader",
     "is_pinned",
     "iter_spans",
     "latest_verdict",
     "load_expectation",
     "load_recording",
+    "merge_attempts",
     "minimize_bundle",
+    "new_attempt_id",
+    "owning_attempt",
     "pack_report",
     "pin",
+    "pin_attempt",
     "pins",
     "read_verdicts",
     "record_verdict",
@@ -127,5 +146,7 @@ __all__ = [
     "run_replay",
     "scan_residuals",
     "span_log_paths",
+    "split_attempt",
     "unpin",
+    "unpin_attempt",
 ]

--- a/raven/trajectory/bundle.py
+++ b/raven/trajectory/bundle.py
@@ -34,7 +34,7 @@ from typing import Any
 from raven import __version__
 from raven.config.paths import get_workspace_path
 from raven.tracing import config as tracing_config
-from raven.trajectory.store import iter_spans, pin, resolve_attempt_id
+from raven.trajectory.store import attempt_alias_ids, iter_spans, pin, pin_attempt, resolve_attempt_id
 from raven.trajectory.verdict import read_verdicts
 
 BUNDLE_FORMAT_VERSION = 1
@@ -116,11 +116,13 @@ def collect_bundle(
     if attempt_id is None:
         raise LookupError(f"no spans found for id {id_!r}")
     spans = list(iter_spans(resolved_state, attempt_id=attempt_id))
+    if not spans:
+        raise LookupError(f"no spans found for attempt {attempt_id!r}")
 
     out_root = (out_dir or resolved_state / "bundles").resolve()
     out_root.mkdir(parents=True, exist_ok=True)
-    # Attempt ids come from span records (user-mintable via begin_attempt), so
-    # refuse any id that would escape out_root as a directory name.
+    # Attempt ids come from span records or the hand-editable attempts.json,
+    # so refuse any id that would escape out_root as a directory name.
     bundle_dir = (out_root / attempt_id).resolve()
     if bundle_dir.parent != out_root:
         raise ValueError(f"id {attempt_id!r} cannot be used as a bundle directory name")
@@ -162,7 +164,7 @@ def collect_bundle(
             "".join(json.dumps(s, ensure_ascii=False) + "\n" for s in out_spans), encoding="utf-8"
         )
 
-        verdicts = read_verdicts(resolved_state, attempt_id=attempt_id)
+        verdicts = read_verdicts(resolved_state, attempt_ids=attempt_alias_ids(attempt_id, resolved_state))
         (staging / "verdicts.jsonl").write_text(
             "".join(json.dumps(asdict(v), ensure_ascii=False) + "\n" for v in verdicts), encoding="utf-8"
         )
@@ -198,5 +200,12 @@ def collect_bundle(
         shutil.rmtree(staging, ignore_errors=True)
         raise
 
-    pin(attempt_id, reason="bundled", state_dir=resolved_state)
+    try:
+        pin_attempt(attempt_id, reason="bundled", state_dir=resolved_state)
+    except LookupError:
+        # The attempt address vanished mid-pack (a concurrent split/merge);
+        # protect exactly the traces that were bundled instead of leaving
+        # them purgeable behind a dangling id.
+        for member in dict.fromkeys(s.get("traceId") for s in out_spans if s.get("traceId")):
+            pin(member, reason="bundled", state_dir=resolved_state)
     return bundle_dir

--- a/raven/trajectory/bundle.py
+++ b/raven/trajectory/bundle.py
@@ -143,13 +143,16 @@ def collect_bundle(
         start: str | None = None
         end: str | None = None
         for span in spans:
-            attrs = dict(span.get("attributes") or {})
-            if session_key is None and attrs.get("session.key"):
+            # Historical records are unvalidated JSON: a truthy non-object
+            # attributes value or non-string key/timestamp degrades per-field.
+            raw_attrs = span.get("attributes")
+            attrs = dict(raw_attrs) if isinstance(raw_attrs, dict) else {}
+            if session_key is None and isinstance(attrs.get("session.key"), str) and attrs["session.key"]:
                 session_key = attrs["session.key"]
             span_start, span_end = span.get("startTime"), span.get("endTime")
-            if span_start and (start is None or span_start < start):
+            if isinstance(span_start, str) and span_start and (start is None or span_start < start):
                 start = span_start
-            if span_end and (end is None or span_end > end):
+            if isinstance(span_end, str) and span_end and (end is None or span_end > end):
                 end = span_end
             for key, value in attrs.items():
                 if not key.endswith(".artifact_path") or not isinstance(value, str) or not value:

--- a/raven/trajectory/store.py
+++ b/raven/trajectory/store.py
@@ -70,6 +70,22 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _span_attrs(span: dict[str, Any]) -> dict[str, Any]:
+    """The span's attributes mapping, or {} — a JSON-legal record whose
+    "attributes" is a truthy non-object must degrade, not crash readers."""
+    attrs = span.get("attributes")
+    return attrs if isinstance(attrs, dict) else {}
+
+
+def _str_value(value: Any) -> str | None:
+    """``value`` when it is a non-empty string, else None.
+
+    Span records are unvalidated history: a list/dict id or key would blow up
+    hashing, sorting, or rendering downstream, so readers treat any non-string
+    field as absent."""
+    return value if isinstance(value, str) and value else None
+
+
 def pins(state_dir: Path | None = None) -> dict[str, dict[str, Any]]:
     """The pin registry: id -> {reason, ts}. Empty on missing/corrupt file."""
     path = _pins_path(state_dir)
@@ -303,17 +319,17 @@ def _expand_group(
     canonical = id_
     traces: list[str] = []
     for span in iter_spans(state_dir, attempt_id=id_):
-        legacy = (span.get("attributes") or {}).get("attempt.id")
+        legacy = _str_value(_span_attrs(span).get("attempt.id"))
         if legacy and legacy != id_:
             canonical = legacy
             break
-        trace_id = span.get("traceId")
+        trace_id = _str_value(span.get("traceId"))
         if trace_id and trace_id not in traces:
             traces.append(trace_id)
     if canonical != id_:
         traces = []
         for span in iter_spans(state_dir, attempt_id=canonical):
-            trace_id = span.get("traceId")
+            trace_id = _str_value(span.get("traceId"))
             if trace_id and trace_id not in traces:
                 traces.append(trace_id)
     if not traces:
@@ -377,9 +393,9 @@ def _merge_publish(ids: Sequence[str], state_dir: Path | None = None) -> tuple[s
         member_set = set(members)
         session_keys: dict[str, str] = {}
         for span in iter_spans(state_dir):
-            trace_id = span.get("traceId")
-            if trace_id in member_set and trace_id not in session_keys:
-                key = (span.get("attributes") or {}).get("session.key")
+            trace_id = _str_value(span.get("traceId"))
+            if trace_id and trace_id in member_set and trace_id not in session_keys:
+                key = _str_value(_span_attrs(span).get("session.key"))
                 if key:
                     session_keys[trace_id] = key
         distinct_sessions = sorted(set(session_keys.values()))
@@ -573,11 +589,11 @@ def is_pinned(
     registry = pins(state_dir) if _pins is None else _pins
     if not registry:
         return False
-    attrs = span.get("attributes") or {}
-    if span.get("traceId") in registry or attrs.get("attempt.id") in registry:
+    trace_id = _str_value(span.get("traceId"))
+    legacy = _str_value(_span_attrs(span).get("attempt.id"))
+    if (trace_id and trace_id in registry) or (legacy and legacy in registry):
         return True
     defs = definitions(state_dir) if _defs is None else _defs
-    trace_id = span.get("traceId")
     for def_id, entry in defs.items():
         if trace_id in (entry.get("traces") or []):
             return def_id in registry or any(alias in registry for alias in entry.get("aliases") or [])
@@ -598,7 +614,7 @@ def resolve_attempt_id(id_: str, state_dir: Path | None = None) -> str | None:
     found = False
     for span in iter_spans(state_dir, attempt_id=id_):
         found = True
-        attempt_id = (span.get("attributes") or {}).get("attempt.id")
+        attempt_id = _str_value(_span_attrs(span).get("attempt.id"))
         if attempt_id:
             return attempt_id
     return id_ if found else None
@@ -638,11 +654,16 @@ def iter_spans(
             match_ids = set(defs[owner]["traces"])
     for path in span_log_paths(state_dir):
         try:
-            lines = path.read_text(encoding="utf-8").splitlines()
+            raw_lines = path.read_bytes().splitlines()
         except OSError:
             continue
-        for line in lines:
-            line = line.strip()
+        for raw_line in raw_lines:
+            # Decode per line: one invalid-UTF-8 byte must hide one record,
+            # not the whole log file.
+            try:
+                line = raw_line.decode("utf-8").strip()
+            except UnicodeDecodeError:
+                continue
             if not line:
                 continue
             try:
@@ -651,14 +672,15 @@ def iter_spans(
                 continue
             if not isinstance(span, dict):
                 continue
-            attrs = span.get("attributes") or {}
+            attrs = _span_attrs(span)
+            span_trace_id = _str_value(span.get("traceId"))
             if attempt_id is not None:
                 if match_ids is not None:
-                    if span.get("traceId") not in match_ids:
+                    if span_trace_id not in match_ids:
                         continue
-                elif attrs.get("attempt.id") != attempt_id and span.get("traceId") != attempt_id:
+                elif attrs.get("attempt.id") != attempt_id and span_trace_id != attempt_id:
                     continue
-            if trace_id is not None and span.get("traceId") != trace_id:
+            if trace_id is not None and span_trace_id != trace_id:
                 continue
             if session_key is not None and attrs.get("session.key") != session_key:
                 continue

--- a/raven/trajectory/store.py
+++ b/raven/trajectory/store.py
@@ -1,4 +1,4 @@
-"""Pin registry + rotation-transparent span reading over the tracing store.
+"""Pin registry, attempt definitions, and rotation-transparent span reading.
 
 Retention contract
 ------------------
@@ -8,33 +8,66 @@ The tracing store keeps logs for troubleshooting: the active log rotates into
 trajectory referenced as corpus (a bug report, a regression case, evolver
 evidence) needs a stronger promise: **pinned ids are never purged**. The pin
 registry (``pins.json`` in the trace state dir) records that promise; any
-future purge tooling MUST drop only spans whose ``attempt.id`` and ``traceId``
-are both unpinned, and must keep every artifact such a span references.
+future purge tooling MUST keep every span whose ``traceId``, legacy
+``attempt.id``, owning definition id, or any of that definition's aliases is
+pinned, and must keep every artifact such a span references.
+
+Attempt definitions
+-------------------
+
+An attempt id equals the trace id unless ``attempts.json`` (the mutable
+sidecar in the trace state dir) defines otherwise: a definition maps a minted
+``att-*`` id to its member trace ids plus the historical ids it absorbed
+(``aliases``), so span logs stay append-only while attempt grouping stays
+editable. :func:`merge_attempts` creates a definition (migrating member-level
+pins up to it); :func:`split_attempt` deletes one (migrating its pin down to
+the members inside the same transaction). Verdicts and pins recorded under an
+absorbed id stay addressable through the aliases.
+
+Pin migration spans two files that cannot be committed together; every path
+orders its writes so any crash or concurrent interleaving over-protects, never
+under-protects. Known residue: a process dying between merge's definition pin
+and the attempts commit leaves one dangling over-protective pin.
 
 Reading
 -------
 
 :func:`iter_spans` yields spans across archived + active logs in write order,
-so callers address trajectories without knowing where rotation put them. Pin
-ids and filter ids match against both ``attempt.id`` and ``traceId`` — the
-two names a trajectory is known by (they coincide for single-turn attempts).
+so callers address trajectories without knowing where rotation put them.
+Filter ids match a definition's member set when one exists, else ``attempt.id``
+OR ``traceId`` — the names a trajectory is known by without a definition.
 """
 
 from __future__ import annotations
 
 import json
+import secrets
+import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Callable, Iterable, Iterator, Sequence, TypeVar
+
+from loguru import logger
 
 from raven.tracing import config as tracing_config
 from raven.utils.atomic_io import atomic_update
 
+T = TypeVar("T")
+
 _PINS_FILE = "pins.json"
+_DEFS_FILE = "attempts.json"
 
 
 def _pins_path(state_dir: Path | None = None) -> Path:
     return (state_dir or tracing_config.state_dir()) / _PINS_FILE
+
+
+def _defs_path(state_dir: Path | None = None) -> Path:
+    return (state_dir or tracing_config.state_dir()) / _DEFS_FILE
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 def pins(state_dir: Path | None = None) -> dict[str, dict[str, Any]]:
@@ -63,18 +96,32 @@ def _dump_pins(registry: dict[str, dict[str, Any]]) -> str:
     return json.dumps(registry, ensure_ascii=False, indent=2) + "\n"
 
 
+def _update_pins(state_dir: Path | None, mutate: Callable[[dict[str, dict[str, Any]]], T]) -> T:
+    """Run one atomic read-mutate-write transaction over the pin registry."""
+
+    def update(text: str | None) -> tuple[str, T]:
+        registry = _parse_pins(text)
+        result = mutate(registry)
+        return _dump_pins(registry), result
+
+    return atomic_update(_pins_path(state_dir), update)
+
+
 def pin(id_: str, *, reason: str = "", state_dir: Path | None = None) -> None:
-    """Protect an attempt/trace id from any future purge. Idempotent."""
+    """Protect the literal ``id_`` from any future purge. Idempotent.
+
+    Low-level: writes the id as given. To pin an attempt *address* (a
+    definition id, alias, member, or turn trace), use :func:`pin_attempt` —
+    it re-resolves under the attempts lock, so it cannot race a concurrent
+    merge/split into pinning an id that no longer owns anything.
+    """
     if not id_:
         raise ValueError("id is required")
-    path = _pins_path(state_dir)
 
-    def update(text: str | None) -> tuple[str, None]:
-        current = _parse_pins(text)
-        current[id_] = {"reason": reason, "ts": datetime.now(timezone.utc).isoformat()}
-        return _dump_pins(current), None
+    def mutate(registry: dict[str, dict[str, Any]]) -> None:
+        registry[id_] = {"reason": reason, "ts": _now_iso()}
 
-    atomic_update(path, update)
+    _update_pins(state_dir, mutate)
 
 
 def unpin(id_: str, state_dir: Path | None = None) -> bool:
@@ -90,25 +137,464 @@ def unpin(id_: str, state_dir: Path | None = None) -> bool:
     return atomic_update(_pins_path(state_dir), update)
 
 
-def is_pinned(span: dict[str, Any], state_dir: Path | None = None, *, _pins: dict | None = None) -> bool:
-    """Whether a span record is protected (by attempt.id or traceId)."""
+def _join_reasons(reasons: Iterable[str | None]) -> str:
+    """Combine pin reasons: distinct non-empty ones joined in first-seen order."""
+    seen: list[str] = []
+    for reason in reasons:
+        if reason and reason not in seen:
+            seen.append(reason)
+    return "; ".join(seen)
+
+
+def _valid_id(id_: Any) -> bool:
+    """Whether ``id_`` is usable as a definition/alias key (also path-safe)."""
+    if not isinstance(id_, str) or not id_:
+        return False
+    return "/" not in id_ and "\\" not in id_ and ".." not in id_
+
+
+def _check_defs_invariants(defs: dict[str, dict[str, Any]]) -> bool:
+    """Global address-space check: definition ids, aliases, and member traces
+    must be three mutually disjoint sets (aliases/traces also unique across
+    entries) — otherwise resolution order would silently pick an owner."""
+    def_ids = set(defs)
+    aliases: set[str] = set()
+    traces: set[str] = set()
+    for entry in defs.values():
+        for alias in entry.get("aliases") or []:
+            if alias in aliases:
+                return False
+            aliases.add(alias)
+        for trace in entry.get("traces") or []:
+            if trace in traces:
+                return False
+            traces.add(trace)
+    return not (def_ids & aliases) and not (def_ids & traces) and not (aliases & traces)
+
+
+def _parse_defs(text: str | None) -> dict[str, dict[str, Any]]:
+    """Parse + validate attempts.json content.
+
+    Entries with invalid shape are dropped individually; any cross-entry
+    address collision rejects the whole file (never silently pick an owner).
+    The result is either fully trustworthy or empty.
+    """
+    if text is None:
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    defs: dict[str, dict[str, Any]] = {}
+    for def_id, entry in data.items():
+        if not _valid_id(def_id) or not isinstance(entry, dict):
+            continue
+        raw_traces = entry.get("traces")
+        if not isinstance(raw_traces, list) or any(not isinstance(t, str) or not t for t in raw_traces):
+            continue
+        traces = list(dict.fromkeys(raw_traces))
+        if len(traces) < 2:
+            continue
+        raw_aliases = entry.get("aliases", [])
+        if (
+            not isinstance(raw_aliases, list)
+            or any(not _valid_id(a) for a in raw_aliases)
+            or len(set(raw_aliases)) != len(raw_aliases)
+        ):
+            continue
+        normalized: dict[str, Any] = {"traces": traces}
+        if raw_aliases:
+            normalized["aliases"] = list(raw_aliases)
+        if isinstance(entry.get("ts"), str):
+            normalized["ts"] = entry["ts"]
+        defs[def_id] = normalized
+    return defs if _check_defs_invariants(defs) else {}
+
+
+def _dump_defs(defs: dict[str, dict[str, Any]]) -> str:
+    return json.dumps(defs, ensure_ascii=False, indent=2) + "\n"
+
+
+def definitions(state_dir: Path | None = None) -> dict[str, dict[str, Any]]:
+    """Attempt definitions: id -> {traces, aliases?, ts?}. Empty on any defect."""
+    path = _defs_path(state_dir)
+    if not path.exists():
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    return _parse_defs(text)
+
+
+def new_attempt_id() -> str:
+    return f"att-{int(time.time() * 1000):x}-{secrets.token_hex(4)}"
+
+
+def _definition_for(id_: str, defs: dict[str, dict[str, Any]]) -> str | None:
+    """Current definition id addressed by ``id_`` as itself or as an alias."""
+    if id_ in defs:
+        return id_
+    for def_id, entry in defs.items():
+        if id_ in (entry.get("aliases") or []):
+            return def_id
+    return None
+
+
+def _owner_of(id_: str, defs: dict[str, dict[str, Any]]) -> str | None:
+    """Definition id owning ``id_`` — as itself, an alias, or a member trace."""
+    owner = _definition_for(id_, defs)
+    if owner is not None:
+        return owner
+    for def_id, entry in defs.items():
+        if id_ in (entry.get("traces") or []):
+            return def_id
+    return None
+
+
+def attempt_members(id_: str, state_dir: Path | None = None) -> tuple[str, ...] | None:
+    """Member trace ids of the definition ``id_`` names (or aliases), else None."""
+    defs = definitions(state_dir)
+    owner = _definition_for(id_, defs)
+    return tuple(defs[owner]["traces"]) if owner else None
+
+
+def owning_attempt(trace_id: str, state_dir: Path | None = None) -> str | None:
+    """The definition id whose members include ``trace_id``, else None."""
+    defs = definitions(state_dir)
+    for def_id, entry in defs.items():
+        if trace_id in (entry.get("traces") or []):
+            return def_id
+    return None
+
+
+def attempt_alias_ids(id_: str, state_dir: Path | None = None) -> tuple[str, ...]:
+    """Every id the attempt addressed by ``id_`` is known by.
+
+    For a defined attempt: (definition id, *aliases, *member traces) — the set
+    verdict/pin readers must consult so labels recorded under absorbed or
+    member ids stay visible. For anything else: just (id_,).
+    """
+    defs = definitions(state_dir)
+    owner = _owner_of(id_, defs)
+    if owner is None:
+        return (id_,)
+    entry = defs[owner]
+    return (owner, *(entry.get("aliases") or []), *entry["traces"])
+
+
+def _expand_group(
+    id_: str, defs: dict[str, dict[str, Any]], state_dir: Path | None
+) -> tuple[str, tuple[str, ...], tuple[str, ...]] | None:
+    """Resolve ``id_`` to its whole attempt group against a defs snapshot.
+
+    Returns (group key, member trace ids, alias ids to carry) — a definition
+    (addressed by id, alias, or member) expands to its members; a legacy
+    attempt id, or any turn trace of one, expands to the entire legacy group
+    (matching how resolve_attempt_id addresses whole attempts by one turn);
+    a bare trace expands to itself. None when nothing matches.
+    """
+    owner = _owner_of(id_, defs)
+    if owner is not None:
+        entry = defs[owner]
+        return owner, tuple(entry["traces"]), (owner, *(entry.get("aliases") or []))
+    canonical = id_
+    traces: list[str] = []
+    for span in iter_spans(state_dir, attempt_id=id_):
+        legacy = (span.get("attributes") or {}).get("attempt.id")
+        if legacy and legacy != id_:
+            canonical = legacy
+            break
+        trace_id = span.get("traceId")
+        if trace_id and trace_id not in traces:
+            traces.append(trace_id)
+    if canonical != id_:
+        traces = []
+        for span in iter_spans(state_dir, attempt_id=canonical):
+            trace_id = span.get("traceId")
+            if trace_id and trace_id not in traces:
+                traces.append(trace_id)
+    if not traces:
+        return None
+    aliases = (canonical,) if canonical not in traces else ()
+    return canonical, tuple(traces), aliases
+
+
+def merge_attempts(ids: Sequence[str], state_dir: Path | None = None) -> str:
+    """Combine the attempts addressed by ``ids`` into one new definition.
+
+    Inputs may be definition ids, aliases, member/legacy/bare trace ids; each
+    expands to its whole group against one snapshot (order-independent), and
+    at least two distinct groups from one session are required. Member-level
+    pins migrate up to the new definition id; pins and verdicts recorded under
+    absorbed ids stay visible through the aliases. Returns the new id.
+    """
+    new_id, snapshot = _merge_publish(ids, state_dir)
+    _merge_cleanup(new_id, snapshot, state_dir)
+    return new_id
+
+
+def _merge_publish(ids: Sequence[str], state_dir: Path | None = None) -> tuple[str, dict[str, dict[str, Any]]]:
+    """Validate, pin the new definition, and commit it to attempts.json.
+
+    All pure validation runs before any pins write, so a rejected merge writes
+    nothing. The definition pin is written just before the attempts commit so
+    a concurrent split can never observe an unpinned definition; if the commit
+    itself then fails, the pin is rolled back (compare-and-delete).
+    """
+    if not ids:
+        raise ValueError("at least two attempt ids are required")
+    if any(not id_ for id_ in ids):
+        raise ValueError("attempt ids must be non-empty")
+    inputs = list(ids)
+    outcome: dict[str, Any] = {}
+
+    def update(text: str | None) -> tuple[str, None]:
+        defs = _parse_defs(text)
+        groups: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {}
+        for id_ in inputs:
+            expanded = _expand_group(id_, defs, state_dir)
+            if expanded is None:
+                raise ValueError(f"unknown id {id_!r}: not a definition, alias, or recorded trace")
+            key, traces, aliases = expanded
+            groups.setdefault(key, (traces, aliases))
+        if len(groups) < 2:
+            raise ValueError("merge needs at least two distinct attempts")
+
+        members: list[str] = []
+        alias_ids: list[str] = []
+        for traces, aliases in groups.values():
+            members.extend(t for t in traces if t not in members)
+            alias_ids.extend(a for a in aliases if a not in alias_ids)
+        if len(members) < 2:
+            raise ValueError("merge needs at least two distinct traces")
+        for alias in alias_ids:
+            if not _valid_id(alias):
+                raise ValueError(f"legacy attempt id {alias!r} is not a safe identifier and cannot be merged")
+
+        member_set = set(members)
+        session_keys: dict[str, str] = {}
+        for span in iter_spans(state_dir):
+            trace_id = span.get("traceId")
+            if trace_id in member_set and trace_id not in session_keys:
+                key = (span.get("attributes") or {}).get("session.key")
+                if key:
+                    session_keys[trace_id] = key
+        distinct_sessions = sorted(set(session_keys.values()))
+        if len(distinct_sessions) > 1:
+            raise ValueError(
+                f"members belong to different sessions {distinct_sessions}; cross-session merge is not supported"
+            )
+
+        remaining = {def_id: entry for def_id, entry in defs.items() if def_id not in groups}
+        occupied = set(remaining) | member_set | set(alias_ids)
+        for entry in remaining.values():
+            occupied.update(entry.get("aliases") or [])
+            occupied.update(entry["traces"])
+        new_id = new_attempt_id()
+        while new_id in occupied:
+            new_id = new_attempt_id()
+
+        entry: dict[str, Any] = {"traces": members, "ts": _now_iso()}
+        if alias_ids:
+            entry["aliases"] = alias_ids
+        candidate = {**remaining, new_id: entry}
+        if not _check_defs_invariants(candidate):
+            raise ValueError("merge would violate attempt definition invariants")
+
+        current_pins = pins(state_dir)
+        snapshot = {m: dict(current_pins[m]) for m in members if m in current_pins}
+        if snapshot:
+            pin(new_id, reason=_join_reasons(r.get("reason") for r in snapshot.values()), state_dir=state_dir)
+            outcome["definition_pin"] = pins(state_dir).get(new_id)
+        outcome["new_id"] = new_id
+        outcome["snapshot"] = snapshot
+        return _dump_defs(candidate), None
+
+    try:
+        atomic_update(_defs_path(state_dir), update)
+    except Exception:
+        written = outcome.get("definition_pin")
+        if written is not None:
+            try:
+
+                def rollback(registry: dict[str, dict[str, Any]]) -> None:
+                    if registry.get(outcome["new_id"]) == written:
+                        del registry[outcome["new_id"]]
+
+                _update_pins(state_dir, rollback)
+            except Exception:  # noqa: BLE001 — rollback is best-effort
+                logger.debug("trajectory: merge pin rollback failed", exc_info=True)
+        raise
+    return outcome["new_id"], outcome["snapshot"]
+
+
+def _merge_cleanup(new_id: str, snapshot: dict[str, dict[str, Any]], state_dir: Path | None = None) -> None:
+    """Drop the member pins the publish migrated up. Best-effort by design:
+    the merge is already committed, so a failure here only leaves redundant
+    over-protective pins (unpin_attempt converges them). Re-checks under the
+    attempts lock and compare-and-deletes, so a concurrent split (protection
+    moved back down) or a fresh manual pin is never clobbered."""
+    if not snapshot:
+        return
+    try:
+
+        def check(text: str | None) -> tuple[None, None]:
+            defs = _parse_defs(text)
+            if new_id in defs:
+
+                def clean(registry: dict[str, dict[str, Any]]) -> None:
+                    for member, record in snapshot.items():
+                        if registry.get(member) == record:
+                            del registry[member]
+
+                _update_pins(state_dir, clean)
+            return None, None
+
+        atomic_update(_defs_path(state_dir), check)
+    except Exception:  # noqa: BLE001 — cleanup must not fail a committed merge
+        logger.debug("trajectory: merge cleanup failed; redundant pins remain", exc_info=True)
+
+
+def split_attempt(id_: str, state_dir: Path | None = None) -> tuple[str, ...] | None:
+    """Delete the definition owning ``id_``; members revert to per-trace attempts.
+
+    Protection carried by the definition or its aliases migrates down: one
+    pins transaction (inside the attempts lock) pins every member (joining any
+    existing member reason) and drops the definition/alias pins, then the
+    deletion commits — so a failed commit leaves members protected and the
+    definition still discoverable. Merged-attempt verdicts do not transfer to
+    members. Returns the member trace ids, or None when nothing owns ``id_``.
+    """
+
+    def update(text: str | None) -> tuple[str | None, tuple[str, ...] | None]:
+        defs = _parse_defs(text)
+        owner = _owner_of(id_, defs)
+        if owner is None:
+            return None, None
+        entry = defs[owner]
+        members = list(entry["traces"])
+        protected_ids = (owner, *(entry.get("aliases") or []))
+
+        # The definition/alias pins must be read inside the pins lock: a
+        # lock-free read races a concurrent pin(), skipping the migration and
+        # leaving members unprotected after the definition is deleted.
+        def mutate(registry: dict[str, dict[str, Any]]) -> None:
+            pinned_records = {pid: registry[pid] for pid in protected_ids if pid in registry}
+            if pinned_records:
+                inherited = [record.get("reason") for record in pinned_records.values()]
+                for member in members:
+                    existing = (registry.get(member) or {}).get("reason")
+                    registry[member] = {"reason": _join_reasons([existing, *inherited]), "ts": _now_iso()}
+            for pid in protected_ids:
+                registry.pop(pid, None)
+
+        _update_pins(state_dir, mutate)
+        remaining = {def_id: e for def_id, e in defs.items() if def_id != owner}
+        return _dump_defs(remaining), tuple(members)
+
+    return atomic_update(_defs_path(state_dir), update)
+
+
+def pin_attempt(id_: str, *, reason: str = "", state_dir: Path | None = None) -> str:
+    """Pin the attempt addressed by ``id_``; returns the id actually pinned.
+
+    Resolves the current owner (definition, alias, member, legacy group, or
+    the trace itself) inside the attempts lock and writes the pin while still
+    holding it, so the operation is linearized against merge/split: a
+    concurrent split either sees this pin and migrates it, or completed first
+    and this call re-resolves (or refuses). Raises ``LookupError`` for an
+    unresolvable id — never writes a dangling pin.
+    """
+
+    def check(text: str | None) -> tuple[None, str]:
+        defs = _parse_defs(text)
+        owner = _owner_of(id_, defs)
+        if owner is None:
+            expanded = _expand_group(id_, defs, state_dir)
+            if expanded is None:
+                raise LookupError(f"no spans found for id {id_!r}")
+            owner = expanded[0]
+        pin(owner, reason=reason, state_dir=state_dir)
+        return None, owner
+
+    return atomic_update(_defs_path(state_dir), check)
+
+
+def unpin_attempt(id_: str, state_dir: Path | None = None) -> bool:
+    """Remove every pin protecting the attempt addressed by ``id_``.
+
+    Resolves the current owner under the attempts lock (a lock-free resolve
+    races re-merges), then clears the definition id, its aliases, all member
+    traces, and the literal id in one pins transaction. Without a definition
+    the id expands through spans, so a legacy group is cleared whole. Note
+    this removes member-level protection too. Returns whether any pin existed.
+    """
+
+    def check(text: str | None) -> tuple[None, bool]:
+        defs = _parse_defs(text)
+        owner = _owner_of(id_, defs)
+        if owner is not None:
+            entry = defs[owner]
+            targets = {owner, *(entry.get("aliases") or []), *entry["traces"]}
+        else:
+            expanded = _expand_group(id_, defs, state_dir)
+            if expanded is None:
+                targets = {id_}
+            else:
+                key, traces, aliases = expanded
+                targets = {key, *aliases, *traces}
+        targets.add(id_)
+
+        def clean(registry: dict[str, dict[str, Any]]) -> bool:
+            removed = False
+            for target in targets:
+                if target in registry:
+                    del registry[target]
+                    removed = True
+            return removed
+
+        return None, _update_pins(state_dir, clean)
+
+    return atomic_update(_defs_path(state_dir), check)
+
+
+def is_pinned(
+    span: dict[str, Any],
+    state_dir: Path | None = None,
+    *,
+    _pins: dict | None = None,
+    _defs: dict | None = None,
+) -> bool:
+    """Whether a span record is protected — directly (traceId / legacy
+    attempt.id) or through its owning definition or any of its aliases."""
     registry = pins(state_dir) if _pins is None else _pins
     if not registry:
         return False
     attrs = span.get("attributes") or {}
-    return span.get("traceId") in registry or attrs.get("attempt.id") in registry
+    if span.get("traceId") in registry or attrs.get("attempt.id") in registry:
+        return True
+    defs = definitions(state_dir) if _defs is None else _defs
+    trace_id = span.get("traceId")
+    for def_id, entry in defs.items():
+        if trace_id in (entry.get("traces") or []):
+            return def_id in registry or any(alias in registry for alias in entry.get("aliases") or [])
+    return False
 
 
 def resolve_attempt_id(id_: str, state_dir: Path | None = None) -> str | None:
-    """Canonical attempt id for ``id_`` (an attempt id or a turn's trace id).
+    """Canonical attempt id for ``id_`` (a definition id, alias, or trace id).
 
-    A turn's trace id addresses the whole multi-turn attempt it belongs to, so
-    every consumer that keys state by id (verdicts, pins, bundles) must write
-    under the canonical ``attempt.id`` — otherwise the same trajectory ends up
-    labeled under one name and packed under another. Returns ``id_`` itself
-    when matching spans carry no ``attempt.id`` (pre-attempt records), and
-    ``None`` when no span matches at all.
+    A definition (addressed by its id, an absorbed alias, or a member trace)
+    wins; otherwise a turn's trace id resolves through its spans' legacy
+    ``attempt.id`` so pre-definition records stay addressable, falling back to
+    the id itself. Returns ``None`` when nothing matches at all.
     """
+    owner = _owner_of(id_, definitions(state_dir))
+    if owner is not None:
+        return owner
     found = False
     for span in iter_spans(state_dir, attempt_id=id_):
         found = True
@@ -136,10 +622,20 @@ def iter_spans(
 ) -> Iterator[dict[str, Any]]:
     """Yield span records across all logs in write order, filtered.
 
-    ``attempt_id`` matches spans whose ``attempt.id`` OR ``traceId`` equals it
-    (single-turn attempts are addressed by their trace id). Unparseable lines
-    are skipped — one bad line must not hide a whole trajectory.
+    ``attempt_id`` naming a definition (directly, via an alias, or via a
+    member trace) matches the definition's member trace ids — one member
+    addresses the whole attempt, like resolve_attempt_id; use ``trace_id`` for
+    a single trace. Otherwise it matches spans whose ``attempt.id`` OR
+    ``traceId`` equals it (single-turn attempts are addressed by their trace
+    id). Unparseable lines are skipped — one bad line must not hide a whole
+    trajectory.
     """
+    match_ids: set[str] | None = None
+    if attempt_id is not None:
+        defs = definitions(state_dir)
+        owner = _owner_of(attempt_id, defs)
+        if owner is not None:
+            match_ids = set(defs[owner]["traces"])
     for path in span_log_paths(state_dir):
         try:
             lines = path.read_text(encoding="utf-8").splitlines()
@@ -156,8 +652,12 @@ def iter_spans(
             if not isinstance(span, dict):
                 continue
             attrs = span.get("attributes") or {}
-            if attempt_id is not None and attrs.get("attempt.id") != attempt_id and span.get("traceId") != attempt_id:
-                continue
+            if attempt_id is not None:
+                if match_ids is not None:
+                    if span.get("traceId") not in match_ids:
+                        continue
+                elif attrs.get("attempt.id") != attempt_id and span.get("traceId") != attempt_id:
+                    continue
             if trace_id is not None and span.get("traceId") != trace_id:
                 continue
             if session_key is not None and attrs.get("session.key") != session_key:

--- a/raven/trajectory/verdict.py
+++ b/raven/trajectory/verdict.py
@@ -19,6 +19,7 @@ import json
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Collection
 
 from raven.tracing import config as tracing_config
 from raven.utils.atomic_io import locked_append
@@ -83,15 +84,26 @@ def record_verdict(
     return verdict
 
 
-def read_verdicts(state_dir: Path | None = None, *, attempt_id: str | None = None) -> list[Verdict]:
-    """All verdicts in file order (oldest first), optionally for one attempt.
+def read_verdicts(
+    state_dir: Path | None = None,
+    *,
+    attempt_id: str | None = None,
+    attempt_ids: Collection[str] | None = None,
+) -> list[Verdict]:
+    """All verdicts in file order (oldest first), optionally filtered.
 
-    Defect-tolerant: unparseable or incomplete lines are skipped — one bad
-    line must not make the whole label store unreadable.
+    ``attempt_id`` matches one exact id; ``attempt_ids`` matches any of a set —
+    pass an attempt's alias ids so verdicts recorded under absorbed or member
+    ids stay visible for a merged attempt. The two filters are mutually
+    exclusive. Defect-tolerant: unparseable or incomplete lines are skipped —
+    one bad line must not make the whole label store unreadable.
     """
+    if attempt_id is not None and attempt_ids is not None:
+        raise ValueError("attempt_id and attempt_ids are mutually exclusive")
     path = _verdicts_path(state_dir)
     if not path.exists():
         return []
+    wanted = set(attempt_ids) if attempt_ids is not None else None
     out: list[Verdict] = []
     for line in path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
@@ -110,8 +122,11 @@ def read_verdicts(state_dir: Path | None = None, *, attempt_id: str | None = Non
             )
         except (json.JSONDecodeError, KeyError, TypeError):
             continue
-        if attempt_id is None or v.attempt_id == attempt_id:
-            out.append(v)
+        if attempt_id is not None and v.attempt_id != attempt_id:
+            continue
+        if wanted is not None and v.attempt_id not in wanted:
+            continue
+        out.append(v)
     return out
 
 

--- a/raven/trajectory/verdict.py
+++ b/raven/trajectory/verdict.py
@@ -6,7 +6,7 @@ infrastructure failure (the evolver's SOP distinction: an infra failure must
 never be diagnosed as an agent failure). Tracing cannot know any of this, so
 verdicts are written by whoever can judge — a user command, an eval judge, a
 replay harness — into an append-only ``verdicts.jsonl`` next to the trace
-logs, keyed by ``attempt.id``.
+logs, keyed by attempt id (the ``attempt_id`` field).
 
 Append-only on purpose: verdicts from different sources coexist (a user's
 "fail" and a judge's "fail" are two records), and re-judging appends rather

--- a/raven/trajectory/verdict.py
+++ b/raven/trajectory/verdict.py
@@ -105,23 +105,39 @@ def read_verdicts(
         return []
     wanted = set(attempt_ids) if attempt_ids is not None else None
     out: list[Verdict] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
+    try:
+        raw_lines = path.read_bytes().splitlines()
+    except OSError:
+        return []
+    for raw_line in raw_lines:
+        # Decode per line: one invalid-UTF-8 byte must hide one record, not
+        # every record before and after it in the append-only file.
+        try:
+            line = raw_line.decode("utf-8").strip()
+        except UnicodeDecodeError:
+            continue
         if not line:
             continue
         try:
             d = json.loads(line)
-            v = Verdict(
-                attempt_id=d["attempt_id"],
-                status=d["status"],
-                source=d["source"],
-                ts=d["ts"],
-                why=d.get("why"),
-                notes=d.get("notes"),
-                session_key=d.get("session_key"),
-            )
-        except (json.JSONDecodeError, KeyError, TypeError):
+        except json.JSONDecodeError:
             continue
+        # Required fields must be non-empty strings: a list/dict attempt_id
+        # would blow up set lookups and dict keys in every consumer.
+        if not isinstance(d, dict):
+            continue
+        required = (d.get("attempt_id"), d.get("status"), d.get("source"), d.get("ts"))
+        if any(not isinstance(value, str) or not value for value in required):
+            continue
+        v = Verdict(
+            attempt_id=d["attempt_id"],
+            status=d["status"],
+            source=d["source"],
+            ts=d["ts"],
+            why=d.get("why"),
+            notes=d.get("notes"),
+            session_key=d.get("session_key"),
+        )
         if attempt_id is not None and v.attempt_id != attempt_id:
             continue
         if wanted is not None and v.attempt_id not in wanted:

--- a/tests/test_cli_trajectory_browse.py
+++ b/tests/test_cli_trajectory_browse.py
@@ -1,0 +1,979 @@
+"""Tests for the interactive trajectory browser (`raven.cli.trajectory_browse`)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from raven.cli import trajectory_browse as tbrowse
+from raven.trajectory import store as tstore
+from raven.trajectory import verdict as tverdict
+
+_CANCEL = object()
+
+
+def _write_log(path, spans):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(s) + "\n" for s in spans), encoding="utf-8")
+
+
+def _span(trace_id, *, attempt_id=None, session_key=None, name="session.turn", attrs=None, span_id=None, end=None):
+    attributes = {"session.key": session_key}
+    if attempt_id is not None:
+        attributes["attempt.id"] = attempt_id
+    if attrs:
+        attributes.update(attrs)
+    return {
+        "schemaVersion": "audit.span.v1",
+        "traceId": trace_id,
+        "spanId": span_id or f"span-{trace_id}-{name}",
+        "name": name,
+        "startTime": "2026-08-20T10:00:00+00:00",
+        "endTime": end or "2026-08-20T10:00:01+00:00",
+        "attributes": attributes,
+    }
+
+
+class _FakeQuestionary:
+    """Scripted questionary stand-in.
+
+    Each prompt pops one scripted answer. An answer may be:
+    - ``("pick", substr)``  — select the first choice whose title contains substr;
+    - ``("pickall", [substr, ...])`` — checkbox: the values of all matching choices;
+    - ``_CANCEL``           — ``ask()`` returns None (Ctrl+C / EOF);
+    - a zero-arg callable   — invoked at answer time (side effects), its return used;
+    - anything else         — returned verbatim.
+    Every prompt is recorded as (kind, message, [choice titles]).
+    """
+
+    class Choice:
+        def __init__(self, title, value=None):
+            self.title = title
+            self.value = value if value is not None else title
+
+    def __init__(self, answers):
+        self.answers = list(answers)
+        self.prompts: list[tuple[str, str, list[str]]] = []
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def _resolve(self, kind, message, choices, kwargs=None):
+        titles = [c.title for c in choices] if choices else []
+        self.prompts.append((kind, message, titles))
+        self.calls.append((kind, message, kwargs or {}))
+        answer = self.answers.pop(0)
+        if callable(answer):
+            answer = answer()
+        if answer is _CANCEL:
+            value = None
+        elif isinstance(answer, tuple) and answer and answer[0] == "pick":
+            value = next(c.value for c in choices if answer[1] in c.title)
+        elif isinstance(answer, tuple) and answer and answer[0] == "pickall":
+            value = [next(c.value for c in choices if s in c.title) for s in answer[1]]
+        else:
+            value = answer
+        return type("_Ask", (), {"ask": staticmethod(lambda: value)})()
+
+    def select(self, message, choices=None, **kw):
+        return self._resolve("select", message, choices, kw)
+
+    def checkbox(self, message, choices=None, **kw):
+        return self._resolve("checkbox", message, choices, kw)
+
+    def confirm(self, message, **kw):
+        return self._resolve("confirm", message, None, kw)
+
+    def text(self, message, **kw):
+        return self._resolve("text", message, None, kw)
+
+
+@pytest.fixture
+def state(tmp_path, monkeypatch):
+    state = tmp_path / "traces"
+    monkeypatch.setenv("RAVEN_TRACING_DIR", str(state))
+    return state
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    return ws
+
+
+def _browse(monkeypatch, answers, workspace):
+    fake = _FakeQuestionary(answers)
+    monkeypatch.setattr(tbrowse, "_require_questionary", lambda: fake)
+    tbrowse.browse_trajectories(workspace=workspace)
+    return fake
+
+
+def _two_turn_log(state, session_key="cli:a"):
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [
+            _span("trace-1", session_key=session_key, attrs={"turn.input_preview": "fix the bug"}),
+            _span("trace-2", session_key=session_key, name="tool.call"),
+            _span("trace-2", session_key=session_key, span_id="span-t2-turn"),
+        ],
+    )
+
+
+_IDS = ("trace-1", "trace-2", "cli:a", "att-")
+
+
+def _assert_no_ids(text: str, ids=_IDS) -> None:
+    for id_ in ids:
+        assert id_ not in text, f"{id_!r} leaked into: {text!r}"
+
+
+# ── aggregation / labels (pure functions) ─────────────────────────────
+
+
+def test_labels_carry_no_ids(state, workspace):
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [
+            _span("trace-1", session_key="cli:a"),
+            _span("trace-2", session_key="cli:a"),
+            _span("trace-3", attempt_id="att-old", session_key="cli:a"),
+        ],
+    )
+    tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+
+    sessions = tbrowse.scan_sessions(workspace)
+
+    assert sessions
+    for srow in sessions:
+        _assert_no_ids(tbrowse.session_label(srow), ("trace-", "cli:a", "att-"))
+        for i, row in enumerate(srow.attempts, start=1):
+            _assert_no_ids(tbrowse.attempt_label(i, row), ("trace-", "cli:a", "att-"))
+
+
+def test_orphan_session_falls_back_label(state, workspace):
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", session_key="cli:a")])
+    (srow,) = tbrowse.scan_sessions(workspace)
+    assert srow.title.startswith("cli session")
+
+
+def test_titled_session_uses_metadata_title(state, workspace):
+    from raven.session.manager import SessionManager
+
+    manager = SessionManager(workspace)
+    session = manager.get_or_create("cli:a")
+    session.add_message("user", "hello")
+    session.set_title("My debugging run")
+    manager.save(session)
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", session_key="cli:a")])
+
+    (srow,) = tbrowse.scan_sessions(workspace)
+
+    assert srow.title == "My debugging run"
+
+
+def test_workspace_read_failure_degrades(state, tmp_path):
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", session_key="cli:a")])
+    (srow,) = tbrowse.scan_sessions(tmp_path / "missing-ws")
+    assert srow.title.startswith("cli session")
+
+
+def test_no_session_bucket(state, workspace):
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1")])
+    (srow,) = tbrowse.scan_sessions(workspace)
+    assert srow.key is None
+    assert srow.title == "(no session)"
+
+
+def test_legacy_multi_trace_is_not_merged(state, workspace):
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [
+            _span("trace-1", attempt_id="att-old", session_key="cli:a"),
+            _span("trace-2", attempt_id="att-old", session_key="cli:a"),
+            _span("trace-3", session_key="cli:a"),
+        ],
+    )
+    aid = tstore.merge_attempts(["trace-3", "att-old"], state_dir=state)
+    tstore.split_attempt(aid, state_dir=state)
+
+    (srow,) = tbrowse.scan_sessions(workspace)
+    by_traces = {row.traces: row for row in srow.attempts}
+
+    assert by_traces[("trace-1", "trace-2")].merged is False
+    aid2 = tstore.merge_attempts(["trace-3", "att-old"], state_dir=state)
+    (srow,) = tbrowse.scan_sessions(workspace)
+    (row,) = srow.attempts
+    assert row.key == aid2 and row.merged is True
+
+
+def test_verdict_via_alias_and_pin_via_definition(state, workspace):
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [
+            _span("trace-1", session_key="cli:a"),
+            _span("trace-2", session_key="cli:a"),
+            _span("trace-3", session_key="cli:a"),
+        ],
+    )
+    d1 = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+    tverdict.record_verdict(d1, "fail", source="user", state_dir=state)
+    tstore.pin(d1, state_dir=state)
+    d2 = tstore.merge_attempts([d1, "trace-3"], state_dir=state)
+
+    (srow,) = tbrowse.scan_sessions(workspace)
+    (row,) = srow.attempts
+
+    assert row.key == d2
+    assert row.verdict == "fail"  # surfaced through the absorbed alias
+    assert row.pinned is True  # alias pin extends to the definition
+
+
+def test_defective_records_tolerated(state, workspace):
+    good = _span("trace-1", session_key="cli:a")
+    bad_preview = _span("trace-2", session_key="cli:a", attrs={"turn.input_preview": 123})
+    bad_attempt = _span("trace-3", session_key="cli:a")
+    bad_attempt["attributes"]["attempt.id"] = ["not", "a", "string"]
+    bad_container = {"schemaVersion": "audit.span.v1", "traceId": "trace-4", "attributes": "bad"}
+    _write_log(state / "logs" / "audit-spans.log", [good, bad_preview, bad_attempt, bad_container])
+
+    sessions = tbrowse.scan_sessions(workspace)
+
+    keys = {row.key for srow in sessions for row in srow.attempts}
+    assert keys == {"trace-1", "trace-2", "trace-3", "trace-4"}
+
+
+def test_label_normalization(state, workspace):
+    from raven.session.manager import SessionManager
+
+    manager = SessionManager(workspace)
+    session = manager.get_or_create("cli:a")
+    session.add_message("user", "x")
+    session.set_title("x[red]y\nmulti\tline\x07title")
+    manager.save(session)
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1", session_key="cli:a", attrs={"turn.input_preview": "pre[/dim]view\nwith\nnewlines"})],
+    )
+
+    (srow,) = tbrowse.scan_sessions(workspace)
+
+    assert "\\" not in srow.title  # plain text boundary: no Rich escaping
+    assert "\n" not in srow.title and "\t" not in srow.title and "\x07" not in srow.title
+    assert "x[red]y" in srow.title
+    (row,) = srow.attempts
+    assert "\n" not in (row.preview or "")
+    assert "pre[/dim]view" in row.preview
+
+
+def test_fallback_title_prefers_span_channel(state, workspace):
+    """With no session file and a separator-less key, the span's own channel
+    attribute still yields a human label (normalized to one line)."""
+    span = _span("trace-1", session_key="weirdkey", attrs={"channel": "discord\nextra"})
+    _write_log(state / "logs" / "audit-spans.log", [span])
+
+    (srow,) = tbrowse.scan_sessions(workspace)
+
+    assert srow.title == "discord extra session · 2026-08-20 10:00"
+    assert "\n" not in srow.title
+    assert "weirdkey" not in srow.title
+
+
+def test_malformed_timestamps_and_session_key_stay_one_line(state, workspace):
+    """Corrupt startTime strings and a separator-less session key must not
+    break the one-line layout or surface the raw key in a fallback title."""
+    bad_key = "weird session key without separator\nline2"
+    span = _span("trace-1", session_key=bad_key)
+    span["startTime"] = "2026-\n08\t20T1\x07:00:00"
+    span["endTime"] = "2026-\n08\t20T1\x07:00:01"
+    _write_log(state / "logs" / "audit-spans.log", [span])
+
+    (srow,) = tbrowse.scan_sessions(workspace)
+
+    label = tbrowse.session_label(srow)
+    assert "\n" not in label and "\t" not in label and "\x07" not in label
+    assert bad_key not in label
+    assert label.startswith("unknown session")
+    (row,) = srow.attempts
+    attempt = tbrowse.attempt_label(1, row)
+    assert "\n" not in attempt and "\t" not in attempt and "\x07" not in attempt
+
+
+def test_malformed_session_entries_degrade(state, workspace, monkeypatch):
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", session_key="cli:a")])
+    monkeypatch.setattr(
+        tbrowse.SessionManager,
+        "list_sessions",
+        lambda self, channel=None: ["junk", {"key": 1, "metadata": {"title": "x"}}, {"key": "cli:a", "metadata": 5}],
+    )
+    (srow,) = tbrowse.scan_sessions(workspace)
+    assert srow.title.startswith("cli session")
+
+
+# ── logical spans ─────────────────────────────────────────────────────
+
+
+def test_checkpoint_and_final_count_as_one_span(state, workspace):
+    checkpoint = _span("trace-1", session_key="cli:a", span_id="span-root", end="2026-08-20T10:00:00+00:00")
+    final = _span("trace-1", session_key="cli:a", span_id="span-root", end="2026-08-20T10:05:00+00:00")
+    _write_log(state / "logs" / "audit-spans.log", [checkpoint, final])
+
+    (srow,) = tbrowse.scan_sessions(workspace)
+    (row,) = srow.attempts
+
+    assert row.turns == 1 and row.spans == 1
+    assert row.end == "2026-08-20T10:05:00+00:00"  # the final record wins
+
+
+def test_missing_span_ids_never_merge(state, workspace):
+    a = _span("trace-1", session_key="cli:a")
+    b = _span("trace-1", session_key="cli:a")
+    del a["spanId"], b["spanId"]
+    _write_log(state / "logs" / "audit-spans.log", [a, b])
+
+    (srow,) = tbrowse.scan_sessions(workspace)
+    (row,) = srow.attempts
+
+    assert row.spans == 2
+
+
+def test_same_span_id_across_traces_stays_separate(state, workspace):
+    a = _span("trace-1", session_key="cli:a", span_id="span-shared")
+    b = _span("trace-2", session_key="cli:a", span_id="span-shared")
+    _write_log(state / "logs" / "audit-spans.log", [a, b])
+
+    (srow,) = tbrowse.scan_sessions(workspace)
+
+    assert {row.key: row.turns for row in srow.attempts} == {"trace-1": 1, "trace-2": 1}
+
+
+def test_snapshot_discipline(state, workspace, monkeypatch):
+    _two_turn_log(state)
+    calls = {"definitions": 0, "pins": 0, "read_verdicts": 0}
+    real_defs, real_pins, real_verdicts = tstore.definitions, tstore.pins, tbrowse.read_verdicts
+
+    def _count(name, real):
+        def wrapper(*args, **kwargs):
+            calls[name] += 1
+            return real(*args, **kwargs)
+
+        return wrapper
+
+    monkeypatch.setattr(tbrowse.tstore, "definitions", _count("definitions", real_defs))
+    monkeypatch.setattr(tbrowse.tstore, "pins", _count("pins", real_pins))
+    monkeypatch.setattr(tbrowse, "read_verdicts", _count("read_verdicts", real_verdicts))
+
+    def _forbidden(*_a, **_k):
+        raise AssertionError("per-row store reads are forbidden in the scan")
+
+    monkeypatch.setattr(tbrowse.tstore, "attempt_alias_ids", _forbidden)
+    monkeypatch.setattr(tbrowse.tstore, "is_pinned", _forbidden)
+
+    tbrowse.scan_sessions(workspace)
+
+    assert calls == {"definitions": 1, "pins": 1, "read_verdicts": 1}
+
+
+# ── flows ─────────────────────────────────────────────────────────────
+
+
+def test_save_flow_bundles_by_member(state, workspace, monkeypatch, capsys):
+    _two_turn_log(state)
+    aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+
+    _browse(
+        monkeypatch,
+        [("pick", "session"), ("pick", "#1"), ("pick", "Save"), ("pick", "Back"), ("pick", "Exit")],
+        workspace,
+    )
+
+    assert (state / "bundles" / aid / "manifest.json").exists()
+    out = capsys.readouterr().out
+    assert str(state / "bundles") in out.replace("\n", "")
+
+
+def test_minimize_flow_and_repeat(state, workspace, monkeypatch):
+    _two_turn_log(state)
+    script = [("pick", "session"), ("pick", "#1"), ("pick", "Minimize"), ("pick", "Back"), ("pick", "Exit")]
+    monkeypatch.setattr(tbrowse, "minimize_bundle", _fake_minimize)
+
+    _browse(monkeypatch, script, workspace)
+    assert (state / "cassettes" / "trace-1" / "manifest.json").exists()
+
+    _browse(monkeypatch, script, workspace)  # repeat replaces / reuses the CLI path
+    assert (state / "cassettes" / "trace-1" / "manifest.json").exists()
+
+
+def _fake_minimize(bundle_dir, dest_dir, config_path=None):
+    """Stand-in cassette writer: real minimize needs a replayable bundle."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    (dest_dir / "manifest.json").write_text("{}", encoding="utf-8")
+    return type("_Rep", (), {"cassette_dir": dest_dir, "span_count": 1, "source_span_count": 1})()
+
+
+def test_verdict_flow_records(state, workspace, monkeypatch):
+    _two_turn_log(state)
+
+    _browse(
+        monkeypatch,
+        [
+            ("pick", "session"),
+            ("pick", "#1"),
+            ("pick", "Verdict"),
+            "fail",
+            "wrong answer",
+            "",
+            ("pick", "Back"),
+            ("pick", "Exit"),
+        ],
+        workspace,
+    )
+
+    got = tverdict.read_verdicts(state, attempt_id="trace-1")
+    assert len(got) == 1 and got[0].status == "fail" and got[0].why == "wrong answer" and got[0].notes is None
+
+
+def test_full_cycle_merge_verdict_save_split(state, workspace, monkeypatch, capsys):
+    """One browser session: merge -> verdict -> save -> split, each step's
+    menu labels and action set coming from freshly rescanned state."""
+    _two_turn_log(state)
+
+    fake = _browse(
+        monkeypatch,
+        [
+            ("pick", "session"),
+            ("pick", "Merge attempts"),
+            ("pickall", ["#1", "#2"]),
+            ("pick", "#1"),
+            ("pick", "Verdict"),
+            "fail",
+            "",
+            "",
+            ("pick", "#1"),
+            ("pick", "Save"),
+            ("pick", "#1"),
+            ("pick", "Split"),
+            True,
+            ("pick", "Back"),
+            ("pick", "Exit"),
+        ],
+        workspace,
+    )
+
+    selects = [(m, titles) for kind, m, titles in fake.prompts if kind == "select"]
+    attempt_screens = [titles for m, titles in selects if m == "Attempt:"]
+    # after merge: one merged row, no more merge entry
+    assert sum("merged" in t for t in attempt_screens[1]) == 1
+    assert not any("Merge attempts" in t for t in attempt_screens[1])
+    # after verdict: the row shows it
+    assert any("fail" in t for t in attempt_screens[2])
+    # after save: the action menu offers Unpin (auto-pin happened)
+    action_screens = [titles for m, titles in selects if m == "Action:"]
+    assert any("Unpin" in t for t in action_screens[2])
+    # after split: two rows again, none merged
+    assert sum(t.startswith("#") for t in attempt_screens[4]) == 2
+    assert not any("merged" in t for t in attempt_screens[4])
+
+    assert tstore.definitions(state) == {}
+    assert {"trace-1", "trace-2"} <= set(tstore.pins(state))  # split moved the pin down
+    _assert_no_ids("".join(m for _, m, _ in fake.prompts))
+
+
+def test_report_declined_still_refreshes(state, workspace, monkeypatch, capsys):
+    """Report bundles (and pins) before confirming: a 'No' must still rescan."""
+    _two_turn_log(state)
+
+    fake = _browse(
+        monkeypatch,
+        [
+            ("pick", "session"),
+            ("pick", "#1"),
+            ("pick", "Report"),
+            False,
+            ("pick", "#1"),
+            ("pick", "Back"),
+            ("pick", "Back"),
+            ("pick", "Exit"),
+        ],
+        workspace,
+    )
+
+    out = capsys.readouterr().out
+    assert "Aborted" in out
+    action_screens = [t for kind, m, t in fake.prompts if kind == "select" and m == "Action:"]
+    assert any("Unpin" in title for title in action_screens[1])  # stale menus would still say Pin
+
+
+def test_minimize_failure_after_pack_refreshes(state, workspace, monkeypatch, capsys):
+    _two_turn_log(state)
+    monkeypatch.setattr(
+        tbrowse, "minimize_bundle", lambda *a, **k: (_ for _ in ()).throw(ValueError("boom trace-1 cli:a"))
+    )
+
+    fake = _browse(
+        monkeypatch,
+        [
+            ("pick", "session"),
+            ("pick", "#1"),
+            ("pick", "Minimize"),
+            ("pick", "#1"),
+            ("pick", "Back"),
+            ("pick", "Back"),
+            ("pick", "Exit"),
+        ],
+        workspace,
+    )
+
+    out = " ".join(capsys.readouterr().out.split())
+    assert tbrowse._STALE_MESSAGE in out
+    _assert_no_ids(out.split("Scanning")[0] if "Scanning" in out else out)
+    action_screens = [t for kind, m, t in fake.prompts if kind == "select" and m == "Action:"]
+    assert any("Unpin" in title for title in action_screens[1])
+
+
+def test_action_outputs_carry_no_ids(state, workspace, monkeypatch, capsys):
+    """Non-artifact actions must never print ids; artifact paths may."""
+    _two_turn_log(state)
+
+    _browse(
+        monkeypatch,
+        [
+            ("pick", "session"),
+            ("pick", "Merge attempts"),
+            ("pickall", ["#1", "#2"]),
+            ("pick", "#1"),
+            ("pick", "Verdict"),
+            "pass",
+            "",
+            "",
+            ("pick", "#1"),
+            ("pick", "Pin"),
+            "keep",
+            ("pick", "#1"),
+            ("pick", "Unpin"),
+            True,
+            ("pick", "#1"),
+            ("pick", "Split"),
+            True,
+            ("pick", "Back"),
+            ("pick", "Exit"),
+        ],
+        workspace,
+    )
+
+    _assert_no_ids(capsys.readouterr().out)
+
+
+@pytest.mark.parametrize(
+    "script, patch_target",
+    [
+        ([("pick", "session"), ("pick", "#1"), ("pick", "Save"), ("pick", "Back"), ("pick", "Exit")], "collect_bundle"),
+        (
+            [("pick", "session"), ("pick", "#1"), ("pick", "Report"), ("pick", "Back"), ("pick", "Exit")],
+            "collect_bundle",
+        ),
+        (
+            [("pick", "session"), ("pick", "#1"), ("pick", "Minimize"), ("pick", "Back"), ("pick", "Exit")],
+            "collect_bundle",
+        ),
+        (
+            [
+                ("pick", "session"),
+                ("pick", "Merge attempts"),
+                ("pickall", ["#1", "#2"]),
+                ("pick", "Back"),
+                ("pick", "Exit"),
+            ],
+            "merge_attempts",
+        ),
+        (
+            [("pick", "session"), ("pick", "#1"), ("pick", "Pin"), "keep", ("pick", "Back"), ("pick", "Exit")],
+            "pin_attempt",
+        ),
+    ],
+    ids=["save", "report", "minimize", "merge", "pin"],
+)
+def test_failed_actions_show_safe_message(state, workspace, monkeypatch, capsys, script, patch_target):
+    """Stale/invalid inputs fail with the fixed id-free message and still
+    refresh (the data-layer error text embeds ids and must stay off-screen)."""
+    _two_turn_log(state)
+
+    def _raise(*_a, **_k):
+        raise LookupError("unknown id 'trace-1': not a definition, alias, or recorded trace (cli:a)")
+
+    if patch_target == "collect_bundle":
+        monkeypatch.setattr(tbrowse, "collect_bundle", _raise)
+        monkeypatch.setattr(tbrowse.tcmd, "collect_bundle", _raise)
+    else:
+        monkeypatch.setattr(tbrowse.tstore, patch_target, _raise)
+
+    _browse(monkeypatch, script, workspace)
+
+    out = " ".join(capsys.readouterr().out.split())
+    assert tbrowse._STALE_MESSAGE in out
+    _assert_no_ids(out)
+
+
+def test_failed_split_shows_safe_message(state, workspace, monkeypatch, capsys):
+    """Split's controlled-exception path (not the None sentinel) must present
+    the fixed id-free message and keep the browser usable."""
+    _two_turn_log(state)
+    aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+
+    def _raise(*_a, **_k):
+        raise LookupError(f"stale definition {aid} member trace-1 of cli:a")
+
+    monkeypatch.setattr(tbrowse.tstore, "split_attempt", _raise)
+
+    fake = _browse(
+        monkeypatch,
+        [("pick", "session"), ("pick", "#1"), ("pick", "Split"), True, ("pick", "Back"), ("pick", "Exit")],
+        workspace,
+    )
+
+    out = " ".join(capsys.readouterr().out.split())
+    assert tbrowse._STALE_MESSAGE in out
+    _assert_no_ids(out, (*_IDS, aid))
+    assert fake.answers == []  # the refreshed menu stayed operable to the end
+
+
+def test_artifact_action_outputs_confine_ids_to_paths(state, workspace, monkeypatch, capsys, tmp_path):
+    """Save/Report/Minimize success output may carry ids only inside artifact
+    paths (state-root prefixed); everything else must be id-free."""
+    from rich.console import Console
+
+    wide = Console(width=400)
+    monkeypatch.setattr(tbrowse, "console", wide)
+    monkeypatch.setattr(tbrowse.tcmd, "console", wide)
+    cfg = tmp_path / "config.json"
+    cfg.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr("raven.config.loader._current_config_path", cfg)
+    monkeypatch.setattr("raven.trajectory.bundle._default_workspace", lambda: workspace)
+    _two_turn_log(state)
+    aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+    monkeypatch.setattr(tbrowse, "minimize_bundle", _fake_minimize)
+
+    _browse(
+        monkeypatch,
+        [
+            ("pick", "session"),
+            ("pick", "#1"),
+            ("pick", "Save"),
+            ("pick", "#1"),
+            ("pick", "Minimize"),
+            ("pick", "#1"),
+            ("pick", "Report"),
+            True,
+            ("pick", "Back"),
+            ("pick", "Exit"),
+        ],
+        workspace,
+    )
+
+    out = capsys.readouterr().out
+    assert "Bundled the selected attempt" in out  # the browser's id-free progress note
+    assert (state / "reports" / f"{aid}.tar.gz").exists()
+    residue = " ".join(token for token in out.split() if str(state) not in token)
+    _assert_no_ids(residue, (*_IDS, aid))
+
+
+def test_split_none_shows_stale_not_success(state, workspace, monkeypatch, capsys):
+    _two_turn_log(state)
+    aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+
+    def _confirm_then_drop():
+        tstore.split_attempt(aid, state_dir=state)  # concurrent split wins the race
+        return True
+
+    _browse(
+        monkeypatch,
+        [
+            ("pick", "session"),
+            ("pick", "#1"),
+            ("pick", "Split"),
+            _confirm_then_drop,
+            ("pick", "Back"),
+            ("pick", "Exit"),
+        ],
+        workspace,
+    )
+
+    out = capsys.readouterr().out
+    assert "no longer merged" in out
+    assert "Split into" not in out
+    _assert_no_ids(out)
+
+
+def test_unpin_false_shows_stale_not_success(state, workspace, monkeypatch, capsys):
+    _two_turn_log(state)
+    tstore.pin("trace-1", state_dir=state)
+
+    def _confirm_then_unpin():
+        tstore.unpin_attempt("trace-1", state)  # concurrent unpin wins the race
+        return True
+
+    _browse(
+        monkeypatch,
+        [
+            ("pick", "session"),
+            ("pick", "#1"),
+            ("pick", "Unpin"),
+            _confirm_then_unpin,
+            ("pick", "Back"),
+            ("pick", "Exit"),
+        ],
+        workspace,
+    )
+
+    out = capsys.readouterr().out
+    assert "Nothing was pinned" in out
+    assert "Unpinned the selected attempt" not in out
+    _assert_no_ids(out)
+
+
+def test_stale_pin_shows_safe_message(state, workspace, monkeypatch, capsys):
+    _two_turn_log(state)
+
+    def _reason_then_wipe():
+        (state / "logs" / "audit-spans.log").write_text("", encoding="utf-8")
+        return "keep"
+
+    _browse(
+        monkeypatch,
+        [("pick", "session"), ("pick", "#1"), ("pick", "Pin"), _reason_then_wipe],
+        workspace,
+    )
+
+    out = " ".join(capsys.readouterr().out.split())
+    assert tbrowse._STALE_MESSAGE in out
+    _assert_no_ids(out)
+
+
+# ── empty states ──────────────────────────────────────────────────────
+
+
+def test_empty_log_prints_notice_without_prompts(state, workspace, monkeypatch, capsys):
+    fake = _browse(monkeypatch, [], workspace)
+    assert "No trajectories found" in capsys.readouterr().out
+    assert fake.prompts == []
+
+
+def test_all_defective_records_prints_notice(state, workspace, monkeypatch, capsys):
+    (state / "logs").mkdir(parents=True)
+    (state / "logs" / "audit-spans.log").write_text('not json\n{"traceId": 5}\n', encoding="utf-8")
+    fake = _browse(monkeypatch, [], workspace)
+    assert "No trajectories found" in capsys.readouterr().out
+    assert fake.prompts == []
+
+
+def test_data_wiped_after_action_ends_controlled(state, workspace, monkeypatch, capsys):
+    _two_turn_log(state)
+
+    def _notes_then_wipe():
+        (state / "logs" / "audit-spans.log").write_text("", encoding="utf-8")
+        return ""
+
+    fake = _browse(
+        monkeypatch,
+        [("pick", "session"), ("pick", "#1"), ("pick", "Verdict"), "pass", "", _notes_then_wipe],
+        workspace,
+    )
+
+    assert "No trajectories found" in capsys.readouterr().out
+    assert fake.answers == []
+
+
+# ── cancellation ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        [("pick", "session"), ("pick", "#1"), ("pick", "Report"), _CANCEL],
+        [("pick", "session"), ("pick", "Merge attempts"), _CANCEL],
+        [("pick", "session"), ("pick", "#1"), ("pick", "Verdict"), "fail", _CANCEL],
+        [("pick", "session"), ("pick", "#1"), ("pick", "Split"), _CANCEL],
+        [("pick", "session"), ("pick", "#1"), ("pick", "Unpin"), _CANCEL],
+        [_CANCEL],
+    ],
+    ids=["report-confirm", "merge-checkbox", "verdict-text", "split-confirm", "unpin-confirm", "session-select"],
+)
+def test_cancel_exits_cleanly_without_further_prompts(state, workspace, monkeypatch, capsys, script):
+    _two_turn_log(state)
+    if "Split" in str(script):
+        tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+    if "Unpin" in str(script):
+        tstore.pin("trace-1", state_dir=state)
+
+    fake = _browse(monkeypatch, script, workspace)
+
+    out = capsys.readouterr().out
+    assert "Cancelled" in out
+    assert tbrowse._STALE_MESSAGE not in out
+    assert fake.answers == []  # nothing consumed past the cancel
+    assert len(fake.prompts) == len(script)
+
+
+def test_selects_share_prompt_chrome(state, workspace, monkeypatch):
+    """Every select/checkbox passes the shared QMARK and POINTER so the
+    browser's prompt chrome matches the rest of the CLI."""
+    from raven.cli._theme import POINTER, QMARK
+
+    _two_turn_log(state)
+
+    fake = _browse(
+        monkeypatch,
+        [
+            ("pick", "session"),
+            ("pick", "Merge attempts"),
+            ("pickall", ["#1", "#2"]),
+            ("pick", "#1"),
+            ("pick", "Verdict"),
+            "pass",
+            "",
+            "",
+            ("pick", "Back"),
+            ("pick", "Exit"),
+        ],
+        workspace,
+    )
+
+    pickers = [(m, kw) for kind, m, kw in fake.calls if kind in ("select", "checkbox")]
+    # The flow must actually visit every picker call site before the chrome
+    # check means anything (a short script would silently skip Action/Verdict).
+    assert {"Session:", "Attempt:", "Action:", "Verdict:", "Select 2+ attempts to merge:"} <= {m for m, _ in pickers}
+    for _m, kw in pickers:
+        assert kw.get("qmark") == QMARK
+        assert kw.get("pointer") == POINTER
+
+
+def test_merge_checkbox_validates_minimum(state, workspace, monkeypatch):
+    """The checkbox itself refuses <2 picks; an empty submit must not reach
+    the data layer and read as a stale/rejected error."""
+    _two_turn_log(state)
+
+    fake = _browse(
+        monkeypatch,
+        [
+            ("pick", "session"),
+            ("pick", "Merge attempts"),
+            ("pickall", ["#1", "#2"]),
+            ("pick", "Back"),
+            ("pick", "Exit"),
+        ],
+        workspace,
+    )
+
+    (checkbox_kw,) = [kw for kind, _m, kw in fake.calls if kind == "checkbox"]
+    validate = checkbox_kw["validate"]
+    assert validate([]) != True  # noqa: E712 - questionary contract: True or an error message
+    assert validate(["only-one"]) != True  # noqa: E712
+    assert validate(["a", "b"]) is True
+
+
+def test_pin_flow_uses_locked_pin_attempt(state, workspace, monkeypatch):
+    _two_turn_log(state)
+    calls = []
+    monkeypatch.setattr(
+        tbrowse.tstore, "pin_attempt", lambda id_, *, reason="", state_dir=None: calls.append((id_, reason)) or id_
+    )
+    monkeypatch.setattr(
+        tbrowse.tstore,
+        "pin",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("browser must pin via pin_attempt")),
+    )
+
+    _browse(
+        monkeypatch,
+        [("pick", "session"), ("pick", "#1"), ("pick", "Pin"), "keep", ("pick", "Back"), ("pick", "Exit")],
+        workspace,
+    )
+
+    assert calls == [("trace-1", "keep")]
+
+
+# ── dependency and import boundaries ──────────────────────────────────
+
+
+def test_commands_import_does_not_load_questionary():
+    code = "import sys; import raven.cli.trajectory_commands; assert 'questionary' not in sys.modules"
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_bare_browser_without_questionary_hints_install(state, workspace, monkeypatch, capsys):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_questionary(name, *args, **kwargs):
+        if name == "questionary":
+            raise ModuleNotFoundError("No module named 'questionary'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_questionary)
+    import typer
+
+    with pytest.raises(typer.Exit):
+        tbrowse.browse_trajectories(workspace=workspace)
+
+    assert "questionary" in capsys.readouterr().out
+
+
+def test_subcommands_work_without_questionary(state, monkeypatch):
+    import builtins
+
+    from typer.testing import CliRunner
+
+    from raven.cli.trajectory_commands import trajectory_app
+
+    real_import = builtins.__import__
+
+    def _no_questionary(name, *args, **kwargs):
+        if name == "questionary":
+            raise ModuleNotFoundError("No module named 'questionary'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_questionary)
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1")])
+
+    r = CliRunner().invoke(trajectory_app, ["list"])
+
+    assert r.exit_code == 0
+    assert "trace-1" in r.stdout
+
+
+# ── workspace propagation ─────────────────────────────────────────────
+
+
+def test_nondefault_workspace_flows_into_save_and_minimize(state, tmp_path, monkeypatch):
+    from raven.session.manager import SessionManager
+
+    other = tmp_path / "other-ws"
+    manager = SessionManager(other)
+    session = manager.get_or_create("cli:a")
+    session.add_message("user", "hello")
+    manager.save(session)
+    _two_turn_log(state)
+    aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+    monkeypatch.setattr(tbrowse, "minimize_bundle", _fake_minimize)
+
+    _browse(
+        monkeypatch,
+        [
+            ("pick", "attempt(s)"),
+            ("pick", "#1"),
+            ("pick", "Save"),
+            ("pick", "#1"),
+            ("pick", "Minimize"),
+            ("pick", "Back"),
+            ("pick", "Exit"),
+        ],
+        other,
+    )
+
+    manifest = json.loads((state / "bundles" / aid / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["session_included"] is True
+    assert (state / "bundles" / aid / "session.jsonl").exists()
+    assert (state / "cassettes" / aid / "manifest.json").exists()

--- a/tests/test_cli_trajectory_commands.py
+++ b/tests/test_cli_trajectory_commands.py
@@ -349,6 +349,30 @@ def test_pin_unpin_roundtrip(state) -> None:
     assert "not pinned" in r.stdout
 
 
+def test_pin_command_uses_locked_pin_attempt(state, monkeypatch) -> None:
+    """Guard: the CLI must pin through the attempts-lock-aware pin_attempt —
+    a lock-free resolve + literal pin() can land on an id a concurrent split
+    just deleted, leaving a dangling pin that protects nothing."""
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", attempt_id="att-1")])
+    calls = []
+
+    def record(id_, *, reason="", state_dir=None):
+        calls.append((id_, reason))
+        return "att-1"
+
+    def forbid(id_, *, reason="", state_dir=None):
+        raise AssertionError("the pin command must not call the literal pin() directly")
+
+    monkeypatch.setattr(tstore, "pin_attempt", record)
+    monkeypatch.setattr(tstore, "pin", forbid)
+
+    r = runner.invoke(trajectory_app, ["pin", "trace-1", "--reason", "keep"])
+
+    assert r.exit_code == 0
+    assert calls == [("trace-1", "keep")]
+    assert "att-1" in r.stdout
+
+
 def test_pin_unpin_resolve_turn_trace_id(state) -> None:
     """Pin/unpin by any turn's trace id must protect/release the whole attempt."""
     _write_log(

--- a/tests/test_cli_trajectory_commands.py
+++ b/tests/test_cli_trajectory_commands.py
@@ -56,7 +56,7 @@ def test_group_registered_on_app() -> None:
 
 
 def test_subcommand_help() -> None:
-    for cmd in ("save", "report", "replay", "minimize", "verdict", "pin", "unpin", "list"):
+    for cmd in ("save", "report", "replay", "minimize", "verdict", "pin", "unpin", "merge", "split", "list"):
         r = runner.invoke(trajectory_app, [cmd, "--help"])
         assert r.exit_code == 0, cmd
 
@@ -110,17 +110,19 @@ def test_save_by_turn_trace_id_bundles_whole_attempt(state) -> None:
     _write_log(
         state / "logs" / "audit-spans.log",
         [
-            _span("trace-1", attempt_id="att-x", session_key="cli:a"),
-            _span("trace-2", attempt_id="att-x", session_key="cli:a", name="tool.call"),
+            _span("trace-1", session_key="cli:a"),
+            _span("trace-2", session_key="cli:a", name="tool.call"),
         ],
     )
+    aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
 
     r = runner.invoke(trajectory_app, ["save", "trace-1"])
 
     assert r.exit_code == 0
-    assert (state / "bundles" / "att-x" / "manifest.json").exists()
-    assert "att-x" in r.stdout and "whole attempt" in r.stdout
-    assert "spans: 2" in r.stdout
+    assert (state / "bundles" / aid / "manifest.json").exists()
+    norm = " ".join(r.stdout.split())
+    assert aid in norm and "whole attempt" in norm
+    assert "spans: 2" in norm
 
 
 def test_save_unknown_id_errors(state) -> None:
@@ -290,12 +292,12 @@ def test_report_unknown_id_errors(state, report_config) -> None:
 
 
 def test_verdict_records_user_source(state) -> None:
-    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", attempt_id="att-1")])
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1")])
 
-    r = runner.invoke(trajectory_app, ["verdict", "att-1", "--status", "fail", "--why", "wrong answer"])
+    r = runner.invoke(trajectory_app, ["verdict", "trace-1", "--status", "fail", "--why", "wrong answer"])
 
     assert r.exit_code == 0
-    got = tverdict.read_verdicts(state, attempt_id="att-1")
+    got = tverdict.read_verdicts(state, attempt_id="trace-1")
     assert len(got) == 1
     assert got[0].status == "fail" and got[0].source == "user" and got[0].why == "wrong answer"
 
@@ -306,16 +308,17 @@ def test_verdict_by_turn_trace_id_lands_on_attempt(state) -> None:
     _write_log(
         state / "logs" / "audit-spans.log",
         [
-            _span("trace-1", attempt_id="att-x"),
-            _span("trace-2", attempt_id="att-x", name="tool.call"),
+            _span("trace-1", session_key="cli:a"),
+            _span("trace-2", session_key="cli:a", name="tool.call"),
         ],
     )
+    aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
 
     r = runner.invoke(trajectory_app, ["verdict", "trace-1", "--status", "fail"])
 
     assert r.exit_code == 0
-    assert "att-x" in r.stdout
-    got = tverdict.read_verdicts(state, attempt_id="att-x")
+    assert aid in " ".join(r.stdout.split())
+    got = tverdict.read_verdicts(state, attempt_id=aid)
     assert len(got) == 1 and got[0].status == "fail"
     assert tverdict.read_verdicts(state, attempt_id="trace-1") == []
 
@@ -337,17 +340,17 @@ def test_verdict_rejects_bad_status(state) -> None:
 
 
 def test_pin_unpin_roundtrip(state) -> None:
-    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", attempt_id="att-1")])
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1")])
 
-    r = runner.invoke(trajectory_app, ["pin", "att-1", "--reason", "bug #42"])
+    r = runner.invoke(trajectory_app, ["pin", "trace-1", "--reason", "bug #42"])
     assert r.exit_code == 0
-    assert tstore.pins(state)["att-1"]["reason"] == "bug #42"
+    assert tstore.pins(state)["trace-1"]["reason"] == "bug #42"
 
-    r = runner.invoke(trajectory_app, ["unpin", "att-1"])
+    r = runner.invoke(trajectory_app, ["unpin", "trace-1"])
     assert r.exit_code == 0
     assert tstore.pins(state) == {}
 
-    r = runner.invoke(trajectory_app, ["unpin", "att-1"])
+    r = runner.invoke(trajectory_app, ["unpin", "trace-1"])
     assert r.exit_code == 0
     assert "not pinned" in r.stdout
 
@@ -356,7 +359,7 @@ def test_pin_command_uses_locked_pin_attempt(state, monkeypatch) -> None:
     """Guard: the CLI must pin through the attempts-lock-aware pin_attempt —
     a lock-free resolve + literal pin() can land on an id a concurrent split
     just deleted, leaving a dangling pin that protects nothing."""
-    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", attempt_id="att-1")])
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1")])
     calls = []
 
     def record(id_, *, reason="", state_dir=None):
@@ -381,14 +384,15 @@ def test_pin_unpin_resolve_turn_trace_id(state) -> None:
     _write_log(
         state / "logs" / "audit-spans.log",
         [
-            _span("trace-1", attempt_id="att-x"),
-            _span("trace-2", attempt_id="att-x", name="tool.call"),
+            _span("trace-1", session_key="cli:a"),
+            _span("trace-2", session_key="cli:a", name="tool.call"),
         ],
     )
+    aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
 
     r = runner.invoke(trajectory_app, ["pin", "trace-1"])
     assert r.exit_code == 0
-    assert set(tstore.pins(state)) == {"att-x"}
+    assert set(tstore.pins(state)) == {aid}
 
     r = runner.invoke(trajectory_app, ["unpin", "trace-2"])
     assert r.exit_code == 0
@@ -412,10 +416,215 @@ def test_unpin_clears_stale_literal_pin(state) -> None:
     assert tstore.pins(state) == {}
 
 
+def test_unpin_clears_definition_aliases_and_members(state) -> None:
+    """Unpin on a definition drops every pin protecting the attempt: the
+    definition id, absorbed aliases, and member-level pins."""
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [
+            _span("trace-1", session_key="cli:a"),
+            _span("trace-2", session_key="cli:a"),
+            _span("trace-3", session_key="cli:a"),
+        ],
+    )
+    tstore.pin("trace-1", reason="member", state_dir=state)
+    d1 = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+    d2 = tstore.merge_attempts([d1, "trace-3"], state_dir=state)
+    tstore.pin("trace-2", reason="manual", state_dir=state)
+    assert tstore.pins(state)
+
+    r = runner.invoke(trajectory_app, ["unpin", d2])
+
+    assert r.exit_code == 0
+    assert tstore.pins(state) == {}
+
+
+# ── merge / split ─────────────────────────────────────────────────────
+
+
+def test_merge_creates_definition(state) -> None:
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1", session_key="cli:a"), _span("trace-2", session_key="cli:a")],
+    )
+
+    r = runner.invoke(trajectory_app, ["merge", "trace-1", "trace-2"])
+
+    assert r.exit_code == 0
+    (aid,) = tstore.definitions(state)
+    assert aid.startswith("att-")
+    assert aid in " ".join(r.stdout.split())
+    assert sorted(tstore.definitions(state)[aid]["traces"]) == ["trace-1", "trace-2"]
+
+
+def test_merge_save_list_split_roundtrip(state) -> None:
+    """The whole flow: merge -> save by member id -> one list row -> split ->
+    two list rows again."""
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [
+            _span("trace-1", session_key="cli:a"),
+            _span("trace-2", session_key="cli:a", name="tool.call"),
+        ],
+    )
+
+    r = runner.invoke(trajectory_app, ["merge", "trace-1", "trace-2"])
+    assert r.exit_code == 0
+    (aid,) = tstore.definitions(state)
+
+    r = runner.invoke(trajectory_app, ["save", "trace-2"])
+    assert r.exit_code == 0
+    assert (state / "bundles" / aid / "manifest.json").exists()
+    assert "whole attempt" in " ".join(r.stdout.split())
+
+    # A wide terminal keeps the minted id in one table cell line (the default
+    # 80 columns folds it mid-id, breaking substring assertions).
+    r = runner.invoke(trajectory_app, ["list"], env={"COLUMNS": "200"})
+    assert r.exit_code == 0
+    squash = "".join(r.stdout.split())
+    assert squash.count(aid) == 1
+    assert "trace-1" not in squash and "trace-2" not in squash
+
+    r = runner.invoke(trajectory_app, ["split", aid])
+    assert r.exit_code == 0
+
+    r = runner.invoke(trajectory_app, ["list"], env={"COLUMNS": "200"})
+    assert r.exit_code == 0
+    squash = "".join(r.stdout.split())
+    assert "trace-1" in squash and "trace-2" in squash
+    assert aid not in squash
+
+
+def test_merge_legacy_attempt_expands_whole_group(state) -> None:
+    """A legacy id input pulls its whole span-attribute group in as members,
+    and the canonical legacy id survives as an alias."""
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [
+            _span("trace-1", attempt_id="att-old", session_key="cli:a"),
+            _span("trace-2", attempt_id="att-old", session_key="cli:a", name="tool.call"),
+            _span("trace-3", session_key="cli:a"),
+        ],
+    )
+
+    r = runner.invoke(trajectory_app, ["merge", "att-old", "trace-3"])
+
+    assert r.exit_code == 0
+    (aid,) = tstore.definitions(state)
+    entry = tstore.definitions(state)[aid]
+    assert sorted(entry["traces"]) == ["trace-1", "trace-2", "trace-3"]
+    assert "att-old" in entry["aliases"]
+
+
+def test_merge_rejects_unknown_id(state) -> None:
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1")])
+    r = runner.invoke(trajectory_app, ["merge", "trace-1", "no-such-id"])
+    assert r.exit_code == 1
+    assert "unknown id" in " ".join(r.stdout.split())
+    assert tstore.definitions(state) == {}
+
+
+def test_merge_rejects_cross_session(state) -> None:
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1", session_key="cli:a"), _span("trace-2", session_key="cli:b")],
+    )
+    r = runner.invoke(trajectory_app, ["merge", "trace-1", "trace-2"])
+    assert r.exit_code == 1
+    assert tstore.definitions(state) == {}
+
+
+def test_merge_rejects_single_group(state) -> None:
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1")])
+    r = runner.invoke(trajectory_app, ["merge", "trace-1", "trace-1"])
+    assert r.exit_code == 1
+    assert tstore.definitions(state) == {}
+
+
+def test_split_pure_legacy_exits_1(state) -> None:
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [
+            _span("trace-1", attempt_id="att-old"),
+            _span("trace-2", attempt_id="att-old", name="tool.call"),
+        ],
+    )
+    r = runner.invoke(trajectory_app, ["split", "att-old"])
+    assert r.exit_code == 1
+    assert "only merged attempts can be split" in " ".join(r.stdout.split())
+
+
+def test_split_unknown_id_exits_1(state) -> None:
+    r = runner.invoke(trajectory_app, ["split", "no-such-id"])
+    assert r.exit_code == 1
+    assert "only merged attempts can be split" in " ".join(r.stdout.split())
+
+
+def test_split_reports_traces_not_attempts(state) -> None:
+    """A definition holding a multi-trace legacy group restores fewer attempts
+    than traces, so the output counts member traces, never attempts."""
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [
+            _span("trace-1", attempt_id="att-old", session_key="cli:a"),
+            _span("trace-2", attempt_id="att-old", session_key="cli:a", name="tool.call"),
+            _span("trace-3", session_key="cli:a"),
+        ],
+    )
+    aid = tstore.merge_attempts(["att-old", "trace-3"], state_dir=state)
+
+    r = runner.invoke(trajectory_app, ["split", aid])
+
+    assert r.exit_code == 0
+    norm = " ".join(r.stdout.split())
+    assert "3 member trace" in norm
+    assert "3 attempts" not in norm and "per-turn" not in norm
+
+    r = runner.invoke(trajectory_app, ["list"])
+    squash = "".join(r.stdout.split())
+    assert "att-old" in squash and "trace-3" in squash
+    assert aid not in squash
+    assert "trace-1" not in squash and "trace-2" not in squash
+
+
+def test_split_by_member_id_does_not_claim_removed_input(state) -> None:
+    """split addressed by a member id (or alias) must not present that input
+    as the deleted definition."""
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [
+            _span("trace-1", session_key="cli:a"),
+            _span("trace-2", session_key="cli:a"),
+            _span("trace-3", session_key="cli:a"),
+        ],
+    )
+    tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+
+    r = runner.invoke(trajectory_app, ["split", "trace-1"])
+
+    assert r.exit_code == 0
+    norm = " ".join(r.stdout.split())
+    assert "addressed by trace-1" in norm
+    assert "Removed definition" not in norm
+    assert tstore.definitions(state) == {}
+
+    d1 = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+    tstore.merge_attempts([d1, "trace-3"], state_dir=state)
+
+    r = runner.invoke(trajectory_app, ["split", d1])
+
+    assert r.exit_code == 0
+    norm = " ".join(r.stdout.split())
+    assert f"addressed by {d1}" in norm
+    assert "Removed definition" not in norm
+    assert tstore.definitions(state) == {}
+
+
 # ── list ──────────────────────────────────────────────────────────────
 
 
-def test_list_aggregates_attempts(state) -> None:
+def test_list_legacy_logs_still_group(state) -> None:
+    """Pre-definition logs (span-level attempt.id) keep aggregating by it."""
     _write_log(
         state / "logs" / "audit-spans.log",
         [
@@ -438,7 +647,7 @@ def test_list_session_filter(state) -> None:
     _write_log(
         state / "logs" / "audit-spans.log",
         [
-            _span("trace-1", attempt_id="att-x", session_key="cli:a"),
+            _span("trace-1", session_key="cli:a"),
             _span("trace-3", session_key="cli:b"),
         ],
     )
@@ -447,13 +656,163 @@ def test_list_session_filter(state) -> None:
 
     assert r.exit_code == 0
     assert "trace-3" in r.stdout
-    assert "att-x" not in r.stdout
+    assert "trace-1" not in r.stdout
+
+
+def test_list_folds_definition_members_single_row(state) -> None:
+    """Definition ownership outranks a member's legacy attempt.id — a merged
+    legacy member must not surface as a second row."""
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [
+            _span("trace-1", attempt_id="att-old", session_key="cli:a"),
+            _span("trace-2", session_key="cli:a"),
+        ],
+    )
+    aid = tstore.merge_attempts(["att-old", "trace-2"], state_dir=state)
+
+    r = runner.invoke(trajectory_app, ["list"], env={"COLUMNS": "200"})
+
+    assert r.exit_code == 0
+    squash = "".join(r.stdout.split())
+    assert aid in squash
+    assert "att-old" not in squash
+    assert "trace-1" not in squash and "trace-2" not in squash
+
+
+def test_list_merged_attempt_shows_verdict_via_alias(state) -> None:
+    """A verdict recorded under an absorbed definition id (now an alias) stays
+    visible on the current definition's row; a later verdict wins."""
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [
+            _span("trace-1", session_key="cli:a"),
+            _span("trace-2", session_key="cli:a"),
+            _span("trace-3", session_key="cli:a"),
+        ],
+    )
+    d1 = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+    tverdict.record_verdict(d1, "fail", source="user", state_dir=state)
+    d2 = tstore.merge_attempts([d1, "trace-3"], state_dir=state)
+    assert d1 in tstore.definitions(state)[d2]["aliases"]
+
+    r = runner.invoke(trajectory_app, ["list"], env={"COLUMNS": "200"})
+    assert r.exit_code == 0
+    assert d2 in "".join(r.stdout.split())
+    assert "fail" in r.stdout
+
+    tverdict.record_verdict(d2, "pass", source="user", state_dir=state)
+    r = runner.invoke(trajectory_app, ["list"], env={"COLUMNS": "200"})
+    assert r.exit_code == 0
+    assert "pass" in r.stdout and "fail" not in r.stdout
 
 
 def test_list_empty(state) -> None:
     r = runner.invoke(trajectory_app, ["list"])
     assert r.exit_code == 0
     assert "No attempts found" in r.stdout
+
+
+# ── markup safety ─────────────────────────────────────────────────────
+
+
+def test_list_renders_markup_legacy_id_literally(state) -> None:
+    """A legal legacy id may contain Rich markup; the table cell must show it
+    literally instead of crashing markup parsing."""
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", attempt_id="x[/red]y")])
+
+    r = runner.invoke(trajectory_app, ["list"])
+
+    assert r.exit_code == 0
+    assert "x[/red]y" in "".join(r.stdout.split())
+
+
+def test_list_empty_markup_session_is_safe(state) -> None:
+    """The no-matches notice echoes the --session filter, which is user input."""
+    r = runner.invoke(trajectory_app, ["list", "--session", "x[/dim]y"])
+
+    assert r.exit_code == 0
+    assert "x[/dim]y" in "".join(r.stdout.split())
+    assert "No attempts found" in r.stdout
+
+
+def test_list_tolerates_malformed_span_attributes(state) -> None:
+    """JSON-legal records with non-string ids, keys, or timestamps degrade
+    per-field instead of killing the whole listing."""
+    spans = [
+        _span("trace-1", session_key="cli:a"),
+        _span("trace-int"),
+        _span("trace-list"),
+        _span("trace-badkey"),
+        _span("trace-badtime", session_key="cli:a"),
+    ]
+    spans[1]["attributes"]["attempt.id"] = 123
+    spans[2]["attributes"]["attempt.id"] = ["not", "hashable"]
+    spans[3]["attributes"]["session.key"] = 123
+    spans[4]["startTime"] = 123
+    spans.append({"schemaVersion": "audit.span.v1", "traceId": 456, "name": "session.turn", "attributes": {}})
+    _write_log(state / "logs" / "audit-spans.log", spans)
+
+    r = runner.invoke(trajectory_app, ["list"])
+
+    assert r.exit_code == 0
+    squash = "".join(r.stdout.split())
+    assert "trace-1" in squash
+    # Non-string attempt.id falls back to the trace id; the rest degrade to "-".
+    assert "trace-int" in squash and "trace-list" in squash
+    assert "trace-badkey" in squash and "trace-badtime" in squash
+
+
+def test_markup_legacy_id_success_paths_are_safe(state) -> None:
+    legacy = "x[/red]y"
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", attempt_id=legacy)])
+
+    r = runner.invoke(trajectory_app, ["verdict", "trace-1", "--status", "fail"])
+    assert r.exit_code == 0
+    assert legacy in "".join(r.stdout.split())
+
+    r = runner.invoke(trajectory_app, ["pin", "trace-1"])
+    assert r.exit_code == 0
+    assert legacy in "".join(r.stdout.split())
+    assert legacy in tstore.pins(state)
+
+    r = runner.invoke(trajectory_app, ["unpin", legacy])
+    assert r.exit_code == 0
+    assert legacy in "".join(r.stdout.split())
+    assert tstore.pins(state) == {}
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["merge", "x[/red]y", "trace-1"],
+        ["split", "x[/red]y"],
+        ["save", "x[/red]y"],
+        ["replay", "x[/red]y"],
+        ["minimize", "x[/red]y"],
+    ],
+    ids=["merge", "split", "save", "replay", "minimize"],
+)
+def test_markup_unknown_target_error_paths_are_safe(state, argv) -> None:
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1")])
+
+    r = runner.invoke(trajectory_app, argv)
+
+    assert r.exit_code == 1
+    assert "x[/red]y" in "".join(r.stdout.split())
+
+
+def test_minimize_markup_manifest_id_error_is_safe(state, tmp_path) -> None:
+    """A markup-bearing manifest attempt_id (it contains '/') is refused as a
+    default cassette directory name, with the id echoed literally."""
+    bundle = tmp_path / "b"
+    bundle.mkdir()
+    (bundle / "manifest.json").write_text(json.dumps({"format_version": 1, "attempt_id": "x[/red]y"}), encoding="utf-8")
+
+    r = runner.invoke(trajectory_app, ["minimize", str(bundle)])
+
+    assert r.exit_code == 1
+    assert "x[/red]y" in "".join(r.stdout.split())
 
 
 # ── replay ────────────────────────────────────────────────────────────

--- a/tests/test_cli_trajectory_commands.py
+++ b/tests/test_cli_trajectory_commands.py
@@ -21,7 +21,10 @@ def _write_log(path, spans):
 
 
 def _span(trace_id, *, attempt_id=None, session_key=None, name="session.turn", attrs=None):
-    attributes = {"attempt.id": attempt_id or trace_id, "session.key": session_key}
+    """Span in the current format; pass ``attempt_id`` for a legacy-format span."""
+    attributes = {"session.key": session_key}
+    if attempt_id is not None:
+        attributes["attempt.id"] = attempt_id
     if attrs:
         attributes.update(attrs)
     return {

--- a/tests/test_cli_trajectory_commands.py
+++ b/tests/test_cli_trajectory_commands.py
@@ -55,6 +55,21 @@ def test_group_registered_on_app() -> None:
     assert "trajectories" in r.stdout
 
 
+def test_bare_invocation_without_tty_exits_2(state) -> None:
+    """The browser needs a terminal; CliRunner provides none."""
+    r = runner.invoke(trajectory_app, [])
+    assert r.exit_code == 2
+    assert "Non-interactive" in r.stdout
+
+
+def test_subcommands_unaffected_by_tty_gate(state) -> None:
+    """The callback must pass subcommands through before the TTY check."""
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1")])
+    r = runner.invoke(trajectory_app, ["list"])
+    assert r.exit_code == 0
+    assert "trace-1" in r.stdout
+
+
 def test_subcommand_help() -> None:
     for cmd in ("save", "report", "replay", "minimize", "verdict", "pin", "unpin", "merge", "split", "list"):
         r = runner.invoke(trajectory_app, [cmd, "--help"])

--- a/tests/test_cli_trajectory_commands.py
+++ b/tests/test_cli_trajectory_commands.py
@@ -707,6 +707,20 @@ def test_list_merged_attempt_shows_verdict_via_alias(state) -> None:
     assert "pass" in r.stdout and "fail" not in r.stdout
 
 
+def test_list_tolerates_malformed_verdict_lines(state) -> None:
+    """A shape-complete verdict line with a list attempt_id must not break the
+    verdict column for the healthy rows."""
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", session_key="cli:a")])
+    tverdict.record_verdict("trace-1", "pass", source="user", state_dir=state)
+    with (state / "verdicts.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"attempt_id": ["bad"], "status": "fail", "source": "user", "ts": "now"}) + "\n")
+
+    r = runner.invoke(trajectory_app, ["list"])
+
+    assert r.exit_code == 0
+    assert "pass" in r.stdout
+
+
 def test_list_empty(state) -> None:
     r = runner.invoke(trajectory_app, ["list"])
     assert r.exit_code == 0
@@ -751,9 +765,11 @@ def test_list_tolerates_malformed_span_attributes(state) -> None:
     spans[3]["attributes"]["session.key"] = 123
     spans[4]["startTime"] = 123
     spans.append({"schemaVersion": "audit.span.v1", "traceId": 456, "name": "session.turn", "attributes": {}})
+    spans.append({"schemaVersion": "audit.span.v1", "traceId": "trace-attrs-list", "attributes": ["bad"]})
+    spans.append({"schemaVersion": "audit.span.v1", "traceId": "trace-attrs-str", "attributes": "bad"})
     _write_log(state / "logs" / "audit-spans.log", spans)
 
-    r = runner.invoke(trajectory_app, ["list"])
+    r = runner.invoke(trajectory_app, ["list"], env={"COLUMNS": "200"})
 
     assert r.exit_code == 0
     squash = "".join(r.stdout.split())
@@ -761,6 +777,17 @@ def test_list_tolerates_malformed_span_attributes(state) -> None:
     # Non-string attempt.id falls back to the trace id; the rest degrade to "-".
     assert "trace-int" in squash and "trace-list" in squash
     assert "trace-badkey" in squash and "trace-badtime" in squash
+    # A truthy non-object attributes container degrades to no attributes.
+    assert "trace-attrs-list" in squash and "trace-attrs-str" in squash
+
+    # The session filter walks the same records inside iter_spans; a defective
+    # container must not shadow the matching rows there either.
+    r = runner.invoke(trajectory_app, ["list", "--session", "cli:a"], env={"COLUMNS": "200"})
+
+    assert r.exit_code == 0
+    squash = "".join(r.stdout.split())
+    assert "trace-1" in squash and "trace-badtime" in squash
+    assert "trace-attrs-list" not in squash and "trace-attrs-str" not in squash
 
 
 def test_markup_legacy_id_success_paths_are_safe(state) -> None:
@@ -813,6 +840,53 @@ def test_minimize_markup_manifest_id_error_is_safe(state, tmp_path) -> None:
 
     assert r.exit_code == 1
     assert "x[/red]y" in "".join(r.stdout.split())
+
+
+@pytest.mark.parametrize("bad_id", [123, ["a", "b"]], ids=["int", "list"])
+def test_minimize_non_string_manifest_id_fails_controlled(state, tmp_path, bad_id) -> None:
+    """A JSON-legal manifest whose attempt_id is not a string falls back to the
+    bundle directory name instead of blowing up the default-path join."""
+    bundle = tmp_path / "b"
+    bundle.mkdir()
+    (bundle / "manifest.json").write_text(json.dumps({"format_version": 1, "attempt_id": bad_id}), encoding="utf-8")
+
+    r = runner.invoke(trajectory_app, ["minimize", str(bundle)])
+
+    # The empty bundle is still rejected, but through the controlled error
+    # path (typer.Exit), never an uncaught TypeError from the path join.
+    assert r.exit_code == 1
+    assert isinstance(r.exception, SystemExit)
+
+
+@pytest.mark.parametrize(
+    "content", ['["not", "an", "object"]', '"just a string"', "{not json"], ids=["list", "string", "broken"]
+)
+def test_minimize_invalid_manifest_fails_controlled(state, tmp_path, content) -> None:
+    """A manifest that is not a JSON object (or not JSON at all) is refused
+    with a readable error instead of an AttributeError/JSONDecodeError."""
+    bundle = tmp_path / "b"
+    bundle.mkdir()
+    (bundle / "manifest.json").write_text(content, encoding="utf-8")
+
+    r = runner.invoke(trajectory_app, ["minimize", str(bundle)])
+
+    assert r.exit_code == 1
+    assert isinstance(r.exception, SystemExit)
+    assert "not a valid bundle manifest" in " ".join(r.stdout.split())
+
+
+def test_minimize_non_utf8_manifest_fails_controlled(state, tmp_path) -> None:
+    """Invalid UTF-8 in the manifest raises before JSON parsing; it must reach
+    the same controlled error path as broken JSON."""
+    bundle = tmp_path / "b"
+    bundle.mkdir()
+    (bundle / "manifest.json").write_bytes(b'\xff\xfe{"attempt_id": 1}')
+
+    r = runner.invoke(trajectory_app, ["minimize", str(bundle)])
+
+    assert r.exit_code == 1
+    assert isinstance(r.exception, SystemExit)
+    assert "not a valid bundle manifest" in " ".join(r.stdout.split())
 
 
 # ── replay ────────────────────────────────────────────────────────────

--- a/tests/test_tracing_api.py
+++ b/tests/test_tracing_api.py
@@ -353,55 +353,43 @@ def test_provider_label_reports_the_normalized_route_prefix() -> None:
     assert _provider_label(None, "AnthropicProvider") == "AnthropicProvider"
 
 
-def test_attempt_id_defaults_to_trace_id(trace_dir):
-    """Without an open attempt, every turn is its own single-turn attempt."""
+def test_spans_carry_no_attempt_attribute(trace_dir):
+    """Attempt grouping lives in attempts.json, not on spans (a turn's attempt
+    id equals its trace id at read time)."""
     with trace.span("session.turn", session_key="cli:a"):
         with trace.span("llm.call"):
             pass
 
     spans = _spans_written(trace_dir)
-    trace_ids = {sp["traceId"] for sp in spans}
-    assert len(trace_ids) == 1
+    assert len({sp["traceId"] for sp in spans}) == 1
     for sp in spans:
-        assert sp["attributes"]["attempt.id"] == sp["traceId"]
+        assert "attempt.id" not in sp["attributes"]
 
 
-def test_explicit_attempt_groups_turns_under_one_id(trace_dir):
-    """begin_attempt groups several turns' spans; end_attempt restores per-turn ids."""
-    aid = trace.begin_attempt("cli:a")
-    try:
-        with trace.span("session.turn", session_key="cli:a"):
-            with trace.span("tool.call"):
-                pass
-        with trace.span("session.turn", session_key="cli:a"):
+def test_checkpoint_and_detached_spans_carry_no_attempt_attribute(trace_dir):
+    with trace.span("session.turn", session_key="cli:c") as root:
+        root.checkpoint()
+        with trace.span("skill.inject", detached=True):
             pass
-        # An unrelated session is not captured by cli:a's attempt.
-        with trace.span("session.turn", session_key="cli:b") as other:
-            assert other.attempt_id == other.trace_id
-    finally:
-        assert trace.end_attempt("cli:a") == aid
-
-    with trace.span("session.turn", session_key="cli:a") as after:
-        assert after.attempt_id == after.trace_id
 
     spans = _spans_written(trace_dir)
-    grouped = [sp for sp in spans if sp["attributes"]["attempt.id"] == aid]
-    assert len(grouped) == 3  # two turns + one tool call
-    assert len({sp["traceId"] for sp in grouped}) == 2  # across two traces
-    assert aid.startswith("att-")
+    # checkpoint + detached leaf + final root emit, all in one trace
+    assert len(spans) == 3
+    assert len({sp["traceId"] for sp in spans}) == 1
+    detached = next(sp for sp in spans if sp["name"] == "skill.inject")
+    assert detached["parentSpanId"] == root.span_id
+    assert [sp["spanId"] for sp in spans].count(root.span_id) == 2
+    for sp in spans:
+        assert "attempt.id" not in sp["attributes"]
 
 
-def test_attempt_id_survives_detached_and_checkpoint(trace_dir):
-    aid = trace.begin_attempt("cli:c")
-    try:
-        with trace.span("session.turn", session_key="cli:c") as root:
-            root.checkpoint()
-            with trace.span("skill.inject", detached=True):
-                pass
-    finally:
-        trace.end_attempt("cli:c")
-    for sp in _spans_written(trace_dir):
-        assert sp["attributes"]["attempt.id"] == aid
+def test_caller_attributes_cannot_reinject_attempt_id(trace_dir):
+    with trace.span("session.turn", {"attempt.id": "att-x"}, session_key="cli:r") as sp:
+        sp.set({"attempt.id": "att-y", "turn.input_preview": "hi"})
+
+    (span,) = _spans_written(trace_dir)
+    assert "attempt.id" not in span["attributes"]
+    assert span["attributes"]["turn.input_preview"] == "hi"
 
 
 def test_suppress_silences_only_its_own_block(trace_dir):

--- a/tests/test_trajectory_bundle.py
+++ b/tests/test_trajectory_bundle.py
@@ -323,6 +323,56 @@ def test_end_to_end_with_real_tracer(tmp_path, monkeypatch):
         _spans._store = None
 
 
+def test_bundle_tolerates_non_string_legacy_id(state, workspace):
+    """save by trace id still bundles when the span carries a list attempt.id
+    (unvalidated history must degrade, not crash the collector)."""
+    span = _span("trace-1", session_key="cli:chat1")
+    span["attributes"]["attempt.id"] = ["not", "a", "string"]
+    _write_log(state / "logs" / "audit-spans.log", [span])
+
+    bundle_dir = tbundle.collect_bundle("trace-1", state_dir=state, workspace=workspace)
+
+    manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["attempt_id"] == "trace-1"
+    assert manifest["span_count"] == 1
+    assert "trace-1" in tstore.pins(state)
+
+
+def test_bundle_of_merged_attempt_survives_bad_neighbor_record(state):
+    """A list-traceId record elsewhere in the log must not break bundling a
+    merged attempt (the member filter is a set lookup)."""
+    bad = {"schemaVersion": "audit.span.v1", "traceId": ["x"], "attributes": {}}
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1", session_key="cli:chat1"), bad, _span("trace-2", session_key="cli:chat1")],
+    )
+    aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+
+    bundle_dir = tbundle.collect_bundle("trace-1", state_dir=state)
+
+    manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["attempt_id"] == aid
+    assert manifest["span_count"] == 2
+
+
+def test_bundle_of_merged_attempt_tolerates_malformed_verdict_lines(state):
+    """The alias-set verdict filter must skip a list attempt_id line instead
+    of failing the whole collection."""
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1", session_key="cli:chat1"), _span("trace-2", session_key="cli:chat1")],
+    )
+    tverdict.record_verdict("trace-1", "fail", source="user", state_dir=state)
+    aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+    with (state / "verdicts.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"attempt_id": ["bad"], "status": "fail", "source": "user", "ts": "now"}) + "\n")
+
+    bundle_dir = tbundle.collect_bundle(aid, state_dir=state)
+
+    verdicts = _read_lines(bundle_dir / "verdicts.jsonl")
+    assert {v["attempt_id"] for v in verdicts} == {"trace-1"}
+
+
 def test_bundle_of_merged_attempt_collects_all_member_traces(state):
     _write_log(
         state / "logs" / "audit-spans.log",

--- a/tests/test_trajectory_bundle.py
+++ b/tests/test_trajectory_bundle.py
@@ -318,3 +318,57 @@ def test_end_to_end_with_real_tracer(tmp_path, monkeypatch):
         assert tstore.pins(state)[aid]["reason"] == "bundled"
     finally:
         _spans._store = None
+
+
+def test_bundle_of_merged_attempt_collects_all_member_traces(state):
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [
+            _span("trace-1", session_key="cli:chat1", start="2026-08-20T10:00:00+00:00"),
+            _span("trace-2", session_key="cli:chat1", start="2026-08-20T11:00:00+00:00"),
+        ],
+    )
+    tverdict.record_verdict("trace-1", "fail", source="user", state_dir=state)
+    aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+    tverdict.record_verdict(aid, "pass", source="user", state_dir=state)
+
+    bundle_dir = tbundle.collect_bundle("trace-2", state_dir=state)
+
+    assert bundle_dir == (state / "bundles" / aid).resolve()
+    spans = _read_lines(bundle_dir / "spans.jsonl")
+    assert [s["traceId"] for s in spans] == ["trace-1", "trace-2"]
+    manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["attempt_id"] == aid
+    assert manifest["span_count"] == 2
+    verdicts = _read_lines(bundle_dir / "verdicts.jsonl")
+    assert {v["attempt_id"] for v in verdicts} == {"trace-1", aid}
+
+
+def test_bundle_of_definition_with_purged_members_raises_lookup_error(state):
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1"), _span("trace-2")],
+    )
+    aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+    (state / "logs" / "audit-spans.log").unlink()
+
+    with pytest.raises(LookupError, match="no spans found for attempt"):
+        tbundle.collect_bundle(aid, state_dir=state)
+
+
+def test_bundle_pin_falls_back_to_member_traces_when_attempt_vanishes(state, monkeypatch):
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1"), _span("trace-2")],
+    )
+    aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+
+    def vanished(id_, *, reason="", state_dir=None):
+        raise LookupError(f"no spans found for id {id_!r}")
+
+    monkeypatch.setattr(tbundle, "pin_attempt", vanished)
+    tbundle.collect_bundle(aid, state_dir=state)
+
+    registry = tstore.pins(state)
+    assert registry["trace-1"]["reason"] == "bundled"
+    assert registry["trace-2"]["reason"] == "bundled"

--- a/tests/test_trajectory_bundle.py
+++ b/tests/test_trajectory_bundle.py
@@ -19,7 +19,10 @@ def _write_log(path, spans):
 
 
 def _span(trace_id, *, attempt_id=None, session_key=None, name="session.turn", start=None, end=None, attrs=None):
-    attributes = {"attempt.id": attempt_id or trace_id, "session.key": session_key}
+    """Span in the current format; pass ``attempt_id`` for a legacy-format span."""
+    attributes = {"session.key": session_key}
+    if attempt_id is not None:
+        attributes["attempt.id"] = attempt_id
     if attrs:
         attributes.update(attrs)
     return {
@@ -298,11 +301,11 @@ def test_end_to_end_with_real_tracer(tmp_path, monkeypatch):
     monkeypatch.setenv("RAVEN_TRACING_DIR", str(state))
     _spans._store = None
     try:
-        aid = trace.begin_attempt("cli:e2e")
-        with trace.span("session.turn", session_key="cli:e2e"):
+        # A single turn is addressed by its trace id (attempt id = trace id).
+        with trace.span("session.turn", session_key="cli:e2e") as root:
             with trace.span("tool.call") as s:
                 s.artifact("tool.output", {"result": "ok", "items": list(range(50))})
-        trace.end_attempt("cli:e2e")
+        aid = root.trace_id
 
         bundle_dir = tbundle.collect_bundle(aid, state_dir=state, workspace=workspace)
 

--- a/tests/test_trajectory_redact.py
+++ b/tests/test_trajectory_redact.py
@@ -463,11 +463,11 @@ def test_end_to_end_report_with_real_tracer(tmp_path, monkeypatch):
     monkeypatch.setattr("raven.trajectory.bundle._default_workspace", lambda: tmp_path / "ws")
     _spans._store = None
     try:
-        aid = trace.begin_attempt("cli:e2e")
-        with trace.span("session.turn", session_key="cli:e2e"):
+        # A single turn is addressed by its trace id (attempt id = trace id).
+        with trace.span("session.turn", session_key="cli:e2e") as root:
             with trace.span("tool.call") as s:
                 s.artifact("tool.output", {"stdout": f"auth={fake_env_key} cfg={fake_config_key}"})
-        trace.end_attempt("cli:e2e")
+        aid = root.trace_id
 
         out = tmp_path / "report.tar.gz"
         result = CliRunner().invoke(trajectory_app, ["report", aid, "--yes", "--out", str(out)])

--- a/tests/test_trajectory_replay.py
+++ b/tests/test_trajectory_replay.py
@@ -827,7 +827,7 @@ async def test_end_to_end_record_save_replay_with_real_tracer(tmp_path, monkeypa
         assert result is not None and result[0] == "all done"
         assert marker.read_text(encoding="utf-8") == "hi", "recording must have run the real tool"
 
-        attempt_id = next(iter(tstore.iter_spans(traces)))["attributes"]["attempt.id"]
+        attempt_id = next(iter(tstore.iter_spans(traces)))["traceId"]
         bundle = collect_bundle(attempt_id, state_dir=traces)
         marker.unlink()
         spans_before = (traces / "logs" / "audit-spans.log").read_text(encoding="utf-8")
@@ -879,7 +879,7 @@ async def test_end_to_end_replay_after_harness_change_diverges(tmp_path, monkeyp
             ),
             session_key="cli:e2e-div",
         )
-        attempt_id = next(iter(tstore.iter_spans(traces)))["attributes"]["attempt.id"]
+        attempt_id = next(iter(tstore.iter_spans(traces)))["traceId"]
         bundle = collect_bundle(attempt_id, state_dir=traces)
 
         # Rewrite the recorded turn input so the live request diverges.
@@ -943,7 +943,7 @@ async def test_end_to_end_streamed_recording_replays_through_the_stream_path(tmp
         recorded_spans = list(tstore.iter_spans(traces))
         assert any(s["attributes"].get("llm.stream") for s in recorded_spans), "recording must be streamed"
 
-        attempt_id = recorded_spans[0]["attributes"]["attempt.id"]
+        attempt_id = recorded_spans[0]["traceId"]
         bundle = collect_bundle(attempt_id, state_dir=traces)
         marker.unlink()
 
@@ -1025,7 +1025,7 @@ async def test_end_to_end_replay_restores_pre_attempt_history(tmp_path, monkeypa
 
         # The second turn is its own single-turn attempt; bundle only it.
         last_span = list(tstore.iter_spans(traces))[-1]
-        bundle = collect_bundle(last_span["attributes"]["attempt.id"], state_dir=traces)
+        bundle = collect_bundle(last_span["traceId"], state_dir=traces)
         assert (bundle / "session.jsonl").is_file()
         marker.unlink()
 
@@ -1088,7 +1088,7 @@ async def test_end_to_end_replay_restores_history_when_first_input_repeats(tmp_p
         await loop._process_message(req(), session_key="cli:e2e-rep")
 
         last_span = list(tstore.iter_spans(traces))[-1]
-        bundle = collect_bundle(last_span["attributes"]["attempt.id"], state_dir=traces)
+        bundle = collect_bundle(last_span["traceId"], state_dir=traces)
         marker.unlink()
 
         report = await run_replay(bundle, mode="strict")

--- a/tests/test_trajectory_store.py
+++ b/tests/test_trajectory_store.py
@@ -43,12 +43,16 @@ def _write_log(path, spans):
 
 
 def _span(trace_id, attempt_id=None, session_key=None, name="session.turn"):
+    """Span in the current format; pass ``attempt_id`` for a legacy-format span."""
+    attributes = {"session.key": session_key}
+    if attempt_id is not None:
+        attributes["attempt.id"] = attempt_id
     return {
         "schemaVersion": "audit.span.v1",
         "traceId": trace_id,
         "spanId": f"span-{trace_id}",
         "name": name,
-        "attributes": {"attempt.id": attempt_id or trace_id, "session.key": session_key},
+        "attributes": attributes,
     }
 
 
@@ -815,7 +819,7 @@ class TestAttemptDefinitions:
 
 
 def test_end_to_end_with_real_tracer(tmp_path, monkeypatch):
-    """Spans written by the live tracer are addressable through iter_spans."""
+    """Two live-tracer turns merged into one definition are addressable as one attempt."""
     from raven.tracing import spans as _spans
     from raven.tracing import trace
 
@@ -823,14 +827,16 @@ def test_end_to_end_with_real_tracer(tmp_path, monkeypatch):
     monkeypatch.setenv("RAVEN_TRACING_DIR", str(tmp_path))
     _spans._store = None
     try:
-        aid = trace.begin_attempt("cli:e2e")
-        with trace.span("session.turn", session_key="cli:e2e"):
+        with trace.span("session.turn", session_key="cli:e2e") as t1:
             with trace.span("tool.call"):
                 pass
-        trace.end_attempt("cli:e2e")
+        with trace.span("session.turn", session_key="cli:e2e") as t2:
+            pass
+        aid = tstore.merge_attempts([t1.trace_id, t2.trace_id], state_dir=tmp_path)
 
         got = list(tstore.iter_spans(tmp_path, attempt_id=aid))
         assert {s["name"] for s in got} == {"session.turn", "tool.call"}
+        assert {s["traceId"] for s in got} == {t1.trace_id, t2.trace_id}
         tverdict.record_verdict(aid, "fail", source="user", state_dir=tmp_path)
         assert tverdict.latest_verdict(aid, tmp_path).status == "fail"
         tstore.pin(aid, reason="repro", state_dir=tmp_path)

--- a/tests/test_trajectory_store.py
+++ b/tests/test_trajectory_store.py
@@ -96,6 +96,31 @@ class TestVerdicts:
         got = tverdict.read_verdicts(tmp_path)
         assert [x.attempt_id for x in got] == ["att-1"]
 
+    def test_non_string_required_fields_are_skipped(self, tmp_path):
+        """A shape-complete line with a list/dict attempt_id must not reach
+        set lookups or dict keys in consumers."""
+        tverdict.record_verdict("att-1", "pass", source="user", state_dir=tmp_path)
+        with (tmp_path / "verdicts.jsonl").open("a", encoding="utf-8") as f:
+            f.write(json.dumps({"attempt_id": ["bad"], "status": "fail", "source": "user", "ts": "now"}) + "\n")
+            f.write(json.dumps({"attempt_id": {"k": "v"}, "status": "fail", "source": "user", "ts": "now"}) + "\n")
+            f.write(json.dumps({"attempt_id": "att-3", "status": 1, "source": "user", "ts": "now"}) + "\n")
+            f.write(json.dumps(["not", "an", "object"]) + "\n")
+        tverdict.record_verdict("att-2", "fail", source="user", state_dir=tmp_path)
+
+        assert [x.attempt_id for x in tverdict.read_verdicts(tmp_path)] == ["att-1", "att-2"]
+        assert [x.attempt_id for x in tverdict.read_verdicts(tmp_path, attempt_ids={"att-1", "att-2"})] == [
+            "att-1",
+            "att-2",
+        ]
+
+    def test_invalid_utf8_line_hides_only_itself(self, tmp_path):
+        tverdict.record_verdict("att-1", "pass", source="user", state_dir=tmp_path)
+        with (tmp_path / "verdicts.jsonl").open("ab") as f:
+            f.write(b"\xff\xfe not utf-8\n")
+        tverdict.record_verdict("att-2", "fail", source="user", state_dir=tmp_path)
+
+        assert [x.attempt_id for x in tverdict.read_verdicts(tmp_path)] == ["att-1", "att-2"]
+
 
 class TestPins:
     def test_pin_unpin_roundtrip(self, tmp_path):
@@ -192,6 +217,78 @@ class TestIterSpans:
         log.parent.mkdir(parents=True)
         log.write_text('not json\n["a list"]\n' + json.dumps(_span("trace-1")) + "\n", encoding="utf-8")
         assert [s["traceId"] for s in tstore.iter_spans(tmp_path)] == ["trace-1"]
+
+    def test_invalid_utf8_line_hides_only_itself(self, tmp_path):
+        """Per-line decoding: one bad byte must not hide the records before
+        and after it in the same log file."""
+        log = tmp_path / "logs" / "audit-spans.log"
+        log.parent.mkdir(parents=True)
+        log.write_bytes(
+            json.dumps(_span("trace-1")).encode("utf-8")
+            + b"\n\xff\xfe not utf-8\n"
+            + json.dumps(_span("trace-2")).encode("utf-8")
+            + b"\n"
+        )
+
+        assert [s["traceId"] for s in tstore.iter_spans(tmp_path)] == ["trace-1", "trace-2"]
+
+    def test_non_dict_attributes_degrade_instead_of_raising(self, tmp_path):
+        """A JSON-legal record whose attributes is a truthy non-object is
+        yielded as-is, and filters treat it as carrying no attributes."""
+        bad = {"schemaVersion": "audit.span.v1", "traceId": "trace-bad", "attributes": ["bad"]}
+        _write_log(tmp_path / "logs" / "audit-spans.log", [bad, _span("trace-1", session_key="cli:a")])
+
+        assert [s["traceId"] for s in tstore.iter_spans(tmp_path)] == ["trace-bad", "trace-1"]
+        assert [s["traceId"] for s in tstore.iter_spans(tmp_path, session_key="cli:a")] == ["trace-1"]
+        assert [s["traceId"] for s in tstore.iter_spans(tmp_path, attempt_id="trace-bad")] == ["trace-bad"]
+
+
+class TestMalformedRecordTolerance:
+    """Non-string ids/keys in JSON-legal records degrade to absent fields
+    instead of raising from hashing, sorting, or membership checks."""
+
+    @pytest.mark.parametrize("bad_id", [["not", "a", "string"], {"k": "v"}, 123], ids=["list", "dict", "int"])
+    def test_non_string_legacy_id_degrades_in_resolve_and_pin(self, tmp_path, bad_id):
+        span = _span("trace-1", session_key="cli:a")
+        span["attributes"]["attempt.id"] = bad_id
+        _write_log(tmp_path / "logs" / "audit-spans.log", [span])
+
+        assert tstore.is_pinned(span, tmp_path) is False  # nothing pinned yet, and no crash
+        assert tstore.resolve_attempt_id("trace-1", tmp_path) == "trace-1"
+        assert tstore.pin_attempt("trace-1", state_dir=tmp_path) == "trace-1"
+        assert set(tstore.pins(tmp_path)) == {"trace-1"}
+        assert tstore.is_pinned(span, tmp_path) is True  # via traceId, not the bad legacy id
+        assert tstore.unpin_attempt("trace-1", tmp_path) is True
+
+    def test_non_string_trace_id_never_matches_pins(self, tmp_path):
+        bad = {"schemaVersion": "audit.span.v1", "traceId": ["x"], "attributes": {}}
+        tstore.pin("trace-1", state_dir=tmp_path)
+        assert tstore.is_pinned(bad, tmp_path) is False
+
+    def test_merge_ignores_non_string_session_keys_and_trace_ids(self, tmp_path):
+        s1 = _span("trace-1", session_key="cli:a")
+        s2 = _span("trace-2", session_key="cli:a")
+        s2["attributes"]["session.key"] = 123
+        bad = {"schemaVersion": "audit.span.v1", "traceId": ["x"], "attributes": {"session.key": ["y"]}}
+        _write_log(tmp_path / "logs" / "audit-spans.log", [s1, s2, bad])
+
+        aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=tmp_path)
+
+        assert sorted(tstore.definitions(tmp_path)[aid]["traces"]) == ["trace-1", "trace-2"]
+
+    def test_definition_filter_skips_non_string_trace_ids(self, tmp_path):
+        """An unrelated record with a list traceId must not break reading a
+        merged attempt's members (the definition filter is a set lookup)."""
+        bad = {"schemaVersion": "audit.span.v1", "traceId": ["x"], "attributes": {}}
+        _write_log(
+            tmp_path / "logs" / "audit-spans.log",
+            [_span("trace-1", session_key="cli:a"), bad, _span("trace-2", session_key="cli:a")],
+        )
+        aid = tstore.merge_attempts(["trace-1", "trace-2"], state_dir=tmp_path)
+
+        got = [s["traceId"] for s in tstore.iter_spans(tmp_path, attempt_id=aid)]
+
+        assert got == ["trace-1", "trace-2"]
 
 
 class TestResolveAttemptId:

--- a/tests/test_trajectory_store.py
+++ b/tests/test_trajectory_store.py
@@ -1,4 +1,5 @@
-"""Tests for the trajectory layer: verdict sidecar, pin registry, span reader."""
+"""Tests for the trajectory layer: verdict sidecar, pin registry, attempt
+definitions, and the span reader."""
 
 from __future__ import annotations
 
@@ -9,6 +10,7 @@ import pytest
 
 from raven.trajectory import store as tstore
 from raven.trajectory import verdict as tverdict
+from raven.utils import atomic_io
 
 
 def _pin_after_barrier(state_dir, id_, barrier):
@@ -20,6 +22,19 @@ def _unpin_after_barrier(state_dir, id_, barrier):
     barrier.wait()
     if not tstore.unpin(id_, state_dir):
         raise AssertionError(f"missing pin {id_}")
+
+
+def _merge_after_barrier(state_dir, ids, barrier):
+    barrier.wait()
+    try:
+        tstore.merge_attempts(ids, state_dir=state_dir)
+    except ValueError:
+        pass
+
+
+def _split_after_barrier(state_dir, id_, barrier):
+    barrier.wait()
+    tstore.split_attempt(id_, state_dir=state_dir)
 
 
 def _write_log(path, spans):
@@ -61,6 +76,13 @@ class TestVerdicts:
             tverdict.record_verdict("", "pass", source="user", state_dir=tmp_path)
         with pytest.raises(ValueError):
             tverdict.record_verdict("att-1", "pass", source="", state_dir=tmp_path)
+
+    def test_filter_params_are_mutually_exclusive(self, tmp_path):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            tverdict.read_verdicts(tmp_path, attempt_id="att-1", attempt_ids=("att-2",))
+        tverdict.record_verdict("att-1", "pass", source="user", state_dir=tmp_path)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            tverdict.read_verdicts(tmp_path, attempt_id="att-1", attempt_ids=("att-1",))
 
     def test_bad_lines_are_skipped(self, tmp_path):
         tverdict.record_verdict("att-1", "pass", source="user", state_dir=tmp_path)
@@ -185,6 +207,611 @@ class TestResolveAttemptId:
     def test_none_when_no_span_matches(self, tmp_path):
         _write_log(tmp_path / "logs" / "audit-spans.log", [_span("trace-1")])
         assert tstore.resolve_attempt_id("missing", tmp_path) is None
+
+
+class TestAttemptDefinitions:
+    def _log(self, tmp_path, spans):
+        _write_log(tmp_path / "logs" / "audit-spans.log", spans)
+
+    def _traces(self, tmp_path, *trace_ids, session_key=None):
+        self._log(tmp_path, [_span(t, session_key=session_key) for t in trace_ids])
+
+    def test_merge_creates_definition_and_resolves_members(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        aid = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        assert aid.startswith("att-")
+        assert tstore.resolve_attempt_id(aid, tmp_path) == aid
+        assert tstore.resolve_attempt_id("trace-a", tmp_path) == aid
+        assert tstore.attempt_members(aid, tmp_path) == ("trace-a", "trace-b")
+        assert tstore.owning_attempt("trace-b", tmp_path) == aid
+
+    def test_merge_of_merged_attempts_unions_and_accumulates_aliases(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b", "trace-c")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        y = tstore.merge_attempts([x, "trace-c"], state_dir=tmp_path)
+        defs = tstore.definitions(tmp_path)
+        assert set(defs) == {y}
+        assert defs[y]["traces"] == ["trace-a", "trace-b", "trace-c"]
+        assert defs[y]["aliases"] == [x]
+        assert tstore.resolve_attempt_id(x, tmp_path) == y
+
+    def test_merge_by_member_trace_id_absorbs_owning_definition(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b", "trace-c")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        z = tstore.merge_attempts(["trace-a", "trace-c"], state_dir=tmp_path)
+        defs = tstore.definitions(tmp_path)
+        assert set(defs) == {z}
+        assert defs[z]["traces"] == ["trace-a", "trace-b", "trace-c"]
+        assert defs[z]["aliases"] == [x]
+
+    def test_merge_accepts_stale_alias_id_as_input(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b", "trace-c", "trace-d")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        y = tstore.merge_attempts([x, "trace-c"], state_dir=tmp_path)
+        z = tstore.merge_attempts([x, "trace-d"], state_dir=tmp_path)
+        defs = tstore.definitions(tmp_path)
+        assert set(defs) == {z}
+        assert defs[z]["traces"] == ["trace-a", "trace-b", "trace-c", "trace-d"]
+        assert set(defs[z]["aliases"]) == {x, y}
+        assert tstore.resolve_attempt_id(x, tmp_path) == z
+        assert tstore.resolve_attempt_id(y, tmp_path) == z
+
+    def test_split_reverts_members_to_per_trace_attempts(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b", "trace-c")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        assert tstore.split_attempt(x, tmp_path) == ("trace-a", "trace-b")
+        assert tstore.definitions(tmp_path) == {}
+        assert tstore.resolve_attempt_id("trace-a", tmp_path) == "trace-a"
+
+        x2 = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        assert tstore.split_attempt("trace-a", tmp_path) == ("trace-a", "trace-b")
+        assert x2 not in tstore.definitions(tmp_path)
+
+        x3 = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        tstore.merge_attempts([x3, "trace-c"], state_dir=tmp_path)
+        assert tstore.split_attempt(x3, tmp_path) == ("trace-a", "trace-b", "trace-c")
+        assert tstore.split_attempt("nope", tmp_path) is None
+
+    def _legacy_log(self, tmp_path):
+        self._log(
+            tmp_path,
+            [
+                _span("trace-l1", attempt_id="att-x"),
+                _span("trace-l2", attempt_id="att-x"),
+                _span("trace-c"),
+            ],
+        )
+
+    def test_merge_expands_legacy_attempt_to_real_member_traces(self, tmp_path):
+        self._legacy_log(tmp_path)
+        y = tstore.merge_attempts(["att-x", "trace-c"], state_dir=tmp_path)
+        defs = tstore.definitions(tmp_path)
+        assert defs[y]["traces"] == ["trace-l1", "trace-l2", "trace-c"]
+        assert defs[y]["aliases"] == ["att-x"]
+        assert [s["traceId"] for s in tstore.iter_spans(tmp_path, attempt_id=y)] == [
+            "trace-l1",
+            "trace-l2",
+            "trace-c",
+        ]
+
+    def test_merge_preserves_legacy_verdict_and_pin_via_alias(self, tmp_path):
+        self._legacy_log(tmp_path)
+        tverdict.record_verdict("att-x", "fail", source="user", state_dir=tmp_path)
+        tstore.pin("att-x", reason="repro", state_dir=tmp_path)
+        y = tstore.merge_attempts(["att-x", "trace-c"], state_dir=tmp_path)
+        alias = tstore.attempt_alias_ids(y, tmp_path)
+        assert "att-x" in alias
+        assert [v.attempt_id for v in tverdict.read_verdicts(tmp_path, attempt_ids=alias)] == ["att-x"]
+        assert tstore.is_pinned(_span("trace-l1", attempt_id="att-x"), tmp_path)
+
+    def test_split_of_pure_legacy_attempt_returns_none(self, tmp_path):
+        self._legacy_log(tmp_path)
+        assert tstore.split_attempt("att-x", tmp_path) is None
+        assert tstore.split_attempt("trace-l1", tmp_path) is None
+
+    def test_split_of_definition_with_legacy_members_restores_legacy_grouping(self, tmp_path):
+        self._legacy_log(tmp_path)
+        y = tstore.merge_attempts(["att-x", "trace-c"], state_dir=tmp_path)
+        assert tstore.split_attempt(y, tmp_path) == ("trace-l1", "trace-l2", "trace-c")
+        assert tstore.resolve_attempt_id("trace-l1", tmp_path) == "att-x"
+        assert tstore.resolve_attempt_id("trace-c", tmp_path) == "trace-c"
+
+    def test_merge_member_of_legacy_group_absorbs_whole_group(self, tmp_path):
+        self._legacy_log(tmp_path)
+        y = tstore.merge_attempts(["trace-l1", "trace-c"], state_dir=tmp_path)
+        defs = tstore.definitions(tmp_path)
+        assert defs[y]["traces"] == ["trace-l1", "trace-l2", "trace-c"]
+        assert defs[y]["aliases"] == ["att-x"]
+
+    def test_unpin_attempt_clears_legacy_group_after_split(self, tmp_path):
+        self._legacy_log(tmp_path)
+        y = tstore.merge_attempts(["att-x", "trace-c"], state_dir=tmp_path)
+        tstore.pin(y, reason="keep", state_dir=tmp_path)
+        tstore.split_attempt(y, tmp_path)
+        assert set(tstore.pins(tmp_path)) == {"trace-l1", "trace-l2", "trace-c"}
+
+        assert tstore.unpin_attempt("att-x", tmp_path) is True
+        assert set(tstore.pins(tmp_path)) == {"trace-c"}
+
+        tstore.pin("trace-l1", state_dir=tmp_path)
+        tstore.pin("trace-l2", state_dir=tmp_path)
+        assert tstore.unpin_attempt("trace-l1", tmp_path) is True
+        assert set(tstore.pins(tmp_path)) == {"trace-c"}
+
+    def test_merge_rejects_unsafe_legacy_alias_id(self, tmp_path):
+        self._log(
+            tmp_path,
+            [
+                _span("trace-l1", attempt_id="../evil"),
+                _span("trace-l2", attempt_id="../evil"),
+                _span("trace-c"),
+            ],
+        )
+        with pytest.raises(ValueError, match="not a safe identifier"):
+            tstore.merge_attempts(["../evil", "trace-c"], state_dir=tmp_path)
+        assert tstore.definitions(tmp_path) == {}
+
+    def test_merge_requires_two_distinct_traces(self, tmp_path):
+        self._traces(tmp_path, "trace-a")
+        with pytest.raises(ValueError):
+            tstore.merge_attempts(["trace-a"], state_dir=tmp_path)
+        with pytest.raises(ValueError):
+            tstore.merge_attempts(["trace-a", "trace-a"], state_dir=tmp_path)
+        assert tstore.definitions(tmp_path) == {}
+
+    def test_merge_requires_two_distinct_input_groups(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b", "trace-c")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        y = tstore.merge_attempts([x, "trace-c"], state_dir=tmp_path)
+        before = tstore.definitions(tmp_path)
+        with pytest.raises(ValueError, match="two distinct attempts"):
+            tstore.merge_attempts([y], state_dir=tmp_path)
+        with pytest.raises(ValueError, match="two distinct attempts"):
+            tstore.merge_attempts([y, x], state_dir=tmp_path)
+        with pytest.raises(ValueError, match="two distinct attempts"):
+            tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        assert tstore.definitions(tmp_path) == before
+
+    def test_merge_input_resolution_is_order_independent(self, tmp_path):
+        results = []
+        for order, state in (("forward", tmp_path / "s1"), ("reverse", tmp_path / "s2")):
+            _write_log(state / "logs" / "audit-spans.log", [_span(t) for t in ("trace-a", "trace-b", "trace-c")])
+            x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=state)
+            ids = [x, "trace-c"] if order == "forward" else ["trace-c", x]
+            merged = tstore.merge_attempts(ids, state_dir=state)
+            entry = tstore.definitions(state)[merged]
+            results.append((set(entry["traces"]), entry["aliases"] == [x]))
+        assert results[0] == results[1] == ({"trace-a", "trace-b", "trace-c"}, True)
+
+    def test_merge_rejects_unknown_input_id(self, tmp_path):
+        self._traces(tmp_path, "trace-a")
+        with pytest.raises(ValueError, match="unknown id"):
+            tstore.merge_attempts(["trace-a", "nope"], state_dir=tmp_path)
+        assert tstore.definitions(tmp_path) == {}
+
+    def test_merge_rejects_empty_input_id(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        with pytest.raises(ValueError, match="non-empty"):
+            tstore.merge_attempts(["trace-a", "", "trace-b"], state_dir=tmp_path)
+        assert not (tmp_path / "attempts.json").exists()
+        assert not (tmp_path / "pins.json").exists()
+
+    def test_merge_rejects_cross_session_members(self, tmp_path):
+        self._log(
+            tmp_path,
+            [
+                _span("trace-a", session_key="cli:a"),
+                _span("trace-b", session_key="cli:b"),
+                _span("trace-c"),
+            ],
+        )
+        with pytest.raises(ValueError, match="different sessions"):
+            tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        assert tstore.definitions(tmp_path) == {}
+        aid = tstore.merge_attempts(["trace-a", "trace-c"], state_dir=tmp_path)
+        assert tstore.attempt_members(aid, tmp_path) == ("trace-a", "trace-c")
+
+    def test_remerge_preserves_pin_and_verdict_of_absorbed_definition(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b", "trace-c")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        tstore.pin(x, reason="px", state_dir=tmp_path)
+        tverdict.record_verdict(x, "fail", source="user", state_dir=tmp_path)
+        y = tstore.merge_attempts([x, "trace-c"], state_dir=tmp_path)
+        assert tstore.is_pinned(_span("trace-a"), tmp_path)
+        alias = tstore.attempt_alias_ids(y, tmp_path)
+        assert [v.attempt_id for v in tverdict.read_verdicts(tmp_path, attempt_ids=alias)] == [x]
+
+    def test_merge_migrates_member_pins_up_with_joined_reason(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        tstore.pin("trace-a", reason="ra", state_dir=tmp_path)
+        tstore.pin("trace-b", reason="rb", state_dir=tmp_path)
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        registry = tstore.pins(tmp_path)
+        assert set(registry) == {x}
+        assert registry[x]["reason"] == "ra; rb"
+
+    def test_is_pinned_extends_to_definition_members(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        tstore.pin(x, state_dir=tmp_path)
+        assert tstore.is_pinned(_span("trace-a"), tmp_path)
+        assert not tstore.is_pinned(_span("trace-z"), tmp_path)
+
+    def test_alias_ids_and_member_verdicts_surface(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        tverdict.record_verdict("trace-a", "fail", source="user", state_dir=tmp_path)
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        assert tstore.attempt_alias_ids(x, tmp_path) == (x, "trace-a", "trace-b")
+        tverdict.record_verdict(x, "pass", source="user", state_dir=tmp_path)
+        got = tverdict.read_verdicts(tmp_path, attempt_ids=tstore.attempt_alias_ids(x, tmp_path))
+        assert [v.attempt_id for v in got] == ["trace-a", x]
+        assert got[-1].status == "pass"
+
+    def test_split_migrates_pins_to_members_and_clears_old(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        tstore.pin(x, reason="defr", state_dir=tmp_path)
+        tstore.split_attempt(x, tmp_path)
+        registry = tstore.pins(tmp_path)
+        assert set(registry) == {"trace-a", "trace-b"}
+        assert registry["trace-a"]["reason"] == "defr"
+
+    def test_split_migration_reads_pins_under_lock_not_stale_snapshot(self, tmp_path, monkeypatch):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        tstore.pin(x, reason="keep", state_dir=tmp_path)
+        # A lock-free pins() reader can be arbitrarily stale; the migration
+        # must not depend on it, only on the locked registry.
+        monkeypatch.setattr(tstore, "pins", lambda state_dir=None: {})
+        assert tstore.split_attempt(x, tmp_path) == ("trace-a", "trace-b")
+        monkeypatch.undo()
+
+        registry = tstore.pins(tmp_path)
+        assert registry["trace-a"]["reason"] == "keep"
+        assert registry["trace-b"]["reason"] == "keep"
+        assert x not in registry
+
+    def test_split_preserves_existing_member_pin_reason(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        tstore.pin(x, reason="defr", state_dir=tmp_path)
+        tstore.pin("trace-a", reason="mine", state_dir=tmp_path)
+        tstore.split_attempt(x, tmp_path)
+        registry = tstore.pins(tmp_path)
+        assert registry["trace-a"]["reason"] == "mine; defr"
+        assert registry["trace-b"]["reason"] == "defr"
+
+    def test_split_does_not_inherit_merged_verdict(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        tverdict.record_verdict(x, "fail", source="user", state_dir=tmp_path)
+        tstore.split_attempt(x, tmp_path)
+        assert tverdict.read_verdicts(tmp_path, attempt_ids=("trace-a",)) == []
+        assert len(tverdict.read_verdicts(tmp_path, attempt_id=x)) == 1
+
+    def test_pin_attempt_resolves_owner_under_attempts_lock(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        assert tstore.pin_attempt("trace-a", reason="keep", state_dir=tmp_path) == x
+        assert tstore.pins(tmp_path)[x]["reason"] == "keep"
+        assert tstore.is_pinned(_span("trace-b"), tmp_path)
+
+        tstore.split_attempt(x, tmp_path)
+        assert tstore.pin_attempt("trace-a", state_dir=tmp_path) == "trace-a"
+
+    def test_pin_attempt_pins_legacy_canonical(self, tmp_path):
+        self._legacy_log(tmp_path)
+        assert tstore.pin_attempt("trace-l1", reason="repro", state_dir=tmp_path) == "att-x"
+        assert tstore.is_pinned(_span("trace-l2", attempt_id="att-x"), tmp_path)
+
+    def test_pin_attempt_refuses_stale_or_unknown_id(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        tstore.split_attempt(x, tmp_path)
+        # x is a minted definition id: after the split nothing owns it, so a
+        # pin on it would protect nothing — the address must be refused.
+        with pytest.raises(LookupError):
+            tstore.pin_attempt(x, state_dir=tmp_path)
+        with pytest.raises(LookupError):
+            tstore.pin_attempt("nope", state_dir=tmp_path)
+        assert tstore.pins(tmp_path) == {}
+
+    def test_unpin_attempt_clears_definition_aliases_and_member_pins(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        tstore.pin(x, reason="r", state_dir=tmp_path)
+        tstore.split_attempt(x, tmp_path)
+        y = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        tstore.pin("trace-a", reason="manual", state_dir=tmp_path)
+        assert tstore.unpin_attempt(y, tmp_path) is True
+        assert tstore.pins(tmp_path) == {}
+        assert not tstore.is_pinned(_span("trace-a"), tmp_path)
+
+    def test_corrupt_definitions_file_reads_empty(self, tmp_path):
+        self._traces(tmp_path, "trace-a")
+        (tmp_path / "attempts.json").write_text("{broken", encoding="utf-8")
+        assert tstore.definitions(tmp_path) == {}
+        assert tstore.resolve_attempt_id("trace-a", tmp_path) == "trace-a"
+
+    def test_parse_defs_drops_schema_invalid_entries(self, tmp_path):
+        (tmp_path / "attempts.json").write_text(
+            json.dumps(
+                {
+                    "att-ok": {"traces": ["trace-a", "trace-b"]},
+                    "att-bad-shape": "not a dict",
+                    "att-bad-traces": {"traces": "not-a-list"},
+                    "att-too-few": {"traces": ["trace-only", "trace-only"]},
+                    "att-empty-member": {"traces": ["trace-x", ""]},
+                    "bad/id": {"traces": ["trace-y1", "trace-y2"]},
+                    "att-alias-dup": {"traces": ["trace-z1", "trace-z2"], "aliases": ["att-d", "att-d"]},
+                    "att-alias-type": {"traces": ["trace-w1", "trace-w2"], "aliases": [123]},
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert set(tstore.definitions(tmp_path)) == {"att-ok"}
+
+    def test_namespace_conflicts_read_whole_file_empty(self, tmp_path):
+        conflicts = [
+            {"att-a": {"traces": ["trace-1", "trace-2"]}, "att-b": {"traces": ["trace-2", "trace-3"]}},
+            {
+                "att-a": {"traces": ["trace-1", "trace-2"], "aliases": ["att-old"]},
+                "att-b": {"traces": ["trace-3", "trace-4"], "aliases": ["att-old"]},
+            },
+            {
+                "att-a": {"traces": ["trace-1", "trace-2"], "aliases": ["att-b"]},
+                "att-b": {"traces": ["trace-3", "trace-4"]},
+            },
+            {
+                "att-a": {"traces": ["trace-1", "trace-2"], "aliases": ["trace-3"]},
+                "att-b": {"traces": ["trace-3", "trace-4"]},
+            },
+            {"trace-1": {"traces": ["trace-5", "trace-6"]}, "att-b": {"traces": ["trace-1", "trace-4"]}},
+            {"att-self": {"traces": ["trace-1", "trace-2"], "aliases": ["att-self"]}},
+        ]
+        for content in conflicts:
+            (tmp_path / "attempts.json").write_text(json.dumps(content), encoding="utf-8")
+            assert tstore.definitions(tmp_path) == {}, content
+
+    def test_merge_construction_rejects_invariant_violation(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        with (tmp_path / "logs" / "audit-spans.log").open("a", encoding="utf-8") as f:
+            f.write(json.dumps(_span("trace-c", attempt_id="trace-a")) + "\n")
+            f.write(json.dumps(_span("trace-d")) + "\n")
+        with pytest.raises(ValueError, match="invariants"):
+            tstore.merge_attempts(["trace-c", "trace-d"], state_dir=tmp_path)
+        assert set(tstore.definitions(tmp_path)) == {x}
+
+    def test_iter_spans_attempt_filter_matches_definition_members(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b", "trace-c")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        assert [s["traceId"] for s in tstore.iter_spans(tmp_path, attempt_id=x)] == ["trace-a", "trace-b"]
+        tstore.merge_attempts([x, "trace-c"], state_dir=tmp_path)
+        assert [s["traceId"] for s in tstore.iter_spans(tmp_path, attempt_id=x)] == [
+            "trace-a",
+            "trace-b",
+            "trace-c",
+        ]
+
+    def test_iter_spans_member_trace_id_matches_whole_definition(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        assert [s["traceId"] for s in tstore.iter_spans(tmp_path, attempt_id="trace-a")] == [
+            "trace-a",
+            "trace-b",
+        ]
+        assert [s["traceId"] for s in tstore.iter_spans(tmp_path, trace_id="trace-a")] == ["trace-a"]
+
+    def test_iter_spans_undefined_id_keeps_legacy_behavior(self, tmp_path):
+        self._legacy_log(tmp_path)
+        assert [s["traceId"] for s in tstore.iter_spans(tmp_path, attempt_id="att-x")] == [
+            "trace-l1",
+            "trace-l2",
+        ]
+        assert [s["traceId"] for s in tstore.iter_spans(tmp_path, attempt_id="trace-l1")] == ["trace-l1"]
+
+    def test_resolve_prefers_definition_over_identity_and_legacy(self, tmp_path):
+        self._log(
+            tmp_path,
+            [
+                _span("trace-l1", attempt_id="att-x"),
+                _span("trace-l2", attempt_id="att-x"),
+                _span("trace-z1", attempt_id="att-z"),
+                _span("trace-c"),
+            ],
+        )
+        y = tstore.merge_attempts(["att-x", "trace-c"], state_dir=tmp_path)
+        assert tstore.resolve_attempt_id("att-x", tmp_path) == y
+        assert tstore.resolve_attempt_id("trace-l1", tmp_path) == y
+        assert tstore.resolve_attempt_id(y, tmp_path) == y
+        assert tstore.resolve_attempt_id("trace-z1", tmp_path) == "att-z"
+
+    def test_concurrent_disjoint_merges_do_not_lose_updates(self, tmp_path):
+        trace_ids = [f"trace-{index}" for index in range(16)]
+        self._traces(tmp_path, *trace_ids)
+        ctx = multiprocessing.get_context("spawn")
+        pairs = [[trace_ids[2 * i], trace_ids[2 * i + 1]] for i in range(8)]
+        barrier = ctx.Barrier(len(pairs))
+        processes = [ctx.Process(target=_merge_after_barrier, args=(tmp_path, pair, barrier)) for pair in pairs]
+
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(30)
+
+        assert all(process.exitcode == 0 for process in processes)
+        defs = tstore.definitions(tmp_path)
+        assert len(defs) == 8
+        assert {t for entry in defs.values() for t in entry["traces"]} == set(trace_ids)
+
+    def test_concurrent_overlapping_merges_converge(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b", "trace-c")
+        ctx = multiprocessing.get_context("spawn")
+        barrier = ctx.Barrier(2)
+        processes = [
+            ctx.Process(target=_merge_after_barrier, args=(tmp_path, ids, barrier))
+            for ids in (["trace-a", "trace-b"], ["trace-b", "trace-c"])
+        ]
+
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(30)
+
+        assert all(process.exitcode == 0 for process in processes)
+        defs = tstore.definitions(tmp_path)
+        assert len(defs) == 1
+        (entry,) = defs.values()
+        assert set(entry["traces"]) == {"trace-a", "trace-b", "trace-c"}
+        (absorbed,) = entry["aliases"]
+        assert tstore.resolve_attempt_id(absorbed, tmp_path) == next(iter(defs))
+
+    def test_split_between_merge_publish_and_cleanup_keeps_protection(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        tstore.pin("trace-a", reason="ra", state_dir=tmp_path)
+        tstore.pin("trace-b", reason="rb", state_dir=tmp_path)
+        y, snapshot = tstore._merge_publish(["trace-a", "trace-b"], tmp_path)
+        assert set(snapshot) == {"trace-a", "trace-b"}
+        assert y in tstore.pins(tmp_path)
+
+        assert tstore.split_attempt(y, tmp_path) == ("trace-a", "trace-b")
+        tstore._merge_cleanup(y, snapshot, tmp_path)
+
+        registry = tstore.pins(tmp_path)
+        assert "trace-a" in registry and "trace-b" in registry
+        assert y not in registry
+        assert tstore.definitions(tmp_path) == {}
+
+    def test_merge_cleanup_skipped_when_definition_absorbed(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b", "trace-c")
+        tstore.pin("trace-a", reason="ra", state_dir=tmp_path)
+        y, snapshot = tstore._merge_publish(["trace-a", "trace-b"], tmp_path)
+        z = tstore.merge_attempts([y, "trace-c"], state_dir=tmp_path)
+        registry_before = tstore.pins(tmp_path)
+        tstore._merge_cleanup(y, snapshot, tmp_path)
+
+        assert tstore.pins(tmp_path) == registry_before
+        assert set(tstore.definitions(tmp_path)) == {z}
+        assert "trace-a" not in registry_before
+        assert z in registry_before and y in registry_before
+
+    def test_merge_cleanup_keeps_repinned_member(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        tstore.pin("trace-a", reason="old", state_dir=tmp_path)
+        tstore.pin("trace-b", reason="oldb", state_dir=tmp_path)
+        y, snapshot = tstore._merge_publish(["trace-a", "trace-b"], tmp_path)
+        tstore.pin("trace-a", reason="new", state_dir=tmp_path)
+        tstore._merge_cleanup(y, snapshot, tmp_path)
+
+        registry = tstore.pins(tmp_path)
+        assert registry["trace-a"]["reason"] == "new"
+        assert "trace-b" not in registry
+        assert y in registry
+
+    def test_concurrent_merge_and_split_multiprocess_final_state(self, tmp_path):
+        self._traces(tmp_path, "trace-a", "trace-b", "trace-c")
+        tstore.pin("trace-a", state_dir=tmp_path)
+        tstore.pin("trace-b", state_dir=tmp_path)
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        ctx = multiprocessing.get_context("spawn")
+        barrier = ctx.Barrier(2)
+        processes = [
+            ctx.Process(target=_split_after_barrier, args=(tmp_path, x, barrier)),
+            ctx.Process(target=_merge_after_barrier, args=(tmp_path, [x, "trace-c"], barrier)),
+        ]
+
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(30)
+
+        assert all(process.exitcode == 0 for process in processes)
+        assert tstore.definitions(tmp_path) == {}
+        registry = tstore.pins(tmp_path)
+        assert "trace-a" in registry and "trace-b" in registry
+
+    def test_merge_returns_id_when_cleanup_fails(self, tmp_path, monkeypatch):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        tstore.pin("trace-a", reason="ra", state_dir=tmp_path)
+        real = tstore._update_pins
+        calls = {"n": 0}
+
+        def flaky(state_dir, mutate):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise OSError("pins store unavailable")
+            return real(state_dir, mutate)
+
+        monkeypatch.setattr(tstore, "_update_pins", flaky)
+        aid = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+
+        assert aid in tstore.definitions(tmp_path)
+        registry = tstore.pins(tmp_path)
+        assert aid in registry
+        assert "trace-a" in registry
+
+    def test_merge_validation_failure_writes_no_pins(self, tmp_path):
+        self._traces(tmp_path, "trace-a")
+        tstore.pin("trace-a", reason="ra", state_dir=tmp_path)
+        before = (tmp_path / "pins.json").read_text(encoding="utf-8")
+        with pytest.raises(ValueError):
+            tstore.merge_attempts(["trace-a", "nope"], state_dir=tmp_path)
+        assert (tmp_path / "pins.json").read_text(encoding="utf-8") == before
+        assert tstore.definitions(tmp_path) == {}
+
+    def test_merge_rolls_back_definition_pin_when_commit_fails(self, tmp_path, monkeypatch):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        tstore.pin("trace-a", reason="ra", state_dir=tmp_path)
+        real = atomic_io._replace_unlocked
+
+        def failing(path, data):
+            if "attempts.json" in path.name:
+                raise OSError("disk full")
+            real(path, data)
+
+        monkeypatch.setattr(atomic_io, "_replace_unlocked", failing)
+        with pytest.raises(OSError, match="disk full"):
+            tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+
+        assert set(tstore.pins(tmp_path)) == {"trace-a"}
+        assert tstore.definitions(tmp_path) == {}
+
+    def test_split_commit_failure_keeps_protection_and_convergence(self, tmp_path, monkeypatch):
+        self._traces(tmp_path, "trace-a", "trace-b")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        tstore.pin(x, reason="keep", state_dir=tmp_path)
+        real = atomic_io._replace_unlocked
+
+        def failing(path, data):
+            if "attempts.json" in path.name:
+                raise OSError("disk full")
+            real(path, data)
+
+        monkeypatch.setattr(atomic_io, "_replace_unlocked", failing)
+        with pytest.raises(OSError, match="disk full"):
+            tstore.split_attempt(x, tmp_path)
+        monkeypatch.undo()
+
+        assert set(tstore.definitions(tmp_path)) == {x}
+        registry = tstore.pins(tmp_path)
+        assert registry["trace-a"]["reason"] == "keep"
+        assert registry["trace-b"]["reason"] == "keep"
+        assert x not in registry
+        assert tstore.unpin_attempt(x, tmp_path) is True
+        assert tstore.pins(tmp_path) == {}
+
+    def test_new_attempt_id_collision_regenerates(self, tmp_path, monkeypatch):
+        self._traces(tmp_path, "trace-a", "trace-b", "trace-c", "trace-d")
+        x = tstore.merge_attempts(["trace-a", "trace-b"], state_dir=tmp_path)
+        minted = iter([x, "att-fresh-1"])
+        monkeypatch.setattr(tstore, "new_attempt_id", lambda: next(minted))
+        aid = tstore.merge_attempts(["trace-c", "trace-d"], state_dir=tmp_path)
+
+        assert aid == "att-fresh-1"
+        defs = tstore.definitions(tmp_path)
+        assert defs[x]["traces"] == ["trace-a", "trace-b"]
+        assert defs["att-fresh-1"]["traces"] == ["trace-c", "trace-d"]
 
 
 def test_end_to_end_with_real_tracer(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

`raven trajectory` had eight id-oriented subcommands; using them meant
copying ids out of `list` by hand. This PR changes the attempt data model
and adds the human face, in four phases:

1. **Attempt definitions** (`attempts.json` sidecar): an attempt id equals
   the trace id unless a definition groups several traces under one minted
   id. Merge creates a definition (absorbing prior definitions and legacy
   groups as aliases, so verdicts/pins recorded under old ids stay
   visible); split deletes it, migrating pins down to members - naturally
   undoable, span logs stay append-only. Pin migration is linearized under
   a fixed lock order (attempts > pins); every failure and concurrency
   interleaving over-protects, never under-protects. Legacy logs
   (span-level `attempt.id`) stay addressable and mergeable, but cannot be
   split (their grouping lives in append-only spans).
2. **Write-side removal**: the span-level attempt mechanism (the
   begin/end/current_attempt trio and the `attempt.id` span attribute,
   shipped in v0.1.13) is deleted; `attempt.id` is now a reserved
   attribute key stripped from caller input, so `attempts.json` is the
   sole grouping source by mechanism. Readers keep resolving legacy logs;
   zero data migration. This is a breaking API change, declared in the
   BREAKING CHANGE footer below.
3. **CLI adaptation and reader defect tolerance**: `list` folds definition
   members into one row and surfaces verdicts through the alias set; new
   `merge`/`split` subcommands wrap the data layer thinly; `unpin` clears
   definition, aliases, members, and the literal id in one transaction.
   Two whole crash surfaces are closed along the way: Rich markup
   injection (a legal id may contain `[/red]`; every dynamic value is
   escaped), and JSON-legal but type-broken records (per-line UTF-8
   decoding, required-field string validation, non-object attribute
   containers) now degrade per record/field instead of killing commands.
4. **Interactive browser**: a bare `raven trajectory` on a TTY opens a
   three-screen questionary flow (sessions -> attempts -> actions: save /
   report / minimize / verdict / pin|unpin / split, plus multi-select
   merge). Menus and action messages never show a session key, trace id,
   or attempt id - only artifact paths carry ids. Every action triggers a
   full rescan (report bundles and auto-pins before confirming, so even an
   aborted action changed state); data-layer errors surface as one fixed
   id-free message; aggregation reads one snapshot per refresh and
   deduplicates records into logical spans keyed by (traceId, spanId), so
   a root turn's checkpoint+final pair counts once.

CONTEXT.md gains the Attempt Definition term and the final-state Attempt
wording.

## Type

- [ ] Fix
- [x] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_cli_trajectory_browse.py tests/test_cli_trajectory_commands.py tests/test_trajectory_store.py tests/test_trajectory_bundle.py tests/test_tracing_api.py -q` -> 241 passed
- `uv run pytest tests/ -q --ignore=tests/integration` -> 6838 passed; the 11 failures + 20 errors match main's pre-existing environment-specific set node-id for node-id (cron timezone cases, everos/config root-permission cases, viewer probe, theme), compared as sorted FAILED/ERROR sets against a baseline recorded before this branch
- `uv run ruff check .` and `uv run ruff format --check .` -> clean

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed (CONTEXT.md terms)

## Risk

- Bare `raven trajectory` changes behavior: it opens the browser on a TTY
  (previously the help page) and exits 2 with a hint when non-interactive.
  Scripts are unaffected: the subcommand check runs before the TTY gate.
- New spans no longer carry `attempt.id`, and `trace.begin_attempt` /
  `trace.end_attempt` / `trace.current_attempt` are removed. These shipped
  in v0.1.13, so an integration calling them raises AttributeError right
  after upgrading - an explicit, immediately visible failure rather than a
  silent one. Migration: group attempts after recording with
  `merge_attempts()` (library) or `raven trajectory merge` (CLI); reader
  fallback keeps existing logs addressable with zero data migration.
- `attempts.json` is the only new mutable state; deleting it reverts every
  attempt to single-turn semantics. Span logs remain append-only.
- Rollback: revert the squash commit; no data migration either way. The one
  known crash window (process death between merge's two file writes) leaves
  a harmless over-protective pin, documented in the store module.

- [x] Security impact considered (markup-injection and path-escape surfaces
  closed; ids treated as untrusted in every renderer)
- [x] Backward compatibility considered (legacy span-attribute logs stay
  addressable, mergeable, and listable)
- [x] Rollback path is clear for risky changes

## Related Issues

#362 (reference only: this PR removes the write-side attempt mechanism
introduced there and shipped in v0.1.13). No issue is closed.

BREAKING CHANGE: trace.begin_attempt, trace.end_attempt, and
trace.current_attempt (shipped in v0.1.13) and the span-level attempt.id
attribute are removed. Group attempts after recording instead:
merge_attempts() in raven.trajectory, or `raven trajectory merge` in the
CLI. Existing logs carrying a span-level attempt.id stay addressable
through the reader fallback; no data migration is needed.
