### PR TITLE
fix(cli): overhaul trajectory browser interaction ux

### DIFF
--- a/raven/cli/_theme.py
+++ b/raven/cli/_theme.py
@@ -9,6 +9,8 @@ and Python cannot share code), but the mapping is not 1:1:
     inline body text, not large glyphs.
   - border stays a gold accent (matching the CLI's gold panel borders), whereas
     theme.ts ``border`` is a neutral grey; separator reuses that grey ``#d0d7de``.
+  - success has no theme.ts ramp; both values are GitHub-style greens chosen to
+    clear 4.5:1 on their respective backgrounds (white / #1e1e1e).
 
 Detection is kept out of import time and runs on the first themed render (see
 ``onboard_commands._ThemedConsole``). Only truecolor values are provided;
@@ -44,6 +46,7 @@ PALETTE: dict[Scheme, dict[str, str]] = {
         "separator": "#444444",
         "disabled": "#585858",
         "error": "#ff5f5f",
+        "success": "#3fb950",
     },
     "light": {
         "accent": "#935F00",
@@ -55,6 +58,7 @@ PALETTE: dict[Scheme, dict[str, str]] = {
         "separator": "#d0d7de",
         "disabled": "#6e7681",
         "error": "#cf222e",
+        "success": "#1a7f37",
     },
 }
 
@@ -203,6 +207,7 @@ def build_rich_theme(scheme: Scheme):
             "separator": p["separator"],
             "disabled": p["disabled"],
             "error": p["error"],
+            "success": p["success"],
         }
     )
 
@@ -224,5 +229,6 @@ def build_questionary_style(scheme: Scheme):
             ("disabled", f"fg:{p['disabled']} italic"),
             ("validation-toolbar", f"fg:{p['error']} bold"),
             ("text", f"fg:{p['text']}"),
+            ("success", f"fg:{p['success']}"),
         ]
     )

--- a/raven/cli/_theme.py
+++ b/raven/cli/_theme.py
@@ -11,6 +11,8 @@ and Python cannot share code), but the mapping is not 1:1:
     theme.ts ``border`` is a neutral grey; separator reuses that grey ``#d0d7de``.
   - success has no theme.ts ramp; both values are GitHub-style greens chosen to
     clear 4.5:1 on their respective backgrounds (white / #1e1e1e).
+  - help is the inline help/table-header text in interactive menus: readable
+    (>= 4.5:1) but quieter than body text — separator is too dark for prose.
 
 Detection is kept out of import time and runs on the first themed render (see
 ``onboard_commands._ThemedConsole``). Only truecolor values are provided;
@@ -47,6 +49,7 @@ PALETTE: dict[Scheme, dict[str, str]] = {
         "disabled": "#585858",
         "error": "#ff5f5f",
         "success": "#3fb950",
+        "help": "#9e9e9e",
     },
     "light": {
         "accent": "#935F00",
@@ -59,6 +62,7 @@ PALETTE: dict[Scheme, dict[str, str]] = {
         "disabled": "#6e7681",
         "error": "#cf222e",
         "success": "#1a7f37",
+        "help": "#57606a",
     },
 }
 
@@ -208,6 +212,7 @@ def build_rich_theme(scheme: Scheme):
             "disabled": p["disabled"],
             "error": p["error"],
             "success": p["success"],
+            "help": p["help"],
         }
     )
 
@@ -230,5 +235,6 @@ def build_questionary_style(scheme: Scheme):
             ("validation-toolbar", f"fg:{p['error']} bold"),
             ("text", f"fg:{p['text']}"),
             ("success", f"fg:{p['success']}"),
+            ("help", f"fg:{p['help']}"),
         ]
     )

--- a/raven/cli/trajectory_browse.py
+++ b/raven/cli/trajectory_browse.py
@@ -23,6 +23,12 @@ Control flow contracts:
 - Prompts erase themselves once answered (``erase_when_done``); navigation is
   kept legible as breadcrumb lines whose dynamic text is markup-escaped
   (titles and previews are untrusted input).
+- Session and attempt lists are fixed-width table rows laid out for the
+  terminal width read at screen build time (a resize re-applies on the next
+  rebuild; below a table's minimum width the tightest layout is kept and
+  overlong lines are clipped at the terminal edge — prompt_toolkit does not
+  wrap option rows). Every dynamic cell is collapsed to one plain line before
+  any width math, and fixed column widths always fit their headers.
 - Once an action runs — normally, refused, cancelled, or failing controlled —
   the browser rescans everything (``_REFRESH``): actions like report bundle
   before confirming, so even an aborted one may have pinned the attempt.
@@ -37,6 +43,7 @@ Control flow contracts:
 from __future__ import annotations
 
 import logging
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -64,6 +71,11 @@ _UNSET = object()
 
 _TITLE_LIMIT = 48
 _PREVIEW_LIMIT = 32
+_TITLE_MIN = 12
+_PREVIEW_MIN = 8
+_COL_GAP = "  "
+_ROW_INDENT = 3
+_WIDTH_MARGIN = 1
 _STALE_MESSAGE = "The action was rejected or the selected attempt is no longer available; the list was refreshed."
 
 _HELP_SESSION = (
@@ -208,12 +220,16 @@ def _select_screen(
     help_lines: tuple[str, ...],
     choices: list,
     *,
+    header: str | None = None,
     extra_keys: tuple[str, ...] = (),
     default: Any = None,
 ) -> Any:
-    """One list screen: help separators under the title, Esc returning
-    ``_BACK``, extra keys returning a :class:`_KeyHit`."""
+    """One list screen: help separators under the title (then an optional
+    table header line), Esc returning ``_BACK``, extra keys returning a
+    :class:`_KeyHit`."""
     items: list[Any] = [questionary.Separator(line) for line in help_lines]
+    if header is not None:
+        items.append(questionary.Separator(header))
     items.extend(choices)
     # A single-space instruction suppresses questionary's default
     # "(Use arrow keys)" hint, which would duplicate the help separator.
@@ -237,17 +253,25 @@ def _str(value: Any) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def _collapse_text(value: Any) -> str | None:
+    """One plain line from an untrusted value: non-printable characters become
+    spaces and whitespace runs collapse. The single sanitization gate every
+    dynamic menu/table/breadcrumb text must pass before layout math."""
+    s = _str(value)
+    if s is None:
+        return None
+    collapsed = " ".join("".join(ch if ch.isprintable() else " " for ch in s).split())
+    return collapsed or None
+
+
 def _label_text(value: Any, limit: int) -> str | None:
     """Normalize an untrusted value into one plain menu-safe line.
 
     questionary renders plain text (no Rich markup, so no escaping), but the
     value may carry newlines or control characters that would break the
     one-item-one-line layout — collapse them, then truncate."""
-    s = _str(value)
-    if s is None:
-        return None
-    collapsed = " ".join("".join(ch if ch.isprintable() else " " for ch in s).split())
-    if not collapsed:
+    collapsed = _collapse_text(value)
+    if collapsed is None:
         return None
     return collapsed if len(collapsed) <= limit else collapsed[: limit - 1] + "…"
 
@@ -256,6 +280,140 @@ def _fmt_ts(ts: str | None) -> str:
     # Timestamps are unvalidated record strings too: normalize the slice so a
     # newline or control character cannot break the one-line menu layout.
     return _label_text((ts or "")[5:16].replace("T", " "), 16) or "?"
+
+
+def _fmt_ts_full(ts: str | None) -> str:
+    # Table time cells keep the year: the short menu stamp is ambiguous across
+    # years, and the column header names what the value means.
+    return _label_text((ts or "")[:16].replace("T", " "), 16) or "?"
+
+
+def _cell_width(text: str) -> int:
+    from prompt_toolkit.utils import get_cwidth
+
+    return get_cwidth(text)
+
+
+def _cell_truncate(text: str, width: int) -> str:
+    """Truncate by terminal display width (CJK cells are 2 wide; ``len()``
+    would misalign every following column)."""
+    if _cell_width(text) <= width:
+        return text
+    out: list[str] = []
+    used = 0
+    for ch in text:
+        w = _cell_width(ch)
+        if used + w > width - 1:
+            break
+        out.append(ch)
+        used += w
+    return "".join(out) + "…"
+
+
+def _cell_pad(text: str, width: int) -> str:
+    return text + " " * max(0, width - _cell_width(text))
+
+
+def _content_budget(width: int, ncols: int) -> int:
+    """Cells available for column content: the terminal width minus the
+    option-row indent, a 1-cell safety margin (the qmark sits on the message
+    line, not on option rows), and the inter-column gaps."""
+    return width - _ROW_INDENT - _WIDTH_MARGIN - (ncols - 1) * _cell_width(_COL_GAP)
+
+
+def _table_min_width(columns: list[tuple[str, int]]) -> int:
+    """Terminal width needed to fit these columns; below it the layout stops
+    deforming and the renderer clips overlong lines at the terminal edge
+    (the declared floor behavior — option rows never wrap)."""
+    return _ROW_INDENT + _WIDTH_MARGIN + sum(w for _, w in columns) + (len(columns) - 1) * _cell_width(_COL_GAP)
+
+
+def _session_layout(width: int) -> list[tuple[str, int]]:
+    avail = _content_budget(width, 3) - 8 - 16
+    return [("TITLE", max(_TITLE_MIN, min(_TITLE_LIMIT, avail))), ("ATTEMPTS", 8), ("LAST ACTIVITY", 16)]
+
+
+def _attempt_fixed(count: int) -> list[tuple[str, int]]:
+    # Fixed widths are max(header, widest legal value): VERDICT is its 7-cell
+    # header (statuses reach 5), so headers never need truncation.
+    return [
+        ("#", 1 + len(str(count))),
+        ("STARTED", 16),
+        ("TURNS", 5),
+        ("SPANS", 5),
+        ("VERDICT", 7),
+        ("PIN", 3),
+        ("MERGED", 6),
+    ]
+
+
+def _attempt_layout(width: int, count: int) -> list[tuple[str, int]]:
+    fixed = _attempt_fixed(count)
+    avail = _content_budget(width, len(fixed) + 1) - sum(w for _, w in fixed)
+    if avail >= _PREVIEW_MIN:
+        return [*fixed, ("PREVIEW", min(_PREVIEW_LIMIT, avail))]
+    return fixed
+
+
+def _header_line(layout: list[tuple[str, int]]) -> str:
+    cells = [h if i == len(layout) - 1 else _cell_pad(h, w) for i, (h, w) in enumerate(layout)]
+    return _COL_GAP.join(cells)
+
+
+def _row_tokens(cells: list[tuple[str, str]], layout: list[tuple[str, int]]) -> list[tuple[str, str]]:
+    """One table row as styled tokens; the last column is never padded so the
+    row ends at its content."""
+    tokens: list[tuple[str, str]] = []
+    for i, ((style, text), (_header, w)) in enumerate(zip(cells, layout)):
+        text = _cell_truncate(text, w)
+        pad = "" if i == len(layout) - 1 else " " * (w - _cell_width(text)) + _COL_GAP
+        if style == "class:text":
+            if text + pad:
+                tokens.append((style, text + pad))
+        else:
+            if text:
+                tokens.append((style, text))
+            if pad:
+                tokens.append(("class:text", pad))
+    return tokens
+
+
+def _session_table(sessions: list[SessionRow], width: int) -> tuple[str, list[list[tuple[str, str]]]]:
+    """Header line + one styled token row per session, fitted to ``width``."""
+    layout = _session_layout(width)
+    rows = []
+    for s in sessions:
+        cells = [
+            ("class:text", _collapse_text(s.title) or "?"),
+            ("class:text", str(len(s.attempts))),
+            ("class:text", _fmt_ts_full(s.end)),
+        ]
+        rows.append(_row_tokens(cells, layout))
+    return _header_line(layout), rows
+
+
+def _attempt_table(rows: list[AttemptRow], width: int) -> tuple[str, list[list[tuple[str, str]]]]:
+    """Header line + one styled token row per attempt.
+
+    Dynamic cells pass the collapse gate before any width math: verdicts come
+    from a sidecar that only guarantees a non-empty string, and ``get_cwidth``
+    does not neutralize newlines or control characters."""
+    layout = _attempt_layout(width, len(rows))
+    out = []
+    for i, r in enumerate(rows, start=1):
+        cells = [
+            ("class:text", f"#{i}"),
+            ("class:text", _fmt_ts_full(r.start)),
+            ("class:text", str(r.turns)),
+            ("class:text", str(r.spans)),
+            ("class:text", _collapse_text(r.verdict) or ""),
+            ("class:success", "✓") if r.pinned else ("class:text", ""),
+            ("class:success", "✓") if r.merged else ("class:text", ""),
+        ]
+        if len(layout) > len(cells):
+            cells.append(("class:text", _collapse_text(r.preview) or ""))
+        out.append(_row_tokens(cells, layout))
+    return _header_line(layout), out
 
 
 @dataclass
@@ -301,18 +459,18 @@ def _session_titles(workspace: Path) -> dict[str, str]:
     return titles
 
 
-def _fallback_title(session_key: str | None, start: str | None, channel: str | None = None) -> str:
+def _fallback_title(session_key: str | None, channel: str | None = None) -> str:
     if session_key is None:
         return "(no session)"
     # The span's own channel attribute is the primary source; only a
     # well-formed "<channel>:<chat>" key yields a prefix fallback — a
     # malformed key must not surface whole (menus never show session ids).
+    # No timestamp here: the table's LAST ACTIVITY column carries the time,
+    # so equally-named fallbacks stay distinguishable there.
     label = _label_text(channel, 16)
     if label is None and ":" in session_key:
         label = _label_text(session_key.split(":", 1)[0], 16)
-    stamp = _label_text((start or "")[:16].replace("T", " "), 16)
-    head = f"{label} session" if label else "unknown session"
-    return f"{head} · {stamp}" if stamp else head
+    return f"{label} session" if label else "unknown session"
 
 
 def scan_sessions(workspace: Path, state_dir: Path | None = None) -> list[SessionRow]:
@@ -421,7 +579,7 @@ def scan_sessions(workspace: Path, state_dir: Path | None = None) -> list[Sessio
     for key, rows in by_session.items():
         rows.sort(key=lambda r: r.start or "")
         title = _label_text(titles.get(key) if key else None, _TITLE_LIMIT) or _fallback_title(
-            key, rows[0].start, channel_by_session.get(key)
+            key, channel_by_session.get(key)
         )
         sessions.append(SessionRow(key=key, title=title, attempts=rows, end=max((r.end or "" for r in rows))))
     sessions.sort(key=lambda s: s.end or "", reverse=True)
@@ -554,13 +712,15 @@ def _merge_action(session_row: SessionRow, questionary: Any, style: Any) -> None
 def _attempt_screen(session_row: SessionRow, workspace: Path, questionary: Any, style: Any) -> object:
     """Pick an attempt and run one action. Returns _BACK or _REFRESH."""
     while True:
+        width = shutil.get_terminal_size((80, 24)).columns
+        header, row_tokens = _attempt_table(session_row.attempts, width)
         choices = [
-            questionary.Choice(attempt_label(i, row), value=(i, row))
-            for i, row in enumerate(session_row.attempts, start=1)
+            questionary.Choice(tokens, value=(i, row))
+            for i, (tokens, row) in enumerate(zip(row_tokens, session_row.attempts), start=1)
         ]
         if len(session_row.attempts) >= 2:
             choices.append(questionary.Choice("Merge attempts…", value=_MERGE))
-        picked = _select_screen(questionary, style, "Attempt:", _HELP_ATTEMPT, choices)
+        picked = _select_screen(questionary, style, "Attempt:", _HELP_ATTEMPT, choices, header=header)
         if picked is _BACK:
             return _BACK
         if picked is _MERGE:
@@ -605,8 +765,10 @@ def browse_trajectories(workspace: Path | None = None) -> None:
             selected = next((s for s in sessions if current_key is not _UNSET and s.key == current_key), None)
             if selected is None:
                 current_key = _UNSET
-                choices = [questionary.Choice(session_label(s), value=s) for s in sessions]
-                picked = _select_screen(questionary, RAVEN_STYLE, "Session:", _HELP_SESSION, choices)
+                width = shutil.get_terminal_size((80, 24)).columns
+                header, row_tokens = _session_table(sessions, width)
+                choices = [questionary.Choice(tokens, value=s) for tokens, s in zip(row_tokens, sessions)]
+                picked = _select_screen(questionary, RAVEN_STYLE, "Session:", _HELP_SESSION, choices, header=header)
                 if picked is _BACK:
                     return
                 selected = picked

--- a/raven/cli/trajectory_browse.py
+++ b/raven/cli/trajectory_browse.py
@@ -29,6 +29,12 @@ Control flow contracts:
   overlong lines are clipped at the terminal edge — prompt_toolkit does not
   wrap option rows). Every dynamic cell is collapsed to one plain line before
   any width math, and fixed column widths always fit their headers.
+- Space on an attempt row prints that attempt's per-turn previews, collected
+  in the same snapshot scan and sorted by a fully-stringified key (ordering
+  never follows log source order; the table PREVIEW cell derives from the
+  same sorted collection). The follow-up waiter maps any key or Esc to a
+  non-None sentinel, so only Ctrl+C keeps the browser-wide cancel meaning;
+  on any non-attempt row Space is a cursor-keeping no-op.
 - Once an action runs — normally, refused, cancelled, or failing controlled —
   the browser rescans everything (``_REFRESH``): actions like report bundle
   before confirming, so even an aborted one may have pinned the attempt.
@@ -68,9 +74,11 @@ _BACK = object()
 _MERGE = object()
 _REFRESH = object()
 _UNSET = object()
+_DONE = object()
 
 _TITLE_LIMIT = 48
 _PREVIEW_LIMIT = 32
+_TURN_TEXT_LIMIT = 400
 _TITLE_MIN = 12
 _PREVIEW_MIN = 8
 _COL_GAP = "  "
@@ -84,7 +92,7 @@ _HELP_SESSION = (
 )
 _HELP_ATTEMPT = (
     "Attempts in the selected session, oldest first.",
-    "↑↓ move · Enter actions · Esc back",
+    "↑↓ move · Enter actions · Space preview · Esc back",
 )
 _HELP_ACTION = (
     "Run one action on the selected attempt.",
@@ -238,6 +246,72 @@ def _select_screen(
     )
     _inject_bindings(question, extra_keys)
     return _ask(question)
+
+
+def _preview_screen(index: int, row: AttemptRow) -> None:
+    """Print one attempt's conversation previews (input/output per turn).
+
+    All text is untrusted log content: collapsed at scan time, markup-escaped
+    here, auto-highlighter off (the same boundary as breadcrumbs)."""
+    console.print(f"[dim]Preview ❯[/dim] #{index}", highlight=False)
+    if not row.turn_previews:
+        console.print("[dim](no turns recorded)[/dim]", highlight=False)
+        return
+    # Old or damaged logs may yield turns whose previews are all empty; the
+    # emptiness check must look at displayable content, not tuple length.
+    if not any(t.input or t.output for t in row.turn_previews):
+        console.print("[dim](no preview recorded)[/dim]", highlight=False)
+        return
+    for turn in row.turn_previews:
+        if turn.input:
+            console.print(f"[dim]❯[/dim] {escape(turn.input)}", highlight=False)
+        if turn.output:
+            console.print(f"[dim]←[/dim] {escape(turn.output)}", highlight=False)
+
+
+def _wait_question(questionary: Any, style: Any, **kwargs: Any) -> Any:
+    """Build the post-preview waiter.
+
+    ``press_any_key_to_continue`` maps every key — Ctrl+C included — to a
+    None result, which :func:`_ask` defines as the browser-wide cancel. Its
+    bindings are therefore replaced outright: any key or Esc exits with the
+    non-None ``_DONE``, and only Ctrl+C keeps the cancel meaning."""
+    question = questionary.press_any_key_to_continue("Press any key to go back…", style=style, **kwargs)
+    app = getattr(question, "application", None)
+    if app is None:
+        return question
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.keys import Keys
+
+    kb = KeyBindings()
+
+    # Everything must be eager: the key processor still merges the default
+    # registry, whose exact non-eager bindings (Up, Backspace, ...) would
+    # otherwise win over a lazy wildcard and leave the waiter stuck.
+    @kb.add("escape", eager=True)
+    @kb.add(Keys.Any, eager=True)
+    def _done(event: Any) -> None:
+        event.app.exit(result=_DONE)
+
+    @kb.add("c-c", eager=True)
+    def _cancel(event: Any) -> None:
+        event.app.exit(result=None)
+
+    # The eager wildcard would also swallow the terminal's CPR reply (an
+    # internal event, not a keypress) and finish the waiter on its own;
+    # mirror prompt_toolkit's default CPR handling instead.
+    @kb.add(Keys.CPRResponse, eager=True)
+    def _cpr(event: Any) -> None:
+        row, _col = map(int, event.data[2:-1].split(";"))
+        event.app.renderer.report_absolute_cursor_row(row)
+
+    app.key_bindings = kb
+    app.erase_when_done = True
+    return question
+
+
+def _preview_wait(questionary: Any, style: Any) -> None:
+    _ask(_wait_question(questionary, style))
 
 
 def _crumb(label: str, text: str) -> None:
@@ -416,6 +490,19 @@ def _attempt_table(rows: list[AttemptRow], width: int) -> tuple[str, list[list[t
     return _header_line(layout), out
 
 
+@dataclass(frozen=True, order=True)
+class _TurnPreview:
+    """One turn's preview texts plus its sort identity. Field order is the
+    sort key: every component is an already-collapsed string (missing -> ""),
+    so ordering can never raise on None and never follows log source order."""
+
+    start: str
+    span_id: str
+    trace_id: str
+    input: str
+    output: str
+
+
 @dataclass
 class AttemptRow:
     key: str
@@ -429,6 +516,7 @@ class AttemptRow:
     pinned: bool
     preview: str | None
     merged: bool
+    turn_previews: tuple[_TurnPreview, ...] = ()
 
 
 @dataclass
@@ -516,7 +604,7 @@ def scan_sessions(workspace: Path, state_dir: Path | None = None) -> list[Sessio
                 "end": None,
                 "spans": 0,
                 "turns": 0,
-                "preview": None,
+                "turn_previews": [],
             },
         )
         g["spans"] += 1
@@ -533,8 +621,15 @@ def scan_sessions(workspace: Path, state_dir: Path | None = None) -> list[Sessio
             g["end"] = end
         if span.get("name") == "session.turn":
             g["turns"] += 1
-            if g["preview"] is None:
-                g["preview"] = _label_text(attrs.get("turn.input_preview"), _PREVIEW_LIMIT)
+            g["turn_previews"].append(
+                _TurnPreview(
+                    start=_label_text(span.get("startTime"), _TURN_TEXT_LIMIT) or "",
+                    span_id=_label_text(span.get("spanId"), _TURN_TEXT_LIMIT) or "",
+                    trace_id=_label_text(span.get("traceId"), _TURN_TEXT_LIMIT) or "",
+                    input=_label_text(attrs.get("turn.input_preview"), _TURN_TEXT_LIMIT) or "",
+                    output=_label_text(attrs.get("turn.output_preview"), _TURN_TEXT_LIMIT) or "",
+                )
+            )
 
     latest: dict[str, tuple[int, str]] = {}
     for idx, v in enumerate(verdict_rows):
@@ -557,6 +652,10 @@ def scan_sessions(workspace: Path, state_dir: Path | None = None) -> list[Sessio
     by_session: dict[str | None, list[AttemptRow]] = {}
     channel_by_session: dict[str | None, str] = {}
     for aid, g in groups.items():
+        # The table PREVIEW cell derives from the same sorted collection the
+        # preview page shows — a first-seen pick would follow log source order.
+        turns = tuple(sorted(g["turn_previews"]))
+        first_input = next((t.input for t in turns if t.input), None)
         row = AttemptRow(
             key=aid,
             traces=tuple(g["traces"]),
@@ -567,8 +666,9 @@ def scan_sessions(workspace: Path, state_dir: Path | None = None) -> list[Sessio
             turns=g["turns"],
             verdict=_verdict_of(aid),
             pinned=_pinned(aid, g["traces"]),
-            preview=g["preview"],
+            preview=_label_text(first_input, _PREVIEW_LIMIT),
             merged=aid in defs,
+            turn_previews=turns,
         )
         by_session.setdefault(row.session_key, []).append(row)
         if g["channel"] and row.session_key not in channel_by_session:
@@ -711,6 +811,7 @@ def _merge_action(session_row: SessionRow, questionary: Any, style: Any) -> None
 
 def _attempt_screen(session_row: SessionRow, workspace: Path, questionary: Any, style: Any) -> object:
     """Pick an attempt and run one action. Returns _BACK or _REFRESH."""
+    default: Any = None
     while True:
         width = shutil.get_terminal_size((80, 24)).columns
         header, row_tokens = _attempt_table(session_row.attempts, width)
@@ -720,9 +821,23 @@ def _attempt_screen(session_row: SessionRow, workspace: Path, questionary: Any, 
         ]
         if len(session_row.attempts) >= 2:
             choices.append(questionary.Choice("Merge attempts…", value=_MERGE))
-        picked = _select_screen(questionary, style, "Attempt:", _HELP_ATTEMPT, choices, header=header)
+        picked = _select_screen(
+            questionary, style, "Attempt:", _HELP_ATTEMPT, choices, header=header, extra_keys=(" ",), default=default
+        )
+        default = None
         if picked is _BACK:
             return _BACK
+        if isinstance(picked, _KeyHit):
+            # Dispatch by key, then by row: only Space on an attempt row
+            # previews. Any other injected key, and any non-attempt row (the
+            # merge entry, no pointed value), is a cursor-keeping no-op —
+            # the value must never be unpacked blindly.
+            default = picked.value
+            if picked.key == " " and isinstance(picked.value, tuple):
+                index, row = picked.value
+                _preview_screen(index, row)
+                _preview_wait(questionary, style)
+            continue
         if picked is _MERGE:
             _merge_action(session_row, questionary, style)
             return _REFRESH

--- a/raven/cli/trajectory_browse.py
+++ b/raven/cli/trajectory_browse.py
@@ -11,8 +11,20 @@ Control flow contracts:
 
 - Every ``.ask()`` goes through :func:`_ask`; a ``None`` answer (Ctrl+C/EOF)
   raises :class:`_CancelledError`, caught only at the top level for a clean exit.
-- Once an action runs — normally, refused, or failing controlled — the
-  browser rescans everything (``_REFRESH``): actions like report bundle
+- Every prompt gets an Escape binding injected after construction by merging a
+  fresh key-binding registry (text/confirm expose a read-only
+  ``_MergedKeyBindings``, so ``.add`` on the existing one is not an option).
+  Esc on a list screen returns ``_BACK`` and navigates one level up (the
+  session screen exits); Esc inside a running action goes through
+  :func:`_ask_action`, which raises :class:`_ActionCancelledError`, caught only at
+  the action boundary — the sentinel never reaches a conversion or the data
+  layer. A cancelled report keeps its pre-confirm side effects (bundle + pin),
+  matching the declined-report contract.
+- Prompts erase themselves once answered (``erase_when_done``); navigation is
+  kept legible as breadcrumb lines whose dynamic text is markup-escaped
+  (titles and previews are untrusted input).
+- Once an action runs — normally, refused, cancelled, or failing controlled —
+  the browser rescans everything (``_REFRESH``): actions like report bundle
   before confirming, so even an aborted one may have pinned the attempt.
 - Action errors are presented as fixed, id-free messages; the original
   exception goes to the debug log (data-layer messages embed ids).
@@ -54,6 +66,20 @@ _TITLE_LIMIT = 48
 _PREVIEW_LIMIT = 32
 _STALE_MESSAGE = "The action was rejected or the selected attempt is no longer available; the list was refreshed."
 
+_HELP_SESSION = (
+    "Sessions with recorded trajectories, most recent first.",
+    "↑↓ move · Enter open · Esc quit",
+)
+_HELP_ATTEMPT = (
+    "Attempts in the selected session, oldest first.",
+    "↑↓ move · Enter actions · Esc back",
+)
+_HELP_ACTION = (
+    "Run one action on the selected attempt.",
+    "↑↓ move · Enter run · Esc back",
+)
+_VERDICT_HINT = "↑↓ move · Enter record · Esc cancel"
+
 _QUESTIONARY_INSTALL_HINT = (
     "[red]The interactive browser needs the questionary package.[/red]"
     " Install it with [cyan]uv add questionary[/cyan], or use the subcommands"
@@ -63,6 +89,20 @@ _QUESTIONARY_INSTALL_HINT = (
 
 class _CancelledError(Exception):
     """A prompt was cancelled (Ctrl+C / EOF); unwinds to the browser top."""
+
+
+class _ActionCancelledError(Exception):
+    """An action-scoped prompt was dismissed with Esc; unwinds only to the
+    action boundary (:func:`_run_action` / :func:`_merge_action`)."""
+
+
+@dataclass(frozen=True)
+class _KeyHit:
+    """An injected extra key was pressed on a list screen; ``value`` carries
+    the pointed row's choice value (None when no list control is present)."""
+
+    key: str
+    value: Any
 
 
 def _require_questionary() -> Any:
@@ -80,6 +120,117 @@ def _ask(prompt: Any) -> Any:
     if value is None:
         raise _CancelledError()
     return value
+
+
+def _find_inquirer_control(app: Any) -> Any:
+    from questionary.prompts.common import InquirerControl
+
+    for control in app.layout.find_all_controls():
+        if isinstance(control, InquirerControl):
+            return control
+    return None
+
+
+def _restyle_pointed_row(control: Any) -> None:
+    """Restore row highlighting for formatted-text titles.
+
+    questionary highlights the pointed row only for plain-string titles; token
+    lists render verbatim. The appended fragment deliberately carries no
+    foreground color so a cell's own semantic color (e.g. a green check)
+    survives — ``class:highlighted`` would override it with the body color.
+    """
+    original = control.text
+
+    def _with_bold_pointed_row() -> list:
+        tokens = []
+        pointed = False
+        for token in original():
+            if token[0] == "[SetCursorPosition]":
+                pointed = True
+            elif pointed:
+                token = (f"{token[0]} bold noreverse", *token[1:])
+                if "\n" in token[1]:
+                    pointed = False
+            tokens.append(token)
+        return tokens
+
+    control.text = _with_bold_pointed_row
+
+
+def _inject_bindings(question: Any, extra_keys: tuple[str, ...] = ()) -> None:
+    """Wire Esc (and optional extra keys) into a questionary prompt.
+
+    Bindings go through a fresh registry merged over the existing one, never
+    ``.add`` on it: text/confirm prompts expose a read-only
+    ``_MergedKeyBindings``. A prompt without a real application (a test fake)
+    is left untouched.
+    """
+    app = getattr(question, "application", None)
+    if app is None:
+        return
+    from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
+
+    control = _find_inquirer_control(app)
+    if control is not None:
+        _restyle_pointed_row(control)
+
+    injected = KeyBindings()
+
+    @injected.add("escape", eager=True)
+    def _escape(event: Any) -> None:
+        event.app.exit(result=_BACK)
+
+    for key in extra_keys:
+
+        def _hit(event: Any, _key: str = key) -> None:
+            pointed = control.get_pointed_at() if control is not None else None
+            event.app.exit(result=_KeyHit(_key, getattr(pointed, "value", None)))
+
+        injected.add(key)(_hit)
+
+    app.key_bindings = merge_key_bindings([app.key_bindings, injected]) if app.key_bindings else injected
+    app.erase_when_done = True
+
+
+def _ask_action(prompt: Any) -> Any:
+    """Ask a prompt that belongs to a running action; Esc cancels the action."""
+    _inject_bindings(prompt)
+    value = _ask(prompt)
+    if value is _BACK:
+        raise _ActionCancelledError()
+    return value
+
+
+def _select_screen(
+    questionary: Any,
+    style: Any,
+    message: str,
+    help_lines: tuple[str, ...],
+    choices: list,
+    *,
+    extra_keys: tuple[str, ...] = (),
+    default: Any = None,
+) -> Any:
+    """One list screen: help separators under the title, Esc returning
+    ``_BACK``, extra keys returning a :class:`_KeyHit`."""
+    items: list[Any] = [questionary.Separator(line) for line in help_lines]
+    items.extend(choices)
+    # A single-space instruction suppresses questionary's default
+    # "(Use arrow keys)" hint, which would duplicate the help separator.
+    question = questionary.select(
+        message, choices=items, style=style, qmark=QMARK, pointer=POINTER, default=default, instruction=" "
+    )
+    _inject_bindings(question, extra_keys)
+    return _ask(question)
+
+
+def _crumb(label: str, text: str) -> None:
+    """Echo one erased screen as a breadcrumb. ``text`` is untrusted: it is
+    collapsed to one plain line here (newlines/control characters would break
+    the single-line record), then markup-escaped, with the auto-highlighter
+    disabled."""
+    line = _label_text(text, _TITLE_LIMIT) or "?"
+    console.print(f"[dim]{label} ❯[/dim] {escape(line)}", highlight=False)
 
 
 def _str(value: Any) -> str | None:
@@ -307,7 +458,7 @@ def _run_action(action: str, row: AttemptRow, workspace: Path, questionary: Any,
     concurrent race, not an exception) — those must not read as success."""
 
     def _confirm(message: str) -> bool:
-        return bool(_ask(questionary.confirm(message, style=style, qmark=QMARK)))
+        return bool(_ask_action(questionary.confirm(message, style=style, qmark=QMARK)))
 
     try:
         if action == "save":
@@ -333,17 +484,22 @@ def _run_action(action: str, row: AttemptRow, workspace: Path, questionary: Any,
             console.print(f"[green]✓[/green] Cassette written to [cyan]{escape(str(report.cassette_dir))}[/cyan]")
             console.print(f"  spans kept: {report.span_count}/{report.source_span_count}")
         elif action == "verdict":
-            status = _ask(
+            status = _ask_action(
                 questionary.select(
-                    "Verdict:", choices=list(VERDICT_STATUSES), style=style, qmark=QMARK, pointer=POINTER
+                    "Verdict:",
+                    choices=[questionary.Separator(_VERDICT_HINT), *VERDICT_STATUSES],
+                    style=style,
+                    qmark=QMARK,
+                    pointer=POINTER,
+                    instruction=" ",
                 )
             )
-            why = _ask(questionary.text("Why (optional):", style=style, qmark=QMARK))
-            notes = _ask(questionary.text("Notes (optional):", style=style, qmark=QMARK))
+            why = _ask_action(questionary.text("Why (optional):", style=style, qmark=QMARK))
+            notes = _ask_action(questionary.text("Notes (optional):", style=style, qmark=QMARK))
             record_verdict(row.key, status, source="user", why=why or None, notes=notes or None)
             console.print(f"[green]✓[/green] Recorded verdict [cyan]{escape(status)}[/cyan]")
         elif action == "pin":
-            reason = _ask(questionary.text("Reason (optional):", style=style, qmark=QMARK))
+            reason = _ask_action(questionary.text("Reason (optional):", style=style, qmark=QMARK))
             tstore.pin_attempt(row.key, reason=reason)
             console.print("[green]✓[/green] Pinned the selected attempt")
         elif action == "unpin":
@@ -362,6 +518,8 @@ def _run_action(action: str, row: AttemptRow, workspace: Path, questionary: Any,
                     console.print("The attempt is no longer merged; the list was refreshed.")
                 else:
                     console.print(f"[green]✓[/green] Split into {len(members)} member trace(s)")
+    except _ActionCancelledError:
+        pass
     except (ValueError, LookupError) as exc:
         _action_error(exc)
     except typer.Exit:
@@ -372,19 +530,21 @@ def _merge_action(session_row: SessionRow, questionary: Any, style: Any) -> None
     choices = [
         questionary.Choice(attempt_label(i, row), value=row.key) for i, row in enumerate(session_row.attempts, start=1)
     ]
-    picked = _ask(
-        questionary.checkbox(
-            "Select 2+ attempts to merge:",
-            choices=choices,
-            style=style,
-            qmark=QMARK,
-            pointer=POINTER,
-            validate=lambda picked: len(picked) >= 2 or "Select at least two attempts",
-        )
-    )
     try:
+        picked = _ask_action(
+            questionary.checkbox(
+                "Select 2+ attempts to merge:",
+                choices=choices,
+                style=style,
+                qmark=QMARK,
+                pointer=POINTER,
+                validate=lambda picked: len(picked) >= 2 or "Select at least two attempts",
+            )
+        )
         tstore.merge_attempts(list(picked))
         console.print(f"[green]✓[/green] Merged {len(picked)} attempts into one")
+    except _ActionCancelledError:
+        pass
     except (ValueError, LookupError) as exc:
         _action_error(exc)
     except typer.Exit:
@@ -395,32 +555,35 @@ def _attempt_screen(session_row: SessionRow, workspace: Path, questionary: Any, 
     """Pick an attempt and run one action. Returns _BACK or _REFRESH."""
     while True:
         choices = [
-            questionary.Choice(attempt_label(i, row), value=row) for i, row in enumerate(session_row.attempts, start=1)
+            questionary.Choice(attempt_label(i, row), value=(i, row))
+            for i, row in enumerate(session_row.attempts, start=1)
         ]
         if len(session_row.attempts) >= 2:
             choices.append(questionary.Choice("Merge attempts…", value=_MERGE))
-        choices.append(questionary.Choice("Back", value=_BACK))
-        picked = _ask(questionary.select("Attempt:", choices=choices, style=style, qmark=QMARK, pointer=POINTER))
+        picked = _select_screen(questionary, style, "Attempt:", _HELP_ATTEMPT, choices)
         if picked is _BACK:
             return _BACK
         if picked is _MERGE:
             _merge_action(session_row, questionary, style)
             return _REFRESH
+        index, row = picked
+        _crumb("Attempt", f"#{index}")
 
-        row = picked
         actions = [
-            questionary.Choice("Save (bundle)", value="save"),
-            questionary.Choice("Report (redact + tarball)", value="report"),
-            questionary.Choice("Minimize (cassette)", value="minimize"),
-            questionary.Choice("Verdict", value="verdict"),
-            questionary.Choice("Unpin" if row.pinned else "Pin", value="unpin" if row.pinned else "pin"),
+            ("Save (bundle)", "save"),
+            ("Report (redact + tarball)", "report"),
+            ("Minimize (cassette)", "minimize"),
+            ("Verdict", "verdict"),
+            ("Unpin", "unpin") if row.pinned else ("Pin", "pin"),
         ]
         if row.merged:
-            actions.append(questionary.Choice("Split", value="split"))
-        actions.append(questionary.Choice("Back", value=_BACK))
-        action = _ask(questionary.select("Action:", choices=actions, style=style, qmark=QMARK, pointer=POINTER))
+            actions.append(("Split", "split"))
+        action = _select_screen(
+            questionary, style, "Action:", _HELP_ACTION, [questionary.Choice(t, value=v) for t, v in actions]
+        )
         if action is _BACK:
             continue
+        _crumb("Action", {v: t for t, v in actions}[action])
         _run_action(action, row, workspace, questionary, style)
         return _REFRESH
 
@@ -443,14 +606,12 @@ def browse_trajectories(workspace: Path | None = None) -> None:
             if selected is None:
                 current_key = _UNSET
                 choices = [questionary.Choice(session_label(s), value=s) for s in sessions]
-                choices.append(questionary.Choice("Exit", value=_BACK))
-                picked = _ask(
-                    questionary.select("Session:", choices=choices, style=RAVEN_STYLE, qmark=QMARK, pointer=POINTER)
-                )
+                picked = _select_screen(questionary, RAVEN_STYLE, "Session:", _HELP_SESSION, choices)
                 if picked is _BACK:
                     return
                 selected = picked
                 current_key = selected.key
+                _crumb("Session", selected.title)
             outcome = _attempt_screen(selected, ws, questionary, RAVEN_STYLE)
             if outcome is _BACK:
                 current_key = _UNSET

--- a/raven/cli/trajectory_browse.py
+++ b/raven/cli/trajectory_browse.py
@@ -15,8 +15,10 @@ Control flow contracts:
 - Every prompt gets an Escape binding injected after construction by merging a
   fresh key-binding registry (text/confirm expose a read-only
   ``_MergedKeyBindings``, so ``.add`` on the existing one is not an option).
-  Esc on a list screen returns ``_BACK`` and navigates one level up (the
-  session screen exits); Esc inside a running action goes through
+  Esc on a list screen returns ``_BACK`` and navigates one level up; at the
+  top-level session screen it stays put — quitting is Ctrl+C only, so a
+  reflexive Esc cannot drop the browser. Esc inside a running action goes
+  through
   :func:`_ask_action`, which raises :class:`_ActionCancelledError`, caught only at
   the action boundary — the sentinel never reaches a conversion or the data
   layer. A cancelled report keeps its pre-confirm side effects (bundle + pin),
@@ -91,22 +93,28 @@ _STALE_MESSAGE = "The action was rejected or the selected attempt is no longer a
 
 _HELP_SESSION = (
     "Sessions with recorded trajectories, most recent first.",
-    "↑↓ move · Enter open · Esc quit",
+    "[↑↓] move · [Enter] open · [Ctrl+C] quit",
 )
 _HELP_ATTEMPT = (
     "Attempts in the selected session, oldest first.",
-    "↑↓ move · Enter actions · Space preview · Esc back",
+    "[↑↓] move · [Enter] actions · [Space] preview · [Esc] back",
 )
 _HELP_ATTEMPT_MERGE = (
     "Attempts in the selected session, oldest first.",
-    "↑↓ move · Enter actions · Space preview · M merge · Esc back",
+    "[↑↓] move · [Enter] actions · [Space] preview · [M] merge · [Esc] back",
 )
-_MERGE_HINT = "Space toggle · Enter confirm · Esc cancel"
+_MERGE_HINT = "[Space] toggle · [Enter] confirm · [Esc] cancel"
 _HELP_ACTION = (
     "Run one action on the selected attempt.",
-    "↑↓ move · Enter run · Esc back",
+    "[↑↓] move · [Enter] run · [Esc] back",
 )
-_VERDICT_HINT = "↑↓ move · Enter record · Esc cancel"
+_VERDICT_HINT = "[↑↓] move · [Enter] record · [Esc] cancel"
+
+# Flush a lone ESC after 50ms instead of prompt_toolkit's 0.5s: the default
+# disambiguation wait (ESC prefixes every escape sequence) reads as lag on a
+# human keypress. Local terminals deliver sequences atomically; the worst
+# case on a slow remote is a split arrow-key sequence read as ESC.
+_ESC_FLUSH_TIMEOUT = 0.05
 
 _QUESTIONARY_INSTALL_HINT = (
     "[red]The interactive browser needs the questionary package.[/red]"
@@ -144,7 +152,14 @@ def _require_questionary() -> Any:
 
 
 def _ask(prompt: Any) -> Any:
-    value = prompt.ask()
+    # unsafe_ask + our own except: questionary's safe ask() prints its own
+    # "Cancelled by user" line, which would double the browser's exit notice
+    # now that Ctrl+C is the standard way out.
+    ask = getattr(prompt, "unsafe_ask", None) or prompt.ask
+    try:
+        value = ask()
+    except KeyboardInterrupt:
+        value = None
     if value is None:
         raise _CancelledError()
     return value
@@ -159,17 +174,18 @@ def _find_inquirer_control(app: Any) -> Any:
     return None
 
 
-def _restyle_pointed_row(control: Any) -> None:
-    """Restore row highlighting for formatted-text titles.
+def _restyle_list_rows(control: Any) -> None:
+    """Two render-time fixes questionary cannot express on its own.
 
-    questionary highlights the pointed row only for plain-string titles; token
-    lists render verbatim. The appended fragment deliberately carries no
-    foreground color so a cell's own semantic color (e.g. a green check)
-    survives — ``class:highlighted`` would override it with the body color.
+    The pointed row gains a bold fragment without a foreground color, so a
+    cell's own semantic color (e.g. a green check) survives — questionary only
+    highlights plain-string titles, and ``class:highlighted`` would override
+    the color. Separator lines (help text, table headers) move from the
+    near-invisible ``separator`` class to the readable ``help`` class.
     """
     original = control.text
 
-    def _with_bold_pointed_row() -> list:
+    def _restyled() -> list:
         tokens = []
         pointed = False
         for token in original():
@@ -179,10 +195,12 @@ def _restyle_pointed_row(control: Any) -> None:
                 token = (f"{token[0]} bold noreverse", *token[1:])
                 if "\n" in token[1]:
                     pointed = False
+            elif "class:separator" in token[0]:
+                token = (token[0].replace("class:separator", "class:help"), *token[1:])
             tokens.append(token)
         return tokens
 
-    control.text = _with_bold_pointed_row
+    control.text = _restyled
 
 
 def _inject_bindings(question: Any, extra_keys: tuple[str, ...] = ()) -> None:
@@ -200,7 +218,7 @@ def _inject_bindings(question: Any, extra_keys: tuple[str, ...] = ()) -> None:
 
     control = _find_inquirer_control(app)
     if control is not None:
-        _restyle_pointed_row(control)
+        _restyle_list_rows(control)
 
     injected = KeyBindings()
 
@@ -218,6 +236,7 @@ def _inject_bindings(question: Any, extra_keys: tuple[str, ...] = ()) -> None:
 
     app.key_bindings = merge_key_bindings([app.key_bindings, injected]) if app.key_bindings else injected
     app.erase_when_done = True
+    app.ttimeoutlen = _ESC_FLUSH_TIMEOUT
 
 
 def _ask_action(prompt: Any) -> Any:
@@ -315,6 +334,7 @@ def _wait_question(questionary: Any, style: Any, **kwargs: Any) -> Any:
 
     app.key_bindings = kb
     app.erase_when_done = True
+    app.ttimeoutlen = _ESC_FLUSH_TIMEOUT
     return question
 
 
@@ -899,9 +919,11 @@ def browse_trajectories(workspace: Path | None = None) -> None:
                 width = shutil.get_terminal_size((80, 24)).columns
                 header, row_tokens = _session_table(sessions, width)
                 choices = [questionary.Choice(tokens, value=s) for tokens, s in zip(row_tokens, sessions)]
-                picked = _select_screen(questionary, RAVEN_STYLE, "Session:", _HELP_SESSION, choices, header=header)
-                if picked is _BACK:
-                    return
+                picked = _BACK
+                while picked is _BACK:
+                    # Esc at the top level stays put: quitting is Ctrl+C
+                    # only, so a reflexive Esc cannot drop the browser.
+                    picked = _select_screen(questionary, RAVEN_STYLE, "Session:", _HELP_SESSION, choices, header=header)
                 selected = picked
                 current_key = selected.key
                 _crumb("Session", selected.title)

--- a/raven/cli/trajectory_browse.py
+++ b/raven/cli/trajectory_browse.py
@@ -2,8 +2,9 @@
 
 A bare ``raven trajectory`` on a TTY opens a three-screen questionary flow:
 session list -> attempt list -> action menu (save / report / minimize /
-verdict / pin|unpin / split, plus a multi-select merge entry). The machine
-face (id-taking subcommands) lives in :mod:`raven.cli.trajectory_commands`;
+verdict / pin|unpin / split); with two or more attempts, the M key opens the
+multi-select merge. The machine face (id-taking subcommands) lives in
+:mod:`raven.cli.trajectory_commands`;
 this module never shows a session key, trace id, or attempt id in menus,
 labels, or action messages — only artifact paths may carry ids.
 
@@ -29,12 +30,15 @@ Control flow contracts:
   overlong lines are clipped at the terminal edge — prompt_toolkit does not
   wrap option rows). Every dynamic cell is collapsed to one plain line before
   any width math, and fixed column widths always fit their headers.
-- Space on an attempt row prints that attempt's per-turn previews, collected
-  in the same snapshot scan and sorted by a fully-stringified key (ordering
-  never follows log source order; the table PREVIEW cell derives from the
-  same sorted collection). The follow-up waiter maps any key or Esc to a
-  non-None sentinel, so only Ctrl+C keeps the browser-wide cancel meaning;
-  on any non-attempt row Space is a cursor-keeping no-op.
+- Injected keys dispatch by key first: Space on an attempt row prints that
+  attempt's per-turn previews, collected in the same snapshot scan and sorted
+  by a fully-stringified key (ordering never follows log source order; the
+  table PREVIEW cell derives from the same sorted collection); M (either
+  case) opens the multi-select merge and is only bound — and only advertised —
+  when two or more attempts exist. Anything else, and Space on a non-attempt
+  row, is a cursor-keeping no-op. The preview's follow-up waiter maps any key
+  or Esc to a non-None sentinel, so only Ctrl+C keeps the browser-wide cancel
+  meaning.
 - Once an action runs — normally, refused, cancelled, or failing controlled —
   the browser rescans everything (``_REFRESH``): actions like report bundle
   before confirming, so even an aborted one may have pinned the attempt.
@@ -71,7 +75,6 @@ console = Console()
 _log = logging.getLogger("raven.cli.trajectory_browse")
 
 _BACK = object()
-_MERGE = object()
 _REFRESH = object()
 _UNSET = object()
 _DONE = object()
@@ -94,6 +97,11 @@ _HELP_ATTEMPT = (
     "Attempts in the selected session, oldest first.",
     "↑↓ move · Enter actions · Space preview · Esc back",
 )
+_HELP_ATTEMPT_MERGE = (
+    "Attempts in the selected session, oldest first.",
+    "↑↓ move · Enter actions · Space preview · M merge · Esc back",
+)
+_MERGE_HINT = "Space toggle · Enter confirm · Esc cancel"
 _HELP_ACTION = (
     "Run one action on the selected attempt.",
     "↑↓ move · Enter run · Esc back",
@@ -785,9 +793,10 @@ def _run_action(action: str, row: AttemptRow, workspace: Path, questionary: Any,
 
 
 def _merge_action(session_row: SessionRow, questionary: Any, style: Any) -> None:
-    choices = [
+    choices: list[Any] = [questionary.Separator(_MERGE_HINT)]
+    choices.extend(
         questionary.Choice(attempt_label(i, row), value=row.key) for i, row in enumerate(session_row.attempts, start=1)
-    ]
+    )
     try:
         picked = _ask_action(
             questionary.checkbox(
@@ -796,6 +805,7 @@ def _merge_action(session_row: SessionRow, questionary: Any, style: Any) -> None
                 style=style,
                 qmark=QMARK,
                 pointer=POINTER,
+                instruction=" ",
                 validate=lambda picked: len(picked) >= 2 or "Select at least two attempts",
             )
         )
@@ -819,28 +829,34 @@ def _attempt_screen(session_row: SessionRow, workspace: Path, questionary: Any, 
             questionary.Choice(tokens, value=(i, row))
             for i, (tokens, row) in enumerate(zip(row_tokens, session_row.attempts), start=1)
         ]
-        if len(session_row.attempts) >= 2:
-            choices.append(questionary.Choice("Merge attempts…", value=_MERGE))
+        can_merge = len(session_row.attempts) >= 2
         picked = _select_screen(
-            questionary, style, "Attempt:", _HELP_ATTEMPT, choices, header=header, extra_keys=(" ",), default=default
+            questionary,
+            style,
+            "Attempt:",
+            _HELP_ATTEMPT_MERGE if can_merge else _HELP_ATTEMPT,
+            choices,
+            header=header,
+            extra_keys=(" ", "m", "M") if can_merge else (" ",),
+            default=default,
         )
         default = None
         if picked is _BACK:
             return _BACK
         if isinstance(picked, _KeyHit):
-            # Dispatch by key, then by row: only Space on an attempt row
-            # previews. Any other injected key, and any non-attempt row (the
-            # merge entry, no pointed value), is a cursor-keeping no-op —
-            # the value must never be unpacked blindly.
+            # Dispatch by key, then by row: M is a screen-level action, Space
+            # previews the pointed attempt row only. Anything else, and Space
+            # on a non-attempt row (no pointed value), is a cursor-keeping
+            # no-op — the value must never be unpacked blindly.
+            if picked.key in ("m", "M"):
+                _merge_action(session_row, questionary, style)
+                return _REFRESH
             default = picked.value
             if picked.key == " " and isinstance(picked.value, tuple):
                 index, row = picked.value
                 _preview_screen(index, row)
                 _preview_wait(questionary, style)
             continue
-        if picked is _MERGE:
-            _merge_action(session_row, questionary, style)
-            return _REFRESH
         index, row = picked
         _crumb("Attempt", f"#{index}")
 

--- a/tests/test_cli_theme.py
+++ b/tests/test_cli_theme.py
@@ -164,6 +164,7 @@ def test_dark_questionary_style_byte_identical():
         "validation-toolbar": "fg:#ff5f5f bold",
         "text": "fg:#FFF5EA",
         "success": "fg:#3fb950",
+        "help": "fg:#9e9e9e",
     }
     got = dict(_theme.build_questionary_style("dark").style_rules)
     assert got == expected
@@ -180,21 +181,24 @@ def test_light_text_is_not_a_light_color():
     assert rules["highlighted"] == "fg:#24201a bold noreverse"
 
 
-@pytest.mark.parametrize("token", ["accent", "text", "selected", "border", "muted", "error", "disabled", "success"])
+@pytest.mark.parametrize(
+    "token", ["accent", "text", "selected", "border", "muted", "error", "disabled", "success", "help"]
+)
 def test_light_body_tokens_pass_wcag_on_white(token):
     assert _wcag_contrast(_theme.PALETTE["light"][token], "#ffffff") >= 4.5
 
 
-@pytest.mark.parametrize("token", ["accent", "text", "selected", "error", "success"])
+@pytest.mark.parametrize("token", ["accent", "text", "selected", "error", "success", "help"])
 def test_dark_body_tokens_pass_wcag_on_black(token):
     assert _wcag_contrast(_theme.PALETTE["dark"][token], "#1e1e1e") >= 4.5
 
 
 @pytest.mark.parametrize("scheme", ["light", "dark"])
-def test_success_token_mapped_in_both_faces(scheme):
-    hex_val = _theme.PALETTE[scheme]["success"]
-    assert dict(_theme.build_questionary_style(scheme).style_rules)["success"] == f"fg:{hex_val}"
-    assert str(_theme.build_rich_theme(scheme).styles["success"]) == hex_val
+@pytest.mark.parametrize("token", ["success", "help"])
+def test_added_tokens_mapped_in_both_faces(scheme, token):
+    hex_val = _theme.PALETTE[scheme][token]
+    assert dict(_theme.build_questionary_style(scheme).style_rules)[token] == f"fg:{hex_val}"
+    assert str(_theme.build_rich_theme(scheme).styles[token]) == hex_val
 
 
 # --- reduced color depth readability (D1 sentinel) ----------------------------
@@ -256,7 +260,19 @@ def test_onboard_panels_render_without_missing_style(scheme):
     console.print(table)  # would raise MissingStyle if 'accent' unresolved
 
 
-_THEME_KEYS = {"accent", "text", "heading", "selected", "border", "muted", "separator", "disabled", "error", "success"}
+_THEME_KEYS = {
+    "accent",
+    "text",
+    "heading",
+    "selected",
+    "border",
+    "muted",
+    "separator",
+    "disabled",
+    "error",
+    "success",
+    "help",
+}
 
 
 def test_no_compound_markup_mixes_theme_key():

--- a/tests/test_cli_theme.py
+++ b/tests/test_cli_theme.py
@@ -163,6 +163,7 @@ def test_dark_questionary_style_byte_identical():
         "disabled": "fg:#585858 italic",
         "validation-toolbar": "fg:#ff5f5f bold",
         "text": "fg:#FFF5EA",
+        "success": "fg:#3fb950",
     }
     got = dict(_theme.build_questionary_style("dark").style_rules)
     assert got == expected
@@ -179,14 +180,21 @@ def test_light_text_is_not_a_light_color():
     assert rules["highlighted"] == "fg:#24201a bold noreverse"
 
 
-@pytest.mark.parametrize("token", ["accent", "text", "selected", "border", "muted", "error", "disabled"])
+@pytest.mark.parametrize("token", ["accent", "text", "selected", "border", "muted", "error", "disabled", "success"])
 def test_light_body_tokens_pass_wcag_on_white(token):
     assert _wcag_contrast(_theme.PALETTE["light"][token], "#ffffff") >= 4.5
 
 
-@pytest.mark.parametrize("token", ["accent", "text", "selected", "error"])
+@pytest.mark.parametrize("token", ["accent", "text", "selected", "error", "success"])
 def test_dark_body_tokens_pass_wcag_on_black(token):
     assert _wcag_contrast(_theme.PALETTE["dark"][token], "#1e1e1e") >= 4.5
+
+
+@pytest.mark.parametrize("scheme", ["light", "dark"])
+def test_success_token_mapped_in_both_faces(scheme):
+    hex_val = _theme.PALETTE[scheme]["success"]
+    assert dict(_theme.build_questionary_style(scheme).style_rules)["success"] == f"fg:{hex_val}"
+    assert str(_theme.build_rich_theme(scheme).styles["success"]) == hex_val
 
 
 # --- reduced color depth readability (D1 sentinel) ----------------------------
@@ -248,7 +256,7 @@ def test_onboard_panels_render_without_missing_style(scheme):
     console.print(table)  # would raise MissingStyle if 'accent' unresolved
 
 
-_THEME_KEYS = {"accent", "text", "heading", "selected", "border", "muted", "separator", "disabled", "error"}
+_THEME_KEYS = {"accent", "text", "heading", "selected", "border", "muted", "separator", "disabled", "error", "success"}
 
 
 def test_no_compound_markup_mixes_theme_key():

--- a/tests/test_cli_trajectory_browse.py
+++ b/tests/test_cli_trajectory_browse.py
@@ -13,6 +13,7 @@ from raven.trajectory import store as tstore
 from raven.trajectory import verdict as tverdict
 
 _CANCEL = object()
+_BACK = tbrowse._BACK
 
 
 def _write_log(path, spans):
@@ -44,15 +45,21 @@ class _FakeQuestionary:
     - ``("pick", substr)``  — select the first choice whose title contains substr;
     - ``("pickall", [substr, ...])`` — checkbox: the values of all matching choices;
     - ``_CANCEL``           — ``ask()`` returns None (Ctrl+C / EOF);
+    - ``_BACK``             — the injected Esc binding fired (returned verbatim);
     - a zero-arg callable   — invoked at answer time (side effects), its return used;
     - anything else         — returned verbatim.
-    Every prompt is recorded as (kind, message, [choice titles]).
+    Every prompt is recorded as (kind, message, [choice titles]); separator
+    lines are recorded like choices but are never matched by a pick.
     """
 
     class Choice:
         def __init__(self, title, value=None):
             self.title = title
             self.value = value if value is not None else title
+
+    class Separator:
+        def __init__(self, line=""):
+            self.title = line
 
     def __init__(self, answers):
         self.answers = list(answers)
@@ -69,9 +76,9 @@ class _FakeQuestionary:
         if answer is _CANCEL:
             value = None
         elif isinstance(answer, tuple) and answer and answer[0] == "pick":
-            value = next(c.value for c in choices if answer[1] in c.title)
+            value = next(c.value for c in choices if hasattr(c, "value") and answer[1] in c.title)
         elif isinstance(answer, tuple) and answer and answer[0] == "pickall":
-            value = [next(c.value for c in choices if s in c.title) for s in answer[1]]
+            value = [next(c.value for c in choices if hasattr(c, "value") and s in c.title) for s in answer[1]]
         else:
             value = answer
         return type("_Ask", (), {"ask": staticmethod(lambda: value)})()
@@ -384,7 +391,7 @@ def test_save_flow_bundles_by_member(state, workspace, monkeypatch, capsys):
 
     _browse(
         monkeypatch,
-        [("pick", "session"), ("pick", "#1"), ("pick", "Save"), ("pick", "Back"), ("pick", "Exit")],
+        [("pick", "session"), ("pick", "#1"), ("pick", "Save"), _BACK, _BACK],
         workspace,
     )
 
@@ -395,7 +402,7 @@ def test_save_flow_bundles_by_member(state, workspace, monkeypatch, capsys):
 
 def test_minimize_flow_and_repeat(state, workspace, monkeypatch):
     _two_turn_log(state)
-    script = [("pick", "session"), ("pick", "#1"), ("pick", "Minimize"), ("pick", "Back"), ("pick", "Exit")]
+    script = [("pick", "session"), ("pick", "#1"), ("pick", "Minimize"), _BACK, _BACK]
     monkeypatch.setattr(tbrowse, "minimize_bundle", _fake_minimize)
 
     _browse(monkeypatch, script, workspace)
@@ -424,8 +431,8 @@ def test_verdict_flow_records(state, workspace, monkeypatch):
             "fail",
             "wrong answer",
             "",
-            ("pick", "Back"),
-            ("pick", "Exit"),
+            _BACK,
+            _BACK,
         ],
         workspace,
     )
@@ -455,8 +462,8 @@ def test_full_cycle_merge_verdict_save_split(state, workspace, monkeypatch, caps
             ("pick", "#1"),
             ("pick", "Split"),
             True,
-            ("pick", "Back"),
-            ("pick", "Exit"),
+            _BACK,
+            _BACK,
         ],
         workspace,
     )
@@ -492,9 +499,9 @@ def test_report_declined_still_refreshes(state, workspace, monkeypatch, capsys):
             ("pick", "Report"),
             False,
             ("pick", "#1"),
-            ("pick", "Back"),
-            ("pick", "Back"),
-            ("pick", "Exit"),
+            _BACK,
+            _BACK,
+            _BACK,
         ],
         workspace,
     )
@@ -518,9 +525,9 @@ def test_minimize_failure_after_pack_refreshes(state, workspace, monkeypatch, ca
             ("pick", "#1"),
             ("pick", "Minimize"),
             ("pick", "#1"),
-            ("pick", "Back"),
-            ("pick", "Back"),
-            ("pick", "Exit"),
+            _BACK,
+            _BACK,
+            _BACK,
         ],
         workspace,
     )
@@ -556,8 +563,8 @@ def test_action_outputs_carry_no_ids(state, workspace, monkeypatch, capsys):
             ("pick", "#1"),
             ("pick", "Split"),
             True,
-            ("pick", "Back"),
-            ("pick", "Exit"),
+            _BACK,
+            _BACK,
         ],
         workspace,
     )
@@ -568,13 +575,13 @@ def test_action_outputs_carry_no_ids(state, workspace, monkeypatch, capsys):
 @pytest.mark.parametrize(
     "script, patch_target",
     [
-        ([("pick", "session"), ("pick", "#1"), ("pick", "Save"), ("pick", "Back"), ("pick", "Exit")], "collect_bundle"),
+        ([("pick", "session"), ("pick", "#1"), ("pick", "Save"), _BACK, _BACK], "collect_bundle"),
         (
-            [("pick", "session"), ("pick", "#1"), ("pick", "Report"), ("pick", "Back"), ("pick", "Exit")],
+            [("pick", "session"), ("pick", "#1"), ("pick", "Report"), _BACK, _BACK],
             "collect_bundle",
         ),
         (
-            [("pick", "session"), ("pick", "#1"), ("pick", "Minimize"), ("pick", "Back"), ("pick", "Exit")],
+            [("pick", "session"), ("pick", "#1"), ("pick", "Minimize"), _BACK, _BACK],
             "collect_bundle",
         ),
         (
@@ -582,13 +589,13 @@ def test_action_outputs_carry_no_ids(state, workspace, monkeypatch, capsys):
                 ("pick", "session"),
                 ("pick", "Merge attempts"),
                 ("pickall", ["#1", "#2"]),
-                ("pick", "Back"),
-                ("pick", "Exit"),
+                _BACK,
+                _BACK,
             ],
             "merge_attempts",
         ),
         (
-            [("pick", "session"), ("pick", "#1"), ("pick", "Pin"), "keep", ("pick", "Back"), ("pick", "Exit")],
+            [("pick", "session"), ("pick", "#1"), ("pick", "Pin"), "keep", _BACK, _BACK],
             "pin_attempt",
         ),
     ],
@@ -628,7 +635,7 @@ def test_failed_split_shows_safe_message(state, workspace, monkeypatch, capsys):
 
     fake = _browse(
         monkeypatch,
-        [("pick", "session"), ("pick", "#1"), ("pick", "Split"), True, ("pick", "Back"), ("pick", "Exit")],
+        [("pick", "session"), ("pick", "#1"), ("pick", "Split"), True, _BACK, _BACK],
         workspace,
     )
 
@@ -665,8 +672,8 @@ def test_artifact_action_outputs_confine_ids_to_paths(state, workspace, monkeypa
             ("pick", "#1"),
             ("pick", "Report"),
             True,
-            ("pick", "Back"),
-            ("pick", "Exit"),
+            _BACK,
+            _BACK,
         ],
         workspace,
     )
@@ -693,8 +700,8 @@ def test_split_none_shows_stale_not_success(state, workspace, monkeypatch, capsy
             ("pick", "#1"),
             ("pick", "Split"),
             _confirm_then_drop,
-            ("pick", "Back"),
-            ("pick", "Exit"),
+            _BACK,
+            _BACK,
         ],
         workspace,
     )
@@ -720,8 +727,8 @@ def test_unpin_false_shows_stale_not_success(state, workspace, monkeypatch, caps
             ("pick", "#1"),
             ("pick", "Unpin"),
             _confirm_then_unpin,
-            ("pick", "Back"),
-            ("pick", "Exit"),
+            _BACK,
+            _BACK,
         ],
         workspace,
     )
@@ -815,6 +822,251 @@ def test_cancel_exits_cleanly_without_further_prompts(state, workspace, monkeypa
     assert len(fake.prompts) == len(script)
 
 
+def test_escape_walks_up_one_level_at_a_time(state, workspace, monkeypatch, capsys):
+    """Esc: action -> attempt list -> session list -> exit (a normal quit,
+    not the Ctrl+C 'Cancelled' path)."""
+    _two_turn_log(state)
+
+    fake = _browse(monkeypatch, [("pick", "session"), ("pick", "#1"), _BACK, _BACK, _BACK], workspace)
+
+    messages = [m for kind, m, _ in fake.prompts if kind == "select"]
+    assert messages == ["Session:", "Attempt:", "Action:", "Attempt:", "Session:"]
+    assert "Cancelled" not in capsys.readouterr().out
+
+
+def test_escape_on_top_level_exits(state, workspace, monkeypatch, capsys):
+    _two_turn_log(state)
+    fake = _browse(monkeypatch, [_BACK], workspace)
+    assert [m for _, m, _ in fake.prompts] == ["Session:"]
+    assert "Cancelled" not in capsys.readouterr().out
+
+
+def test_menu_screens_hide_back_exit_and_show_help(state, workspace, monkeypatch):
+    """No Back/Exit entries anywhere; every list screen opens with its help
+    separators directly under the title."""
+    _two_turn_log(state)
+
+    fake = _browse(monkeypatch, [("pick", "session"), ("pick", "#1"), _BACK, _BACK, _BACK], workspace)
+
+    screens = {m: titles for kind, m, titles in fake.prompts if kind == "select"}
+    for message, help_lines in [
+        ("Session:", tbrowse._HELP_SESSION),
+        ("Attempt:", tbrowse._HELP_ATTEMPT),
+        ("Action:", tbrowse._HELP_ACTION),
+    ]:
+        titles = screens[message]
+        assert titles[: len(help_lines)] == list(help_lines)
+        assert "Back" not in titles and "Exit" not in titles
+
+
+@pytest.mark.parametrize(
+    "extra_answers, action_pick, prep, absent",
+    [
+        ([], "Merge attempts", None, "Merged"),
+        ([], "Verdict", None, "Recorded verdict"),
+        (["fail"], "Verdict", None, "Recorded verdict"),
+        (["fail", "why"], "Verdict", None, "Recorded verdict"),
+        ([], "Pin", None, "Pinned"),
+        ([], "Unpin", "pin", "Unpinned"),
+        ([], "Split", "merge", "Split into"),
+    ],
+    ids=[
+        "merge-checkbox",
+        "verdict-status",
+        "verdict-why",
+        "verdict-notes",
+        "pin-reason",
+        "unpin-confirm",
+        "split-confirm",
+    ],
+)
+def test_escape_cancels_action_without_side_effects(
+    state, workspace, monkeypatch, capsys, extra_answers, action_pick, prep, absent
+):
+    """Esc inside an action cancels just that action: no data change, no
+    stale/error output, and the refreshed browser stays operable."""
+    _two_turn_log(state)
+    if prep == "merge":
+        tstore.merge_attempts(["trace-1", "trace-2"], state_dir=state)
+    if prep == "pin":
+        tstore.pin("trace-1", state_dir=state)
+    pins_before = set(tstore.pins(state))
+    defs_before = dict(tstore.definitions(state))
+
+    if action_pick == "Merge attempts":
+        script = [("pick", "session"), ("pick", "Merge attempts"), *extra_answers, _BACK, _BACK, _BACK]
+    else:
+        script = [("pick", "session"), ("pick", "#1"), ("pick", action_pick), *extra_answers, _BACK, _BACK, _BACK]
+
+    fake = _browse(monkeypatch, script, workspace)
+
+    out = capsys.readouterr().out
+    assert fake.answers == []
+    assert len(fake.prompts) == len(script)  # no extra prompt after the Esc
+    assert absent not in out
+    assert tbrowse._STALE_MESSAGE not in out
+    assert "Cancelled" not in out
+    assert set(tstore.pins(state)) == pins_before
+    assert dict(tstore.definitions(state)) == defs_before
+    assert tverdict.read_verdicts(state) == []
+
+
+def test_escape_on_report_confirm_keeps_bundle_and_pin(state, workspace, monkeypatch, capsys):
+    """Esc on the report confirm skips the tarball only: bundling and the
+    auto-pin happen before the confirm (the declined-report contract), so the
+    refreshed action menu must offer Unpin."""
+    _two_turn_log(state)
+
+    fake = _browse(
+        monkeypatch,
+        [("pick", "session"), ("pick", "#1"), ("pick", "Report"), _BACK, ("pick", "#1"), _BACK, _BACK, _BACK],
+        workspace,
+    )
+
+    out = capsys.readouterr().out
+    assert fake.answers == []
+    reports = state / "reports"
+    assert not (reports.exists() and any(reports.glob("*.tar.gz")))
+    assert "Report ready" not in out
+    assert "Aborted" not in out  # that message belongs to the answered-No path
+    assert tbrowse._STALE_MESSAGE not in out
+    assert (state / "bundles" / "trace-1" / "manifest.json").exists()
+    assert "trace-1" in tstore.pins(state)
+    action_screens = [t for kind, m, t in fake.prompts if kind == "select" and m == "Action:"]
+    assert any("Unpin" in title for title in action_screens[1])
+
+
+# ── breadcrumbs ───────────────────────────────────────────────────────
+
+
+def test_crumb_escapes_untrusted_text(monkeypatch):
+    """Markup in a title must render literally (no color, no MarkupError),
+    on a console that actually emits ANSI (pytest capture alone would pass
+    vacuously with colors off)."""
+    from io import StringIO
+
+    from rich.console import Console
+
+    buf = StringIO()
+    monkeypatch.setattr(tbrowse, "console", Console(file=buf, force_terminal=True, color_system="truecolor", width=200))
+
+    tbrowse._crumb("Session", "x[red]y")
+    tbrowse._crumb("Session", "pre[/dim]view")
+    tbrowse._crumb("Session", "multi\nline\rwith\x07controls")
+
+    out = buf.getvalue()
+    assert "x[red]y" in out
+    assert "pre[/dim]view" in out
+    assert "multi line with controls" in out
+    assert "\x07" not in out and "\r" not in out
+    assert out.count("\n") == 3
+    assert "\x1b[31" not in out
+
+
+def test_breadcrumbs_echo_navigation(state, workspace, monkeypatch, capsys):
+    from raven.session.manager import SessionManager
+
+    manager = SessionManager(workspace)
+    session = manager.get_or_create("cli:a")
+    session.add_message("user", "x")
+    session.set_title("x[red]y title")
+    manager.save(session)
+    _two_turn_log(state)
+
+    _browse(
+        monkeypatch,
+        [("pick", "x[red]y"), ("pick", "#1"), ("pick", "Verdict"), "pass", "", "", _BACK, _BACK],
+        workspace,
+    )
+
+    out = capsys.readouterr().out
+    assert "Session ❯ x[red]y title" in out
+    assert "Attempt ❯ #1" in out
+    assert "Action ❯ Verdict" in out
+
+
+# ── real questionary key bindings ─────────────────────────────────────
+
+
+def _pipe_io():
+    from prompt_toolkit.input.defaults import create_pipe_input
+    from prompt_toolkit.output import DummyOutput
+
+    return create_pipe_input, DummyOutput
+
+
+@pytest.mark.parametrize("kind", ["select", "checkbox", "text", "confirm"])
+def test_escape_binding_installs_on_every_prompt_kind(kind):
+    """text/confirm expose a read-only _MergedKeyBindings: the merge-based
+    injection must install on all four prompt kinds, not just select."""
+    questionary = pytest.importorskip("questionary")
+    create_pipe_input, DummyOutput = _pipe_io()
+
+    with create_pipe_input() as pipe:
+        kwargs = {"input": pipe, "output": DummyOutput()}
+        if kind == "select":
+            q = questionary.select("m", choices=["a"], **kwargs)
+        elif kind == "checkbox":
+            q = questionary.checkbox("m", choices=["a"], **kwargs)
+        elif kind == "text":
+            q = questionary.text("m", **kwargs)
+        else:
+            q = questionary.confirm("m", **kwargs)
+        tbrowse._inject_bindings(q)
+        assert q.application.erase_when_done is True
+        pipe.send_text("\x1b")
+        assert q.application.run() is tbrowse._BACK
+
+
+def test_extra_key_reports_pointed_row():
+    questionary = pytest.importorskip("questionary")
+    create_pipe_input, DummyOutput = _pipe_io()
+
+    with create_pipe_input() as pipe:
+        q = questionary.select(
+            "m",
+            choices=[questionary.Choice("first", value="v1"), questionary.Choice("second", value="v2")],
+            input=pipe,
+            output=DummyOutput(),
+        )
+        tbrowse._inject_bindings(q, extra_keys=("m",))
+        pipe.send_text("m")
+        hit = q.application.run()
+
+    assert isinstance(hit, tbrowse._KeyHit)
+    assert hit.key == "m" and hit.value == "v1"
+
+
+def test_pointed_row_restyle_keeps_semantic_color():
+    """The pointed row gains bold without a foreground override: a green cell
+    resolves to the success color on the pointed row and the plain row alike
+    (asserting final attrs, not class names)."""
+    questionary = pytest.importorskip("questionary")
+    create_pipe_input, DummyOutput = _pipe_io()
+    from raven.cli._theme import PALETTE, build_questionary_style
+
+    def title(word):
+        return [("class:success", "✓"), ("class:text", f" {word}")]
+
+    with create_pipe_input() as pipe:
+        q = questionary.select(
+            "m",
+            choices=[questionary.Choice(title("one"), value="1"), questionary.Choice(title("two"), value="2")],
+            input=pipe,
+            output=DummyOutput(),
+        )
+        tbrowse._inject_bindings(q)
+        control = tbrowse._find_inquirer_control(q.application)
+        checks = [tok[0] for tok in control.text() if "class:success" in tok[0]]
+
+    style = build_questionary_style("dark")
+    success = PALETTE["dark"]["success"].lstrip("#")
+    pointed = style.get_attrs_for_style_str(checks[0])
+    plain = style.get_attrs_for_style_str(checks[1])
+    assert pointed.color == success and pointed.bold
+    assert plain.color == success and not plain.bold
+
+
 def test_selects_share_prompt_chrome(state, workspace, monkeypatch):
     """Every select/checkbox passes the shared QMARK and POINTER so the
     browser's prompt chrome matches the rest of the CLI."""
@@ -833,8 +1085,8 @@ def test_selects_share_prompt_chrome(state, workspace, monkeypatch):
             "pass",
             "",
             "",
-            ("pick", "Back"),
-            ("pick", "Exit"),
+            _BACK,
+            _BACK,
         ],
         workspace,
     )
@@ -859,8 +1111,8 @@ def test_merge_checkbox_validates_minimum(state, workspace, monkeypatch):
             ("pick", "session"),
             ("pick", "Merge attempts"),
             ("pickall", ["#1", "#2"]),
-            ("pick", "Back"),
-            ("pick", "Exit"),
+            _BACK,
+            _BACK,
         ],
         workspace,
     )
@@ -886,7 +1138,7 @@ def test_pin_flow_uses_locked_pin_attempt(state, workspace, monkeypatch):
 
     _browse(
         monkeypatch,
-        [("pick", "session"), ("pick", "#1"), ("pick", "Pin"), "keep", ("pick", "Back"), ("pick", "Exit")],
+        [("pick", "session"), ("pick", "#1"), ("pick", "Pin"), "keep", _BACK, _BACK],
         workspace,
     )
 
@@ -967,8 +1219,8 @@ def test_nondefault_workspace_flows_into_save_and_minimize(state, tmp_path, monk
             ("pick", "Save"),
             ("pick", "#1"),
             ("pick", "Minimize"),
-            ("pick", "Back"),
-            ("pick", "Exit"),
+            _BACK,
+            _BACK,
         ],
         other,
     )

--- a/tests/test_cli_trajectory_browse.py
+++ b/tests/test_cli_trajectory_browse.py
@@ -44,6 +44,8 @@ class _FakeQuestionary:
     Each prompt pops one scripted answer. An answer may be:
     - ``("pick", substr)``  — select the first choice whose title contains substr;
     - ``("pickall", [substr, ...])`` — checkbox: the values of all matching choices;
+    - ``("hit", key, substr)`` — an injected extra key fired on the matching
+      choice: returns ``_KeyHit(key, value)``;
     - ``_CANCEL``           — ``ask()`` returns None (Ctrl+C / EOF);
     - ``_BACK``             — the injected Esc binding fired (returned verbatim);
     - a zero-arg callable   — invoked at answer time (side effects), its return used;
@@ -90,6 +92,9 @@ class _FakeQuestionary:
             value = [
                 next(c.value for c in choices if hasattr(c, "value") and s in self._title_text(c)) for s in answer[1]
             ]
+        elif isinstance(answer, tuple) and answer and answer[0] == "hit":
+            picked = next(c.value for c in choices if hasattr(c, "value") and answer[2] in self._title_text(c))
+            value = tbrowse._KeyHit(answer[1], picked)
         else:
             value = answer
         return type("_Ask", (), {"ask": staticmethod(lambda: value)})()
@@ -105,6 +110,9 @@ class _FakeQuestionary:
 
     def text(self, message, **kw):
         return self._resolve("text", message, None, kw)
+
+    def press_any_key_to_continue(self, message=None, **kw):
+        return self._resolve("press", message, None, kw)
 
 
 @pytest.fixture
@@ -1228,6 +1236,257 @@ def test_below_floor_rows_render_clipped_and_selectable():
     raw = buf.getvalue()
     assert "VERDICT" in raw  # the visible region reached the stream
     assert "MERGED" not in raw  # the clipped tail was never emitted, so no wrap row exists
+
+
+# ── space preview ─────────────────────────────────────────────────────
+
+
+def _turn_span(trace_id, span_id, start, inp=None, out=None):
+    s = _span(trace_id, session_key="cli:a", span_id=span_id)
+    s["startTime"] = start
+    if inp is not None:
+        s["attributes"]["turn.input_preview"] = inp
+    if out is not None:
+        s["attributes"]["turn.output_preview"] = out
+    return s
+
+
+def test_turn_previews_sorted_and_table_preview_derived(state, workspace):
+    """Turn order and the table PREVIEW cell both come from the sorted
+    collection, never from log source order."""
+    spans = [
+        _turn_span("trace-1", "s3", "2026-08-20T10:02:00+00:00", inp="third in", out="third out"),
+        _turn_span("trace-1", "s1", "2026-08-20T10:00:00+00:00", inp="first in"),
+        _turn_span("trace-1", "s2", "2026-08-20T10:01:00+00:00", out="second out"),
+    ]
+    _write_log(state / "logs" / "audit-spans.log", spans)
+    (srow,) = tbrowse.scan_sessions(workspace)
+    (row,) = srow.attempts
+
+    assert [t.input for t in row.turn_previews] == ["first in", "", "third in"]
+    assert [t.output for t in row.turn_previews] == ["", "second out", "third out"]
+    assert row.preview == "first in"
+
+    _write_log(state / "logs" / "audit-spans.log", list(reversed(spans)))
+    (srow2,) = tbrowse.scan_sessions(workspace)
+    (row2,) = srow2.attempts
+    assert row2.turn_previews == row.turn_previews
+    assert row2.preview == "first in"
+
+
+def test_turn_previews_checkpoint_final_dedup(state, workspace):
+    checkpoint = _turn_span("trace-1", "root", "2026-08-20T10:00:00+00:00", inp="ask")
+    final = _turn_span("trace-1", "root", "2026-08-20T10:00:00+00:00", inp="ask", out="answer")
+    _write_log(state / "logs" / "audit-spans.log", [checkpoint, final])
+
+    (srow,) = tbrowse.scan_sessions(workspace)
+    (row,) = srow.attempts
+
+    (turn,) = row.turn_previews
+    assert turn.input == "ask" and turn.output == "answer"  # the final record won
+
+
+def test_turn_previews_missing_span_ids_stable(state, workspace):
+    """Same start, one record with a spanId and one without: no TypeError,
+    and the order does not follow the input order."""
+    start = "2026-08-20T10:00:00+00:00"
+    a = _turn_span("trace-1", "sX", start, inp="with id")
+    b = _turn_span("trace-1", "tmp", start, inp="without id")
+    del b["spanId"]
+
+    _write_log(state / "logs" / "audit-spans.log", [a, b])
+    (srow,) = tbrowse.scan_sessions(workspace)
+    (row,) = srow.attempts
+    assert len(row.turn_previews) == 2
+
+    _write_log(state / "logs" / "audit-spans.log", [b, a])
+    (srow2,) = tbrowse.scan_sessions(workspace)
+    (row2,) = srow2.attempts
+    assert row2.turn_previews == row.turn_previews
+
+
+def test_turn_previews_sanitize_types_and_length(state, workspace):
+    bad = _turn_span("trace-1", "s1", "2026-08-20T10:00:00+00:00")
+    bad["attributes"]["turn.input_preview"] = 123
+    long_turn = _turn_span("trace-1", "s2", "2026-08-20T10:01:00+00:00", inp="x" * 500, out="y\nz\x07w")
+    _write_log(state / "logs" / "audit-spans.log", [bad, long_turn])
+
+    (srow,) = tbrowse.scan_sessions(workspace)
+    (row,) = srow.attempts
+
+    t1, t2 = row.turn_previews
+    assert t1.input == ""
+    assert len(t2.input) == 400 and t2.input.endswith("…")
+    assert t2.output == "y z w"
+    assert len(row.preview) == 32 and row.preview.endswith("…")
+
+
+def test_preview_screen_placeholder_and_escape(monkeypatch):
+    from io import StringIO
+
+    from rich.console import Console
+
+    buf = StringIO()
+    monkeypatch.setattr(tbrowse, "console", Console(file=buf, force_terminal=True, color_system="truecolor", width=500))
+
+    tbrowse._preview_screen(1, _mk_attempt())
+    tbrowse._preview_screen(
+        2, _mk_attempt(turn_previews=(tbrowse._TurnPreview("s", "i", "t", "x[red]y", "pre[/dim]view"),))
+    )
+    tbrowse._preview_screen(3, _mk_attempt(turn_previews=(tbrowse._TurnPreview("s", "i", "t", "", ""),)))
+
+    out = buf.getvalue()
+    assert "(no turns recorded)" in out
+    assert "x[red]y" in out and "pre[/dim]view" in out
+    assert "(no preview recorded)" in out  # turns exist, but nothing is displayable
+    assert "\x1b[31" not in out
+
+
+@pytest.mark.parametrize(
+    "key, done",
+    [("x", True), ("\x1b", True), ("\x1b[A", True), ("\x7f", True), ("\x03", False)],
+    ids=["any-key", "esc", "up", "backspace", "ctrl-c"],
+)
+def test_preview_wait_key_paths(key, done):
+    """The waiter maps any key/Esc to the non-None _DONE; only Ctrl+C keeps
+    the browser-wide cancel result (None)."""
+    questionary = pytest.importorskip("questionary")
+    create_pipe_input, DummyOutput = _pipe_io()
+
+    with create_pipe_input() as pipe:
+        q = tbrowse._wait_question(questionary, None, input=pipe, output=DummyOutput())
+        pipe.send_text(key)
+        result = q.application.run()
+
+    assert (result is tbrowse._DONE) if done else (result is None)
+
+
+def test_preview_wait_passes_cpr_response_through():
+    """A terminal's CPR reply is an internal event, not a keypress: it must
+    reach the renderer (default semantics) and never finish the waiter."""
+    import threading
+
+    questionary = pytest.importorskip("questionary")
+    create_pipe_input, DummyOutput = _pipe_io()
+
+    with create_pipe_input() as pipe:
+        q = tbrowse._wait_question(questionary, None, input=pipe, output=DummyOutput())
+        reported = []
+        q.application.renderer.report_absolute_cursor_row = reported.append
+        result = []
+        thread = threading.Thread(target=lambda: result.append(q.application.run()), daemon=True)
+        thread.start()
+        pipe.send_text("\x1b[35;1R")
+        thread.join(timeout=1)
+        assert thread.is_alive()  # the CPR reply alone must not finish the waiter
+        pipe.send_text("x")
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+    assert result == [tbrowse._DONE]
+    assert reported == [35]
+
+
+def test_space_key_binding_returns_pointed_attempt():
+    """The real Space keypress must reach the injected binding (questionary
+    has its own catch-all bindings a fake-returned _KeyHit would bypass)."""
+    questionary = pytest.importorskip("questionary")
+    create_pipe_input, DummyOutput = _pipe_io()
+
+    with create_pipe_input() as pipe:
+        q = questionary.select(
+            "m",
+            choices=[questionary.Choice("first", value=(1, "row")), questionary.Choice("second", value=(2, "row"))],
+            input=pipe,
+            output=DummyOutput(),
+        )
+        tbrowse._inject_bindings(q, extra_keys=(" ",))
+        pipe.send_text(" ")
+        hit = q.application.run()
+
+    assert isinstance(hit, tbrowse._KeyHit)
+    assert hit.key == " " and hit.value == (1, "row")
+
+
+def test_space_previews_and_keeps_cursor(state, workspace, monkeypatch, capsys):
+    _two_turn_log(state)
+    assert "Space preview" in tbrowse._HELP_ATTEMPT[1]
+    scans = []
+    real_scan = tbrowse.scan_sessions
+    monkeypatch.setattr(tbrowse, "scan_sessions", lambda ws: scans.append(1) or real_scan(ws))
+
+    fake = _browse(
+        monkeypatch,
+        [("pick", "session"), ("hit", " ", "#1"), tbrowse._DONE, _BACK, _BACK],
+        workspace,
+    )
+
+    out = capsys.readouterr().out
+    assert "Preview ❯ #1" in out
+    assert "fix the bug" in out
+    assert [k for k, _m, _t in fake.prompts] == ["select", "select", "press", "select", "select"]
+    attempt_calls = [kw for kind, m, kw in fake.calls if kind == "select" and m == "Attempt:"]
+    assert attempt_calls[0].get("default") is None
+    kept = attempt_calls[1].get("default")
+    assert kept is not None and kept[0] == 1
+    assert len(scans) == 2  # the preview itself never rescans
+
+
+def test_non_space_keyhit_on_attempt_row_is_noop(state, workspace, monkeypatch, capsys):
+    """Dispatch is by key, not by value shape: a future extra key (step 4's
+    'm') pointing at an attempt tuple must not fall into the preview path."""
+    _two_turn_log(state)
+
+    fake = _browse(
+        monkeypatch,
+        [("pick", "session"), ("hit", "m", "#1"), _BACK, _BACK],
+        workspace,
+    )
+
+    out = capsys.readouterr().out
+    assert "Preview ❯" not in out
+    assert "press" not in [k for k, _m, _t in fake.prompts]
+    attempt_calls = [kw for kind, m, kw in fake.calls if kind == "select" and m == "Attempt:"]
+    kept = attempt_calls[1]["default"]
+    assert kept is not None and kept[0] == 1  # cursor kept on the row
+    assert fake.answers == []
+
+
+def test_space_on_merge_entry_is_noop(state, workspace, monkeypatch, capsys):
+    _two_turn_log(state)
+
+    fake = _browse(
+        monkeypatch,
+        [("pick", "session"), ("hit", " ", "Merge attempts"), _BACK, _BACK],
+        workspace,
+    )
+
+    out = capsys.readouterr().out
+    assert "Preview ❯" not in out
+    assert "press" not in [k for k, _m, _t in fake.prompts]
+    assert [m for k, m, _t in fake.prompts if k == "select"] == ["Session:", "Attempt:", "Attempt:", "Session:"]
+    attempt_calls = [kw for kind, m, kw in fake.calls if kind == "select" and m == "Attempt:"]
+    assert attempt_calls[1]["default"] is tbrowse._MERGE
+    assert fake.answers == []
+
+
+def test_space_on_merge_entry_then_merge_still_works(state, workspace, monkeypatch):
+    _two_turn_log(state)
+
+    _browse(
+        monkeypatch,
+        [
+            ("pick", "session"),
+            ("hit", " ", "Merge attempts"),
+            ("pick", "Merge attempts"),
+            ("pickall", ["#1", "#2"]),
+            _BACK,
+            _BACK,
+        ],
+        workspace,
+    )
+
+    assert len(tstore.definitions(state)) == 1
 
 
 # ── real questionary key bindings ─────────────────────────────────────

--- a/tests/test_cli_trajectory_browse.py
+++ b/tests/test_cli_trajectory_browse.py
@@ -484,7 +484,7 @@ def test_full_cycle_merge_verdict_save_split(state, workspace, monkeypatch, caps
         monkeypatch,
         [
             ("pick", "session"),
-            ("pick", "Merge attempts"),
+            ("hit", "m", "#1"),
             ("pickall", ["#1", "#2"]),
             ("pick", "#1"),
             ("pick", "Verdict"),
@@ -507,7 +507,7 @@ def test_full_cycle_merge_verdict_save_split(state, workspace, monkeypatch, caps
     # after merge: one row with a MERGED check, no more merge entry
     merged_rows = _data_rows(attempt_screens[1])
     assert sum(_cell_of(attempt_screens[1], t, "MERGED").strip() == "✓" for t in merged_rows) == 1
-    assert not any("Merge attempts" in t for t in attempt_screens[1])
+    assert not any("Merge attempts" in t for titles in attempt_screens for t in titles)
     # after verdict: the row shows it
     assert any("fail" in t for t in _data_rows(attempt_screens[2]))
     # after save: the action menu offers Unpin (auto-pin happened)
@@ -583,7 +583,7 @@ def test_action_outputs_carry_no_ids(state, workspace, monkeypatch, capsys):
         monkeypatch,
         [
             ("pick", "session"),
-            ("pick", "Merge attempts"),
+            ("hit", "m", "#1"),
             ("pickall", ["#1", "#2"]),
             ("pick", "#1"),
             ("pick", "Verdict"),
@@ -623,7 +623,7 @@ def test_action_outputs_carry_no_ids(state, workspace, monkeypatch, capsys):
         (
             [
                 ("pick", "session"),
-                ("pick", "Merge attempts"),
+                ("hit", "m", "#1"),
                 ("pickall", ["#1", "#2"]),
                 _BACK,
                 _BACK,
@@ -834,7 +834,7 @@ def test_data_wiped_after_action_ends_controlled(state, workspace, monkeypatch, 
     "script",
     [
         [("pick", "session"), ("pick", "#1"), ("pick", "Report"), _CANCEL],
-        [("pick", "session"), ("pick", "Merge attempts"), _CANCEL],
+        [("pick", "session"), ("hit", "m", "#1"), _CANCEL],
         [("pick", "session"), ("pick", "#1"), ("pick", "Verdict"), "fail", _CANCEL],
         [("pick", "session"), ("pick", "#1"), ("pick", "Split"), _CANCEL],
         [("pick", "session"), ("pick", "#1"), ("pick", "Unpin"), _CANCEL],
@@ -887,7 +887,7 @@ def test_menu_screens_hide_back_exit_and_show_help(state, workspace, monkeypatch
     screens = {m: titles for kind, m, titles in fake.prompts if kind == "select"}
     for message, help_lines in [
         ("Session:", tbrowse._HELP_SESSION),
-        ("Attempt:", tbrowse._HELP_ATTEMPT),
+        ("Attempt:", tbrowse._HELP_ATTEMPT_MERGE),  # two attempts: merge advertised
         ("Action:", tbrowse._HELP_ACTION),
     ]:
         titles = screens[message]
@@ -895,7 +895,7 @@ def test_menu_screens_hide_back_exit_and_show_help(state, workspace, monkeypatch
         assert "Back" not in titles and "Exit" not in titles
     # the table header separator sits right after the help lines
     assert "LAST ACTIVITY" in screens["Session:"][len(tbrowse._HELP_SESSION)]
-    assert "STARTED" in screens["Attempt:"][len(tbrowse._HELP_ATTEMPT)]
+    assert "STARTED" in screens["Attempt:"][len(tbrowse._HELP_ATTEMPT_MERGE)]
 
 
 @pytest.mark.parametrize(
@@ -933,7 +933,7 @@ def test_escape_cancels_action_without_side_effects(
     defs_before = dict(tstore.definitions(state))
 
     if action_pick == "Merge attempts":
-        script = [("pick", "session"), ("pick", "Merge attempts"), *extra_answers, _BACK, _BACK, _BACK]
+        script = [("pick", "session"), ("hit", "m", "#1"), *extra_answers, _BACK, _BACK, _BACK]
     else:
         script = [("pick", "session"), ("pick", "#1"), ("pick", action_pick), *extra_answers, _BACK, _BACK, _BACK]
 
@@ -1433,13 +1433,13 @@ def test_space_previews_and_keeps_cursor(state, workspace, monkeypatch, capsys):
 
 
 def test_non_space_keyhit_on_attempt_row_is_noop(state, workspace, monkeypatch, capsys):
-    """Dispatch is by key, not by value shape: a future extra key (step 4's
-    'm') pointing at an attempt tuple must not fall into the preview path."""
+    """Dispatch is by key, not by value shape: a foreign injected key
+    pointing at an attempt tuple must not fall into the preview path."""
     _two_turn_log(state)
 
     fake = _browse(
         monkeypatch,
-        [("pick", "session"), ("hit", "m", "#1"), _BACK, _BACK],
+        [("pick", "session"), ("hit", "z", "#1"), _BACK, _BACK],
         workspace,
     )
 
@@ -1452,41 +1452,71 @@ def test_non_space_keyhit_on_attempt_row_is_noop(state, workspace, monkeypatch, 
     assert fake.answers == []
 
 
-def test_space_on_merge_entry_is_noop(state, workspace, monkeypatch, capsys):
+@pytest.mark.parametrize("key", ["m", "M"])
+def test_m_key_opens_merge_and_merges(state, workspace, monkeypatch, capsys, key):
     _two_turn_log(state)
 
     fake = _browse(
         monkeypatch,
-        [("pick", "session"), ("hit", " ", "Merge attempts"), _BACK, _BACK],
-        workspace,
-    )
-
-    out = capsys.readouterr().out
-    assert "Preview ❯" not in out
-    assert "press" not in [k for k, _m, _t in fake.prompts]
-    assert [m for k, m, _t in fake.prompts if k == "select"] == ["Session:", "Attempt:", "Attempt:", "Session:"]
-    attempt_calls = [kw for kind, m, kw in fake.calls if kind == "select" and m == "Attempt:"]
-    assert attempt_calls[1]["default"] is tbrowse._MERGE
-    assert fake.answers == []
-
-
-def test_space_on_merge_entry_then_merge_still_works(state, workspace, monkeypatch):
-    _two_turn_log(state)
-
-    _browse(
-        monkeypatch,
-        [
-            ("pick", "session"),
-            ("hit", " ", "Merge attempts"),
-            ("pick", "Merge attempts"),
-            ("pickall", ["#1", "#2"]),
-            _BACK,
-            _BACK,
-        ],
+        [("pick", "session"), ("hit", key, "#2"), ("pickall", ["#1", "#2"]), _BACK, _BACK],
         workspace,
     )
 
     assert len(tstore.definitions(state)) == 1
+    assert "Merged 2 attempts into one" in capsys.readouterr().out
+    assert [k for k, _m, _t in fake.prompts if k == "checkbox"] == ["checkbox"]
+
+
+def test_merge_checkbox_shows_help_and_suppresses_instruction(state, workspace, monkeypatch):
+    _two_turn_log(state)
+
+    fake = _browse(
+        monkeypatch,
+        [("pick", "session"), ("hit", "m", "#1"), _BACK, _BACK, _BACK],
+        workspace,
+    )
+
+    (checkbox,) = [
+        (titles, kw) for (kind, _m, titles), (_k, _m2, kw) in zip(fake.prompts, fake.calls) if kind == "checkbox"
+    ]
+    titles, kw = checkbox
+    assert titles[0] == tbrowse._MERGE_HINT
+    assert kw.get("instruction") == " "
+
+
+def test_merge_key_only_bound_with_multiple_attempts(state, workspace, monkeypatch):
+    _two_turn_log(state)
+    recorded = []
+    real = tbrowse._select_screen
+
+    def spy(questionary, style, message, help_lines, choices, **kw):
+        recorded.append((message, help_lines, kw.get("extra_keys", ())))
+        return real(questionary, style, message, help_lines, choices, **kw)
+
+    monkeypatch.setattr(tbrowse, "_select_screen", spy)
+    _browse(monkeypatch, [("pick", "session"), _BACK, _BACK], workspace)
+
+    message, help_lines, extra_keys = next(r for r in recorded if r[0] == "Attempt:")
+    assert "M merge" in help_lines[1]
+    assert {"m", "M"} <= set(extra_keys)
+
+
+def test_merge_key_absent_with_single_attempt(state, workspace, monkeypatch):
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", session_key="cli:a")])
+    recorded = []
+    real = tbrowse._select_screen
+
+    def spy(questionary, style, message, help_lines, choices, **kw):
+        recorded.append((message, help_lines, kw.get("extra_keys", ()), [getattr(c, "title", "") for c in choices]))
+        return real(questionary, style, message, help_lines, choices, **kw)
+
+    monkeypatch.setattr(tbrowse, "_select_screen", spy)
+    fake = _browse(monkeypatch, [("pick", "session"), _BACK, _BACK], workspace)
+
+    message, help_lines, extra_keys, _titles = next(r for r in recorded if r[0] == "Attempt:")
+    assert "M merge" not in help_lines[1]
+    assert "m" not in extra_keys and "M" not in extra_keys
+    assert not any("Merge attempts" in t for _k, _m, titles in fake.prompts for t in titles)
 
 
 # ── real questionary key bindings ─────────────────────────────────────
@@ -1522,7 +1552,8 @@ def test_escape_binding_installs_on_every_prompt_kind(kind):
         assert q.application.run() is tbrowse._BACK
 
 
-def test_extra_key_reports_pointed_row():
+@pytest.mark.parametrize("key", ["m", "M"])
+def test_extra_key_reports_pointed_row(key):
     questionary = pytest.importorskip("questionary")
     create_pipe_input, DummyOutput = _pipe_io()
 
@@ -1533,12 +1564,12 @@ def test_extra_key_reports_pointed_row():
             input=pipe,
             output=DummyOutput(),
         )
-        tbrowse._inject_bindings(q, extra_keys=("m",))
-        pipe.send_text("m")
+        tbrowse._inject_bindings(q, extra_keys=("m", "M"))
+        pipe.send_text(key)
         hit = q.application.run()
 
     assert isinstance(hit, tbrowse._KeyHit)
-    assert hit.key == "m" and hit.value == "v1"
+    assert hit.key == key and hit.value == "v1"
 
 
 def test_pointed_row_restyle_keeps_semantic_color():
@@ -1582,7 +1613,7 @@ def test_selects_share_prompt_chrome(state, workspace, monkeypatch):
         monkeypatch,
         [
             ("pick", "session"),
-            ("pick", "Merge attempts"),
+            ("hit", "m", "#1"),
             ("pickall", ["#1", "#2"]),
             ("pick", "#1"),
             ("pick", "Verdict"),
@@ -1613,7 +1644,7 @@ def test_merge_checkbox_validates_minimum(state, workspace, monkeypatch):
         monkeypatch,
         [
             ("pick", "session"),
-            ("pick", "Merge attempts"),
+            ("hit", "m", "#1"),
             ("pickall", ["#1", "#2"]),
             _BACK,
             _BACK,

--- a/tests/test_cli_trajectory_browse.py
+++ b/tests/test_cli_trajectory_browse.py
@@ -49,7 +49,9 @@ class _FakeQuestionary:
     - a zero-arg callable   — invoked at answer time (side effects), its return used;
     - anything else         — returned verbatim.
     Every prompt is recorded as (kind, message, [choice titles]); separator
-    lines are recorded like choices but are never matched by a pick.
+    lines are recorded like choices but are never matched by a pick. A title
+    may be a styled token list (table rows) — it is flattened to plain text
+    for recording and matching, like a terminal renders it.
     """
 
     class Choice:
@@ -66,8 +68,15 @@ class _FakeQuestionary:
         self.prompts: list[tuple[str, str, list[str]]] = []
         self.calls: list[tuple[str, str, dict]] = []
 
+    @staticmethod
+    def _title_text(choice):
+        title = getattr(choice, "title", "")
+        if isinstance(title, list):
+            return "".join(seg[1] for seg in title)
+        return title
+
     def _resolve(self, kind, message, choices, kwargs=None):
-        titles = [c.title for c in choices] if choices else []
+        titles = [self._title_text(c) for c in choices] if choices else []
         self.prompts.append((kind, message, titles))
         self.calls.append((kind, message, kwargs or {}))
         answer = self.answers.pop(0)
@@ -76,9 +85,11 @@ class _FakeQuestionary:
         if answer is _CANCEL:
             value = None
         elif isinstance(answer, tuple) and answer and answer[0] == "pick":
-            value = next(c.value for c in choices if hasattr(c, "value") and answer[1] in c.title)
+            value = next(c.value for c in choices if hasattr(c, "value") and answer[1] in self._title_text(c))
         elif isinstance(answer, tuple) and answer and answer[0] == "pickall":
-            value = [next(c.value for c in choices if hasattr(c, "value") and s in c.title) for s in answer[1]]
+            value = [
+                next(c.value for c in choices if hasattr(c, "value") and s in self._title_text(c)) for s in answer[1]
+            ]
         else:
             value = answer
         return type("_Ask", (), {"ask": staticmethod(lambda: value)})()
@@ -134,6 +145,20 @@ _IDS = ("trace-1", "trace-2", "cli:a", "att-")
 def _assert_no_ids(text: str, ids=_IDS) -> None:
     for id_ in ids:
         assert id_ not in text, f"{id_!r} leaked into: {text!r}"
+
+
+def _data_rows(titles):
+    """Attempt-table data rows among one screen's recorded titles (the header
+    line also starts with '#', but is followed by padding, not a digit)."""
+    return [t for t in titles if t[:1] == "#" and t[1:2].isdigit()]
+
+
+def _cell_of(titles, row_text, col):
+    """Text under fixed column ``col`` of one data row, located by the header
+    (fixed columns are exactly as wide as their headers here)."""
+    header = next(t for t in titles if t.startswith("#") and "STARTED" in t)
+    start = header.index(col)
+    return row_text[start : start + len(col)]
 
 
 # ── aggregation / labels (pure functions) ─────────────────────────────
@@ -276,13 +301,14 @@ def test_label_normalization(state, workspace):
 
 def test_fallback_title_prefers_span_channel(state, workspace):
     """With no session file and a separator-less key, the span's own channel
-    attribute still yields a human label (normalized to one line)."""
+    attribute still yields a human label (normalized to one line). The time
+    lives in the table's LAST ACTIVITY column, not in the title."""
     span = _span("trace-1", session_key="weirdkey", attrs={"channel": "discord\nextra"})
     _write_log(state / "logs" / "audit-spans.log", [span])
 
     (srow,) = tbrowse.scan_sessions(workspace)
 
-    assert srow.title == "discord extra session · 2026-08-20 10:00"
+    assert srow.title == "discord extra session"
     assert "\n" not in srow.title
     assert "weirdkey" not in srow.title
 
@@ -470,17 +496,19 @@ def test_full_cycle_merge_verdict_save_split(state, workspace, monkeypatch, caps
 
     selects = [(m, titles) for kind, m, titles in fake.prompts if kind == "select"]
     attempt_screens = [titles for m, titles in selects if m == "Attempt:"]
-    # after merge: one merged row, no more merge entry
-    assert sum("merged" in t for t in attempt_screens[1]) == 1
+    # after merge: one row with a MERGED check, no more merge entry
+    merged_rows = _data_rows(attempt_screens[1])
+    assert sum(_cell_of(attempt_screens[1], t, "MERGED").strip() == "✓" for t in merged_rows) == 1
     assert not any("Merge attempts" in t for t in attempt_screens[1])
     # after verdict: the row shows it
-    assert any("fail" in t for t in attempt_screens[2])
+    assert any("fail" in t for t in _data_rows(attempt_screens[2]))
     # after save: the action menu offers Unpin (auto-pin happened)
     action_screens = [titles for m, titles in selects if m == "Action:"]
     assert any("Unpin" in t for t in action_screens[2])
     # after split: two rows again, none merged
-    assert sum(t.startswith("#") for t in attempt_screens[4]) == 2
-    assert not any("merged" in t for t in attempt_screens[4])
+    split_rows = _data_rows(attempt_screens[4])
+    assert len(split_rows) == 2
+    assert not any(_cell_of(attempt_screens[4], t, "MERGED").strip() == "✓" for t in split_rows)
 
     assert tstore.definitions(state) == {}
     assert {"trace-1", "trace-2"} <= set(tstore.pins(state))  # split moved the pin down
@@ -857,6 +885,9 @@ def test_menu_screens_hide_back_exit_and_show_help(state, workspace, monkeypatch
         titles = screens[message]
         assert titles[: len(help_lines)] == list(help_lines)
         assert "Back" not in titles and "Exit" not in titles
+    # the table header separator sits right after the help lines
+    assert "LAST ACTIVITY" in screens["Session:"][len(tbrowse._HELP_SESSION)]
+    assert "STARTED" in screens["Attempt:"][len(tbrowse._HELP_ATTEMPT)]
 
 
 @pytest.mark.parametrize(
@@ -983,6 +1014,220 @@ def test_breadcrumbs_echo_navigation(state, workspace, monkeypatch, capsys):
     assert "Session ❯ x[red]y title" in out
     assert "Attempt ❯ #1" in out
     assert "Action ❯ Verdict" in out
+
+
+# ── table layout ──────────────────────────────────────────────────────
+
+
+def _mk_attempt(**kw):
+    base = dict(
+        key="trace-x",
+        traces=("trace-x",),
+        session_key="cli:a",
+        start="2026-08-20T10:00:00+00:00",
+        end="2026-08-20T10:00:01+00:00",
+        spans=1,
+        turns=1,
+        verdict=None,
+        pinned=False,
+        preview=None,
+        merged=False,
+    )
+    base.update(kw)
+    return tbrowse.AttemptRow(**base)
+
+
+def _flat(tokens):
+    return "".join(t[1] for t in tokens)
+
+
+def _row_cap(width):
+    return width - tbrowse._ROW_INDENT - tbrowse._WIDTH_MARGIN
+
+
+def test_attempt_table_fits_budget_and_drops_preview():
+    rows = [
+        _mk_attempt(verdict="pass", pinned=True, merged=True, preview="fix the bug in the long preview"),
+        _mk_attempt(key="trace-y", preview="another attempt preview text"),
+    ]
+
+    h80, rows80 = tbrowse._attempt_table(rows, 80)
+    h60, rows60 = tbrowse._attempt_table(rows, 60)
+
+    assert "PREVIEW" in h80 and "PREVIEW" not in h60
+    for width, header, row_tokens in [(80, h80, rows80), (60, h60, rows60)]:
+        assert tbrowse._cell_width(header) <= _row_cap(width)
+        for tokens in row_tokens:
+            line = _flat(tokens)
+            assert "\n" not in line
+            assert tbrowse._cell_width(line) <= _row_cap(width)
+            _assert_no_ids(line, ("trace-", "cli:a"))
+
+
+def test_table_headers_complete_and_columns_aligned():
+    rows = [_mk_attempt(verdict="pass", pinned=True, preview="p"), _mk_attempt(key="trace-y", merged=True)]
+
+    header, row_tokens = tbrowse._attempt_table(rows, 100)
+
+    for col in ("#", "STARTED", "TURNS", "SPANS", "VERDICT", "PIN", "MERGED", "PREVIEW"):
+        assert col in header
+    layout = tbrowse._attempt_layout(100, len(rows))
+    gap = tbrowse._cell_width(tbrowse._COL_GAP)
+    offsets, off = [], 0
+    for _h, w in layout:
+        offsets.append(off)
+        off += w + gap
+    for (h, _w), start in zip(layout, offsets):
+        assert header[start : start + len(h)] == h
+    lines = [header, *(_flat(t) for t in row_tokens)]
+    for start in offsets[1:]:
+        for line in lines:
+            if len(line) >= start:
+                assert line[start - gap : start] == tbrowse._COL_GAP
+
+
+def test_session_table_time_column_and_fit():
+    sessions = [
+        tbrowse.SessionRow(
+            key="cli:a", title="My debugging run", attempts=[_mk_attempt()], end="2026-08-20T11:22:33+00:00"
+        ),
+        tbrowse.SessionRow(key="cli:b", title="cli session", attempts=[_mk_attempt(key="t2")], end=None),
+    ]
+
+    header, rows = tbrowse._session_table(sessions, 80)
+
+    assert "TITLE" in header and "ATTEMPTS" in header and "LAST ACTIVITY" in header
+    line0, line1 = _flat(rows[0]), _flat(rows[1])
+    assert "2026-08-20 11:22" in line0
+    assert line1.rstrip().endswith("?")
+    for line in (line0, line1):
+        assert tbrowse._cell_width(line) <= _row_cap(80)
+
+
+def test_table_min_width_boundary_and_growth():
+    rows = [_mk_attempt(preview="p", verdict="pass")]
+    floor = tbrowse._table_min_width(tbrowse._attempt_fixed(len(rows)))
+
+    h_at, rows_at = tbrowse._attempt_table(rows, floor)
+    h_below, _ = tbrowse._attempt_table(rows, floor - 1)
+
+    assert "PREVIEW" not in h_at
+    assert tbrowse._cell_width(h_at) <= _row_cap(floor)
+    assert all(tbrowse._cell_width(_flat(t)) <= _row_cap(floor) for t in rows_at)
+    assert h_below == h_at  # the tightest layout stops deforming below the floor
+    assert tbrowse._cell_width(h_below) > _row_cap(floor - 1)  # the declared clipping floor
+    assert (
+        tbrowse._table_min_width(tbrowse._attempt_fixed(10)) == tbrowse._table_min_width(tbrowse._attempt_fixed(9)) + 1
+    )
+
+
+def test_table_cjk_cells_stay_within_budget():
+    rows = [_mk_attempt(preview="宽字符预览" * 8, verdict="pass")]
+
+    _header, row_tokens = tbrowse._attempt_table(rows, 80)
+    assert tbrowse._cell_width(_flat(row_tokens[0])) <= _row_cap(80)
+
+    sessions = [tbrowse.SessionRow(key="cli:a", title="中文标题" * 12, attempts=rows, end=None)]
+    _sh, srows = tbrowse._session_table(sessions, 80)
+    assert tbrowse._cell_width(_flat(srows[0])) <= _row_cap(80)
+
+
+def test_table_sanitizes_untrusted_cells(state, workspace):
+    """A corrupt verdict sidecar or malformed timestamp must not split a table
+    row: read_verdicts only guarantees a non-empty string status, and cwidth
+    math alone would let newlines and control characters through."""
+    span = _span("trace-1", session_key="cli:a")
+    span["startTime"] = "2026-\n08\t20T1\x07:00:00"
+    span["endTime"] = "2026-\r08-20T11:00:00"
+    _write_log(state / "logs" / "audit-spans.log", [span])
+    (state / "verdicts.jsonl").write_text(
+        json.dumps({"attempt_id": "trace-1", "status": "bad\nsta\rtus\x07x", "source": "user", "ts": "t"}) + "\n",
+        encoding="utf-8",
+    )
+
+    (srow,) = tbrowse.scan_sessions(workspace)
+    _ah, row_tokens = tbrowse._attempt_table(srow.attempts, 100)
+    _sh, srows = tbrowse._session_table([srow], 100)
+
+    for line in [_flat(row_tokens[0]), _flat(srows[0])]:
+        assert "\n" not in line and "\r" not in line and "\x07" not in line
+        assert tbrowse._cell_width(line) <= _row_cap(100)
+
+
+def test_boolean_cells_use_success_style_and_resolve_green():
+    rows = [_mk_attempt(pinned=True, merged=False), _mk_attempt(key="t2", pinned=False, merged=True)]
+
+    _h, row_tokens = tbrowse._attempt_table(rows, 100)
+
+    assert [(s, t) for s, t in row_tokens[0] if t == "✓"] == [("class:success", "✓")]
+    assert [(s, t) for s, t in row_tokens[1] if t == "✓"] == [("class:success", "✓")]
+
+    questionary = pytest.importorskip("questionary")
+    create_pipe_input, DummyOutput = _pipe_io()
+    from raven.cli._theme import PALETTE, build_questionary_style
+
+    with create_pipe_input() as pipe:
+        q = questionary.select(
+            "m",
+            choices=[questionary.Choice(tokens, value=i) for i, tokens in enumerate(row_tokens)],
+            input=pipe,
+            output=DummyOutput(),
+        )
+        tbrowse._inject_bindings(q)
+        control = tbrowse._find_inquirer_control(q.application)
+        styles = [tok[0] for tok in control.text() if tok[1] == "✓"]
+
+    style = build_questionary_style("dark")
+    success = PALETTE["dark"]["success"].lstrip("#")
+    pointed = style.get_attrs_for_style_str(styles[0])
+    plain = style.get_attrs_for_style_str(styles[1])
+    assert pointed.color == success and pointed.bold
+    assert plain.color == success and not plain.bold
+
+
+def test_below_floor_rows_render_clipped_and_selectable():
+    """Below the floor the real renderer clips overlong lines at the terminal
+    edge (prompt_toolkit never wraps option rows) and the menu stays usable.
+
+    The width puts the MERGED column entirely beyond the right edge: a
+    clipping renderer never emits that column name at all, while a wrapping
+    one would write it contiguously on a continuation row — so its absence
+    from the raw output stream pins clipping without any ANSI parsing."""
+    import io
+
+    questionary = pytest.importorskip("questionary")
+    from prompt_toolkit.data_structures import Size
+    from prompt_toolkit.output.vt100 import Vt100_Output
+
+    create_pipe_input, _dummy = _pipe_io()
+
+    rows = [_mk_attempt(verdict="pass", pinned=True, merged=True)]
+    layout = tbrowse._attempt_fixed(len(rows))
+    width = tbrowse._table_min_width(layout) - 10
+    gap = tbrowse._cell_width(tbrowse._COL_GAP)
+    merged_start = tbrowse._ROW_INDENT + sum(w + gap for _h, w in layout[:-1])
+    assert merged_start >= width  # premise: MERGED lies fully beyond the edge
+    header, row_tokens = tbrowse._attempt_table(rows, width)
+
+    class _Buf(io.StringIO):
+        encoding = "utf-8"
+
+    buf = _Buf()
+    output = Vt100_Output(buf, lambda: Size(rows=24, columns=width), term="xterm-256color")
+    with create_pipe_input() as pipe:
+        q = questionary.select(
+            "m",
+            choices=[questionary.Separator(header), questionary.Choice(row_tokens[0], value="v")],
+            input=pipe,
+            output=output,
+        )
+        tbrowse._inject_bindings(q)
+        pipe.send_text("\r")
+        assert q.application.run() == "v"
+
+    raw = buf.getvalue()
+    assert "VERDICT" in raw  # the visible region reached the stream
+    assert "MERGED" not in raw  # the clipped tail was never emitted, so no wrap row exists
 
 
 # ── real questionary key bindings ─────────────────────────────────────
@@ -1214,7 +1459,7 @@ def test_nondefault_workspace_flows_into_save_and_minimize(state, tmp_path, monk
     _browse(
         monkeypatch,
         [
-            ("pick", "attempt(s)"),
+            ("pick", "hello"),
             ("pick", "#1"),
             ("pick", "Save"),
             ("pick", "#1"),

--- a/tests/test_cli_trajectory_browse.py
+++ b/tests/test_cli_trajectory_browse.py
@@ -46,7 +46,8 @@ class _FakeQuestionary:
     - ``("pickall", [substr, ...])`` — checkbox: the values of all matching choices;
     - ``("hit", key, substr)`` — an injected extra key fired on the matching
       choice: returns ``_KeyHit(key, value)``;
-    - ``_CANCEL``           — ``ask()`` returns None (Ctrl+C / EOF);
+    - ``_CANCEL``           — Ctrl+C: ``unsafe_ask()`` raises KeyboardInterrupt
+      (the production path; the fallback ``ask()`` would return None);
     - ``_BACK``             — the injected Esc binding fired (returned verbatim);
     - a zero-arg callable   — invoked at answer time (side effects), its return used;
     - anything else         — returned verbatim.
@@ -97,7 +98,13 @@ class _FakeQuestionary:
             value = tbrowse._KeyHit(answer[1], picked)
         else:
             value = answer
-        return type("_Ask", (), {"ask": staticmethod(lambda: value)})()
+
+        def unsafe_ask():
+            if value is None:
+                raise KeyboardInterrupt
+            return value
+
+        return type("_Ask", (), {"ask": staticmethod(lambda: value), "unsafe_ask": staticmethod(unsafe_ask)})()
 
     def select(self, message, choices=None, **kw):
         return self._resolve("select", message, choices, kw)
@@ -425,7 +432,7 @@ def test_save_flow_bundles_by_member(state, workspace, monkeypatch, capsys):
 
     _browse(
         monkeypatch,
-        [("pick", "session"), ("pick", "#1"), ("pick", "Save"), _BACK, _BACK],
+        [("pick", "session"), ("pick", "#1"), ("pick", "Save"), _BACK, _CANCEL],
         workspace,
     )
 
@@ -436,7 +443,7 @@ def test_save_flow_bundles_by_member(state, workspace, monkeypatch, capsys):
 
 def test_minimize_flow_and_repeat(state, workspace, monkeypatch):
     _two_turn_log(state)
-    script = [("pick", "session"), ("pick", "#1"), ("pick", "Minimize"), _BACK, _BACK]
+    script = [("pick", "session"), ("pick", "#1"), ("pick", "Minimize"), _BACK, _CANCEL]
     monkeypatch.setattr(tbrowse, "minimize_bundle", _fake_minimize)
 
     _browse(monkeypatch, script, workspace)
@@ -466,7 +473,7 @@ def test_verdict_flow_records(state, workspace, monkeypatch):
             "wrong answer",
             "",
             _BACK,
-            _BACK,
+            _CANCEL,
         ],
         workspace,
     )
@@ -497,7 +504,7 @@ def test_full_cycle_merge_verdict_save_split(state, workspace, monkeypatch, caps
             ("pick", "Split"),
             True,
             _BACK,
-            _BACK,
+            _CANCEL,
         ],
         workspace,
     )
@@ -537,7 +544,7 @@ def test_report_declined_still_refreshes(state, workspace, monkeypatch, capsys):
             ("pick", "#1"),
             _BACK,
             _BACK,
-            _BACK,
+            _CANCEL,
         ],
         workspace,
     )
@@ -563,7 +570,7 @@ def test_minimize_failure_after_pack_refreshes(state, workspace, monkeypatch, ca
             ("pick", "#1"),
             _BACK,
             _BACK,
-            _BACK,
+            _CANCEL,
         ],
         workspace,
     )
@@ -600,7 +607,7 @@ def test_action_outputs_carry_no_ids(state, workspace, monkeypatch, capsys):
             ("pick", "Split"),
             True,
             _BACK,
-            _BACK,
+            _CANCEL,
         ],
         workspace,
     )
@@ -611,13 +618,13 @@ def test_action_outputs_carry_no_ids(state, workspace, monkeypatch, capsys):
 @pytest.mark.parametrize(
     "script, patch_target",
     [
-        ([("pick", "session"), ("pick", "#1"), ("pick", "Save"), _BACK, _BACK], "collect_bundle"),
+        ([("pick", "session"), ("pick", "#1"), ("pick", "Save"), _BACK, _CANCEL], "collect_bundle"),
         (
-            [("pick", "session"), ("pick", "#1"), ("pick", "Report"), _BACK, _BACK],
+            [("pick", "session"), ("pick", "#1"), ("pick", "Report"), _BACK, _CANCEL],
             "collect_bundle",
         ),
         (
-            [("pick", "session"), ("pick", "#1"), ("pick", "Minimize"), _BACK, _BACK],
+            [("pick", "session"), ("pick", "#1"), ("pick", "Minimize"), _BACK, _CANCEL],
             "collect_bundle",
         ),
         (
@@ -626,12 +633,12 @@ def test_action_outputs_carry_no_ids(state, workspace, monkeypatch, capsys):
                 ("hit", "m", "#1"),
                 ("pickall", ["#1", "#2"]),
                 _BACK,
-                _BACK,
+                _CANCEL,
             ],
             "merge_attempts",
         ),
         (
-            [("pick", "session"), ("pick", "#1"), ("pick", "Pin"), "keep", _BACK, _BACK],
+            [("pick", "session"), ("pick", "#1"), ("pick", "Pin"), "keep", _BACK, _CANCEL],
             "pin_attempt",
         ),
     ],
@@ -671,7 +678,7 @@ def test_failed_split_shows_safe_message(state, workspace, monkeypatch, capsys):
 
     fake = _browse(
         monkeypatch,
-        [("pick", "session"), ("pick", "#1"), ("pick", "Split"), True, _BACK, _BACK],
+        [("pick", "session"), ("pick", "#1"), ("pick", "Split"), True, _BACK, _CANCEL],
         workspace,
     )
 
@@ -709,7 +716,7 @@ def test_artifact_action_outputs_confine_ids_to_paths(state, workspace, monkeypa
             ("pick", "Report"),
             True,
             _BACK,
-            _BACK,
+            _CANCEL,
         ],
         workspace,
     )
@@ -737,7 +744,7 @@ def test_split_none_shows_stale_not_success(state, workspace, monkeypatch, capsy
             ("pick", "Split"),
             _confirm_then_drop,
             _BACK,
-            _BACK,
+            _CANCEL,
         ],
         workspace,
     )
@@ -764,7 +771,7 @@ def test_unpin_false_shows_stale_not_success(state, workspace, monkeypatch, caps
             ("pick", "Unpin"),
             _confirm_then_unpin,
             _BACK,
-            _BACK,
+            _CANCEL,
         ],
         workspace,
     )
@@ -858,23 +865,40 @@ def test_cancel_exits_cleanly_without_further_prompts(state, workspace, monkeypa
     assert len(fake.prompts) == len(script)
 
 
+def test_ask_prefers_unsafe_ask_and_maps_ctrl_c():
+    """_ask must take the unsafe_ask path and convert KeyboardInterrupt into
+    the browser-wide cancel: the safe ask() fallback would print questionary's
+    own "Cancelled by user" line next to the browser's exit notice."""
+
+    class _Prompt:
+        def unsafe_ask(self):
+            raise KeyboardInterrupt
+
+        def ask(self):
+            raise AssertionError("safe ask() must not be used when unsafe_ask exists")
+
+    with pytest.raises(tbrowse._CancelledError):
+        tbrowse._ask(_Prompt())
+
+
 def test_escape_walks_up_one_level_at_a_time(state, workspace, monkeypatch, capsys):
-    """Esc: action -> attempt list -> session list -> exit (a normal quit,
-    not the Ctrl+C 'Cancelled' path)."""
+    """Esc: action -> attempt list -> session list, then Ctrl+C quits."""
     _two_turn_log(state)
 
-    fake = _browse(monkeypatch, [("pick", "session"), ("pick", "#1"), _BACK, _BACK, _BACK], workspace)
+    fake = _browse(monkeypatch, [("pick", "session"), ("pick", "#1"), _BACK, _BACK, _CANCEL], workspace)
 
     messages = [m for kind, m, _ in fake.prompts if kind == "select"]
     assert messages == ["Session:", "Attempt:", "Action:", "Attempt:", "Session:"]
-    assert "Cancelled" not in capsys.readouterr().out
+    assert capsys.readouterr().out.count("Cancelled") == 1  # only the final Ctrl+C
 
 
-def test_escape_on_top_level_exits(state, workspace, monkeypatch, capsys):
+def test_escape_on_top_level_stays_until_ctrl_c(state, workspace, monkeypatch, capsys):
+    """Esc on the session screen is a guarded no-op (reflexive Esc must not
+    drop the browser); Ctrl+C is the only quit."""
     _two_turn_log(state)
-    fake = _browse(monkeypatch, [_BACK], workspace)
-    assert [m for _, m, _ in fake.prompts] == ["Session:"]
-    assert "Cancelled" not in capsys.readouterr().out
+    fake = _browse(monkeypatch, [_BACK, _BACK, _CANCEL], workspace)
+    assert [m for _, m, _ in fake.prompts] == ["Session:", "Session:", "Session:"]
+    assert "Cancelled" in capsys.readouterr().out
 
 
 def test_menu_screens_hide_back_exit_and_show_help(state, workspace, monkeypatch):
@@ -882,7 +906,7 @@ def test_menu_screens_hide_back_exit_and_show_help(state, workspace, monkeypatch
     separators directly under the title."""
     _two_turn_log(state)
 
-    fake = _browse(monkeypatch, [("pick", "session"), ("pick", "#1"), _BACK, _BACK, _BACK], workspace)
+    fake = _browse(monkeypatch, [("pick", "session"), ("pick", "#1"), _BACK, _BACK, _CANCEL], workspace)
 
     screens = {m: titles for kind, m, titles in fake.prompts if kind == "select"}
     for message, help_lines in [
@@ -933,9 +957,9 @@ def test_escape_cancels_action_without_side_effects(
     defs_before = dict(tstore.definitions(state))
 
     if action_pick == "Merge attempts":
-        script = [("pick", "session"), ("hit", "m", "#1"), *extra_answers, _BACK, _BACK, _BACK]
+        script = [("pick", "session"), ("hit", "m", "#1"), *extra_answers, _BACK, _BACK, _CANCEL]
     else:
-        script = [("pick", "session"), ("pick", "#1"), ("pick", action_pick), *extra_answers, _BACK, _BACK, _BACK]
+        script = [("pick", "session"), ("pick", "#1"), ("pick", action_pick), *extra_answers, _BACK, _BACK, _CANCEL]
 
     fake = _browse(monkeypatch, script, workspace)
 
@@ -944,7 +968,7 @@ def test_escape_cancels_action_without_side_effects(
     assert len(fake.prompts) == len(script)  # no extra prompt after the Esc
     assert absent not in out
     assert tbrowse._STALE_MESSAGE not in out
-    assert "Cancelled" not in out
+    assert out.count("Cancelled") == 1  # only the final Ctrl+C quit, not the Esc
     assert set(tstore.pins(state)) == pins_before
     assert dict(tstore.definitions(state)) == defs_before
     assert tverdict.read_verdicts(state) == []
@@ -958,7 +982,7 @@ def test_escape_on_report_confirm_keeps_bundle_and_pin(state, workspace, monkeyp
 
     fake = _browse(
         monkeypatch,
-        [("pick", "session"), ("pick", "#1"), ("pick", "Report"), _BACK, ("pick", "#1"), _BACK, _BACK, _BACK],
+        [("pick", "session"), ("pick", "#1"), ("pick", "Report"), _BACK, ("pick", "#1"), _BACK, _BACK, _CANCEL],
         workspace,
     )
 
@@ -1014,7 +1038,7 @@ def test_breadcrumbs_echo_navigation(state, workspace, monkeypatch, capsys):
 
     _browse(
         monkeypatch,
-        [("pick", "x[red]y"), ("pick", "#1"), ("pick", "Verdict"), "pass", "", "", _BACK, _BACK],
+        [("pick", "x[red]y"), ("pick", "#1"), ("pick", "Verdict"), "pass", "", "", _BACK, _CANCEL],
         workspace,
     )
 
@@ -1355,6 +1379,7 @@ def test_preview_wait_key_paths(key, done):
 
     with create_pipe_input() as pipe:
         q = tbrowse._wait_question(questionary, None, input=pipe, output=DummyOutput())
+        assert q.application.ttimeoutlen == tbrowse._ESC_FLUSH_TIMEOUT
         pipe.send_text(key)
         result = q.application.run()
 
@@ -1410,14 +1435,14 @@ def test_space_key_binding_returns_pointed_attempt():
 
 def test_space_previews_and_keeps_cursor(state, workspace, monkeypatch, capsys):
     _two_turn_log(state)
-    assert "Space preview" in tbrowse._HELP_ATTEMPT[1]
+    assert "[Space] preview" in tbrowse._HELP_ATTEMPT[1]
     scans = []
     real_scan = tbrowse.scan_sessions
     monkeypatch.setattr(tbrowse, "scan_sessions", lambda ws: scans.append(1) or real_scan(ws))
 
     fake = _browse(
         monkeypatch,
-        [("pick", "session"), ("hit", " ", "#1"), tbrowse._DONE, _BACK, _BACK],
+        [("pick", "session"), ("hit", " ", "#1"), tbrowse._DONE, _BACK, _CANCEL],
         workspace,
     )
 
@@ -1439,7 +1464,7 @@ def test_non_space_keyhit_on_attempt_row_is_noop(state, workspace, monkeypatch, 
 
     fake = _browse(
         monkeypatch,
-        [("pick", "session"), ("hit", "z", "#1"), _BACK, _BACK],
+        [("pick", "session"), ("hit", "z", "#1"), _BACK, _CANCEL],
         workspace,
     )
 
@@ -1458,7 +1483,7 @@ def test_m_key_opens_merge_and_merges(state, workspace, monkeypatch, capsys, key
 
     fake = _browse(
         monkeypatch,
-        [("pick", "session"), ("hit", key, "#2"), ("pickall", ["#1", "#2"]), _BACK, _BACK],
+        [("pick", "session"), ("hit", key, "#2"), ("pickall", ["#1", "#2"]), _BACK, _CANCEL],
         workspace,
     )
 
@@ -1472,7 +1497,7 @@ def test_merge_checkbox_shows_help_and_suppresses_instruction(state, workspace, 
 
     fake = _browse(
         monkeypatch,
-        [("pick", "session"), ("hit", "m", "#1"), _BACK, _BACK, _BACK],
+        [("pick", "session"), ("hit", "m", "#1"), _BACK, _BACK, _CANCEL],
         workspace,
     )
 
@@ -1494,10 +1519,10 @@ def test_merge_key_only_bound_with_multiple_attempts(state, workspace, monkeypat
         return real(questionary, style, message, help_lines, choices, **kw)
 
     monkeypatch.setattr(tbrowse, "_select_screen", spy)
-    _browse(monkeypatch, [("pick", "session"), _BACK, _BACK], workspace)
+    _browse(monkeypatch, [("pick", "session"), _BACK, _CANCEL], workspace)
 
     message, help_lines, extra_keys = next(r for r in recorded if r[0] == "Attempt:")
-    assert "M merge" in help_lines[1]
+    assert "[M] merge" in help_lines[1]
     assert {"m", "M"} <= set(extra_keys)
 
 
@@ -1511,10 +1536,10 @@ def test_merge_key_absent_with_single_attempt(state, workspace, monkeypatch):
         return real(questionary, style, message, help_lines, choices, **kw)
 
     monkeypatch.setattr(tbrowse, "_select_screen", spy)
-    fake = _browse(monkeypatch, [("pick", "session"), _BACK, _BACK], workspace)
+    fake = _browse(monkeypatch, [("pick", "session"), _BACK, _CANCEL], workspace)
 
     message, help_lines, extra_keys, _titles = next(r for r in recorded if r[0] == "Attempt:")
-    assert "M merge" not in help_lines[1]
+    assert "[M] merge" not in help_lines[1]
     assert "m" not in extra_keys and "M" not in extra_keys
     assert not any("Merge attempts" in t for _k, _m, titles in fake.prompts for t in titles)
 
@@ -1548,6 +1573,7 @@ def test_escape_binding_installs_on_every_prompt_kind(kind):
             q = questionary.confirm("m", **kwargs)
         tbrowse._inject_bindings(q)
         assert q.application.erase_when_done is True
+        assert q.application.ttimeoutlen == tbrowse._ESC_FLUSH_TIMEOUT
         pipe.send_text("\x1b")
         assert q.application.run() is tbrowse._BACK
 
@@ -1602,6 +1628,29 @@ def test_pointed_row_restyle_keeps_semantic_color():
     assert plain.color == success and not plain.bold
 
 
+def test_separator_lines_restyle_to_help_color():
+    """Help lines and table headers render with the readable ``help`` class,
+    not questionary's near-invisible ``separator`` — asserted on final attrs."""
+    questionary = pytest.importorskip("questionary")
+    create_pipe_input, DummyOutput = _pipe_io()
+    from raven.cli._theme import PALETTE, build_questionary_style
+
+    with create_pipe_input() as pipe:
+        q = questionary.select(
+            "m",
+            choices=[questionary.Separator("help line"), questionary.Choice("row", value="v")],
+            input=pipe,
+            output=DummyOutput(),
+        )
+        tbrowse._inject_bindings(q)
+        control = tbrowse._find_inquirer_control(q.application)
+        (sep_style,) = [tok[0] for tok in control.text() if tok[1] == "help line"]
+
+    assert "class:separator" not in sep_style
+    style = build_questionary_style("dark")
+    assert style.get_attrs_for_style_str(sep_style).color == PALETTE["dark"]["help"].lstrip("#")
+
+
 def test_selects_share_prompt_chrome(state, workspace, monkeypatch):
     """Every select/checkbox passes the shared QMARK and POINTER so the
     browser's prompt chrome matches the rest of the CLI."""
@@ -1621,7 +1670,7 @@ def test_selects_share_prompt_chrome(state, workspace, monkeypatch):
             "",
             "",
             _BACK,
-            _BACK,
+            _CANCEL,
         ],
         workspace,
     )
@@ -1647,7 +1696,7 @@ def test_merge_checkbox_validates_minimum(state, workspace, monkeypatch):
             ("hit", "m", "#1"),
             ("pickall", ["#1", "#2"]),
             _BACK,
-            _BACK,
+            _CANCEL,
         ],
         workspace,
     )
@@ -1673,7 +1722,7 @@ def test_pin_flow_uses_locked_pin_attempt(state, workspace, monkeypatch):
 
     _browse(
         monkeypatch,
-        [("pick", "session"), ("pick", "#1"), ("pick", "Pin"), "keep", _BACK, _BACK],
+        [("pick", "session"), ("pick", "#1"), ("pick", "Pin"), "keep", _BACK, _CANCEL],
         workspace,
     )
 
@@ -1755,7 +1804,7 @@ def test_nondefault_workspace_flows_into_save_and_minimize(state, tmp_path, monk
             ("pick", "#1"),
             ("pick", "Minimize"),
             _BACK,
-            _BACK,
+            _CANCEL,
         ],
         other,
     )


### PR DESCRIPTION
## Summary

Overhaul the interactive `raven trajectory` browser end to end, fixing every
issue from real-terminal testing:

- Navigation: every screen opens with a help area under its title (page
  purpose plus "[Key] function" hotkey hints, rendered in a new readable
  help color). Esc walks one level up (action -> attempt -> session); on the
  top-level session screen Esc stays put and quitting is Ctrl+C only, which
  prints a single exit notice. Esc inside a running action cancels just that
  action through a dedicated exception at the action boundary, so the back
  sentinel can never reach a conversion or the data layer; a cancelled
  report keeps its pre-confirm bundle-and-pin side effects (the existing
  declined-report contract). Back/Exit menu entries are gone; answered
  prompts erase themselves and navigation is echoed as breadcrumb lines
  with markup-escaped untrusted text.
- Tables: the session list is TITLE | ATTEMPTS | LAST ACTIVITY and the
  attempt list is # | STARTED | TURNS | SPANS | VERDICT | PIN | MERGED |
  PREVIEW with green check cells. Time cells keep the year. The layout is
  budgeted per screen build from the live terminal width (row indent, a
  safety margin, and inter-column gaps are all part of the math); PREVIEW
  drops as a whole column when it no longer fits, and below the dynamic
  minimum width the tightest layout is kept while the renderer clips
  overlong lines at the terminal edge. Every dynamic cell passes a
  single-line sanitization gate before width math (verdict sidecars only
  guarantee a non-empty string), cells are measured and truncated by
  terminal display width (CJK is 2 cells), and fixed column widths always
  fit their headers.
- Space preview: Space on an attempt row prints that attempt's per-turn
  input/output previews, collected in the same snapshot scan and sorted by
  a fully-stringified key so ordering never follows log source order (the
  table PREVIEW cell derives from the same sorted collection). Any key,
  arrow keys included, returns with the cursor kept on the row; the waiter
  passes the terminal's CPR reply through to the renderer instead of
  treating it as a keypress, and Ctrl+C keeps the browser-wide cancel.
- Merge hotkey: with two or more attempts, m/M opens the multi-select merge
  (advertised in the help line; the old "Merge attempts" menu entry is
  gone). The checkbox screen carries its own help line for toggle, confirm,
  and cancel. A single attempt neither binds nor advertises the key.
- Theme and feel: new success (green check) and help (readable hint text)
  colors in both palettes, all WCAG AA on their backgrounds; a lone ESC is
  flushed after 50ms instead of prompt_toolkit's 0.5s default, removing the
  laggy Esc feel.

The data layer is untouched: changes are confined to
raven/cli/trajectory_browse.py, raven/cli/_theme.py, and their tests. The
id-taking subcommands (raven trajectory save/list/...) behave as before.

## Type

- [x] Fix
- [ ] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `COLORTERM=truecolor uv run pytest tests/test_cli_theme.py tests/test_cli_trajectory_browse.py tests/test_cli_trajectory_commands.py -q` -> 220 passed
- `COLORTERM=truecolor uv run pytest tests/ --ignore=tests/integration -q` -> 6917 passed; the 10 failed + 20 errors are the pre-existing environment-dependent set, identical file-by-file on a clean main checkout (cron, everos server, config loader, tracing viewer)
- `uv run ruff check` and `uv run ruff format --check` on the four touched files -> clean
- PTY smoke on a CPR-answering pseudo terminal at 100 and 58 columns: full flow (preview, merge cancel, action screen, staged Esc backout, Ctrl+C quit) and the narrow-width degradation contract
- New coverage includes real pipe-input key-binding tests (Esc on all four prompt kinds, Space/m/M hits, waiter key paths with CPR pass-through), table budget/clipping boundaries at the computed minimum width, and corrupt verdict/timestamp corpora

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

## Risk

- The interactive browser's look and key protocol change wholesale (that is
  the point of this PR): Esc no longer quits from the top level (Ctrl+C
  does), Back/Exit entries are gone, and lists render as tables. The
  machine-facing subcommands and the trajectory data layer are untouched.
- Rollback: revert the squash commit; the browser returns to the previous
  interaction wholesale, no data migration involved.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A