### PR TITLE
test(tracing): isolate span emission into per-test tmp dirs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,33 @@ def _no_real_oauth_credentials(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_tracing_state_dir(tmp_path, monkeypatch):
+    """Keep span emission off the real ``~/.raven/traces`` for the whole suite.
+
+    Tracing is on by default and ``trace.span()`` calls are embedded in library
+    code (agent loop, subagents, TUI RPC), so any test exercising those paths
+    emits spans with fabricated session keys (``session-a``, ``weixin:c``, ...)
+    into the real trace store — they then surface as phantom sessions in
+    ``raven trajectory``. Redirect only the directory, not the enabled switch,
+    so the suite keeps exercising the real emission path with zero behavior
+    change; leaks land in tmp instead.
+
+    ``raven.tracing.spans._store`` is a lazy module-level singleton pinned to
+    the directory resolved at first emit, so it must be reset around each test
+    or it keeps pointing at whichever directory was active when some earlier
+    test (or the real environment) first emitted. Tests that need their own
+    directory keep working: their ``monkeypatch.setenv`` runs after this
+    fixture and wins, and they already reset ``_store`` themselves.
+    """
+    from raven.tracing import spans as _spans
+
+    monkeypatch.setenv("RAVEN_TRACING_DIR", str(tmp_path / "traces"))
+    _spans._store = None
+    yield
+    _spans._store = None
+
+
+@pytest.fixture(autouse=True)
 def _no_openrouter_network(tmp_path):
     """Keep the OpenRouter catalog fetch off the network and off the real disk.
 


### PR DESCRIPTION
## Summary

Unit tests were leaking tracing spans into the real `~/.raven/traces` store. Tracing is on by default and `trace.span()` calls are embedded in library code (agent loop, subagents, TUI RPC), so any test exercising those paths emitted spans with fabricated session keys (`session-a`, `weixin:c`, `tui:default`, ...). Those spans then surfaced as phantom sessions in `raven trajectory`, while the TUI `/sessions` list (which reads the real session store) stayed clean.

This PR adds an autouse fixture in `tests/conftest.py` that:

- redirects `RAVEN_TRACING_DIR` to a per-test tmp directory, and
- resets the lazy module-level `TraceStore` cache (`raven.tracing.spans._store`) around each test, since it pins the directory resolved at first emit.

Key decisions:

- Only the directory is redirected, not the enabled switch, so the suite keeps exercising the real emission path with zero behavior change; leaks land in tmp instead.
- This centralizes the setenv-plus-cache-reset pattern that 8 tracing/trajectory test files already perform manually. Those tests keep working: their own `monkeypatch.setenv` runs after the fixture and wins, and they already reset the cache themselves.
- Existing phantom sessions come from archived span logs written before this fix; the fixture only prevents new leaks. One archive file mixes a real session with test keys, so cleanup needs line-level filtering and is left out of scope.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [x] Other

Test-suite hygiene (`test` commit type).

## Verification

- `uv run pytest tests/test_tracing_api.py tests/test_trajectory_store.py tests/test_trajectory_bundle.py tests/test_trajectory_replay.py tests/test_trajectory_redact.py tests/test_cli_tracing_commands.py tests/test_cli_trajectory_commands.py tests/test_cli_trajectory_browse.py -q`: 308 passed, 1 failed (`test_viewer_health_true_for_our_viewer`, fails identically on unmodified `main`, environment-specific)
- `uv run pytest tests/test_agent_loop_run_emit.py tests/test_subagent_manager.py tests/test_tui_rpc_turn_send.py tests/test_deep_research_tool.py tests/test_agent_loop_approval.py -q`: 109 passed; the real `~/.raven/traces` log did not grow during the run
- Positive check: running `tests/test_agent_loop_run_emit.py` with `--basetemp` shows the previously leaked session keys (`cli:c`, `tg:c`, `weixin:c`) now land in per-test tmp dirs
- `uv run pytest tests/ --ignore=tests/integration -q`: 6837 passed, 11 failed, 20 errors; the same failure set reproduces on unmodified `main` (environment-specific: cron/tz, everos server, theme, config loader, viewer health), zero regressions from this change
- `uv run ruff check tests/conftest.py` and `uv run ruff format --check tests/conftest.py`: both pass

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [ ] User-facing docs or screenshots are updated when needed

Docs box left blank: test-only change, no user-facing docs affected.

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

Test-only change; no production code touched. One known interaction: `RAVEN_TRACING_DIR` takes precedence over `RAVEN_HOME`, so a future test that fakes `RAVEN_HOME` and expects traces under it must also set `RAVEN_TRACING_DIR` itself. Rollback: revert the single commit.

## Related Issues

N/A