### PR TITLE
fix(*): refresh onboard model defaults and gate EverOS spawns on inotify headroom

### DIFF
--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -583,7 +583,7 @@ def _match_provider_by_url(base_url: Optional[str]) -> Optional[str]:
 _EVEROS_ROLES: dict[str, dict[str, Any]] = {
     "llm": {
         "label": ("Memory LLM", "记忆 LLM"),
-        "example": "gpt-5.6-luna",
+        "example": "qwen/qwen3.8-flash",
         "optional": False,
         "verify": True,
         "purpose": (
@@ -594,8 +594,8 @@ _EVEROS_ROLES: dict[str, dict[str, Any]] = {
         # the user's own main model, because a recommended id is only reachable
         # if their key carries it. This tells them how to judge their own.
         "recommendation": (
-            "Capability floor: [bold]gpt-5.6-luna[/bold] -- weaker models degrade extraction",
-            "能力下限参考 [bold]gpt-5.6-luna[/bold]：低于这个水平会明显影响提取质量",
+            "Capability floor: [bold]qwen/qwen3.8-flash[/bold] -- weaker models degrade extraction",
+            "能力下限参考 [bold]qwen/qwen3.8-flash[/bold]：低于这个水平会明显影响提取质量",
         ),
         "continue_hint": ("memory extraction may fail", "记忆抽取可能失败"),
     },
@@ -834,8 +834,8 @@ def _fetch_multimodal_models(
 def _match_everos_default(example: str, models: list[str]) -> str:
     """Find the best match for ``example`` in the fetched model list.
 
-    The example (e.g. ``gpt-5.6-luna``) is a bare model name, while
-    ``models`` may carry provider prefixes (``openai/gpt-5.6-luna``).
+    The example (e.g. ``qwen/qwen3.8-flash``) is a bare model name, while
+    ``models`` may carry provider prefixes (``openrouter/qwen/qwen3.8-flash``).
     Returns the first model whose id ends with ``/example`` or equals
     ``example`` exactly; falls back to the bare example string so the
     autocomplete input is pre-filled even if no exact match exists.

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -583,7 +583,7 @@ def _match_provider_by_url(base_url: Optional[str]) -> Optional[str]:
 _EVEROS_ROLES: dict[str, dict[str, Any]] = {
     "llm": {
         "label": ("Memory LLM", "记忆 LLM"),
-        "example": "gpt-4.1-mini",
+        "example": "gpt-5.6-luna",
         "optional": False,
         "verify": True,
         "purpose": (
@@ -594,8 +594,8 @@ _EVEROS_ROLES: dict[str, dict[str, Any]] = {
         # the user's own main model, because a recommended id is only reachable
         # if their key carries it. This tells them how to judge their own.
         "recommendation": (
-            "Capability floor: [bold]gpt-4.1-mini[/bold] -- weaker models degrade extraction",
-            "能力下限参考 [bold]gpt-4.1-mini[/bold]：低于这个水平会明显影响提取质量",
+            "Capability floor: [bold]gpt-5.6-luna[/bold] -- weaker models degrade extraction",
+            "能力下限参考 [bold]gpt-5.6-luna[/bold]：低于这个水平会明显影响提取质量",
         ),
         "continue_hint": ("memory extraction may fail", "记忆抽取可能失败"),
     },
@@ -660,7 +660,7 @@ _EVEROS_ROLES: dict[str, dict[str, Any]] = {
     },
     "multimodal": {
         "label": ("Memory multimodal", "记忆多模态"),
-        "example": "google/gemini-3-flash-preview",
+        "example": "google/gemini-3.7-flash",
         "optional": True,
         "verify": True,
         "purpose": (
@@ -673,8 +673,8 @@ _EVEROS_ROLES: dict[str, dict[str, Any]] = {
             "不配置：这类文件不进入记忆；有这类文件并不等于需要，确有此需求时再配即可。",
         ),
         "recommendation": (
-            "Recommended: [bold]google/gemini-3-flash-preview[/bold]",
-            "推荐 [bold]google/gemini-3-flash-preview[/bold]",
+            "Recommended: [bold]google/gemini-3.7-flash[/bold]",
+            "推荐 [bold]google/gemini-3.7-flash[/bold]",
         ),
         "skip_note": (
             "  [dim]Skipped; nothing else is affected -- configure it if you come to need\n  multimodal memory.[/dim]",
@@ -834,8 +834,8 @@ def _fetch_multimodal_models(
 def _match_everos_default(example: str, models: list[str]) -> str:
     """Find the best match for ``example`` in the fetched model list.
 
-    The example (e.g. ``gpt-4.1-mini``) is a bare model name, while
-    ``models`` may carry provider prefixes (``openai/gpt-4.1-mini``).
+    The example (e.g. ``gpt-5.6-luna``) is a bare model name, while
+    ``models`` may carry provider prefixes (``openai/gpt-5.6-luna``).
     Returns the first model whose id ends with ``/example`` or equals
     ``example`` exactly; falls back to the bare example string so the
     autocomplete input is pre-filled even if no exact match exists.

--- a/raven/cli/onboard_everos.py
+++ b/raven/cli/onboard_everos.py
@@ -637,7 +637,7 @@ _EVEROS_ROLES: dict[str, dict[str, Any]] = {
     },
     "rerank": {
         "label": ("Memory rerank", "记忆 rerank"),
-        "example": "Qwen/Qwen3-Reranker-4B",
+        "example": "qwen/qwen3-reranker-8b",
         "optional": True,
         "verify": True,
         "purpose": (
@@ -649,8 +649,8 @@ _EVEROS_ROLES: dict[str, dict[str, Any]] = {
             "[accent]（可选，建议配置）[/accent]",
         ),
         "recommendation": (
-            "Recommended: [bold]Qwen/Qwen3-Reranker-4B[/bold]",
-            "推荐 [bold]Qwen/Qwen3-Reranker-4B[/bold]",
+            "Recommended: [bold]qwen/qwen3-reranker-8b[/bold]",
+            "推荐 [bold]qwen/qwen3-reranker-8b[/bold]",
         ),
         "continue_hint": ("rerank quality may degrade", "rerank 精度可能下降"),
         "skip_note": (

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -102,10 +102,12 @@ def _inotify_usage() -> tuple[int, int] | None:
     """(inotify instances held by this user, the kernel cap), or ``None``.
 
     ``max_user_instances`` limits instances per real user id, and the spawned
-    server inherits this process's uid, so only same-uid instances count.
-    ``/proc/<pid>/fdinfo`` marks an inotify instance with a line starting with
-    ``inotify``; when procfs is absent or unreadable (non-Linux), ``None`` lets
-    callers skip the check rather than guess.
+    server inherits this process's uid, so only same-uid instances count. An
+    instance is an fd whose ``/proc/<pid>/fd`` link reads ``anon_inode:inotify``;
+    fdinfo cannot be the marker because a freshly created instance carries no
+    ``inotify`` lines until its first watch, yet still consumes the cap. When
+    procfs is absent or unreadable (non-Linux), ``None`` lets callers skip the
+    check rather than guess.
     """
     try:
         limit = int(_INOTIFY_LIMIT_PATH.read_text(encoding="ascii").strip())
@@ -117,16 +119,15 @@ def _inotify_usage() -> tuple[int, int] | None:
         try:
             if pid_dir.stat().st_uid != me:
                 continue
-            entries = (pid_dir / "fdinfo").iterdir()
+            entries = (pid_dir / "fd").iterdir()
         except OSError:
             continue
         for entry in entries:
             try:
-                blob = entry.read_bytes()
+                if os.readlink(entry) == "anon_inode:inotify":
+                    used += 1
             except OSError:
                 continue
-            if any(line.startswith(b"inotify") for line in blob.splitlines()):
-                used += 1
     return used, limit
 
 

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -119,15 +119,14 @@ def _inotify_usage() -> tuple[int, int] | None:
         try:
             if pid_dir.stat().st_uid != me:
                 continue
-            entries = (pid_dir / "fd").iterdir()
+            for entry in (pid_dir / "fd").iterdir():
+                try:
+                    if os.readlink(entry) == "anon_inode:inotify":
+                        used += 1
+                except OSError:
+                    continue
         except OSError:
             continue
-        for entry in entries:
-            try:
-                if os.readlink(entry) == "anon_inode:inotify":
-                    used += 1
-            except OSError:
-                continue
     return used, limit
 
 

--- a/raven/plugin/memory/everos/_server.py
+++ b/raven/plugin/memory/everos/_server.py
@@ -93,6 +93,94 @@ def server_log_path() -> Path:
     return get_logs_dir() / "everos-server.log"
 
 
+_INOTIFY_LIMIT_PATH = Path("/proc/sys/fs/inotify/max_user_instances")
+_INOTIFY_LIMIT_FLOOR = 1024
+_PROC_ROOT = Path("/proc")
+
+
+def _inotify_usage() -> tuple[int, int] | None:
+    """(inotify instances held by this user, the kernel cap), or ``None``.
+
+    ``max_user_instances`` limits instances per real user id, and the spawned
+    server inherits this process's uid, so only same-uid instances count.
+    ``/proc/<pid>/fdinfo`` marks an inotify instance with a line starting with
+    ``inotify``; when procfs is absent or unreadable (non-Linux), ``None`` lets
+    callers skip the check rather than guess.
+    """
+    try:
+        limit = int(_INOTIFY_LIMIT_PATH.read_text(encoding="ascii").strip())
+    except (OSError, ValueError):
+        return None
+    me = os.getuid()
+    used = 0
+    for pid_dir in _PROC_ROOT.glob("[0-9]*"):
+        try:
+            if pid_dir.stat().st_uid != me:
+                continue
+            entries = (pid_dir / "fdinfo").iterdir()
+        except OSError:
+            continue
+        for entry in entries:
+            try:
+                blob = entry.read_bytes()
+            except OSError:
+                continue
+            if any(line.startswith(b"inotify") for line in blob.splitlines()):
+                used += 1
+    return used, limit
+
+
+def _try_raise_inotify_limit() -> int | None:
+    """Raise the per-user inotify cap when the kernel allows it, else ``None``.
+
+    Writing ``/proc/sys`` needs root (or a dedicated capability); when that
+    fails the caller falls back to spelling out the command, because the cap is
+    the documented remedy and there is no raven-side substitute for it.
+    """
+    try:
+        current = int(_INOTIFY_LIMIT_PATH.read_text(encoding="ascii").strip())
+    except (OSError, ValueError):
+        return None
+    target = max(_INOTIFY_LIMIT_FLOOR, current * 2)
+    try:
+        _INOTIFY_LIMIT_PATH.write_text(str(target), encoding="ascii")
+    except OSError:
+        return None
+    return target
+
+
+def _inotify_gate() -> str | None:
+    """``None`` when a spawn can proceed, else the diagnosis + fix text.
+
+    With the cap exhausted a spawned server dies immediately on a cryptic
+    OSError, so exhaustion is caught here instead: raise the cap when the
+    kernel lets us (root), otherwise hand back the fix so the caller fails
+    before spawning a process that cannot start.
+    """
+    usage = _inotify_usage()
+    if usage is None:
+        return None
+    used, limit = usage
+    if used < limit:
+        return None
+    raised = _try_raise_inotify_limit()
+    after = _inotify_usage()
+    if after is not None and after[0] < after[1]:
+        if raised is not None:
+            logger.info("raised fs.inotify.max_user_instances to {} so EverOS can start", raised)
+        return None
+    used, limit = after if after is not None else (used, limit)
+    target = _INOTIFY_LIMIT_FLOOR if limit < _INOTIFY_LIMIT_FLOOR else limit * 2
+    return (
+        f"EverOS needs an inotify instance to watch its memory directory, but this user "
+        f"already holds {used} of the {limit} allowed "
+        f"(fs.inotify.max_user_instances). Raise it with:\n"
+        f"  sudo sysctl -w fs.inotify.max_user_instances={target}\n"
+        f"To make the change permanent:\n"
+        f"  echo 'fs.inotify.max_user_instances={target}' | sudo tee /etc/sysctl.d/99-inotify-limits.conf"
+    )
+
+
 class EverosBinaryMissingError(RuntimeError):
     """The everos CLI is not installed where raven can reach it.
 
@@ -729,6 +817,14 @@ async def ensure_everos_server(
     # its LLM client, so its credentials are proven by the probe above.
     _require_llm_configured()
 
+    # A machine whose per-user inotify cap is exhausted cannot hold a spawned
+    # server: its watcher dies at boot with an OSError the log buries. Catch it
+    # here -- raising the cap when this process may, failing with the commands
+    # when it may not -- instead of spawning a child that cannot start.
+    inotify_block = await asyncio.to_thread(_inotify_gate)
+    if inotify_block:
+        raise RuntimeError(inotify_block)
+
     if on_wait is not None:
         on_wait()
 
@@ -754,6 +850,10 @@ async def ensure_everos_server(
         # child of ours to inspect and polling health is all we can do.
         if proc is not None and proc.poll() is not None:
             detail = await asyncio.to_thread(_last_error_line)
+            if "inotify" in detail.lower():
+                hint = await asyncio.to_thread(_inotify_gate)
+                if hint:
+                    detail = f"{detail} {hint}"
             raise RuntimeError(
                 f"EverOS server exited with code {proc.returncode} while starting at {base_url}. "
                 + (f"{detail} " if detail else "")

--- a/raven/providers/azure_openai_provider.py
+++ b/raven/providers/azure_openai_provider.py
@@ -39,7 +39,7 @@ class AzureOpenAIProvider(LLMProvider):
         self,
         api_key: str = "",
         api_base: str = "",
-        default_model: str = "gpt-5.2-chat",
+        default_model: str = "gpt-5.6-sol",
         deployment: str = "",
         api_version: str = "2024-10-21",
     ):

--- a/raven/providers/azure_openai_provider.py
+++ b/raven/providers/azure_openai_provider.py
@@ -138,7 +138,8 @@ class AzureOpenAIProvider(LLMProvider):
         if tools:
             payload["tools"] = tools
             payload["tool_choice"] = tool_choice or "auto"
-            if reasoning_effort is None and "gpt-5" in deployment_name.lower():
+            if "gpt-5" in deployment_name.lower():
+                # GPT-5.x Chat Completions reject tools under any reasoning effort but "none".
                 payload["reasoning_effort"] = "none"
 
         return payload

--- a/raven/providers/azure_openai_provider.py
+++ b/raven/providers/azure_openai_provider.py
@@ -138,6 +138,8 @@ class AzureOpenAIProvider(LLMProvider):
         if tools:
             payload["tools"] = tools
             payload["tool_choice"] = tool_choice or "auto"
+            if reasoning_effort is None and "gpt-5" in deployment_name.lower():
+                payload["reasoning_effort"] = "none"
 
         return payload
 

--- a/tests/test_azure_openai_provider.py
+++ b/tests/test_azure_openai_provider.py
@@ -261,8 +261,13 @@ def test_gpt5_with_tools_defaults_to_no_reasoning() -> None:
     assert "temperature" not in payload
 
 
-def test_gpt5_keeps_the_callers_reasoning_effort() -> None:
+def test_gpt5_tools_force_none_over_configured_effort() -> None:
     payload = _gpt_payload("gpt-5.6-sol", tools=True, reasoning_effort="medium")
+    assert payload["reasoning_effort"] == "none"
+
+
+def test_gpt5_without_tools_keeps_configured_effort() -> None:
+    payload = _gpt_payload("gpt-5.6-sol", tools=False, reasoning_effort="medium")
     assert payload["reasoning_effort"] == "medium"
 
 

--- a/tests/test_azure_openai_provider.py
+++ b/tests/test_azure_openai_provider.py
@@ -236,3 +236,42 @@ def test_arguments_that_needed_repair_are_reported_as_such() -> None:
     assert cut.tool_calls[0].run_meta.arguments_repaired is True
     # Still repaired: the signal is additional, not a replacement.
     assert cut.tool_calls[0].arguments["content"] == "import ran"
+
+
+def _gpt_payload(
+    deployment: str,
+    *,
+    tools: bool,
+    reasoning_effort: str | None = None,
+) -> dict[str, Any]:
+    provider = AzureOpenAIProvider(api_key="k", api_base="https://x.openai.azure.com")
+    tool_list = [{"type": "function", "function": {"name": "f", "parameters": {}}}] if tools else None
+    return provider._prepare_request_payload(
+        deployment,
+        [{"role": "user", "content": "hi"}],
+        tools=tool_list,
+        reasoning_effort=reasoning_effort,
+    )
+
+
+def test_gpt5_with_tools_defaults_to_no_reasoning() -> None:
+    """GPT-5.x chat completions 400 on tools without reasoning_effort=none."""
+    payload = _gpt_payload("gpt-5.6-sol", tools=True)
+    assert payload["reasoning_effort"] == "none"
+    assert "temperature" not in payload
+
+
+def test_gpt5_keeps_the_callers_reasoning_effort() -> None:
+    payload = _gpt_payload("gpt-5.6-sol", tools=True, reasoning_effort="medium")
+    assert payload["reasoning_effort"] == "medium"
+
+
+def test_gpt5_without_tools_gets_no_injected_effort() -> None:
+    payload = _gpt_payload("gpt-5.6-sol", tools=False)
+    assert "reasoning_effort" not in payload
+
+
+def test_other_deployments_are_untouched() -> None:
+    payload = _gpt_payload("gpt-4o", tools=True)
+    assert "reasoning_effort" not in payload
+    assert payload["temperature"] == 0.7

--- a/tests/test_cli_onboard_commands.py
+++ b/tests/test_cli_onboard_commands.py
@@ -2044,6 +2044,14 @@ def test_memory_rerank_reuse_llm_provider(
     assert everos["rerank"]["base_url"] == "https://api.deepinfra.com/v1/inference"
 
 
+def test_memory_rerank_default_is_qwen8b() -> None:
+    """The rerank role's shipped default is the 8B Qwen3 reranker."""
+    role = onboard_everos._EVEROS_ROLES["rerank"]
+    assert role["example"] == "qwen/qwen3-reranker-8b"
+    for recommendation in role["recommendation"]:
+        assert "qwen/qwen3-reranker-8b" in recommendation
+
+
 def test_memory_seeded_role_is_not_configured(tmp_env: Path, everos_isolated: Path) -> None:
     """A seeded model with an empty api_key does not count as configured."""
     from raven.config.update_everos import set_everos_section

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -148,22 +148,16 @@ class TestInotifyGate:
         cap.write_text("128\n", encoding="ascii")
         monkeypatch.setattr(everos_server, "_INOTIFY_LIMIT_PATH", cap)
         proc = tmp_path / "proc"
-        (proc / "111" / "fdinfo").mkdir(parents=True)
-        (proc / "111" / "fdinfo" / "3").write_text(
-            "pos:\t0\nflags:\t02004000\ninotify wd:1 ino:1 mask:80c\n", encoding="ascii"
-        )
-        (proc / "111" / "fdinfo" / "4").write_text("pos:\t0\nflags:\t02004000\n", encoding="ascii")
-        (proc / "222" / "fdinfo").mkdir(parents=True)
-        (proc / "222" / "fdinfo" / "5").write_text(
-            "pos:\t0\ninotify wd:1 ino:2 mask:80c\ninotify wd:2 ino:3 mask:80c\n",
-            encoding="ascii",
-        )
-        (proc / "111" / "fdinfo" / "9").symlink_to(proc / "vanished")
+        (proc / "111" / "fd").mkdir(parents=True)
+        (proc / "111" / "fd" / "3").symlink_to("anon_inode:inotify")
+        (proc / "111" / "fd" / "4").symlink_to("socket:[123]")
+        (proc / "222" / "fd").mkdir(parents=True)
+        (proc / "222" / "fd" / "5").symlink_to("anon_inode:inotify")
+        (proc / "111" / "fd" / "9").symlink_to(proc / "vanished")
         (proc / "333").symlink_to(proc / "vanished")
-        (proc / "notaproc" / "fdinfo").mkdir(parents=True)
+        (proc / "notaproc" / "fd").mkdir(parents=True)
         monkeypatch.setattr(everos_server, "_PROC_ROOT", proc)
 
-        # One instance per fd with an inotify line, whatever the watch count.
         assert everos_server._inotify_usage() == (2, 128)
 
     def test_usage_ignores_other_users_instances(self, monkeypatch, tmp_path) -> None:
@@ -171,8 +165,8 @@ class TestInotifyGate:
         cap.write_text("128\n", encoding="ascii")
         monkeypatch.setattr(everos_server, "_INOTIFY_LIMIT_PATH", cap)
         proc = tmp_path / "proc"
-        (proc / "111" / "fdinfo").mkdir(parents=True)
-        (proc / "111" / "fdinfo" / "3").write_text("inotify wd:1 ino:1\n", encoding="ascii")
+        (proc / "111" / "fd").mkdir(parents=True)
+        (proc / "111" / "fd" / "3").symlink_to("anon_inode:inotify")
         monkeypatch.setattr(everos_server, "_PROC_ROOT", proc)
         monkeypatch.setattr(everos_server.os, "getuid", lambda: 424242)
 
@@ -570,6 +564,30 @@ class TestThePrimitivesAgainstTheRealOS:
         from raven.plugin.memory.everos._server import ome_lock_held
 
         assert ome_lock_held(tmp_path / "never-started") is False
+
+    def test_zero_watch_instances_count_against_the_cap(self) -> None:
+        import ctypes
+
+        from raven.plugin.memory.everos import _server
+
+        libc = ctypes.CDLL(None, use_errno=True)
+        libc.inotify_init.restype = ctypes.c_int
+        before = _server._inotify_usage()
+        assert before is not None
+        fds = []
+        try:
+            for _ in range(2):
+                fd = libc.inotify_init()
+                if fd < 0:
+                    pytest.skip("per-user inotify cap is exhausted on this host")
+                fds.append(fd)
+            after = _server._inotify_usage()
+        finally:
+            for fd in fds:
+                libc.close(fd)
+        assert after is not None
+        assert after[0] >= before[0] + 2
+        assert after[1] == before[1]
 
     def test_a_held_ome_lock_is_detected(self, tmp_path) -> None:
         """The signal the whole "served elsewhere" state rests on.

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -155,6 +155,8 @@ class TestInotifyGate:
         (proc / "222" / "fd" / "5").symlink_to("anon_inode:inotify")
         (proc / "111" / "fd" / "9").symlink_to(proc / "vanished")
         (proc / "333").symlink_to(proc / "vanished")
+        (proc / "947").mkdir()
+        (proc / "947" / "fd").write_text("not a dir", encoding="ascii")
         (proc / "notaproc" / "fd").mkdir(parents=True)
         monkeypatch.setattr(everos_server, "_PROC_ROOT", proc)
 

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import raven.plugin.memory.everos._server as everos_server
 from raven.plugin.memory.everos._server import (
     EverosNotConfiguredError,
     StopOutcome,
@@ -113,6 +114,205 @@ def _write_llm_section(cfg, *, model="mem-llm", api_key="k"):
     if api_key is not None:
         body += f'api_key = "{api_key}"\n'
     cfg.write_text(body, encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_inotify_gate(request, monkeypatch):
+    """Spawn tests must not depend on the host's inotify headroom.
+
+    ``_inotify_gate`` scans procfs and refuses the spawn when the per-user
+    cap is exhausted -- real behaviour that ``TestInotifyGate`` covers
+    explicitly, and a wall the other tests should not have to pass on a host
+    that happens to be near the cap.
+    """
+    if request.cls is TestInotifyGate:
+        return
+    monkeypatch.setattr("raven.plugin.memory.everos._server._inotify_gate", lambda: None)
+
+
+class TestInotifyGate:
+    """The inotify headroom check keeps a spawn that cannot survive off the host."""
+
+    @pytest.fixture
+    def _logs(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("raven.plugin.memory.everos._server.get_logs_dir", lambda: tmp_path)
+        return tmp_path / "everos-server.log"
+
+    def test_usage_is_none_when_the_cap_is_unreadable(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setattr(everos_server, "_INOTIFY_LIMIT_PATH", tmp_path / "missing")
+
+        assert everos_server._inotify_usage() is None
+
+    def test_usage_counts_same_uid_instances(self, monkeypatch, tmp_path) -> None:
+        cap = tmp_path / "max"
+        cap.write_text("128\n", encoding="ascii")
+        monkeypatch.setattr(everos_server, "_INOTIFY_LIMIT_PATH", cap)
+        proc = tmp_path / "proc"
+        (proc / "111" / "fdinfo").mkdir(parents=True)
+        (proc / "111" / "fdinfo" / "3").write_text(
+            "pos:\t0\nflags:\t02004000\ninotify wd:1 ino:1 mask:80c\n", encoding="ascii"
+        )
+        (proc / "111" / "fdinfo" / "4").write_text("pos:\t0\nflags:\t02004000\n", encoding="ascii")
+        (proc / "222" / "fdinfo").mkdir(parents=True)
+        (proc / "222" / "fdinfo" / "5").write_text(
+            "pos:\t0\ninotify wd:1 ino:2 mask:80c\ninotify wd:2 ino:3 mask:80c\n",
+            encoding="ascii",
+        )
+        (proc / "notaproc" / "fdinfo").mkdir(parents=True)
+        monkeypatch.setattr(everos_server, "_PROC_ROOT", proc)
+
+        # One instance per fd with an inotify line, whatever the watch count.
+        assert everos_server._inotify_usage() == (2, 128)
+
+    def test_usage_ignores_other_users_instances(self, monkeypatch, tmp_path) -> None:
+        cap = tmp_path / "max"
+        cap.write_text("128\n", encoding="ascii")
+        monkeypatch.setattr(everos_server, "_INOTIFY_LIMIT_PATH", cap)
+        proc = tmp_path / "proc"
+        (proc / "111" / "fdinfo").mkdir(parents=True)
+        (proc / "111" / "fdinfo" / "3").write_text("inotify wd:1 ino:1\n", encoding="ascii")
+        monkeypatch.setattr(everos_server, "_PROC_ROOT", proc)
+        monkeypatch.setattr(everos_server.os, "getuid", lambda: 424242)
+
+        assert everos_server._inotify_usage() == (0, 128)
+
+    def test_raise_limit_writes_a_floor_and_reports_it(self, monkeypatch, tmp_path) -> None:
+        cap = tmp_path / "max"
+        cap.write_text("128\n", encoding="ascii")
+        monkeypatch.setattr(everos_server, "_INOTIFY_LIMIT_PATH", cap)
+
+        assert everos_server._try_raise_inotify_limit() == 1024
+        assert cap.read_text(encoding="ascii") == "1024"
+
+    def test_raise_limit_is_none_when_the_write_is_refused(self, monkeypatch) -> None:
+        class _RefusingCap:
+            def read_text(self, *a, **kw):
+                return "128"
+
+            def write_text(self, *a, **kw):
+                raise OSError("read-only /proc/sys")
+
+        monkeypatch.setattr(everos_server, "_INOTIFY_LIMIT_PATH", _RefusingCap())
+
+        assert everos_server._try_raise_inotify_limit() is None
+
+    def test_gate_is_open_with_headroom(self, monkeypatch) -> None:
+        monkeypatch.setattr(everos_server, "_inotify_usage", lambda: (10, 128))
+        monkeypatch.setattr(everos_server, "_try_raise_inotify_limit", lambda: pytest.fail("must not raise"))
+
+        assert everos_server._inotify_gate() is None
+
+    def test_gate_is_open_when_the_kernel_cannot_be_measured(self, monkeypatch) -> None:
+        monkeypatch.setattr(everos_server, "_inotify_usage", lambda: None)
+
+        assert everos_server._inotify_gate() is None
+
+    def test_gate_raises_the_cap_when_privileged(self, monkeypatch) -> None:
+        calls = {"n": 0}
+
+        def usage():
+            calls["n"] += 1
+            return (128, 128) if calls["n"] == 1 else (128, 1024)
+
+        monkeypatch.setattr(everos_server, "_inotify_usage", usage)
+        raised = []
+        monkeypatch.setattr(everos_server, "_try_raise_inotify_limit", lambda: raised.append(1) or 1024)
+
+        assert everos_server._inotify_gate() is None
+        assert raised == [1]
+
+    @pytest.mark.parametrize(
+        ("usage", "expected"),
+        [((128, 128), "1024"), ((2048, 2048), "4096")],
+        ids=["under-the-floor", "at-or-above-the-floor"],
+    )
+    def test_gate_returns_the_fix_text_when_raising_fails(self, monkeypatch, usage, expected) -> None:
+        monkeypatch.setattr(everos_server, "_inotify_usage", lambda: usage)
+        monkeypatch.setattr(everos_server, "_try_raise_inotify_limit", lambda: None)
+
+        msg = everos_server._inotify_gate()
+        assert msg is not None
+        used, limit = usage
+        assert f"{used} of the {limit}" in msg
+        assert f"sudo sysctl -w fs.inotify.max_user_instances={expected}" in msg
+        assert "/etc/sysctl.d/99-inotify-limits.conf" in msg
+
+    @pytest.mark.asyncio
+    async def test_an_exhausted_cap_refuses_to_spawn(self, everos_toml, monkeypatch) -> None:
+        _write_llm_section(everos_toml)
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._inotify_gate",
+            lambda: "no inotify room; run sudo sysctl.",
+        )
+        spawn = MagicMock()
+        monkeypatch.setattr("raven.plugin.memory.everos._server._start_server_if_unlocked", spawn)
+
+        with patch("raven.plugin.memory.everos._server._probe_health", return_value=False):
+            with pytest.raises(RuntimeError, match="no inotify room"):
+                await ensure_everos_server("http://localhost:18791", timeout=5.0)
+
+        spawn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_the_gate_is_consulted_before_a_spawn(self, everos_toml, monkeypatch) -> None:
+        _write_llm_section(everos_toml)
+        gate = MagicMock(return_value=None)
+        monkeypatch.setattr("raven.plugin.memory.everos._server._inotify_gate", gate)
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._start_server_if_unlocked",
+            lambda *a, **kw: _live_child(),
+        )
+
+        with patch("raven.plugin.memory.everos._server._probe_health", side_effect=[False, True]):
+            await ensure_everos_server("http://localhost:18791", timeout=5.0)
+
+        gate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_inotify_log_failure_carries_the_fix(self, everos_toml, _logs, monkeypatch) -> None:
+        _write_llm_section(everos_toml)
+        _logs.parent.mkdir(parents=True, exist_ok=True)
+        _logs.write_text(
+            "OSError: [Errno 24] inotify instance limit reached\nApplication startup failed. Exiting.\n",
+            encoding="utf-8",
+        )
+        dead = MagicMock()
+        dead.poll.return_value = 3
+        dead.returncode = 3
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._start_server_if_unlocked",
+            lambda *a, **kw: dead,
+        )
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._inotify_gate",
+            lambda: "inotify fix: sudo sysctl -w fs.inotify.max_user_instances=1024",
+        )
+
+        with patch("raven.plugin.memory.everos._server._probe_health", return_value=False):
+            with pytest.raises(RuntimeError, match="inotify.*sudo sysctl"):
+                await ensure_everos_server("http://localhost:18791", timeout=5.0)
+
+    @pytest.mark.asyncio
+    async def test_unrelated_failure_keeps_the_gate_out(self, everos_toml, _logs, monkeypatch) -> None:
+        _write_llm_section(everos_toml)
+        _logs.parent.mkdir(parents=True, exist_ok=True)
+        _logs.write_text("EngineLockHeldError: held\n", encoding="utf-8")
+        dead = MagicMock()
+        dead.poll.return_value = 3
+        dead.returncode = 3
+        monkeypatch.setattr(
+            "raven.plugin.memory.everos._server._start_server_if_unlocked",
+            lambda *a, **kw: dead,
+        )
+        gate = MagicMock(return_value=None)
+        monkeypatch.setattr("raven.plugin.memory.everos._server._inotify_gate", gate)
+
+        with patch("raven.plugin.memory.everos._server._probe_health", return_value=False):
+            with pytest.raises(RuntimeError, match="EngineLockHeldError") as exc:
+                await ensure_everos_server("http://localhost:18791", timeout=5.0)
+
+        gate.assert_called_once()
+        assert "fs.inotify" not in str(exc.value)
 
 
 class TestSpawnPreflight:

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -158,6 +158,8 @@ class TestInotifyGate:
             "pos:\t0\ninotify wd:1 ino:2 mask:80c\ninotify wd:2 ino:3 mask:80c\n",
             encoding="ascii",
         )
+        (proc / "111" / "fdinfo" / "9").symlink_to(proc / "vanished")
+        (proc / "333").symlink_to(proc / "vanished")
         (proc / "notaproc" / "fdinfo").mkdir(parents=True)
         monkeypatch.setattr(everos_server, "_PROC_ROOT", proc)
 
@@ -193,6 +195,13 @@ class TestInotifyGate:
                 raise OSError("read-only /proc/sys")
 
         monkeypatch.setattr(everos_server, "_INOTIFY_LIMIT_PATH", _RefusingCap())
+
+        assert everos_server._try_raise_inotify_limit() is None
+
+    def test_raise_limit_is_none_when_the_cap_is_unreadable(self, monkeypatch, tmp_path) -> None:
+        cap_dir = tmp_path / "maxdir"
+        cap_dir.mkdir()
+        monkeypatch.setattr(everos_server, "_INOTIFY_LIMIT_PATH", cap_dir)
 
         assert everos_server._try_raise_inotify_limit() is None
 
@@ -285,7 +294,7 @@ class TestInotifyGate:
         )
         monkeypatch.setattr(
             "raven.plugin.memory.everos._server._inotify_gate",
-            lambda: "inotify fix: sudo sysctl -w fs.inotify.max_user_instances=1024",
+            MagicMock(side_effect=[None, "inotify fix: sudo sysctl -w fs.inotify.max_user_instances=1024"]),
         )
 
         with patch("raven.plugin.memory.everos._server._probe_health", return_value=False):

--- a/tests/test_everos_server.py
+++ b/tests/test_everos_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -567,6 +568,7 @@ class TestThePrimitivesAgainstTheRealOS:
 
         assert ome_lock_held(tmp_path / "never-started") is False
 
+    @pytest.mark.skipif(sys.platform != "linux", reason="inotify is Linux-only")
     def test_zero_watch_instances_count_against_the_cap(self) -> None:
         import ctypes
 


### PR DESCRIPTION
## Summary

Onboard model-default refreshes plus an EverOS startup fix:

1. Rerank default: Qwen/Qwen3-Reranker-4B has been retired from OpenRouter, so the onboard wizard's rerank example and EN/ZH recommendations now point to qwen/qwen3-reranker-8b, which OpenRouter still serves.

2. Stale defaults: the memory-LLM capability floor (gpt-4.1-mini), the multimodal recommendation (google/gemini-3-flash-preview), and the Azure OpenAI provider default (gpt-5.2-chat) all point at generations behind what OpenRouter/Azure serve today. They now read qwen/qwen3.8-flash (the EverOS client always sends temperature, which the GPT-5.x reasoning family rejects), google/gemini-3.7-flash, and gpt-5.6-sol. GPT-5.x Azure deployments force reasoning_effort="none" on tool calls, matching Microsoft's tool-calling requirement; configured effort still applies to non-tool calls.

3. Startup failure: an exhausted fs.inotify.max_user_instances makes the spawned EverOS server's watcher die at boot with "OSError: [Errno 24] inotify instance limit reached", which surfaces only as a cryptic exit buried in the dead-child log. ensure_everos_server now measures per-user inotify headroom (counting same-uid inotify instances via /proc/<pid>/fd links that read anon_inode:inotify against the kernel cap) before spawning: it raises the cap when the process is privileged, otherwise it fails fast with the exact sudo sysctl commands. A dead child whose log blames inotify gets the same hint appended to its error.

## Type

- [x] Fix

## Verification

- make coverage (full default suite, uv run --frozen --python 3.12 --all-extras pytest -q): 7119 passed, 2 failed, 37 skipped, 13 deselected. The 2 failures are pre-existing on main and environment-dependent (reproduced on main in a throwaway worktree): both expect a chmod-based write to be refused, which cannot happen when the suite runs as root (CAP_DAC_OVERRIDE):
  - tests/test_config_loader.py::test_migration_is_correct_even_when_the_file_cannot_be_written
  - tests/test_everos_server.py::TestAnUnwritableRootFailsAsAStartFailure::test_it_surfaces_as_runtime_error
- make coverage-diff COVERAGE_BASE_REF=origin/main: 100.00% (57/57 executable changed lines), passed the 90.00% threshold
- make coverage-ratchet: passed (line +2.11pp, branch +3.24pp over baseline)
- uv run pytest tests/test_cli_onboard_commands.py: 251 passed
- uv run pytest tests/test_azure_openai_provider.py: 9 passed
- uv run ruff check (changed files): clean
- uv run ruff format --check (changed files): clean
- pre-commit commitlint hook (conventional commit message): passed on all commits

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally

## Risk

- Security impact considered: the sysctl write runs only when the process already holds the privilege to write /proc/sys; otherwise the gate only returns the instructions.
- Backward compatibility considered: the gate is a no-op when headroom exists or when procfs/sysctl cannot be read (non-Linux); the model-default changes are wizard text and one provider default constant, no config migration needed.
- Rollback path is clear: revert the merge; the check is isolated to ensure_everos_server and three module-level helpers.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A