### PR TITLE
feat(trajectory): adjudicate redaction findings per item in bug reports

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -653,6 +653,26 @@ never re-collects.
 _Avoid_: confusing it with the Trajectory Report it embeds — the Package wraps
 one and adds the problem metadata envelope.
 
+**Review Item** (`raven/trajectory/review.py`):
+One decision the user must make before a Bug Report Package may ship, built by
+`build_review_items` from the merged redaction signals: a *suspected* item per
+residual-finding token value (adjudicated by value across every file it appears
+in — keep as-is, or replace with `[REDACTED:user-confirmed]`), or the
+*confirmed sensitive* item for a private-key pattern hit (content already
+replaced; the user acknowledges the risk rather than choosing content). Items
+whose token values contain one another are linked and must share one decision.
+_Avoid_: "finding" for the decision unit — a finding is the residual scan's
+raw signal; an item may merge several findings of the same value.
+
+**User Decision** (`raven/trajectory/review.py`, `raven/trajectory/bugreport.py`):
+The recorded outcome of one Review Item — `acknowledged`, `kept`, or
+`redacted` — carried in the `user_decisions` array of `bugreport.json` and
+`record.json` (item id, category, semantic sources with counts, masked
+sample, action) so the recipient can see what a human kept, replaced, or
+acknowledged. `apply_review_decisions` guarantees the array matches the
+delivered bytes: replaced values are verified gone in every spelling variant
+and kept values verified untouched before the export freezes.
+
 **Trajectory Replay** (`raven/trajectory/replay.py`):
 Mock re-run of the harness against a Trajectory Bundle (`raven trajectory replay`):
 recorded model replies (`llm.output`) and tool results (`tool.output`) are fed back

--- a/raven/cli/trajectory_browse.py
+++ b/raven/cli/trajectory_browse.py
@@ -958,9 +958,7 @@ def _ask_review_item(
         ]
     while True:
         action = _ask_action(
-            questionary.select(
-                "Decision:", choices=choices, style=style, qmark=QMARK, pointer=POINTER, instruction=" "
-            )
+            questionary.select("Decision:", choices=choices, style=style, qmark=QMARK, pointer=POINTER, instruction=" ")
         )
         if action == _REVIEW_CANCEL:
             raise treview.ReviewCancelledError("the report was cancelled from the review screen")

--- a/raven/cli/trajectory_browse.py
+++ b/raven/cli/trajectory_browse.py
@@ -63,12 +63,14 @@ from typing import Any
 import typer
 from rich.console import Console
 from rich.markup import escape
+from rich.text import Text
 
 from raven.cli import trajectory_commands as tcmd
 from raven.cli._theme import POINTER, QMARK
 from raven.session.manager import SessionManager
 from raven.tracing import config as tracing_config
 from raven.trajectory import bugreport as breport
+from raven.trajectory import review as treview
 from raven.trajectory import store as tstore
 from raven.trajectory.bundle import _default_workspace, collect_bundle
 from raven.trajectory.cassette import minimize_bundle
@@ -881,25 +883,128 @@ def _print_packaging_failure(report_id: str, reason: str, *, retryable: bool) ->
         console.print("  entry — retrying will not re-collect the trajectory.")
 
 
-def _print_blocked(trigger: str) -> None:
-    if trigger == "trajectory":
-        console.print("[red]✗ Cannot create a bug report from this attempt.[/red]", highlight=False)
+# Reasons whose content the review screen already presents as items (the
+# remaining reasons are the warning lines the screen must still show).
+_REVIEW_ITEM_REASON_PREFIXES = ("residual scan flagged", "the original trajectory contained")
+
+_REVIEW_CONTEXT_WINDOW = 80
+_REVIEW_OCCURRENCE_LIMIT = 5
+
+
+def _review_warnings(reasons: list[str]) -> list[str]:
+    return [reason for reason in reasons if not reason.startswith(_REVIEW_ITEM_REASON_PREFIXES)]
+
+
+def _print_review_occurrence(occurrence: dict[str, Any]) -> None:
+    line, start, end = occurrence["line"], occurrence["start"], occurrence["end"]
+    lo = max(0, start - _REVIEW_CONTEXT_WINDOW)
+    hi = min(len(line), end + _REVIEW_CONTEXT_WINDOW)
+    text = Text("  ")
+    if lo:
+        text.append("...")
+    text.append(line[lo:start])
+    text.append(line[start:end], style="bold red")
+    text.append(line[end:hi])
+    if hi < len(line):
+        text.append("...")
+    console.print(text)
+
+
+def _print_review_item(item: Any, index: int, total: int, index_by_id: dict[str, int]) -> None:
+    console.print()
+    title = (
+        "Confirmed sensitive: private key block (already replaced)"
+        if item.kind == treview.KIND_CONFIRMED
+        else f"Suspected: {item.category} token"
+    )
+    console.print(escape(f"[{index}/{total}] {title}"), highlight=False)
+    for source in item.sources:
+        count = f" ({source['count']})" if source["count"] > 1 else ""
+        console.print(f"  Source: {escape(source['label'])}{count}", highlight=False)
+    for occurrence in item.occurrences[:_REVIEW_OCCURRENCE_LIMIT]:
+        _print_review_occurrence(occurrence)
+    if len(item.occurrences) > _REVIEW_OCCURRENCE_LIMIT:
         console.print(
-            "  The original trajectory contains a private key block. Even though the copy\n"
-            "  was redacted, this material is not allowed to leave the machine as a bug\n"
-            "  report package.\n"
-            "  Remove the key from the source data and retry, or use the expert command\n"
-            "  `raven trajectory report` at your own risk.",
-            highlight=False,
+            f"  ... and {len(item.occurrences) - _REVIEW_OCCURRENCE_LIMIT} more occurrence(s)", highlight=False
         )
+    if item.linked:
+        linked = ", ".join(f"#{index_by_id[other]}" for other in item.linked)
+        console.print(f"  Linked with item {linked} (overlapping values) — decisions must match.", highlight=False)
+
+
+_REVIEW_CANCEL = "__cancel_report__"
+
+
+def _ask_review_item(
+    item: Any, index: int, total: int, index_by_id: dict[str, int], questionary: Any, style: Any
+) -> str:
+    _print_review_item(item, index, total, index_by_id)
+    # questionary.Choice falls back to the title when value is None, so the
+    # cancel row needs an explicit sentinel value.
+    if item.kind == treview.KIND_CONFIRMED:
+        choices = [
+            questionary.Choice("Acknowledge and continue", value=treview.ACTION_ACKNOWLEDGED),
+            questionary.Choice("Cancel the report", value=_REVIEW_CANCEL),
+        ]
     else:
-        console.print("[red]✗ Cannot create a bug report with these details.[/red]", highlight=False)
-        console.print(
-            "  The problem details you entered contain a private key block. This material\n"
-            "  is not allowed to leave the machine as a bug report package.\n"
-            "  Start over and describe the problem without pasting the key itself.",
-            highlight=False,
-        )
+        choices = [
+            questionary.Choice("Keep (harmless, ship as-is)", value=treview.ACTION_KEPT),
+            questionary.Choice("Replace with [REDACTED:user-confirmed]", value=treview.ACTION_REDACTED),
+            questionary.Choice("Cancel the report", value=_REVIEW_CANCEL),
+        ]
+    action = _ask_action(
+        questionary.select("Decision:", choices=choices, style=style, qmark=QMARK, pointer=POINTER, instruction=" ")
+    )
+    if action == _REVIEW_CANCEL:
+        raise treview.ReviewCancelledError("the report was cancelled from the review screen")
+    return action
+
+
+def _conflicted_review_items(items: list[Any], actions: dict[str, str]) -> list[Any]:
+    by_id = {item.id: item for item in items}
+    conflicted: list[Any] = []
+    seen: set[str] = set()
+    for item in items:
+        for other_id in item.linked:
+            if actions[item.id] != actions[other_id]:
+                for item_id in (item.id, other_id):
+                    if item_id not in seen:
+                        seen.add(item_id)
+                        conflicted.append(by_id[item_id])
+    return conflicted
+
+
+def make_review_decider(questionary: Any, style: Any) -> Any:
+    """The interactive ``decide`` callback for :func:`breport.freeze_export`.
+
+    Validates before returning and re-asks only the conflicting linked group,
+    so the pipeline never sees an inconsistent decision set (and nothing is
+    applied until the set is legal). Shared by the browser and the CLI's TTY
+    path.
+    """
+
+    def _decide(items: list[Any], reasons: list[str]) -> list[Any]:
+        console.print()
+        console.print(f"Redaction review — {len(items)} item(s) need your decision", highlight=False)
+        for warning in _review_warnings(reasons):
+            console.print(f"  [yellow]! {escape(warning)}[/yellow]", highlight=False)
+        index_by_id = {item.id: index for index, item in enumerate(items, 1)}
+        actions: dict[str, str] = {}
+        for index, item in enumerate(items, 1):
+            actions[item.id] = _ask_review_item(item, index, len(items), index_by_id, questionary, style)
+        while True:
+            decisions = [treview.ReviewDecision(item.id, actions[item.id]) for item in items]
+            try:
+                treview.validate_review_decisions(items, decisions)
+                return decisions
+            except treview.ReviewConflictError as exc:
+                console.print(f"[red]{escape(str(exc))}[/red]", highlight=False)
+                for item in _conflicted_review_items(items, actions):
+                    actions[item.id] = _ask_review_item(
+                        item, index_by_id[item.id], len(items), index_by_id, questionary, style
+                    )
+
+    return _decide
 
 
 def _ask_problem_fields(questionary: Any, style: Any) -> dict[str, str]:
@@ -979,15 +1084,20 @@ def _print_bug_summary(session_row: SessionRow, index: int, row: AttemptRow, pre
     counts = f"{exact} known-value + {patterns} pattern replacement(s)"
     if prep.classification == breport.CLASSIFICATION_NEEDS_REVIEW:
         _summary_line("Redaction", f"{counts} · NEEDS REVIEW")
-        findings = redaction["residual_findings"]
+        for notice in redaction.get("security_notices") or []:
+            console.print(f"    [yellow]! {escape(notice)}[/yellow]", highlight=False)
         for reason in prep.reasons:
-            console.print(f"    - {escape(reason)}{':' if reason.startswith('residual') and findings else ''}")
-            if reason.startswith("residual"):
-                for finding in findings[:5]:
-                    sample = _collapse_text(f"{finding['file']}: {finding['sample']}") or ""
-                    console.print(f"        {escape(sample)}", highlight=False)
-                if len(findings) > 5:
-                    console.print(f"        ... and {len(findings) - 5} more (see redaction.json)")
+            console.print(f"    - {escape(reason)}", highlight=False)
+        decisions = redaction.get("user_decisions") or []
+        if decisions:
+            _summary_line("Decisions", f"{len(decisions)} review decision(s)")
+            for entry in decisions:
+                sources = ", ".join(
+                    entry_source["source"] + (f" x{entry_source['count']}" if entry_source["count"] > 1 else "")
+                    for entry_source in entry["sources"]
+                )
+                line = _collapse_text(f"{entry['action']:<12} {entry['masked_sample']} — {sources}") or ""
+                console.print(f"    - {escape(line)}", highlight=False)
     else:
         _summary_line("Redaction", f"{counts} · residual scan: clean")
     console.print(_PII_NOTE, highlight=False)
@@ -996,21 +1106,21 @@ def _print_bug_summary(session_row: SessionRow, index: int, row: AttemptRow, pre
 
 
 def _confirm_create(questionary: Any, style: Any, prep: Any) -> bool:
-    ok = _ask_action(questionary.confirm("Create the bug report?", default=True, style=style, qmark=QMARK))
-    if not ok:
-        return False
+    """One confirmation: the review variant carries the risk authorization.
+
+    The per-item adjudication already happened during the freeze, so a review
+    report needs exactly one risk-worded consent (listing was printed by the
+    summary) instead of the old create-then-review double prompt.
+    """
     if prep.classification == breport.CLASSIFICATION_NEEDS_REVIEW:
         return bool(
             _ask_action(
                 questionary.confirm(
-                    "The redaction needs review: flagged content may include real secrets. Ship the package anyway?",
-                    default=False,
-                    style=style,
-                    qmark=QMARK,
+                    "Ship the package with the risks listed above?", default=False, style=style, qmark=QMARK
                 )
             )
         )
-    return True
+    return bool(_ask_action(questionary.confirm("Create the bug report?", default=True, style=style, qmark=QMARK)))
 
 
 def _bug_report_action(
@@ -1040,19 +1150,13 @@ def _bug_report_action(
         return
 
     try:
-        if prep.classification == breport.CLASSIFICATION_BLOCKED:
-            _print_blocked("trajectory")
-            return
         fields = _ask_problem_fields(questionary, style)
         try:
-            prep = breport.freeze_export(prep, **fields)
+            prep = breport.freeze_export(prep, **fields, decide=make_review_decider(questionary, style))
         except breport.PreparationError as exc:
             console.print(
                 f"[red]✗ Could not prepare the trajectory snapshot: {escape(str(exc))}[/red]", highlight=False
             )
-            return
-        if prep.classification == breport.CLASSIFICATION_BLOCKED:
-            _print_blocked("problem")
             return
         _print_bug_summary(session_row, index, row, prep)
         if not _confirm_create(questionary, style, prep):
@@ -1072,7 +1176,7 @@ def _bug_report_action(
             _print_packaging_failure(prep.report_id, str(exc), retryable=exc.retryable)
             return
         _print_report_ready(record)
-    except _ActionCancelledError:
+    except (_ActionCancelledError, treview.ReviewCancelledError):
         console.print(_CANCELLED_MESSAGE)
     finally:
         # A no-op after the record landed (the staging directory was renamed
@@ -1091,6 +1195,8 @@ def _print_report_details(record: dict[str, Any]) -> None:
     if reasons:
         status_text += f" ({len(reasons)} reason(s))"
     console.print(f"  Completeness: {escape(status_text)}", highlight=False)
+    for notice in (record.get("redaction") or {}).get("security_notices") or []:
+        console.print(f"  [yellow]! {escape(notice)}[/yellow]", highlight=False)
     if record["status"] == breport.STATUS_LOCAL_READY:
         console.print(f"  Package:  [cyan]{escape(record['package']['path'])}[/cyan]", highlight=False)
         console.print("  Not uploaded — hand the package file to a developer yourself.")

--- a/raven/cli/trajectory_browse.py
+++ b/raven/cli/trajectory_browse.py
@@ -933,6 +933,7 @@ def _print_review_item(item: Any, index: int, total: int, index_by_id: dict[str,
 
 
 _REVIEW_CANCEL = "__cancel_report__"
+_REVIEW_UNDECIDED = "__no_decision__"
 
 
 def _ask_review_item(
@@ -940,7 +941,9 @@ def _ask_review_item(
 ) -> str:
     _print_review_item(item, index, total, index_by_id)
     # questionary.Choice falls back to the title when value is None, so the
-    # cancel row needs an explicit sentinel value.
+    # cancel/placeholder rows need explicit sentinel values. Suspected items
+    # have no default action: the pointer starts on a placeholder that records
+    # nothing, so a bare Enter cannot silently keep an unknown token.
     if item.kind == treview.KIND_CONFIRMED:
         choices = [
             questionary.Choice("Acknowledge and continue", value=treview.ACTION_ACKNOWLEDGED),
@@ -948,16 +951,22 @@ def _ask_review_item(
         ]
     else:
         choices = [
+            questionary.Choice("(select a decision)", value=_REVIEW_UNDECIDED),
             questionary.Choice("Keep (harmless, ship as-is)", value=treview.ACTION_KEPT),
             questionary.Choice("Replace with [REDACTED:user-confirmed]", value=treview.ACTION_REDACTED),
             questionary.Choice("Cancel the report", value=_REVIEW_CANCEL),
         ]
-    action = _ask_action(
-        questionary.select("Decision:", choices=choices, style=style, qmark=QMARK, pointer=POINTER, instruction=" ")
-    )
-    if action == _REVIEW_CANCEL:
-        raise treview.ReviewCancelledError("the report was cancelled from the review screen")
-    return action
+    while True:
+        action = _ask_action(
+            questionary.select(
+                "Decision:", choices=choices, style=style, qmark=QMARK, pointer=POINTER, instruction=" "
+            )
+        )
+        if action == _REVIEW_CANCEL:
+            raise treview.ReviewCancelledError("the report was cancelled from the review screen")
+        if action != _REVIEW_UNDECIDED:
+            return action
+        console.print("  This item has no default — choose Keep, Replace, or Cancel.", highlight=False)
 
 
 def _conflicted_review_items(items: list[Any], actions: dict[str, str]) -> list[Any]:

--- a/raven/cli/trajectory_browse.py
+++ b/raven/cli/trajectory_browse.py
@@ -55,7 +55,9 @@ Control flow contracts:
 from __future__ import annotations
 
 import logging
+import re
 import shutil
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -887,27 +889,67 @@ def _print_packaging_failure(report_id: str, reason: str, *, retryable: bool) ->
 # remaining reasons are the warning lines the screen must still show).
 _REVIEW_ITEM_REASON_PREFIXES = ("residual scan flagged", "the original trajectory contained")
 
-_REVIEW_CONTEXT_WINDOW = 80
-_REVIEW_OCCURRENCE_LIMIT = 5
+_REVIEW_CONTEXT_WINDOW = 200
+_REVIEW_WHOLE_LINE_LIMIT = 300
+_REVIEW_CONTEXT_GROUP_LIMIT = 5
+_REVIEW_PATHS_NOTE = "Paths are relative to the trajectory snapshot inside the package."
 
 
 def _review_warnings(reasons: list[str]) -> list[str]:
     return [reason for reason in reasons if not reason.startswith(_REVIEW_ITEM_REASON_PREFIXES)]
 
 
-def _print_review_occurrence(occurrence: dict[str, Any]) -> None:
+def _occurrence_display(occurrence: dict[str, Any]) -> tuple[str, list[tuple[int, int]]]:
+    """(rendered context, highlight spans) for one occurrence.
+
+    Short lines render whole with every hit of the value highlighted (two
+    hits on one line must not lose their positions to display-text dedup);
+    long lines get a window centered on this occurrence, so hits at other
+    positions naturally render as distinct texts.
+    """
     line, start, end = occurrence["line"], occurrence["start"], occurrence["end"]
+    token = line[start:end]
+    stripped = line.strip()
+    if len(stripped) <= _REVIEW_WHOLE_LINE_LIMIT:
+        offset = line.find(stripped) if stripped else 0
+        spans = [(m.start(), m.end()) for m in re.finditer(re.escape(token), stripped)] if token else []
+        return stripped, spans or [(max(0, start - offset), max(0, end - offset))]
     lo = max(0, start - _REVIEW_CONTEXT_WINDOW)
     hi = min(len(line), end + _REVIEW_CONTEXT_WINDOW)
-    text = Text("  ")
-    if lo:
-        text.append("...")
-    text.append(line[lo:start])
-    text.append(line[start:end], style="bold red")
-    text.append(line[end:hi])
-    if hi < len(line):
-        text.append("...")
-    console.print(text)
+    prefix = "..." if lo else ""
+    suffix = "..." if hi < len(line) else ""
+    text = prefix + line[lo:hi] + suffix
+    return text, [(len(prefix) + start - lo, len(prefix) + end - lo)]
+
+
+def _grouped_occurrences(item: Any) -> list[dict[str, Any]]:
+    groups: list[dict[str, Any]] = []
+    by_text: dict[str, dict[str, Any]] = {}
+    for occurrence in item.occurrences:
+        text, spans = _occurrence_display(occurrence)
+        group = by_text.get(text)
+        if group is None:
+            group = {"text": text, "spans": spans, "occurrences": []}
+            by_text[text] = group
+            groups.append(group)
+        group["occurrences"].append(occurrence)
+    return groups
+
+
+def _print_context_text(group: dict[str, Any]) -> None:
+    text = group["text"]
+    rendered = Text("    ")
+    pos = 0
+    for start, end in sorted(group["spans"]):
+        rendered.append(text[pos:start])
+        rendered.append(text[start:end], style="bold red")
+        pos = end
+    rendered.append(text[pos:])
+    console.print(rendered)
+
+
+def _occurrence_location(occurrence: dict[str, Any]) -> str:
+    return f"{occurrence['label']} — {occurrence['file']}:{occurrence['line_no']}"
 
 
 def _print_review_item(item: Any, index: int, total: int, index_by_id: dict[str, int]) -> None:
@@ -918,53 +960,74 @@ def _print_review_item(item: Any, index: int, total: int, index_by_id: dict[str,
         else f"Suspected: {item.category} token"
     )
     console.print(escape(f"[{index}/{total}] {title}"), highlight=False)
-    for source in item.sources:
-        count = f" ({source['count']})" if source["count"] > 1 else ""
-        console.print(f"  Source: {escape(source['label'])}{count}", highlight=False)
-    for occurrence in item.occurrences[:_REVIEW_OCCURRENCE_LIMIT]:
-        _print_review_occurrence(occurrence)
-    if len(item.occurrences) > _REVIEW_OCCURRENCE_LIMIT:
-        console.print(
-            f"  ... and {len(item.occurrences) - _REVIEW_OCCURRENCE_LIMIT} more occurrence(s)", highlight=False
-        )
+    places = len(item.occurrences)
+    if item.kind == treview.KIND_CONFIRMED:
+        console.print(f"  Token: {escape(item.masked_sample)} — already replaced, {places} place(s)", highlight=False)
+    else:
+        console.print(f"  Token: {escape(item.token)} — the same value in {places} place(s)", highlight=False)
     if item.linked:
         linked = ", ".join(f"#{index_by_id[other]}" for other in item.linked)
         console.print(f"  Linked with item {linked} (overlapping values) — decisions must match.", highlight=False)
-
-
-_REVIEW_CANCEL = "__cancel_report__"
-_REVIEW_UNDECIDED = "__no_decision__"
+    groups = _grouped_occurrences(item)
+    shown = groups[:_REVIEW_CONTEXT_GROUP_LIMIT]
+    hidden = groups[_REVIEW_CONTEXT_GROUP_LIMIT:]
+    for position, group in enumerate(shown, 1):
+        header = f"  Context {position} of {len(groups)}" if len(groups) > 1 else "  Context"
+        if len(group["occurrences"]) > 1:
+            header += f" (identical in {len(group['occurrences'])} place(s))"
+        console.print(header + ":", highlight=False)
+        _print_context_text(group)
+        console.print("  Seen at:", highlight=False)
+        for occurrence in group["occurrences"]:
+            console.print(f"    - {escape(_occurrence_location(occurrence))}", highlight=False)
+    if hidden:
+        # Context text is the only thing capped: every occurrence's semantic
+        # source and file:line stay visible no matter how many groups exist.
+        console.print(f"  ... {len(hidden)} more distinct context(s), locations listed below:", highlight=False)
+        for group in hidden:
+            for occurrence in group["occurrences"]:
+                console.print(f"    - {escape(_occurrence_location(occurrence))} (context omitted)", highlight=False)
 
 
 def _ask_review_item(
     item: Any, index: int, total: int, index_by_id: dict[str, int], questionary: Any, style: Any
 ) -> str:
     _print_review_item(item, index, total, index_by_id)
-    # questionary.Choice falls back to the title when value is None, so the
-    # cancel/placeholder rows need explicit sentinel values. Suspected items
-    # have no default action: the pointer starts on a placeholder that records
-    # nothing, so a bare Enter cannot silently keep an unknown token.
     if item.kind == treview.KIND_CONFIRMED:
-        choices = [
-            questionary.Choice("Acknowledge and continue", value=treview.ACTION_ACKNOWLEDGED),
-            questionary.Choice("Cancel the report", value=_REVIEW_CANCEL),
-        ]
-    else:
-        choices = [
-            questionary.Choice("(select a decision)", value=_REVIEW_UNDECIDED),
-            questionary.Choice("Keep (harmless, ship as-is)", value=treview.ACTION_KEPT),
-            questionary.Choice("Replace with [REDACTED:user-confirmed]", value=treview.ACTION_REDACTED),
-            questionary.Choice("Cancel the report", value=_REVIEW_CANCEL),
-        ]
+        while True:
+            answer = (
+                _ask_action(
+                    questionary.text(
+                        "Decision — [Enter] acknowledge and continue / [c] cancel:", style=style, qmark=QMARK
+                    )
+                )
+                .strip()
+                .lower()
+            )
+            if answer == "":
+                return treview.ACTION_ACKNOWLEDGED
+            if answer == "c":
+                raise treview.ReviewCancelledError("the report was cancelled from the review screen")
+            console.print("  Press Enter to acknowledge, or c to cancel.", highlight=False)
     while True:
-        action = _ask_action(
-            questionary.select("Decision:", choices=choices, style=style, qmark=QMARK, pointer=POINTER, instruction=" ")
+        answer = (
+            _ask_action(
+                questionary.text(
+                    "Decision — [k] keep / [r] replace with [REDACTED:user-confirmed] / [c] cancel:",
+                    style=style,
+                    qmark=QMARK,
+                )
+            )
+            .strip()
+            .lower()
         )
-        if action == _REVIEW_CANCEL:
+        if answer == "k":
+            return treview.ACTION_KEPT
+        if answer == "r":
+            return treview.ACTION_REDACTED
+        if answer == "c":
             raise treview.ReviewCancelledError("the report was cancelled from the review screen")
-        if action != _REVIEW_UNDECIDED:
-            return action
-        console.print("  This item has no default — choose Keep, Replace, or Cancel.", highlight=False)
+        console.print("  Choose k, r, or c — this item has no default.", highlight=False)
 
 
 def _conflicted_review_items(items: list[Any], actions: dict[str, str]) -> list[Any]:
@@ -993,6 +1056,7 @@ def make_review_decider(questionary: Any, style: Any) -> Any:
     def _decide(items: list[Any], reasons: list[str]) -> list[Any]:
         console.print()
         console.print(f"Redaction review — {len(items)} item(s) need your decision", highlight=False)
+        console.print(f"  {_REVIEW_PATHS_NOTE}", highlight=False)
         for warning in _review_warnings(reasons):
             console.print(f"  [yellow]! {escape(warning)}[/yellow]", highlight=False)
         index_by_id = {item.id: index for index, item in enumerate(items, 1)}
@@ -1055,6 +1119,24 @@ def _ask_problem_fields(questionary: Any, style: Any) -> dict[str, str]:
     return fields
 
 
+def _decision_tally(decisions: list[dict[str, Any]]) -> str:
+    """`N decision(s) complete — X kept, Y redacted, Z acknowledged` (hit kinds only)."""
+    tally = Counter(entry.get("action") for entry in decisions)
+    breakdown = ", ".join(
+        f"{tally[action]} {action}" for action in ("kept", "redacted", "acknowledged") if tally[action]
+    )
+    return f"{len(decisions)} decision(s) complete — {breakdown}"
+
+
+def _decision_line(entry: dict[str, Any]) -> str:
+    """One decision row: action, short masked token, first source (+N more)."""
+    token_label = entry.get("masked_token") or entry.get("masked_sample") or ""
+    sources = entry.get("sources") or []
+    first = sources[0]["source"] if sources else ""
+    more = f" (+{len(sources) - 1} more sources)" if len(sources) > 1 else ""
+    return _collapse_text(f"{entry.get('action', ''):<12} {token_label} — {first}{more}") or ""
+
+
 def _summary_line(label: str, value: str) -> None:
     console.print(f"  {label + ':':<14}{value}", highlight=False)
 
@@ -1097,14 +1179,9 @@ def _print_bug_summary(session_row: SessionRow, index: int, row: AttemptRow, pre
             console.print(f"    - {escape(reason)}", highlight=False)
         decisions = redaction.get("user_decisions") or []
         if decisions:
-            _summary_line("Decisions", f"{len(decisions)} review decision(s)")
+            _summary_line("Reviewed", _decision_tally(decisions))
             for entry in decisions:
-                sources = ", ".join(
-                    entry_source["source"] + (f" x{entry_source['count']}" if entry_source["count"] > 1 else "")
-                    for entry_source in entry["sources"]
-                )
-                line = _collapse_text(f"{entry['action']:<12} {entry['masked_sample']} — {sources}") or ""
-                console.print(f"    - {escape(line)}", highlight=False)
+                console.print(f"    - {escape(_decision_line(entry))}", highlight=False)
     else:
         _summary_line("Redaction", f"{counts} · residual scan: clean")
     console.print(_PII_NOTE, highlight=False)
@@ -1120,6 +1197,8 @@ def _confirm_create(questionary: Any, style: Any, prep: Any) -> bool:
     summary) instead of the old create-then-review double prompt.
     """
     if prep.classification == breport.CLASSIFICATION_NEEDS_REVIEW:
+        if prep.user_decisions:
+            console.print("Review decisions are complete. Confirm the report contents shown above.", highlight=False)
         return bool(
             _ask_action(
                 questionary.confirm(

--- a/raven/cli/trajectory_browse.py
+++ b/raven/cli/trajectory_browse.py
@@ -929,18 +929,29 @@ def _grouped_occurrences(item: Any) -> list[dict[str, Any]]:
         text, spans = _occurrence_display(occurrence)
         group = by_text.get(text)
         if group is None:
-            group = {"text": text, "spans": spans, "occurrences": []}
+            group = {"text": text, "spans": [], "occurrences": []}
             by_text[text] = group
             groups.append(group)
+        # Two windows on a long line can render the same text from different
+        # hit positions; every occurrence's spans must survive the merge.
+        for span in spans:
+            if span not in group["spans"]:
+                group["spans"].append(span)
         group["occurrences"].append(occurrence)
     return groups
 
 
 def _print_context_text(group: dict[str, Any]) -> None:
     text = group["text"]
+    merged: list[list[int]] = []
+    for start, end in sorted(group["spans"]):
+        if merged and start <= merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
     rendered = Text("    ")
     pos = 0
-    for start, end in sorted(group["spans"]):
+    for start, end in merged:
         rendered.append(text[pos:start])
         rendered.append(text[start:end], style="bold red")
         pos = end

--- a/raven/cli/trajectory_commands.py
+++ b/raven/cli/trajectory_commands.py
@@ -354,10 +354,15 @@ def trajectory_report_bug(
 
     def _decide(items: list, reasons: list[str]) -> list:
         if interactive:
+            from raven.cli import trajectory_browse as tbrowse
             from raven.cli._styles import RAVEN_STYLE
-            from raven.cli.trajectory_browse import _require_questionary, make_review_decider
 
-            return make_review_decider(_require_questionary(), RAVEN_STYLE)(items, reasons)
+            try:
+                return tbrowse.make_review_decider(tbrowse._require_questionary(), RAVEN_STYLE)(items, reasons)
+            except (tbrowse._ActionCancelledError, tbrowse._CancelledError) as exc:
+                # Esc/Ctrl-C during adjudication: the CLI has no outer screen
+                # to unwind to, so both mean "cancel this report".
+                raise treview.ReviewCancelledError("cancelled from the review screen") from exc
         if not accept_risk:
             # Deciding needs authorization a script has not granted; stop
             # before any further export work (the staging cleanup still runs).

--- a/raven/cli/trajectory_commands.py
+++ b/raven/cli/trajectory_commands.py
@@ -14,8 +14,9 @@ wrappers over the trajectory layer:
   a Bug Report (record + shippable package with the problem metadata) for an
   explicit attempt and description (:mod:`raven.trajectory.bugreport`). Unlike
   ``report``, its deliverable embeds the trajectory inside a problem-metadata
-  envelope and is gated by the redaction classification; ``blocked`` cannot be
-  bypassed by any flag.
+  envelope and is gated by the redaction classification: review findings are
+  adjudicated per item, and shipping a review report always takes an explicit
+  risk authorization (never implied by ``--yes``).
 - ``replay``  — feed a bundle's recorded model replies and tool results back
   through the live harness (:func:`raven.trajectory.replay.run_replay`; no
   real tool code runs, no spans are emitted).
@@ -296,7 +297,14 @@ def trajectory_report_bug(
     accept_risk: bool = typer.Option(
         False,
         "--accept-risk",
-        help="Grant the separate needs_review authorization (--yes does not imply it)",
+        help="Authorize a review report: acknowledges confirmed-sensitive items"
+        " and grants the risk consent (--yes does not imply it)",
+    ),
+    keep_findings: bool = typer.Option(
+        False, "--keep-findings", help="Keep every suspected finding as-is (confirms they are harmless)"
+    ),
+    redact_findings: bool = typer.Option(
+        False, "--redact-findings", help="Replace every suspected finding with [REDACTED:user-confirmed]"
     ),
     workspace: Path | None = typer.Option(
         None, "--workspace", "-w", help="Workspace holding the session records (default: the configured workspace)"
@@ -309,9 +317,11 @@ def trajectory_report_bug(
 
     The package embeds a redacted, path-sanitized Trajectory Report inside a
     problem-metadata envelope (completeness, environment, redaction summary).
-    Review findings are adjudicated per item on a TTY; without one, --yes is
-    required and any review report additionally requires --accept-risk
-    (findings ship as kept, private-key hits as acknowledged).
+    Review findings are adjudicated per item on a TTY (a flag pre-decides the
+    items of its kind); without one, --yes is required, suspected findings
+    need --keep-findings or --redact-findings, and every review report needs
+    --accept-risk — a run missing flags fails listing all items and every
+    missing flag at once, producing nothing.
     """
     from raven.trajectory import bugreport as breport
     from raven.trajectory import review as treview
@@ -324,6 +334,11 @@ def trajectory_report_bug(
         raise typer.Exit(code=1)
     if severity and severity not in breport.SEVERITIES:
         console.print(f"[red]--severity must be one of: {', '.join(breport.SEVERITIES)}[/red]")
+        raise typer.Exit(code=1)
+    if keep_findings and redact_findings:
+        console.print(
+            "[red]--keep-findings and --redact-findings are mutually exclusive; nothing was collected or pinned.[/red]"
+        )
         raise typer.Exit(code=1)
 
     interactive = _stdin_is_tty()
@@ -352,29 +367,58 @@ def trajectory_report_bug(
         for reason in reasons:
             console.print(f"  - {escape(reason)}", highlight=False)
 
-    def _decide(items: list, reasons: list[str]) -> list:
-        if interactive:
-            from raven.cli import trajectory_browse as tbrowse
-            from raven.cli._styles import RAVEN_STYLE
+    def _print_review_failure(items: list, reasons: list[str], missing: list[str]) -> None:
+        from raven.cli import trajectory_browse as tbrowse
 
-            try:
-                return tbrowse.make_review_decider(tbrowse._require_questionary(), RAVEN_STYLE)(items, reasons)
-            except (tbrowse._ActionCancelledError, tbrowse._CancelledError) as exc:
-                # Esc/Ctrl-C during adjudication: the CLI has no outer screen
-                # to unwind to, so both mean "cancel this report".
-                raise treview.ReviewCancelledError("cancelled from the review screen") from exc
-        if not accept_risk:
-            # Deciding needs authorization a script has not granted; stop
-            # before any further export work (the staging cleanup still runs).
-            _deny_noninteractive(reasons)
-            raise typer.Exit(code=1)
-        return [
-            treview.ReviewDecision(
-                item.id,
-                treview.ACTION_ACKNOWLEDGED if item.kind == treview.KIND_CONFIRMED else treview.ACTION_KEPT,
-            )
-            for item in items
-        ]
+        console.print(f"[red]The redaction needs review; {len(items)} item(s) require your decision:[/red]")
+        for warning in tbrowse._review_warnings(reasons):
+            console.print(f"  [yellow]! {escape(warning)}[/yellow]", highlight=False)
+        index_by_id = {item.id: index for index, item in enumerate(items, 1)}
+        for index, item in enumerate(items, 1):
+            tbrowse._print_review_item(item, index, len(items), index_by_id)
+        console.print(f"[red]Pass: {'; '.join(missing)} (--yes does not imply them).[/red]")
+
+    def _decide(items: list, reasons: list[str]) -> list:
+        if not interactive:
+            # Missing flags are judged on the ORIGINAL items, before any
+            # early return or decision application: otherwise a run whose
+            # items are all flag-covered but that lacks --accept-risk would
+            # keep exporting and fail late without the item listing (a
+            # redact run would even rewrite the context before failing).
+            missing = []
+            if any(item.kind == treview.KIND_SUSPECTED for item in items) and not (keep_findings or redact_findings):
+                missing.append("--keep-findings or --redact-findings")
+            if not accept_risk:
+                missing.append("--accept-risk")
+            if missing:
+                _print_review_failure(items, reasons, missing)
+                raise typer.Exit(code=1)
+        flag_decisions: list = []
+        remaining: list = []
+        for item in items:
+            if item.kind == treview.KIND_CONFIRMED and accept_risk:
+                flag_decisions.append(treview.ReviewDecision(item.id, treview.ACTION_ACKNOWLEDGED))
+            elif item.kind == treview.KIND_SUSPECTED and (keep_findings or redact_findings):
+                action = treview.ACTION_REDACTED if redact_findings else treview.ACTION_KEPT
+                flag_decisions.append(treview.ReviewDecision(item.id, action))
+            else:
+                remaining.append(item)
+        if not remaining:
+            return flag_decisions
+        # Only reachable on a TTY (without one, missing flags exited above
+        # and complete flags leave nothing remaining). Linked groups exist
+        # only among suspected items and the flags cover a kind whole, so a
+        # group is never split between flags and interaction.
+        from raven.cli import trajectory_browse as tbrowse
+        from raven.cli._styles import RAVEN_STYLE
+
+        try:
+            decided = tbrowse.make_review_decider(tbrowse._require_questionary(), RAVEN_STYLE)(remaining, reasons)
+        except (tbrowse._ActionCancelledError, tbrowse._CancelledError) as exc:
+            # Esc/Ctrl-C during adjudication: the CLI has no outer screen
+            # to unwind to, so both mean "cancel this report".
+            raise treview.ReviewCancelledError("cancelled from the review screen") from exc
+        return flag_decisions + decided
 
     exit_code = 0
     try:

--- a/raven/cli/trajectory_commands.py
+++ b/raven/cli/trajectory_commands.py
@@ -309,10 +309,12 @@ def trajectory_report_bug(
 
     The package embeds a redacted, path-sanitized Trajectory Report inside a
     problem-metadata envelope (completeness, environment, redaction summary).
-    Without a TTY, --yes is required and needs_review additionally requires
-    --accept-risk; blocked reports cannot be produced by any flag.
+    Review findings are adjudicated per item on a TTY; without one, --yes is
+    required and any review report additionally requires --accept-risk
+    (findings ship as kept, private-key hits as acknowledged).
     """
     from raven.trajectory import bugreport as breport
+    from raven.trajectory import review as treview
 
     description = description.strip()
     if not description:
@@ -342,12 +344,35 @@ def trajectory_report_bug(
         raise typer.Exit(code=1)
     console.print("Snapshot collected; the attempt was pinned so cleanup won't remove it.")
 
+    def _deny_noninteractive(reasons: list[str]) -> None:
+        console.print(
+            "[red]The redaction needs review; pass --accept-risk to grant the separate"
+            " authorization (--yes does not imply it):[/red]"
+        )
+        for reason in reasons:
+            console.print(f"  - {escape(reason)}", highlight=False)
+
+    def _decide(items: list, reasons: list[str]) -> list:
+        if interactive:
+            from raven.cli._styles import RAVEN_STYLE
+            from raven.cli.trajectory_browse import _require_questionary, make_review_decider
+
+            return make_review_decider(_require_questionary(), RAVEN_STYLE)(items, reasons)
+        if not accept_risk:
+            # Deciding needs authorization a script has not granted; stop
+            # before any further export work (the staging cleanup still runs).
+            _deny_noninteractive(reasons)
+            raise typer.Exit(code=1)
+        return [
+            treview.ReviewDecision(
+                item.id,
+                treview.ACTION_ACKNOWLEDGED if item.kind == treview.KIND_CONFIRMED else treview.ACTION_KEPT,
+            )
+            for item in items
+        ]
+
     exit_code = 0
     try:
-        if prep.classification == breport.CLASSIFICATION_BLOCKED:
-            _print_blocked_cli("trajectory")
-            exit_code = 1
-            return
         try:
             prep = breport.freeze_export(
                 prep,
@@ -357,41 +382,36 @@ def trajectory_report_bug(
                 severity=severity,
                 steps=steps,
                 reporter=reporter,
+                decide=_decide,
             )
+        except treview.ReviewCancelledError:
+            console.print("Cancelled — no bug report was created.")
+            exit_code = 1
+            return
         except breport.PreparationError as exc:
             console.print(
                 f"[red]✗ Could not prepare the trajectory snapshot: {escape(str(exc))}[/red]", highlight=False
             )
             exit_code = 1
             return
-        if prep.classification == breport.CLASSIFICATION_BLOCKED:
-            _print_blocked_cli("problem")
-            exit_code = 1
-            return
 
         _print_bug_cli_summary(prep)
-        if not yes and not typer.confirm("Create the bug report?", default=True):
-            console.print("Cancelled — no bug report was created.")
-            exit_code = 1
-            return
         if prep.classification == breport.CLASSIFICATION_NEEDS_REVIEW and not accept_risk:
+            # The review authorization can only come from --accept-risk or
+            # this risk-worded consent; --yes never grants it.
             if interactive:
-                if not typer.confirm(
-                    "The redaction needs review: flagged content may include real secrets. Ship the package anyway?",
-                    default=False,
-                ):
+                if not typer.confirm("Ship the package with the risks listed above?", default=False):
                     console.print("Cancelled — no bug report was created.")
                     exit_code = 1
                     return
             else:
-                console.print(
-                    "[red]The redaction needs review; pass --accept-risk to grant the separate"
-                    " authorization (--yes does not imply it):[/red]"
-                )
-                for reason in prep.reasons:
-                    console.print(f"  - {escape(reason)}", highlight=False)
+                _deny_noninteractive(prep.reasons)
                 exit_code = 1
                 return
+        elif not yes and not typer.confirm("Create the bug report?", default=True):
+            console.print("Cancelled — no bug report was created.")
+            exit_code = 1
+            return
 
         try:
             _record_dir, record = breport.confirm_and_package(prep)
@@ -426,28 +446,6 @@ def _stdin_is_tty() -> bool:
     import sys
 
     return sys.stdin.isatty()
-
-
-def _print_blocked_cli(trigger: str) -> None:
-    """The blocked refusal, trigger-specific: the recovery action differs."""
-    if trigger == "trajectory":
-        console.print("[red]✗ Cannot create a bug report from this attempt.[/red]")
-        console.print(
-            "  The original trajectory contains a private key block. Even though the copy\n"
-            "  was redacted, this material is not allowed to leave the machine as a bug\n"
-            "  report package.\n"
-            "  Remove the key from the source data and retry, or use the expert command\n"
-            "  `raven trajectory report` at your own risk.",
-            highlight=False,
-        )
-    else:
-        console.print("[red]✗ Cannot create a bug report with these details.[/red]")
-        console.print(
-            "  The problem details you entered contain a private key block. This material\n"
-            "  is not allowed to leave the machine as a bug report package.\n"
-            "  Run again and describe the problem without pasting the key itself.",
-            highlight=False,
-        )
 
 
 def _print_bug_cli_summary(prep) -> None:
@@ -496,17 +494,22 @@ def _print_bug_cli_summary(prep) -> None:
     counts = f"{exact} known-value + {patterns} pattern replacement(s)"
     if prep.classification == breport.CLASSIFICATION_NEEDS_REVIEW:
         console.print(f"  Redaction:    {counts} · NEEDS REVIEW", highlight=False)
-        findings = redaction["residual_findings"]
+        for notice in redaction.get("security_notices") or []:
+            console.print(f"    [yellow]! {escape(notice)}[/yellow]", highlight=False)
         for reason in prep.reasons:
-            suffix = ":" if reason.startswith("residual") and findings else ""
-            console.print(f"    - {escape(reason)}{suffix}", highlight=False)
-            if reason.startswith("residual"):
-                # The bounded sample block the independent authorization is
-                # judged on — sanitized canonical values, never raw input.
-                for finding in findings[:5]:
-                    console.print(f"        {escape(f'{finding["file"]}: {finding["sample"]}')}", highlight=False)
-                if len(findings) > 5:
-                    console.print(f"        ... and {len(findings) - 5} more (see redaction.json)", highlight=False)
+            console.print(f"    - {escape(reason)}", highlight=False)
+        decisions = redaction.get("user_decisions") or []
+        if decisions:
+            console.print(f"  Decisions:    {len(decisions)} review decision(s)", highlight=False)
+            for entry in decisions:
+                sources = ", ".join(
+                    source["source"] + (f" x{source['count']}" if source["count"] > 1 else "")
+                    for source in entry["sources"]
+                )
+                console.print(
+                    f"    - {escape(f'{entry["action"]:<12} {entry["masked_sample"]} — {sources}')}",
+                    highlight=False,
+                )
     else:
         console.print(f"  Redaction:    {counts} · residual scan: clean", highlight=False)
     console.print(

--- a/raven/cli/trajectory_commands.py
+++ b/raven/cli/trajectory_commands.py
@@ -371,6 +371,7 @@ def trajectory_report_bug(
         from raven.cli import trajectory_browse as tbrowse
 
         console.print(f"[red]The redaction needs review; {len(items)} item(s) require your decision:[/red]")
+        console.print(f"  {tbrowse._REVIEW_PATHS_NOTE}", highlight=False)
         for warning in tbrowse._review_warnings(reasons):
             console.print(f"  [yellow]! {escape(warning)}[/yellow]", highlight=False)
         index_by_id = {item.id: index for index, item in enumerate(items, 1)}
@@ -449,6 +450,8 @@ def trajectory_report_bug(
             # The review authorization can only come from --accept-risk or
             # this risk-worded consent; --yes never grants it.
             if interactive:
+                if prep.user_decisions:
+                    console.print("Review decisions are complete. Confirm the report contents shown above.")
                 if not typer.confirm("Ship the package with the risks listed above?", default=False):
                     console.print("Cancelled — no bug report was created.")
                     exit_code = 1
@@ -549,16 +552,11 @@ def _print_bug_cli_summary(prep) -> None:
             console.print(f"    - {escape(reason)}", highlight=False)
         decisions = redaction.get("user_decisions") or []
         if decisions:
-            console.print(f"  Decisions:    {len(decisions)} review decision(s)", highlight=False)
+            from raven.cli.trajectory_browse import _decision_line, _decision_tally
+
+            console.print(f"  Reviewed:     {_decision_tally(decisions)}", highlight=False)
             for entry in decisions:
-                sources = ", ".join(
-                    source["source"] + (f" x{source['count']}" if source["count"] > 1 else "")
-                    for source in entry["sources"]
-                )
-                console.print(
-                    f"    - {escape(f'{entry["action"]:<12} {entry["masked_sample"]} — {sources}')}",
-                    highlight=False,
-                )
+                console.print(f"    - {escape(_decision_line(entry))}", highlight=False)
     else:
         console.print(f"  Redaction:    {counts} · residual scan: clean", highlight=False)
     console.print(

--- a/raven/trajectory/bugreport.py
+++ b/raven/trajectory/bugreport.py
@@ -47,14 +47,17 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import TYPE_CHECKING, Any, Callable, Mapping
 
 from raven import __version__
 from raven.tracing import config as tracing_config
 from raven.trajectory.bundle import BUNDLE_FORMAT_VERSION, collect_bundle
-from raven.trajectory.redact import KnownSecret, RedactionReport, collect_known_secrets, redact_bundle
+from raven.trajectory.redact import KnownSecret, RedactionReport, _variants, collect_known_secrets, redact_bundle
 from raven.trajectory.sanitize import sanitize_export_tree, sanitize_text, scan_absolute_paths, tree_digest
 from raven.trajectory.store import member_traces
+
+if TYPE_CHECKING:
+    from raven.trajectory.review import ReviewDecision, ReviewItem
 
 _log = logging.getLogger("raven.trajectory.bugreport")
 
@@ -68,7 +71,6 @@ SCHEMA_VERSION = 1
 
 CLASSIFICATION_CLEAN = "clean"
 CLASSIFICATION_NEEDS_REVIEW = "needs_review"
-CLASSIFICATION_BLOCKED = "blocked"
 
 STATUS_DRAFT = "draft"
 STATUS_LOCAL_READY = "local_ready"
@@ -168,18 +170,18 @@ def new_report_id(root: Path) -> str:
 def classify_redaction(*reports: RedactionReport, require_review: bool = False) -> tuple[str, list[str]]:
     """The single classification rule, over the merged signals of ``reports``.
 
-    ``blocked`` keys off the **original-content** private-key hit
-    (``patterns``), not the residual scan — a trajectory that ever held a full
-    private key is not fit to leave the machine even after replacement.
-    ``require_review`` is the organization-policy signal (read by the caller,
-    keeping this function pure): it adds its reason unconditionally — even
-    alongside other review reasons, the reviewer must see the policy applied —
-    but never outranks ``blocked``.
+    The private-key reason keys off the **original-content** pattern counts
+    (``patterns``), not the residual scan — the content is already replaced,
+    but the reporter must acknowledge the hit and the recipient must see it
+    (a review reason, no longer a hard stop). ``require_review`` is the
+    organization-policy signal (read by the caller, keeping this function
+    pure): it adds its reason unconditionally — even alongside other review
+    reasons, the reviewer must see the policy applied.
     """
+    reasons: list[str] = []
     key_hits = sum(r.patterns.get("private-key-block", 0) for r in reports)
     if key_hits:
-        return CLASSIFICATION_BLOCKED, ["the original trajectory contains a private key block"]
-    reasons: list[str] = []
+        reasons.append(f"the original trajectory contained {key_hits} private key block(s), replaced before export")
     finding_count = sum(len(r.findings) for r in reports)
     if finding_count:
         reasons.append(f"residual scan flagged {finding_count} suspicious token(s)")
@@ -416,11 +418,27 @@ def _validate_record(payload: dict[str, Any], dir_name: str) -> None:
     _check(_is_str_list(completeness.get("reasons")), "completeness reasons")
     redaction = payload.get("redaction")
     _check(isinstance(redaction, dict), "redaction")
-    # A blocked or unreviewed record cannot legally land: blocked never
-    # creates a record, and landing itself is the user's confirmation.
+    # An unreviewed record cannot legally land: landing itself is the user's
+    # confirmation (with review items, their adjudication came first).
     _check(redaction.get("classification") in (CLASSIFICATION_CLEAN, CLASSIFICATION_NEEDS_REVIEW), "classification")
     _check(_is_str_list(redaction.get("reasons")), "redaction reasons")
     _check(redaction.get("reviewed_by_user") is True, "reviewed flag")
+    # Absent on records written before the review flow existed; validated
+    # when present so a damaged writer cannot land malformed entries.
+    _check(_is_str_list(redaction.get("security_notices", [])), "security notices")
+    decisions = redaction.get("user_decisions", [])
+    _check(isinstance(decisions, list), "user decisions")
+    for entry in decisions:
+        _check(isinstance(entry, dict), "user decision")
+        _check(isinstance(entry.get("id"), str) and entry["id"], "user decision id")
+        _check(isinstance(entry.get("category"), str) and entry["category"], "user decision category")
+        _check(isinstance(entry.get("masked_sample"), str), "user decision sample")
+        _check(entry.get("action") in ("acknowledged", "kept", "redacted"), "user decision action")
+        sources = entry.get("sources")
+        _check(isinstance(sources, list), "user decision sources")
+        for source in sources:
+            _check(isinstance(source, dict) and isinstance(source.get("source"), str), "user decision source")
+            _check(_is_int(source.get("count")) and source["count"] >= 0, "user decision source count")
     upload = payload.get("upload")
     _check(isinstance(upload, dict), "upload")
     for key in ("state", "issue_url", "receipt"):
@@ -495,6 +513,8 @@ class ExportPreparation:
     problem_report: RedactionReport | None = None
     environment: dict[str, str] = field(default_factory=dict)
     completeness: tuple[str, list[str]] = ("unknown", [])
+    security_notices: list[str] = field(default_factory=list)
+    user_decisions: list[dict[str, Any]] = field(default_factory=list)
     package_metadata: dict[str, Any] | None = None
     source_digest: str = ""
     export_digest: str = ""
@@ -525,8 +545,8 @@ def prepare_trajectory(
     ``expected_traces`` is the member set the user saw when picking the row;
     a snapshot resolving to a different set means the attempt changed under
     them (``StaleAttemptError``). The returned preparation carries the
-    trajectory-only classification — ``blocked`` here means the flow must stop
-    before asking for a description.
+    trajectory-only pre-classification; the authoritative one is computed in
+    :func:`freeze_export` once the problem fields joined the same pipeline.
     """
     resolved_state = (state_dir or tracing_config.state_dir()).resolve()
     root = bugreports_root(resolved_state)
@@ -605,16 +625,21 @@ def freeze_export(
     severity: str = "",
     steps: str = "",
     reporter: str = "",
+    decide: Callable[[list["ReviewItem"], list[str]], list["ReviewDecision"]] | None = None,
 ) -> ExportPreparation:
     """Freeze the complete deliverable under ``snapshot/export/``.
 
     The user fields go through the same redaction as the trajectory (written
     as ``problem.<field>`` files and redacted with the same known secrets, so
-    residual findings carry that name), then path sanitization; the merged
-    classification decides the flow. On anything but ``blocked`` the embedded
-    tarball and the canonical ``bugreport.json`` are produced, asserted clean,
-    and digested — the confirmation screen and every later packaging run use
-    exactly these bytes.
+    residual findings carry that name). When the merged findings yield review
+    items, ``decide`` is called with them (plus the current reasons, for the
+    warning lines) and its decisions are applied to the redacted trees before
+    anything downstream reads them — a caller without a ``decide`` cannot
+    freeze such a report (silent shipping is not a fallback). Then path
+    sanitization, the completeness probe (over the post-decision tree), the
+    embedded tarball, and the canonical ``bugreport.json`` are produced,
+    asserted clean, and digested — the confirmation screen and every later
+    packaging run use exactly these bytes.
     """
     description = description.strip()
     if not description:
@@ -644,6 +669,33 @@ def freeze_export(
         problem_report.config_loaded = prep.config_loaded
         prep.problem_report = problem_report
 
+        # Pre-classification carries the reasons the review screen shows as
+        # warning lines; the authoritative classification is recomputed below
+        # once the completeness reasons have been through the same pipeline.
+        require_review = _policy_review_enabled()
+        classification, reasons = classify_redaction(
+            prep.trajectory_report, problem_report, require_review=require_review
+        )
+        prep.classification = classification
+        prep.reasons = reasons
+
+        from raven.trajectory import review as _review
+
+        items = _review.build_review_items([prep.trajectory_report, problem_report])
+        if items:
+            if decide is None:
+                raise BugReportError("this report carries review items but no decide callback was provided")
+            decisions = decide(list(items), list(reasons))
+            # The interactive callers validate before returning (re-asking on
+            # conflicts); a defect that slips through here is a caller bug.
+            _review.validate_review_decisions(items, decisions)
+            outcome = _review.apply_review_decisions(items, decisions, reports=[prep.trajectory_report, problem_report])
+            prep.secrets = list(prep.secrets) + outcome.user_secrets
+            prep.security_notices = outcome.security_notices
+            prep.user_decisions = outcome.user_decisions
+
+        # Read after the decisions are applied: these strings land in the
+        # package metadata, so they must carry the user-redacted spellings.
         def _redacted_value(name: str, written: bool) -> str:
             source = prep.snapshot_dir / "problem_redacted" / name
             text = source.read_text(encoding="utf-8") if written and source.is_file() else ""
@@ -651,20 +703,8 @@ def freeze_export(
 
         redacted_fields = {name: _redacted_value(f"problem.{name}", bool(value)) for name, value in raw_fields.items()}
         prep.environment = {key: _redacted_value(f"environment.{key}", True) for key in environment}
-
-        # Pre-classification gates the blocked flows before any export work;
-        # the authoritative classification is recomputed below once the
-        # completeness reasons have been through the same pipeline.
-        require_review = _policy_review_enabled()
-        classification, reasons = classify_redaction(
-            prep.trajectory_report, problem_report, require_review=require_review
-        )
-        prep.classification = classification
-        prep.reasons = reasons
         prep.reporter = redacted_fields.pop("reporter")
         prep.problem = redacted_fields
-        if classification == CLASSIFICATION_BLOCKED:
-            return prep
 
         redacted_dir = prep.snapshot_dir / "redacted" / prep.attempt_id
         sanitize_export_tree(redacted_dir, prep.roots)
@@ -677,10 +717,15 @@ def freeze_export(
 
         reports = [prep.trajectory_report, problem_report] + ([meta_report] if meta_report else [])
         classification, reasons = classify_redaction(*reports, require_review=require_review)
+        if items:
+            replaced = sum(1 for entry in prep.user_decisions if entry["action"] == "redacted")
+            if replaced:
+                reasons.append(f"{replaced} suspicious token(s) were replaced at your direction")
+            # Adjudication happened, so risk_accepted must be truthful even
+            # when replacing every finding emptied the residual signals.
+            classification = CLASSIFICATION_NEEDS_REVIEW
         prep.classification = classification
         prep.reasons = reasons
-        if classification == CLASSIFICATION_BLOCKED:
-            return prep
 
         prep.source_digest = tree_digest(prep.snapshot_dir / "bundle" / prep.attempt_id)
 
@@ -766,6 +811,8 @@ def _build_package_metadata(
             "classification": prep.classification,
             "reasons": list(prep.reasons),
             "risk_accepted": prep.classification == CLASSIFICATION_NEEDS_REVIEW,
+            "security_notices": list(prep.security_notices),
+            "user_decisions": [dict(entry) for entry in prep.user_decisions],
             **merged,
         },
         "environment": {
@@ -813,6 +860,15 @@ def _assert_export_ready(prep: ExportPreparation, metadata: dict[str, Any]) -> N
     hits = _metadata_leaks(metadata_text, prep.roots)
     if hits:
         raise ExportLeakError(f"absolute path leaked into the export: {PACKAGE_METADATA_FILE}: {hits[0]}")
+    # The record's redaction/problem/completeness fields come from the same
+    # prep values this metadata serializes, so this one gate covers both
+    # landing surfaces.
+    for secret in prep.secrets:
+        if secret.label != "user-confirmed":
+            continue
+        for variant in _variants(secret.value):
+            if variant and variant in metadata_text:
+                raise ExportLeakError(f"user-redacted content leaked into the export: {PACKAGE_METADATA_FILE}")
 
 
 def _metadata_leaks(text: str, roots: list[str]) -> list[str]:
@@ -858,6 +914,8 @@ def _new_record_payload(prep: ExportPreparation) -> dict[str, Any]:
             "classification": prep.classification,
             "reasons": list(prep.reasons),
             "reviewed_by_user": True,
+            "security_notices": list(prep.security_notices),
+            "user_decisions": [dict(entry) for entry in prep.user_decisions],
         },
         "upload": {"state": "", "issue_url": "", "receipt": ""},
         "links": {"issue": "", "pr": "", "regression_case": ""},
@@ -1060,7 +1118,6 @@ def cleanup_stale_staging(state_dir: Path | None = None, *, max_age_seconds: flo
 __all__ = [
     "BUGREPORTS_DIR",
     "BugReportError",
-    "CLASSIFICATION_BLOCKED",
     "CLASSIFICATION_CLEAN",
     "CLASSIFICATION_NEEDS_REVIEW",
     "ExportLeakError",

--- a/raven/trajectory/bugreport.py
+++ b/raven/trajectory/bugreport.py
@@ -433,6 +433,9 @@ def _validate_record(payload: dict[str, Any], dir_name: str) -> None:
         _check(isinstance(entry.get("id"), str) and entry["id"], "user decision id")
         _check(isinstance(entry.get("category"), str) and entry["category"], "user decision category")
         _check(isinstance(entry.get("masked_sample"), str), "user decision sample")
+        if "masked_token" in entry:
+            # Absent on decisions written before the masked_token field existed.
+            _check(isinstance(entry["masked_token"], str) and entry["masked_token"], "user decision masked token")
         _check(entry.get("action") in ("acknowledged", "kept", "redacted"), "user decision action")
         sources = entry.get("sources")
         _check(isinstance(sources, list), "user decision sources")

--- a/raven/trajectory/redact.py
+++ b/raven/trajectory/redact.py
@@ -132,6 +132,11 @@ _CANDIDATE = re.compile(r"[A-Za-z0-9_\-+=]{20,}")
 # (<seq>-<traceId>-<session>-<label>-<hash>.json), and every bundle references
 # them — flagging those would put false positives in every report preview.
 _TRACING_ID = re.compile(r"(?:trace|span|att)-[0-9a-f]{6,}")
+# Provider-generated tool-call ids (``call_`` + alphanumerics) hit the entropy
+# bar in every trajectory that carries a tool call — same nature as the
+# tracing-id exemption above. Anchored full match: a credential merely
+# containing ``call_`` does not qualify.
+_CALL_ID = re.compile(r"^call_[A-Za-z0-9]+$")
 _UUID = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 _DATE = re.compile(r"\d{4}-\d{2}-\d{2}")
 _PURE_DIGITS = re.compile(r"^[0-9]+$")
@@ -169,12 +174,20 @@ class KnownSecret:
 
 @dataclass
 class ResidualFinding:
-    """One suspicious token that survived redaction (layer 3 reports, never rewrites)."""
+    """One suspicious token that survived redaction (layer 3 reports, never rewrites).
+
+    ``token`` and ``occurrences`` live in memory only, for the review flow to
+    adjudicate by value and render context; :meth:`RedactionReport.metadata`
+    never serializes them — the plaintext and full source lines must not land
+    in ``redaction.json``.
+    """
 
     category: str
     sample: str
     file: str
     count: int = 1
+    token: str = ""
+    occurrences: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
@@ -470,9 +483,9 @@ def scan_residuals(root: Path) -> list[ResidualFinding]:
     Reports long tokens whose Shannon entropy clears a charset-aware bar
     (:func:`_flag_threshold`) — pure hex and letter-only tokens included,
     since real credentials take both shapes. Skipped as benign: tracing ids
-    (by prefix), UUIDs, date-stamped names, and digit-only tokens (ids and
-    quantities; a 10-symbol alphabet cannot clear any meaningful entropy
-    bar). Deduped by token value.
+    (by prefix), provider tool-call ids (``call_…``), UUIDs, date-stamped
+    names, and digit-only tokens (ids and quantities; a 10-symbol alphabet
+    cannot clear any meaningful entropy bar). Deduped by token value.
     """
     findings: dict[str, ResidualFinding] = {}
     for path in sorted(p for p in root.rglob("*") if p.is_file()):
@@ -481,12 +494,12 @@ def scan_residuals(root: Path) -> list[ResidualFinding]:
         except (OSError, UnicodeDecodeError):
             continue
         rel = str(path.relative_to(root))
-        for line in text.splitlines():
+        for line_no, line in enumerate(text.splitlines(), 1):
             for match in _CANDIDATE.finditer(line):
                 token = match.group(0)
                 if "REDACTED" in token:
                     continue
-                if _TRACING_ID.search(token) or _UUID.match(token) or _DATE.search(token):
+                if _TRACING_ID.search(token) or _CALL_ID.match(token) or _UUID.match(token) or _DATE.search(token):
                     continue
                 if _PURE_DIGITS.match(token):
                     continue
@@ -494,13 +507,25 @@ def scan_residuals(root: Path) -> list[ResidualFinding]:
                     continue
                 if _entropy(token) < _flag_threshold(token):
                     continue
+                occurrence = {
+                    "file": rel,
+                    "line_no": line_no,
+                    "line": line,
+                    "start": match.start(),
+                    "end": match.end(),
+                }
                 known = findings.get(token)
                 if known:
                     known.count += 1
+                    known.occurrences.append(occurrence)
                     continue
                 category = "jwt-like" if token.startswith("eyJ") else "high-entropy"
                 findings[token] = ResidualFinding(
-                    category=category, sample=_sample(line, match.start(), match.end()), file=rel
+                    category=category,
+                    sample=_sample(line, match.start(), match.end()),
+                    file=rel,
+                    token=token,
+                    occurrences=[occurrence],
                 )
     return list(findings.values())
 

--- a/raven/trajectory/redact.py
+++ b/raven/trajectory/redact.py
@@ -137,6 +137,10 @@ _TRACING_ID = re.compile(r"(?:trace|span|att)-[0-9a-f]{6,}")
 # tracing-id exemption above. Anchored full match: a credential merely
 # containing ``call_`` does not qualify.
 _CALL_ID = re.compile(r"^call_[A-Za-z0-9]+$")
+# Fixed field names of provider usage blocks: they clear the entropy bar in
+# every trajectory with a model call. Exact literals only — any variation
+# still flags.
+_BENIGN_LITERALS = frozenset({"completion_tokens_details", "prompt_tokens_details"})
 _UUID = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 _DATE = re.compile(r"\d{4}-\d{2}-\d{2}")
 _PURE_DIGITS = re.compile(r"^[0-9]+$")
@@ -500,6 +504,8 @@ def scan_residuals(root: Path) -> list[ResidualFinding]:
                 if "REDACTED" in token:
                     continue
                 if _TRACING_ID.search(token) or _CALL_ID.match(token) or _UUID.match(token) or _DATE.search(token):
+                    continue
+                if token in _BENIGN_LITERALS:
                     continue
                 if _PURE_DIGITS.match(token):
                     continue

--- a/raven/trajectory/replay.py
+++ b/raven/trajectory/replay.py
@@ -1064,6 +1064,11 @@ async def run_replay(bundle_dir: Path, mode: str = "warn") -> ReplayReport:
                 restrict_to_workspace=True,
                 session_manager=sessions,
             )
+            # The loop's ContextBuilder starts the skill file watcher, a
+            # daemon thread nothing here would ever stop: a replay feeds
+            # recorded content only, and leaked watcher threads crash the
+            # process at interpreter shutdown once probes run repeatedly.
+            loop.context.skills.stop_file_watcher()
             loop.tools = registry
             for turn in recording.turns:
                 if state.halted:

--- a/raven/trajectory/review.py
+++ b/raven/trajectory/review.py
@@ -329,14 +329,14 @@ def _token_pattern(token: str) -> re.Pattern[str]:
     return re.compile("|".join(re.escape(v) for v in variants))
 
 
-def _body_files(reports: Sequence[RedactionReport]) -> list[tuple[Path, str]]:
-    files: list[tuple[Path, str]] = []
+def _body_files(reports: Sequence[RedactionReport]) -> list[tuple[Path, Path, str]]:
+    files: list[tuple[Path, Path, str]] = []
     for report in reports:
         root = report.redacted_dir
         for path in sorted(p for p in root.rglob("*") if p.is_file()):
             rel = str(path.relative_to(root))
             if rel != REDACTION_METADATA_FILE:
-                files.append((path, rel))
+                files.append((root, path, rel))
     return files
 
 
@@ -356,8 +356,10 @@ def apply_review_decisions(
 
     Order is load-bearing: the kept-token baseline is counted before any
     change (finding counts use a different scan scope and would misfire);
-    body text is replaced before the summaries are rewritten (a summary built
-    from unfiltered findings would reintroduce replaced plaintext); and every
+    body text is replaced, then export paths carrying a redacted value are
+    renamed with the same replacement (member names ship in the tar exactly
+    like content), and only then are the summaries rewritten (a summary built
+    from unfiltered findings would reintroduce replaced plaintext); every
     string headed for serialization is filtered through the user-confirmed
     replacements. Verification failures raise ``PreparationError`` — a
     decision record that does not match the delivered bytes must never ship.
@@ -372,7 +374,7 @@ def apply_review_decisions(
     files = _body_files(reports)
     kept_patterns = {token: _token_pattern(token) for token in kept_tokens}
     baseline: dict[str, int] = {token: 0 for token in kept_tokens}
-    for path, _rel in files:
+    for _root, path, _rel in files:
         text = path.read_text(encoding="utf-8")
         for token, pattern in kept_patterns.items():
             baseline[token] += sum(1 for _ in pattern.finditer(text))
@@ -381,8 +383,8 @@ def apply_review_decisions(
         for report in reports:
             counts: dict[str, int] = {}
             root = report.redacted_dir
-            for path, _rel in files:
-                if root not in path.parents:
+            for file_root, path, _rel in files:
+                if file_root != root:
                     continue
                 text = path.read_text(encoding="utf-8")
                 replaced = _apply_exact(text, user_secrets, counts)
@@ -396,6 +398,28 @@ def apply_review_decisions(
     def _filter(text: str) -> str:
         return _apply_exact(text, user_secrets, {}) if user_secrets else text
 
+    if user_secrets:
+        # Export paths can carry a redacted value too (artifact files are
+        # named after payload-derived basenames, and tar member names come
+        # from the tree). Rename them with the exact replacement the content
+        # got, so the already-rewritten references keep resolving and no
+        # member name ships the original.
+        renamed: list[tuple[Path, Path, str]] = []
+        planned: set[Path] = set()
+        for root, path, rel in files:
+            new_rel = _filter(rel)
+            if new_rel == rel:
+                renamed.append((root, path, rel))
+                continue
+            target = root / new_rel
+            if target in planned or target.exists():
+                raise PreparationError(f"renaming a redacted export path collides with another file: {rel}")
+            planned.add(target)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            path.rename(target)
+            renamed.append((root, target, new_rel))
+        files = renamed
+
     redacted_set = set(redacted_tokens)
     for report in reports:
         pruned: list[ResidualFinding] = []
@@ -403,8 +427,10 @@ def apply_review_decisions(
             if finding.token in redacted_set:
                 continue
             finding.sample = _filter(finding.sample)
+            finding.file = _filter(finding.file)
             pruned.append(finding)
         report.findings = pruned
+        report.skipped_binaries = [_filter(entry) for entry in report.skipped_binaries]
         _write_metadata(report)
 
     summary_files = [report.redacted_dir / REDACTION_METADATA_FILE for report in reports]
@@ -412,7 +438,9 @@ def apply_review_decisions(
         for variant in _variants(token):
             if not variant:
                 continue
-            for path, rel in files:
+            for _root, path, rel in files:
+                if variant in rel:
+                    raise PreparationError(f"user-redacted content survived in an export path: {rel}")
                 if variant in path.read_text(encoding="utf-8"):
                     raise PreparationError(f"user-redacted content survived in the export: {rel}")
             for path in summary_files:
@@ -420,7 +448,7 @@ def apply_review_decisions(
                     raise PreparationError(f"user-redacted content survived in the export: {path.name}")
     for token, pattern in kept_patterns.items():
         count = 0
-        for path, _rel in files:
+        for _root, path, _rel in files:
             count += sum(1 for _ in pattern.finditer(path.read_text(encoding="utf-8")))
         if count != baseline[token]:
             raise PreparationError(

--- a/raven/trajectory/review.py
+++ b/raven/trajectory/review.py
@@ -179,7 +179,7 @@ def _source_label(rel: str, artifact_labels: dict[str, str]) -> str:
     if rel in _PROBLEM_LABELS:
         return _PROBLEM_LABELS[rel]
     if rel.startswith(_ENVIRONMENT_PREFIX):
-        return f"environment summary ({rel[len(_ENVIRONMENT_PREFIX):]})"
+        return f"environment summary ({rel[len(_ENVIRONMENT_PREFIX) :]})"
     return rel
 
 
@@ -256,7 +256,9 @@ def build_review_items(reports: Sequence[RedactionReport]) -> list[ReviewItem]:
     order: list[str] = []
     for index, (report, labels) in enumerate(zip(reports, labels_by_report)):
         for finding in report.findings:
-            occurrences = [{**occ, "label": _source_label(occ["file"], labels), "report": index} for occ in finding.occurrences]
+            occurrences = [
+                {**occ, "label": _source_label(occ["file"], labels), "report": index} for occ in finding.occurrences
+            ]
             item = by_token.get(finding.token)
             if item is None:
                 item = ReviewItem(
@@ -415,9 +417,7 @@ def apply_review_decisions(
                     raise PreparationError(f"user-redacted content survived in the export: {rel}")
             for path in summary_files:
                 if variant in path.read_text(encoding="utf-8"):
-                    raise PreparationError(
-                        f"user-redacted content survived in the export: {path.name}"
-                    )
+                    raise PreparationError(f"user-redacted content survived in the export: {path.name}")
     for token, pattern in kept_patterns.items():
         count = 0
         for path, _rel in files:
@@ -438,9 +438,7 @@ def apply_review_decisions(
         {
             "id": item.id,
             "category": item.category,
-            "sources": [
-                {"source": _filter(source["label"]), "count": source["count"]} for source in item.sources
-            ],
+            "sources": [{"source": _filter(source["label"]), "count": source["count"]} for source in item.sources],
             "masked_sample": _filter(item.masked_sample),
             "action": actions[item.id],
         }

--- a/raven/trajectory/review.py
+++ b/raven/trajectory/review.py
@@ -1,0 +1,472 @@
+"""Redaction review — per-item adjudication of what redaction could not decide.
+
+The redaction layers (see :mod:`raven.trajectory.redact`) either replace
+content they can prove sensitive or flag what they merely suspect. This module
+turns those signals into an explicit user decision step for the bug-report
+flow:
+
+- :func:`build_review_items` merges the residual findings of every redaction
+  report into review items — one item per token **value** (replacement is a
+  global by-value operation, so a per-occurrence decision could not be
+  honored), plus one "confirmed sensitive" item when a private-key block was
+  hit (its content is already replaced; the item asks for informed
+  acknowledgment, not a content choice). Sources are translated from artifact
+  file names into human terms via the bundle's span records.
+- :func:`validate_review_decisions` checks a decision set without side
+  effects, so interactive callers can re-ask on conflicts before anything is
+  applied.
+- :func:`apply_review_decisions` rewrites the redacted trees according to the
+  decisions and verifies the result: tokens the user redacted are gone in
+  every spelling variant, tokens the user kept are provably untouched, and
+  every string that will be serialized (samples, source labels, notices) has
+  the user-redacted values filtered out.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from raven.trajectory.bugreport import BugReportError, PreparationError
+from raven.trajectory.redact import (
+    REDACTION_METADATA_FILE,
+    KnownSecret,
+    RedactionReport,
+    ResidualFinding,
+    _apply_exact,
+    _variants,
+)
+
+KIND_CONFIRMED = "confirmed"
+KIND_SUSPECTED = "suspected"
+
+ACTION_ACKNOWLEDGED = "acknowledged"
+ACTION_KEPT = "kept"
+ACTION_REDACTED = "redacted"
+
+USER_CONFIRMED_LABEL = "user-confirmed"
+PRIVATE_KEY_CATEGORY = "private-key-block"
+PRIVATE_KEY_PLACEHOLDER = "[REDACTED:pattern.private-key-block]"
+
+_FIXED_LABELS = {
+    "spans.jsonl": "the span log",
+    "session.jsonl": "the session transcript",
+    "verdicts.jsonl": "the verdict log",
+    "manifest.json": "the bundle manifest",
+    REDACTION_METADATA_FILE: "the redaction summary",
+}
+_PROBLEM_LABELS = {
+    "problem.description": "your problem description",
+    "problem.expected": "your expected result",
+    "problem.actual": "your actual result",
+    "problem.steps": "your steps to reproduce",
+    "problem.severity": "your severity rating",
+    "problem.reporter": "your reporter handle",
+}
+_ENVIRONMENT_PREFIX = "environment."
+
+
+class ReviewCancelledError(BugReportError):
+    """The user cancelled the report from the review screen."""
+
+
+class ReviewConflictError(BugReportError):
+    """Linked items (overlapping token values) received contradictory decisions."""
+
+
+@dataclass
+class ReviewItem:
+    """One decision the user must make before the report may ship."""
+
+    id: str
+    kind: str
+    category: str
+    token: str
+    masked_sample: str
+    sources: list[dict[str, Any]] = field(default_factory=list)
+    occurrences: list[dict[str, Any]] = field(default_factory=list)
+    linked: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ReviewDecision:
+    item_id: str
+    action: str
+
+
+@dataclass
+class ReviewOutcome:
+    """What :func:`apply_review_decisions` produced, for the caller to merge."""
+
+    user_secrets: list[KnownSecret] = field(default_factory=list)
+    user_decisions: list[dict[str, Any]] = field(default_factory=list)
+    security_notices: list[str] = field(default_factory=list)
+
+
+def _item_id(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+
+
+def _ordered_spans(spans_file: Path) -> list[dict[str, Any]]:
+    spans: list[dict[str, Any]] = []
+    try:
+        lines = spans_file.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return spans
+    for line in lines:
+        try:
+            span = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(span, dict):
+            spans.append(span)
+    spans.sort(key=lambda s: s.get("startTime") if isinstance(s.get("startTime"), str) else "")
+    return spans
+
+
+def _artifact_labels(root: Path) -> dict[str, str]:
+    """Semantic names for ``artifacts/<name>`` files, from the span records.
+
+    Model and tool calls are numbered in start-time order, so a finding can
+    say "model call #2 input" instead of the artifact file name.
+    """
+    spans_file = root / "spans.jsonl"
+    if not spans_file.is_file():
+        return {}
+    labels: dict[str, str] = {}
+    llm_n = tool_n = 0
+    for span in _ordered_spans(spans_file):
+        raw_attrs = span.get("attributes")
+        attrs = raw_attrs if isinstance(raw_attrs, dict) else {}
+        art_keys = [
+            key
+            for key, value in attrs.items()
+            if isinstance(key, str) and key.endswith(".artifact_path") and isinstance(value, str) and value
+        ]
+        if not art_keys:
+            continue
+        if any(key.startswith("llm.") for key in art_keys):
+            llm_n += 1
+        if any(key.startswith("tool.") for key in art_keys):
+            tool_n += 1
+        for key in art_keys:
+            prefix = key[: -len(".artifact_path")]
+            if prefix == "llm.input":
+                label = f"model call #{llm_n} input"
+            elif prefix == "llm.output":
+                label = f"model call #{llm_n} output"
+            elif prefix.startswith("tool."):
+                side = prefix.split(".", 1)[1]
+                name = attrs.get("tool.name")
+                named = f" ({name})" if isinstance(name, str) and name else ""
+                label = f"tool call #{tool_n}{named} {side}"
+            else:
+                span_name = span.get("name")
+                label = f"{span_name} {prefix}" if isinstance(span_name, str) and span_name else prefix
+            labels.setdefault(attrs[key], label)
+    return labels
+
+
+def _source_label(rel: str, artifact_labels: dict[str, str]) -> str:
+    if rel in artifact_labels:
+        return artifact_labels[rel]
+    if rel in _FIXED_LABELS:
+        return _FIXED_LABELS[rel]
+    if rel in _PROBLEM_LABELS:
+        return _PROBLEM_LABELS[rel]
+    if rel.startswith(_ENVIRONMENT_PREFIX):
+        return f"environment summary ({rel[len(_ENVIRONMENT_PREFIX):]})"
+    return rel
+
+
+def _sources_from_occurrences(occurrences: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    sources: list[dict[str, Any]] = []
+    by_file: dict[str, dict[str, Any]] = {}
+    for occurrence in occurrences:
+        entry = by_file.get(occurrence["file"])
+        if entry is None:
+            entry = {"label": occurrence["label"], "file": occurrence["file"], "count": 0}
+            by_file[occurrence["file"]] = entry
+            sources.append(entry)
+        entry["count"] += 1
+    return sources
+
+
+def _placeholder_occurrences(root: Path, artifact_labels: dict[str, str]) -> list[dict[str, Any]]:
+    occurrences: list[dict[str, Any]] = []
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        rel = str(path.relative_to(root))
+        if rel == REDACTION_METADATA_FILE:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for line_no, line in enumerate(text.splitlines(), 1):
+            start = line.find(PRIVATE_KEY_PLACEHOLDER)
+            while start != -1:
+                end = start + len(PRIVATE_KEY_PLACEHOLDER)
+                occurrences.append(
+                    {
+                        "file": rel,
+                        "line_no": line_no,
+                        "line": line,
+                        "start": start,
+                        "end": end,
+                        "label": _source_label(rel, artifact_labels),
+                    }
+                )
+                start = line.find(PRIVATE_KEY_PLACEHOLDER, end)
+    return occurrences
+
+
+def build_review_items(reports: Sequence[RedactionReport]) -> list[ReviewItem]:
+    """The adjudication list over the merged findings of ``reports``.
+
+    Suspected items merge by token value across every report (a value either
+    is a secret or is not, wherever it appears); linked marks value-containment
+    pairs whose decisions must agree. The confirmed private-key item is built
+    from the replacement placeholders — the original content no longer exists.
+    """
+    labels_by_report = [_artifact_labels(report.redacted_dir) for report in reports]
+
+    items: list[ReviewItem] = []
+    key_hits = sum(report.patterns.get(PRIVATE_KEY_CATEGORY, 0) for report in reports)
+    if key_hits:
+        occurrences: list[dict[str, Any]] = []
+        for report, labels in zip(reports, labels_by_report):
+            occurrences.extend(_placeholder_occurrences(report.redacted_dir, labels))
+        items.append(
+            ReviewItem(
+                id=_item_id(f"pattern.{PRIVATE_KEY_CATEGORY}"),
+                kind=KIND_CONFIRMED,
+                category=PRIVATE_KEY_CATEGORY,
+                token="",
+                masked_sample=PRIVATE_KEY_PLACEHOLDER,
+                sources=_sources_from_occurrences(occurrences),
+                occurrences=occurrences,
+            )
+        )
+
+    by_token: dict[str, ReviewItem] = {}
+    order: list[str] = []
+    for index, (report, labels) in enumerate(zip(reports, labels_by_report)):
+        for finding in report.findings:
+            occurrences = [{**occ, "label": _source_label(occ["file"], labels), "report": index} for occ in finding.occurrences]
+            item = by_token.get(finding.token)
+            if item is None:
+                item = ReviewItem(
+                    id=_item_id(finding.token),
+                    kind=KIND_SUSPECTED,
+                    category=finding.category,
+                    token=finding.token,
+                    masked_sample=finding.sample,
+                    occurrences=occurrences,
+                )
+                by_token[finding.token] = item
+                order.append(finding.token)
+            else:
+                item.occurrences.extend(occurrences)
+
+    suspected = [by_token[token] for token in order]
+    for item in suspected:
+        item.occurrences.sort(key=lambda o: (o["report"], o["file"], o["line_no"], o["start"]))
+        item.sources = _sources_from_occurrences(item.occurrences)
+    suspected.sort(key=lambda i: (i.occurrences[0]["report"], i.occurrences[0]["file"], i.occurrences[0]["line_no"]))
+
+    for a in suspected:
+        for b in suspected:
+            if a is not b and a.token in b.token:
+                a.linked.append(b.id)
+                # containment is what makes decisions collide: replacing the
+                # contained value rewrites inside the containing one.
+                if a.id not in b.linked:
+                    b.linked.append(a.id)
+
+    return items + suspected
+
+
+def validate_review_decisions(items: Sequence[ReviewItem], decisions: Sequence[ReviewDecision]) -> None:
+    """Check a decision set without touching anything; raise on any defect.
+
+    ``ReviewConflictError`` marks the one user-fixable case (linked items
+    deciding differently); every other defect is a caller bug and raises
+    ``BugReportError``.
+    """
+    by_id = {item.id: item for item in items}
+    seen: dict[str, str] = {}
+    for decision in decisions:
+        item = by_id.get(decision.item_id)
+        if item is None:
+            raise BugReportError(f"decision for unknown review item {decision.item_id!r}")
+        if decision.item_id in seen:
+            raise BugReportError(f"duplicate decision for review item {decision.item_id!r}")
+        allowed = (ACTION_ACKNOWLEDGED,) if item.kind == KIND_CONFIRMED else (ACTION_KEPT, ACTION_REDACTED)
+        if decision.action not in allowed:
+            raise BugReportError(f"invalid action {decision.action!r} for review item {decision.item_id!r}")
+        seen[decision.item_id] = decision.action
+    missing = [item.id for item in items if item.id not in seen]
+    if missing:
+        raise BugReportError(f"missing decision(s) for review item(s): {', '.join(missing)}")
+
+    for item in items:
+        for other_id in item.linked:
+            if seen[item.id] != seen[other_id]:
+                raise ReviewConflictError(
+                    f"linked review items {item.id} and {other_id} have overlapping values"
+                    " and must share one decision (keep both or replace both)"
+                )
+
+
+def _token_pattern(token: str) -> re.Pattern[str]:
+    variants = sorted({v for v in _variants(token) if v}, key=len, reverse=True)
+    return re.compile("|".join(re.escape(v) for v in variants))
+
+
+def _body_files(reports: Sequence[RedactionReport]) -> list[tuple[Path, str]]:
+    files: list[tuple[Path, str]] = []
+    for report in reports:
+        root = report.redacted_dir
+        for path in sorted(p for p in root.rglob("*") if p.is_file()):
+            rel = str(path.relative_to(root))
+            if rel != REDACTION_METADATA_FILE:
+                files.append((path, rel))
+    return files
+
+
+def _write_metadata(report: RedactionReport) -> None:
+    (report.redacted_dir / REDACTION_METADATA_FILE).write_text(
+        json.dumps(report.metadata(), ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def apply_review_decisions(
+    items: Sequence[ReviewItem],
+    decisions: Sequence[ReviewDecision],
+    *,
+    reports: Sequence[RedactionReport],
+) -> ReviewOutcome:
+    """Rewrite the redacted trees per ``decisions`` and prove the result.
+
+    Order is load-bearing: the kept-token baseline is counted before any
+    change (finding counts use a different scan scope and would misfire);
+    body text is replaced before the summaries are rewritten (a summary built
+    from unfiltered findings would reintroduce replaced plaintext); and every
+    string headed for serialization is filtered through the user-confirmed
+    replacements. Verification failures raise ``PreparationError`` — a
+    decision record that does not match the delivered bytes must never ship.
+    """
+    validate_review_decisions(items, decisions)
+    actions = {decision.item_id: decision.action for decision in decisions}
+
+    redacted_tokens = [item.token for item in items if actions[item.id] == ACTION_REDACTED]
+    kept_tokens = [item.token for item in items if actions[item.id] == ACTION_KEPT]
+    user_secrets = [KnownSecret(USER_CONFIRMED_LABEL, token) for token in redacted_tokens]
+
+    files = _body_files(reports)
+    kept_patterns = {token: _token_pattern(token) for token in kept_tokens}
+    baseline: dict[str, int] = {token: 0 for token in kept_tokens}
+    for path, _rel in files:
+        text = path.read_text(encoding="utf-8")
+        for token, pattern in kept_patterns.items():
+            baseline[token] += sum(1 for _ in pattern.finditer(text))
+
+    if user_secrets:
+        for report in reports:
+            counts: dict[str, int] = {}
+            root = report.redacted_dir
+            for path, _rel in files:
+                if root not in path.parents:
+                    continue
+                text = path.read_text(encoding="utf-8")
+                replaced = _apply_exact(text, user_secrets, counts)
+                if replaced != text:
+                    path.write_text(replaced, encoding="utf-8")
+            if counts.get(USER_CONFIRMED_LABEL):
+                report.exact[USER_CONFIRMED_LABEL] = (
+                    report.exact.get(USER_CONFIRMED_LABEL, 0) + counts[USER_CONFIRMED_LABEL]
+                )
+
+    def _filter(text: str) -> str:
+        return _apply_exact(text, user_secrets, {}) if user_secrets else text
+
+    redacted_set = set(redacted_tokens)
+    for report in reports:
+        pruned: list[ResidualFinding] = []
+        for finding in report.findings:
+            if finding.token in redacted_set:
+                continue
+            finding.sample = _filter(finding.sample)
+            pruned.append(finding)
+        report.findings = pruned
+        _write_metadata(report)
+
+    summary_files = [report.redacted_dir / REDACTION_METADATA_FILE for report in reports]
+    for token in redacted_tokens:
+        for variant in _variants(token):
+            if not variant:
+                continue
+            for path, rel in files:
+                if variant in path.read_text(encoding="utf-8"):
+                    raise PreparationError(f"user-redacted content survived in the export: {rel}")
+            for path in summary_files:
+                if variant in path.read_text(encoding="utf-8"):
+                    raise PreparationError(
+                        f"user-redacted content survived in the export: {path.name}"
+                    )
+    for token, pattern in kept_patterns.items():
+        count = 0
+        for path, _rel in files:
+            count += sum(1 for _ in pattern.finditer(path.read_text(encoding="utf-8")))
+        if count != baseline[token]:
+            raise PreparationError(
+                f"a kept token changed during review application ({baseline[token]} -> {count} occurrence(s))"
+            )
+
+    key_hits = sum(report.patterns.get(PRIVATE_KEY_CATEGORY, 0) for report in reports)
+    notices = (
+        [f"the original trajectory contained {key_hits} private key block(s), replaced before export"]
+        if key_hits
+        else []
+    )
+
+    user_decisions = [
+        {
+            "id": item.id,
+            "category": item.category,
+            "sources": [
+                {"source": _filter(source["label"]), "count": source["count"]} for source in item.sources
+            ],
+            "masked_sample": _filter(item.masked_sample),
+            "action": actions[item.id],
+        }
+        for item in items
+    ]
+
+    return ReviewOutcome(
+        user_secrets=user_secrets,
+        user_decisions=user_decisions,
+        security_notices=[_filter(notice) for notice in notices],
+    )
+
+
+__all__ = [
+    "ACTION_ACKNOWLEDGED",
+    "ACTION_KEPT",
+    "ACTION_REDACTED",
+    "KIND_CONFIRMED",
+    "KIND_SUSPECTED",
+    "PRIVATE_KEY_PLACEHOLDER",
+    "ReviewCancelledError",
+    "ReviewConflictError",
+    "ReviewDecision",
+    "ReviewItem",
+    "ReviewOutcome",
+    "apply_review_decisions",
+    "build_review_items",
+    "validate_review_decisions",
+]

--- a/raven/trajectory/review.py
+++ b/raven/trajectory/review.py
@@ -38,6 +38,7 @@ from raven.trajectory.redact import (
     RedactionReport,
     ResidualFinding,
     _apply_exact,
+    _mask,
     _variants,
 )
 
@@ -468,6 +469,7 @@ def apply_review_decisions(
             "category": item.category,
             "sources": [{"source": _filter(source["label"]), "count": source["count"]} for source in item.sources],
             "masked_sample": _filter(item.masked_sample),
+            "masked_token": _filter(_mask(item.token)) if item.token else item.masked_sample,
             "action": actions[item.id],
         }
         for item in items

--- a/tests/test_cli_trajectory_browse.py
+++ b/tests/test_cli_trajectory_browse.py
@@ -1943,7 +1943,7 @@ def test_bug_report_declined_confirmation_keeps_nothing(state, workspace, monkey
     assert breport.list_reports(state) == []
 
 
-def test_bug_report_needs_review_requires_second_confirm(state, workspace, monkeypatch, capsys, _no_machine_secrets):
+def test_bug_report_review_single_risk_confirm_declined(state, workspace, monkeypatch, capsys, _no_machine_secrets):
     from raven.trajectory import bugreport as breport
 
     _write_log(
@@ -1951,18 +1951,21 @@ def test_bug_report_needs_review_requires_second_confirm(state, workspace, monke
         [_span("trace-1", session_key="cli:a", attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})],
     )
 
-    fake = _bug_flow(monkeypatch, workspace, ["it broke", False, True, False, _CANCEL])
+    fake = _bug_flow(monkeypatch, workspace, ["it broke", False, ("pick", "Keep"), False, _CANCEL])
 
     out = capsys.readouterr().out
+    assert "Redaction review — 1 item(s) need your decision" in out
+    assert "Suspected: high-entropy token" in out
+    assert "the span log" in out
     assert "NEEDS REVIEW" in out
-    assert "residual scan flagged" in out
     assert "Cancelled — no bug report was created." in out
     assert breport.list_reports(state) == []
-    ship_prompt = next(msg for kind, msg, _t in fake.prompts if "Ship the package anyway?" in msg)
-    assert "flagged content may include real secrets" in ship_prompt
+    assert any("Ship the package with the risks listed above?" in msg for _k, msg, _t in fake.prompts)
+    # One confirmation only: the risk consent replaces the plain create prompt.
+    assert not any("Create the bug report?" in msg for _k, msg, _t in fake.prompts)
 
 
-def test_bug_report_needs_review_accepted_ships(state, workspace, monkeypatch, capsys, _no_machine_secrets):
+def test_bug_report_review_kept_finding_ships(state, workspace, monkeypatch, capsys, _no_machine_secrets):
     import tarfile as _tarfile
 
     _write_log(
@@ -1970,48 +1973,49 @@ def test_bug_report_needs_review_accepted_ships(state, workspace, monkeypatch, c
         [_span("trace-1", session_key="cli:a", attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})],
     )
 
-    _bug_flow(monkeypatch, workspace, ["it broke", False, True, True, _CANCEL])
+    _bug_flow(monkeypatch, workspace, ["it broke", False, ("pick", "Keep"), True, _CANCEL])
 
     _record_dir, record = _single_report(state)
     assert record["status"] == "local_ready"
     assert record["redaction"]["classification"] == "needs_review"
+    assert [entry["action"] for entry in record["redaction"]["user_decisions"]] == ["kept"]
     with _tarfile.open(record["package"]["path"]) as tar:
         meta = json.loads(tar.extractfile(f"{record['report_id']}/bugreport.json").read().decode("utf-8"))
     assert meta["redaction"]["risk_accepted"] is True
+    assert meta["redaction"]["user_decisions"] == record["redaction"]["user_decisions"]
 
 
-def test_bug_report_blocked_trajectory_stops_before_input(state, workspace, monkeypatch, capsys, _no_machine_secrets):
-    from raven.trajectory import bugreport as breport
-
+def test_bug_report_private_key_acknowledged_ships(state, workspace, monkeypatch, capsys, _no_machine_secrets):
     _write_log(
         state / "logs" / "audit-spans.log",
         [_span("trace-1", session_key="cli:a", attrs={"llm.output": _PEM})],
     )
 
-    fake = _bug_flow(monkeypatch, workspace, [_CANCEL])
+    _bug_flow(monkeypatch, workspace, ["it broke", False, ("pick", "Acknowledge"), True, _CANCEL])
 
     out = capsys.readouterr().out
-    assert "Cannot create a bug report from this attempt." in out
-    assert "private key block" in out
-    assert "raven trajectory report" in out
-    assert breport.list_reports(state) == []
-    assert not any(kind == "text" for kind, _m, _t in fake.prompts)
+    assert "Confirmed sensitive: private key block (already replaced)" in out
+    _record_dir, record = _single_report(state)
+    assert record["status"] == "local_ready"
+    assert record["redaction"]["security_notices"] == [
+        "the original trajectory contained 1 private key block(s), replaced before export"
+    ]
+    assert [entry["action"] for entry in record["redaction"]["user_decisions"]] == ["acknowledged"]
 
 
-def test_bug_report_blocked_description_stops_before_confirm(
-    state, workspace, monkeypatch, capsys, _no_machine_secrets
-):
+def test_bug_report_review_cancel_keeps_nothing(state, workspace, monkeypatch, capsys, _no_machine_secrets):
     from raven.trajectory import bugreport as breport
 
     _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", session_key="cli:a")])
 
-    fake = _bug_flow(monkeypatch, workspace, [f"look: {_PEM}", False, _CANCEL])
+    fake = _bug_flow(monkeypatch, workspace, [f"look: {_PEM}", False, ("pick", "Cancel the report"), _CANCEL])
 
     out = capsys.readouterr().out
-    assert "Cannot create a bug report with these details." in out
-    assert "without pasting the key itself" in out
+    assert "Cancelled — no bug report was created." in out
     assert breport.list_reports(state) == []
-    assert not any("Create the bug report?" in msg for _k, msg, _t in fake.prompts)
+    staging = breport.bugreports_root(state) / breport.STAGING_DIR
+    assert not any(staging.iterdir())
+    assert not any("Ship the package" in msg for _k, msg, _t in fake.prompts)
 
 
 def test_bug_report_concurrent_member_change_rejected(state, workspace, monkeypatch, capsys, _no_machine_secrets):
@@ -2098,21 +2102,88 @@ def test_bug_report_io_failure_shows_prepare_block(state, workspace, monkeypatch
 
 
 def test_bug_report_policy_review_flow(state, workspace, monkeypatch, capsys, _no_machine_secrets):
+    """A zero-item review (policy only) skips the item screen but still gets
+    the risk-worded confirmation — never the plain create prompt."""
     from raven.trajectory import bugreport as breport
 
     monkeypatch.setenv("RAVEN_BUGREPORT_REQUIRE_REVIEW", "1")
     _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", session_key="cli:a")])
 
-    _bug_flow(monkeypatch, workspace, ["it broke", False, True, False, _CANCEL])
+    fake = _bug_flow(monkeypatch, workspace, ["it broke", False, False, _CANCEL])
     out = capsys.readouterr().out
     assert "organization policy requires manual review" in out
     assert "Cancelled — no bug report was created." in out
     assert breport.list_reports(state) == []
+    assert any("Ship the package with the risks listed above?" in msg for _k, msg, _t in fake.prompts)
+    assert not any("Create the bug report?" in msg for _k, msg, _t in fake.prompts)
+    assert not any(msg == "Decision:" for _k, msg, _t in fake.prompts)
 
-    _bug_flow(monkeypatch, workspace, ["it broke", False, True, True, _CANCEL])
+    _bug_flow(monkeypatch, workspace, ["it broke", False, True, _CANCEL])
     ((_record_dir, record),) = breport.list_reports(state)
     assert record["status"] == "local_ready"
     assert "organization policy requires manual review" in record["redaction"]["reasons"]
+
+
+def test_bug_report_review_lists_every_item(state, workspace, monkeypatch, capsys, _no_machine_secrets):
+    tokens = [f"qT7zK9mP4vX2sW8dQ5nR{suffix}" for suffix in ("fJ3a", "fJ3b", "fJ3c", "fJ3d", "fJ3e", "fJ3f")]
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1", session_key="cli:a", attrs={"llm.output": " ".join(tokens)})],
+    )
+
+    answers = ["it broke", False] + [("pick", "Keep")] * 6 + [True, _CANCEL]
+    fake = _bug_flow(monkeypatch, workspace, answers)
+
+    out = capsys.readouterr().out
+    assert "Redaction review — 6 item(s) need your decision" in out
+    assert "[6/6]" in out
+    assert sum(1 for _k, msg, _t in fake.prompts if msg == "Decision:") == 6
+    _record_dir, record = _single_report(state)
+    assert len(record["redaction"]["user_decisions"]) == 6
+
+
+def test_bug_report_review_mixed_decisions(state, workspace, monkeypatch, capsys, _no_machine_secrets):
+    keep = "qW3eR5tY7uI9oP1aS2dF4gH6"
+    drop = "zX8cV6bN4mL2kJ9hG7fD5sQ3"
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1", session_key="cli:a", attrs={"llm.output": f"keep {keep} drop {drop}"})],
+    )
+
+    _bug_flow(monkeypatch, workspace, ["it broke", False, ("pick", "Keep"), ("pick", "Replace"), True, _CANCEL])
+
+    _record_dir, record = _single_report(state)
+    actions = sorted(entry["action"] for entry in record["redaction"]["user_decisions"])
+    assert actions == ["kept", "redacted"]
+    assert drop not in json.dumps(record)
+
+
+def test_bug_report_review_conflict_reasks_linked_group(state, workspace, monkeypatch, capsys, _no_machine_secrets):
+    inner = "Hj5tR8uE3iO7pA1sD4fGk9lZ"
+    outer = inner + "W6xC2v"
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1", session_key="cli:a", attrs={"llm.output": f"a {inner} b {outer}"})],
+    )
+
+    answers = [
+        "it broke",
+        False,
+        ("pick", "Keep"),
+        ("pick", "Replace"),
+        ("pick", "Replace"),
+        ("pick", "Replace"),
+        True,
+        _CANCEL,
+    ]
+    fake = _bug_flow(monkeypatch, workspace, answers)
+
+    out = capsys.readouterr().out
+    assert "must share one decision" in out
+    assert sum(1 for _k, msg, _t in fake.prompts if msg == "Decision:") == 4
+    _record_dir, record = _single_report(state)
+    assert [entry["action"] for entry in record["redaction"]["user_decisions"]] == ["redacted", "redacted"]
+    assert inner not in json.dumps(record) and outer not in json.dumps(record)
 
 
 def test_bug_report_details_show_completeness(state, workspace, monkeypatch, capsys, _no_machine_secrets):

--- a/tests/test_cli_trajectory_browse.py
+++ b/tests/test_cli_trajectory_browse.py
@@ -2142,6 +2142,40 @@ def test_bug_report_review_lists_every_item(state, workspace, monkeypatch, capsy
     assert len(record["redaction"]["user_decisions"]) == 6
 
 
+def test_bug_report_review_suspected_item_has_no_default(state, workspace, monkeypatch, capsys, _no_machine_secrets):
+    """A bare Enter lands on the placeholder and records nothing; the item is
+    re-asked until a real action is chosen."""
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1", session_key="cli:a", attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})],
+    )
+
+    answers = ["it broke", False, ("pick", "(select a decision)"), ("pick", "Keep"), True, _CANCEL]
+    fake = _bug_flow(monkeypatch, workspace, answers)
+
+    out = capsys.readouterr().out
+    assert "This item has no default" in out
+    assert sum(1 for _k, msg, _t in fake.prompts if msg == "Decision:") == 2
+    decision_prompts = [titles for _k, msg, titles in fake.prompts if msg == "Decision:"]
+    assert decision_prompts[0][0] == "(select a decision)"
+    _record_dir, record = _single_report(state)
+    assert [entry["action"] for entry in record["redaction"]["user_decisions"]] == ["kept"]
+
+
+def test_bug_report_private_key_default_stays_acknowledge(state, workspace, monkeypatch, capsys, _no_machine_secrets):
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1", session_key="cli:a", attrs={"llm.output": _PEM})],
+    )
+
+    fake = _bug_flow(monkeypatch, workspace, ["it broke", False, ("pick", "Acknowledge"), True, _CANCEL])
+
+    decision_prompts = [titles for _k, msg, titles in fake.prompts if msg == "Decision:"]
+    assert decision_prompts[0][0] == "Acknowledge and continue"
+    _record_dir, record = _single_report(state)
+    assert [entry["action"] for entry in record["redaction"]["user_decisions"]] == ["acknowledged"]
+
+
 def test_bug_report_review_mixed_decisions(state, workspace, monkeypatch, capsys, _no_machine_secrets):
     keep = "qW3eR5tY7uI9oP1aS2dF4gH6"
     drop = "zX8cV6bN4mL2kJ9hG7fD5sQ3"

--- a/tests/test_cli_trajectory_browse.py
+++ b/tests/test_cli_trajectory_browse.py
@@ -2225,6 +2225,29 @@ def test_bug_report_review_same_line_double_hit_keeps_positions(
     assert out.count("Seen at:") == 1
 
 
+def test_grouped_occurrences_keep_every_span_for_identical_windows(tmp_path):
+    """Two hits on a just-over-300 line render the same windowed text; the
+    merged group must keep both highlight spans (review-verified trap)."""
+    from raven.trajectory import redact as tredact
+    from raven.trajectory import review as treview
+
+    token = _ENTROPY_TOKEN
+    line = "a" * 100 + f" {token} " + "b" * 30 + f" {token} " + "c" * 140
+    assert len(line) > tbrowse._REVIEW_WHOLE_LINE_LIMIT
+    tree = tmp_path / "trajectory"
+    tree.mkdir()
+    (tree / "long.json").write_text(line, encoding="utf-8")
+    report = tredact.RedactionReport(bundle_dir=tree, redacted_dir=tree.resolve())
+    report.findings = tredact.scan_residuals(tree)
+    (item,) = treview.build_review_items([report])
+    assert len(item.occurrences) == 2
+
+    (group,) = tbrowse._grouped_occurrences(item)
+
+    assert len(group["occurrences"]) == 2
+    assert sorted(group["spans"]) == [(101, 125), (157, 181)]
+
+
 def test_bug_report_review_long_line_windowed(state, workspace, monkeypatch, capsys, tmp_path, _no_machine_secrets):
     artifact = tmp_path / "long.json"
     artifact.write_text("m" * 400 + f" {_ENTROPY_TOKEN} end", encoding="utf-8")

--- a/tests/test_cli_trajectory_browse.py
+++ b/tests/test_cli_trajectory_browse.py
@@ -2227,7 +2227,7 @@ def test_bug_report_review_same_line_double_hit_keeps_positions(
 
 def test_grouped_occurrences_keep_every_span_for_identical_windows(tmp_path):
     """Two hits on a just-over-300 line render the same windowed text; the
-    merged group must keep both highlight spans (review-verified trap)."""
+    merged group must keep both highlight spans."""
     from raven.trajectory import redact as tredact
     from raven.trajectory import review as treview
 

--- a/tests/test_cli_trajectory_browse.py
+++ b/tests/test_cli_trajectory_browse.py
@@ -1951,13 +1951,18 @@ def test_bug_report_review_single_risk_confirm_declined(state, workspace, monkey
         [_span("trace-1", session_key="cli:a", attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})],
     )
 
-    fake = _bug_flow(monkeypatch, workspace, ["it broke", False, ("pick", "Keep"), False, _CANCEL])
+    fake = _bug_flow(monkeypatch, workspace, ["it broke", False, "k", False, _CANCEL])
 
     out = capsys.readouterr().out
     assert "Redaction review — 1 item(s) need your decision" in out
+    assert "Paths are relative to the trajectory snapshot inside the package." in out
     assert "Suspected: high-entropy token" in out
+    assert f"Token: {_ENTROPY_TOKEN}" in out
     assert "the span log" in out
+    assert "spans.jsonl:1" in out
     assert "NEEDS REVIEW" in out
+    assert "Review decisions are complete. Confirm the report contents shown above." in out
+    assert "Reviewed:" in out and "1 kept" in out
     assert "Cancelled — no bug report was created." in out
     assert breport.list_reports(state) == []
     assert any("Ship the package with the risks listed above?" in msg for _k, msg, _t in fake.prompts)
@@ -1973,7 +1978,7 @@ def test_bug_report_review_kept_finding_ships(state, workspace, monkeypatch, cap
         [_span("trace-1", session_key="cli:a", attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})],
     )
 
-    _bug_flow(monkeypatch, workspace, ["it broke", False, ("pick", "Keep"), True, _CANCEL])
+    _bug_flow(monkeypatch, workspace, ["it broke", False, "k", True, _CANCEL])
 
     _record_dir, record = _single_report(state)
     assert record["status"] == "local_ready"
@@ -1991,7 +1996,7 @@ def test_bug_report_private_key_acknowledged_ships(state, workspace, monkeypatch
         [_span("trace-1", session_key="cli:a", attrs={"llm.output": _PEM})],
     )
 
-    _bug_flow(monkeypatch, workspace, ["it broke", False, ("pick", "Acknowledge"), True, _CANCEL])
+    _bug_flow(monkeypatch, workspace, ["it broke", False, "", True, _CANCEL])
 
     out = capsys.readouterr().out
     assert "Confirmed sensitive: private key block (already replaced)" in out
@@ -2008,7 +2013,7 @@ def test_bug_report_review_cancel_keeps_nothing(state, workspace, monkeypatch, c
 
     _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", session_key="cli:a")])
 
-    fake = _bug_flow(monkeypatch, workspace, [f"look: {_PEM}", False, ("pick", "Cancel the report"), _CANCEL])
+    fake = _bug_flow(monkeypatch, workspace, [f"look: {_PEM}", False, "c", _CANCEL])
 
     out = capsys.readouterr().out
     assert "Cancelled — no bug report was created." in out
@@ -2116,7 +2121,8 @@ def test_bug_report_policy_review_flow(state, workspace, monkeypatch, capsys, _n
     assert breport.list_reports(state) == []
     assert any("Ship the package with the risks listed above?" in msg for _k, msg, _t in fake.prompts)
     assert not any("Create the bug report?" in msg for _k, msg, _t in fake.prompts)
-    assert not any(msg == "Decision:" for _k, msg, _t in fake.prompts)
+    assert not any(str(msg).startswith("Decision") for _k, msg, _t in fake.prompts)
+    assert "Review decisions are complete." not in out
 
     _bug_flow(monkeypatch, workspace, ["it broke", False, True, _CANCEL])
     ((_record_dir, record),) = breport.list_reports(state)
@@ -2131,33 +2137,33 @@ def test_bug_report_review_lists_every_item(state, workspace, monkeypatch, capsy
         [_span("trace-1", session_key="cli:a", attrs={"llm.output": " ".join(tokens)})],
     )
 
-    answers = ["it broke", False] + [("pick", "Keep")] * 6 + [True, _CANCEL]
+    answers = ["it broke", False] + ["k"] * 6 + [True, _CANCEL]
     fake = _bug_flow(monkeypatch, workspace, answers)
 
     out = capsys.readouterr().out
     assert "Redaction review — 6 item(s) need your decision" in out
     assert "[6/6]" in out
-    assert sum(1 for _k, msg, _t in fake.prompts if msg == "Decision:") == 6
+    assert sum(1 for _k, msg, _t in fake.prompts if str(msg).startswith("Decision")) == 6
     _record_dir, record = _single_report(state)
     assert len(record["redaction"]["user_decisions"]) == 6
 
 
 def test_bug_report_review_suspected_item_has_no_default(state, workspace, monkeypatch, capsys, _no_machine_secrets):
-    """A bare Enter lands on the placeholder and records nothing; the item is
-    re-asked until a real action is chosen."""
+    """A bare Enter (or any unknown input) records nothing; the item is
+    re-asked until k, r, or c is typed."""
     _write_log(
         state / "logs" / "audit-spans.log",
         [_span("trace-1", session_key="cli:a", attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})],
     )
 
-    answers = ["it broke", False, ("pick", "(select a decision)"), ("pick", "Keep"), True, _CANCEL]
+    answers = ["it broke", False, "", "x", "k", True, _CANCEL]
     fake = _bug_flow(monkeypatch, workspace, answers)
 
     out = capsys.readouterr().out
-    assert "This item has no default" in out
-    assert sum(1 for _k, msg, _t in fake.prompts if msg == "Decision:") == 2
-    decision_prompts = [titles for _k, msg, titles in fake.prompts if msg == "Decision:"]
-    assert decision_prompts[0][0] == "(select a decision)"
+    assert out.count("Choose k, r, or c — this item has no default.") == 2
+    decision_prompts = [msg for _k, msg, _t in fake.prompts if str(msg).startswith("Decision")]
+    assert len(decision_prompts) == 3
+    assert "[k] keep" in decision_prompts[0]
     _record_dir, record = _single_report(state)
     assert [entry["action"] for entry in record["redaction"]["user_decisions"]] == ["kept"]
 
@@ -2168,12 +2174,71 @@ def test_bug_report_private_key_default_stays_acknowledge(state, workspace, monk
         [_span("trace-1", session_key="cli:a", attrs={"llm.output": _PEM})],
     )
 
-    fake = _bug_flow(monkeypatch, workspace, ["it broke", False, ("pick", "Acknowledge"), True, _CANCEL])
+    fake = _bug_flow(monkeypatch, workspace, ["it broke", False, "", True, _CANCEL])
 
-    decision_prompts = [titles for _k, msg, titles in fake.prompts if msg == "Decision:"]
-    assert decision_prompts[0][0] == "Acknowledge and continue"
+    decision_prompts = [msg for _k, msg, _t in fake.prompts if str(msg).startswith("Decision")]
+    assert "[Enter] acknowledge and continue" in decision_prompts[0]
     _record_dir, record = _single_report(state)
     assert [entry["action"] for entry in record["redaction"]["user_decisions"]] == ["acknowledged"]
+
+
+def test_bug_report_review_locations_survive_context_cap(
+    state, workspace, monkeypatch, capsys, tmp_path, _no_machine_secrets
+):
+    """Only context text is capped: with six distinct contexts across six
+    files, every location stays visible and the extras say so."""
+    attrs = {}
+    for i in range(6):
+        artifact = tmp_path / f"ctx{i}.json"
+        artifact.write_text(f"lead{i} {_ENTROPY_TOKEN} tail{i}", encoding="utf-8")
+        attrs[f"x{i}.artifact_path"] = str(artifact)
+    _write_log(state / "logs" / "audit-spans.log", [_span("trace-1", session_key="cli:a", attrs=attrs)])
+
+    _bug_flow(monkeypatch, workspace, ["it broke", False, "k", True, _CANCEL])
+
+    out = capsys.readouterr().out
+    assert f"Token: {_ENTROPY_TOKEN} — the same value in 6 place(s)" in out
+    assert "Context 1 of 6" in out
+    assert "... 1 more distinct context(s), locations listed below:" in out
+    assert "(context omitted)" in out
+    for i in range(6):
+        assert f"ctx{i}.json:1" in out
+
+
+def test_bug_report_review_same_line_double_hit_keeps_positions(
+    state, workspace, monkeypatch, capsys, tmp_path, _no_machine_secrets
+):
+    """Two hits of the same value on one short line stay one context group
+    with both positions counted (display-text dedup must not lose them)."""
+    artifact = tmp_path / "double.json"
+    artifact.write_text(f"a {_ENTROPY_TOKEN} b {_ENTROPY_TOKEN} c", encoding="utf-8")
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1", session_key="cli:a", attrs={"x.artifact_path": str(artifact)})],
+    )
+
+    _bug_flow(monkeypatch, workspace, ["it broke", False, "k", True, _CANCEL])
+
+    out = capsys.readouterr().out
+    assert "the same value in 2 place(s)" in out
+    assert "(identical in 2 place(s))" in out
+    assert out.count("Seen at:") == 1
+
+
+def test_bug_report_review_long_line_windowed(state, workspace, monkeypatch, capsys, tmp_path, _no_machine_secrets):
+    artifact = tmp_path / "long.json"
+    artifact.write_text("m" * 400 + f" {_ENTROPY_TOKEN} end", encoding="utf-8")
+    _write_log(
+        state / "logs" / "audit-spans.log",
+        [_span("trace-1", session_key="cli:a", attrs={"x.artifact_path": str(artifact)})],
+    )
+
+    _bug_flow(monkeypatch, workspace, ["it broke", False, "k", True, _CANCEL])
+
+    flat = "".join(capsys.readouterr().out.split())
+    assert "..." in flat
+    assert "m" * 250 not in flat
+    assert "m" * 100 in flat
 
 
 def test_bug_report_review_mixed_decisions(state, workspace, monkeypatch, capsys, _no_machine_secrets):
@@ -2184,7 +2249,7 @@ def test_bug_report_review_mixed_decisions(state, workspace, monkeypatch, capsys
         [_span("trace-1", session_key="cli:a", attrs={"llm.output": f"keep {keep} drop {drop}"})],
     )
 
-    _bug_flow(monkeypatch, workspace, ["it broke", False, ("pick", "Keep"), ("pick", "Replace"), True, _CANCEL])
+    _bug_flow(monkeypatch, workspace, ["it broke", False, "k", "r", True, _CANCEL])
 
     _record_dir, record = _single_report(state)
     actions = sorted(entry["action"] for entry in record["redaction"]["user_decisions"])
@@ -2200,21 +2265,12 @@ def test_bug_report_review_conflict_reasks_linked_group(state, workspace, monkey
         [_span("trace-1", session_key="cli:a", attrs={"llm.output": f"a {inner} b {outer}"})],
     )
 
-    answers = [
-        "it broke",
-        False,
-        ("pick", "Keep"),
-        ("pick", "Replace"),
-        ("pick", "Replace"),
-        ("pick", "Replace"),
-        True,
-        _CANCEL,
-    ]
+    answers = ["it broke", False, "k", "r", "r", "r", True, _CANCEL]
     fake = _bug_flow(monkeypatch, workspace, answers)
 
     out = capsys.readouterr().out
     assert "must share one decision" in out
-    assert sum(1 for _k, msg, _t in fake.prompts if msg == "Decision:") == 4
+    assert sum(1 for _k, msg, _t in fake.prompts if str(msg).startswith("Decision")) == 4
     _record_dir, record = _single_report(state)
     assert [entry["action"] for entry in record["redaction"]["user_decisions"]] == ["redacted", "redacted"]
     assert inner not in json.dumps(record) and outer not in json.dumps(record)

--- a/tests/test_cli_trajectory_commands.py
+++ b/tests/test_cli_trajectory_commands.py
@@ -1320,6 +1320,86 @@ def test_report_bug_summary_shows_session_and_trajectory_context(state, _no_mach
     assert "session record" in r.output
 
 
+class _FakeReviewQuestionary:
+    """Minimal questionary stand-in: every select resolves via the factory.
+
+    No ``application`` attribute, so ``_inject_bindings`` leaves it untouched
+    and the real ``_ask`` / ``_ask_action`` conversion logic runs.
+    """
+
+    class Choice:
+        def __init__(self, title, value=None):
+            self.title = title
+            self.value = value if value is not None else title
+
+    def __init__(self, result_factory):
+        self._factory = result_factory
+
+    def select(self, *_a, **_k):
+        factory = self._factory
+        return type("_Ask", (), {"unsafe_ask": staticmethod(factory)})()
+
+
+def _tty_review_setup(state, monkeypatch, attrs):
+    from raven.cli import trajectory_commands as tcmd
+
+    _simple_log(state, attrs=attrs)
+    monkeypatch.setattr(tcmd, "_stdin_is_tty", lambda: True)
+
+
+def test_report_bug_tty_escape_during_review_cancels(state, _no_machine_secrets, monkeypatch):
+    import raven.cli.trajectory_browse as tbrowse
+    from raven.trajectory import bugreport as breport
+
+    _tty_review_setup(state, monkeypatch, {"llm.output": f"token {_ENTROPY_TOKEN}"})
+    monkeypatch.setattr(tbrowse, "_require_questionary", lambda: _FakeReviewQuestionary(lambda: tbrowse._BACK))
+
+    r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x"])
+
+    assert r.exit_code == 1
+    assert "Cancelled — no bug report was created." in r.output
+    assert breport.list_reports(state) == []
+    assert _staging_entries(state) == []
+
+
+def test_report_bug_tty_ctrl_c_during_review_cancels(state, _no_machine_secrets, monkeypatch):
+    import raven.cli.trajectory_browse as tbrowse
+    from raven.trajectory import bugreport as breport
+
+    def _interrupt():
+        raise KeyboardInterrupt
+
+    _tty_review_setup(state, monkeypatch, {"llm.output": f"token {_ENTROPY_TOKEN}"})
+    monkeypatch.setattr(tbrowse, "_require_questionary", lambda: _FakeReviewQuestionary(_interrupt))
+
+    r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x"])
+
+    assert r.exit_code == 1
+    assert "Cancelled — no bug report was created." in r.output
+    assert breport.list_reports(state) == []
+    assert _staging_entries(state) == []
+
+
+def test_report_bug_tty_conflict_then_cancel(state, _no_machine_secrets, monkeypatch):
+    import raven.cli.trajectory_browse as tbrowse
+    from raven.trajectory import bugreport as breport
+    from raven.trajectory import review as treview
+
+    inner = "Hj5tR8uE3iO7pA1sD4fGk9lZ"
+    outer = inner + "W6xC2v"
+    _tty_review_setup(state, monkeypatch, {"llm.output": f"a {inner} b {outer}"})
+    answers = iter([treview.ACTION_KEPT, treview.ACTION_REDACTED, tbrowse._REVIEW_CANCEL])
+    monkeypatch.setattr(tbrowse, "_require_questionary", lambda: _FakeReviewQuestionary(lambda: next(answers)))
+
+    r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x"])
+
+    assert r.exit_code == 1
+    assert "must share one decision" in r.output
+    assert "Cancelled — no bug report was created." in r.output
+    assert breport.list_reports(state) == []
+    assert _staging_entries(state) == []
+
+
 def test_report_bug_summary_shows_semantic_decisions(state, _no_machine_secrets, monkeypatch):
     """The confirmation summary lists every decision with its semantic source."""
     from raven.cli import trajectory_commands as tcmd

--- a/tests/test_cli_trajectory_commands.py
+++ b/tests/test_cli_trajectory_commands.py
@@ -1151,16 +1151,20 @@ def test_report_bug_accept_risk_ships_needs_review(state, _no_machine_secrets):
     assert record["status"] == "local_ready"
 
 
-def test_report_bug_blocked_cannot_be_forced(state, _no_machine_secrets):
+def test_report_bug_private_key_ships_with_accept_risk(state, _no_machine_secrets):
     from raven.trajectory import bugreport as breport
 
     _simple_log(state, attrs={"llm.output": _PEM})
     r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "it broke", "--yes", "--accept-risk"])
 
-    assert r.exit_code == 1
-    assert "private key block" in r.output
-    assert breport.list_reports(state) == []
-    assert _staging_entries(state) == []
+    assert r.exit_code == 0, r.output
+    ((_dir, record),) = breport.list_reports(state)
+    assert record["status"] == "local_ready"
+    assert record["redaction"]["security_notices"] == [
+        "the original trajectory contained 1 private key block(s), replaced before export"
+    ]
+    assert [entry["action"] for entry in record["redaction"]["user_decisions"]] == ["acknowledged"]
+    assert _PEM not in json.dumps(record)
 
 
 def test_report_bug_rejects_bogus_severity(state, _no_machine_secrets):
@@ -1225,26 +1229,30 @@ def test_report_bug_blank_description_fails_before_side_effects(state, _no_machi
     assert tstore_module.pins(state) == {}
 
 
-def test_report_bug_blocked_by_description_has_problem_wording(state, _no_machine_secrets):
+def test_report_bug_private_key_in_description_requires_accept_risk(state, _no_machine_secrets):
     from raven.trajectory import bugreport as breport
 
     _simple_log(state)
     r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", f"look: {_PEM}", "--yes"])
 
     assert r.exit_code == 1
-    assert "Cannot create a bug report with these details." in r.output
-    assert "without pasting the key itself" in r.output
+    assert "--accept-risk" in r.output
+    assert "private key block(s)" in r.output
     assert breport.list_reports(state) == []
     assert _staging_entries(state) == []
 
 
-def test_report_bug_blocked_by_trajectory_has_source_wording(state, _no_machine_secrets):
+def test_report_bug_private_key_in_trajectory_requires_accept_risk(state, _no_machine_secrets):
+    from raven.trajectory import bugreport as breport
+
     _simple_log(state, attrs={"llm.output": _PEM})
     r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x", "--yes"])
 
     assert r.exit_code == 1
-    assert "Cannot create a bug report from this attempt." in r.output
-    assert "raven trajectory report" in r.output
+    assert "--accept-risk" in r.output
+    assert "private key block(s)" in r.output
+    assert breport.list_reports(state) == []
+    assert _staging_entries(state) == []
 
 
 def test_report_bug_tty_confirmation_shows_canonical_summary(state, _no_machine_secrets, monkeypatch):
@@ -1312,17 +1320,32 @@ def test_report_bug_summary_shows_session_and_trajectory_context(state, _no_mach
     assert "session record" in r.output
 
 
-def test_report_bug_needs_review_shows_sanitized_samples(state, _no_machine_secrets, monkeypatch):
-    """The independent authorization is judged on the bounded sample block."""
+def test_report_bug_summary_shows_semantic_decisions(state, _no_machine_secrets, monkeypatch):
+    """The confirmation summary lists every decision with its semantic source."""
     from raven.cli import trajectory_commands as tcmd
+    from raven.trajectory import bugreport as breport
 
     _simple_log(state, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
 
     r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x", "--yes", "--accept-risk"])
     assert r.exit_code == 0, r.output
     assert "residual scan flagged" in r.output
-    assert "spans.jsonl:" in r.output
+    assert "review decision(s)" in r.output
+    assert "the span log" in r.output
+    assert _ENTROPY_TOKEN not in r.output
 
+    # TTY path: the interactive decider is stubbed to keep-all; declining the
+    # single risk confirmation must leave nothing behind.
+    import raven.cli.trajectory_browse as tbrowse
+    from raven.trajectory import review as treview
+
+    def _keep_all(_questionary, _style):
+        def _decide(items, _reasons):
+            return [treview.ReviewDecision(item.id, treview.ACTION_KEPT) for item in items]
+
+        return _decide
+
+    monkeypatch.setattr(tbrowse, "make_review_decider", _keep_all)
     monkeypatch.setattr(tcmd, "_stdin_is_tty", lambda: True)
     confirms: list[str] = []
 
@@ -1334,4 +1357,7 @@ def test_report_bug_needs_review_shows_sanitized_samples(state, _no_machine_secr
     _simple_log(state, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
     r2 = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x"])
     assert r2.exit_code == 1
-    assert "spans.jsonl:" in r2.output
+    assert "the span log" in r2.output
+    assert confirms == ["Ship the package with the risks listed above?"]
+    assert len(breport.list_reports(state)) == 1  # only the first run's report
+    assert _staging_entries(state) == []

--- a/tests/test_cli_trajectory_commands.py
+++ b/tests/test_cli_trajectory_commands.py
@@ -1126,29 +1126,206 @@ def test_report_bug_non_tty_without_yes_fails_before_side_effects(state, _no_mac
     assert tstore_module.pins(state) == {}
 
 
-def test_report_bug_needs_review_requires_accept_risk(state, _no_machine_secrets):
+def test_report_bug_suspected_without_flags_lists_items_and_both_flags(state, _no_machine_secrets):
     from raven.trajectory import bugreport as breport
 
     _simple_log(state, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
     r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "it broke", "--yes"])
 
     assert r.exit_code == 1
+    assert "1 item(s) require your decision" in r.output
+    assert "Suspected: high-entropy token" in r.output
+    assert "the span log" in r.output
+    assert _ENTROPY_TOKEN in r.output  # the highlighted context (terminal is local)
+    assert "--keep-findings or --redact-findings" in r.output
     assert "--accept-risk" in r.output
-    assert "residual scan flagged" in r.output
     assert breport.list_reports(state) == []
     assert _staging_entries(state) == []
 
 
-def test_report_bug_accept_risk_ships_needs_review(state, _no_machine_secrets):
+def _inner_spans_text(record, tmp_path):
+    import tarfile as _tarfile
+
+    with _tarfile.open(record["package"]["path"]) as tar:
+        inner = tar.extractfile(f"{record['report_id']}/trajectory/trace-1.tar.gz").read()
+    inner_tar = tmp_path / "inner.tar.gz"
+    inner_tar.write_bytes(inner)
+    extract_dir = tmp_path / "inner"
+    with _tarfile.open(inner_tar) as tar:
+        tar.extractall(extract_dir, filter="data")
+    return (extract_dir / "trace-1" / "spans.jsonl").read_text(encoding="utf-8")
+
+
+def test_report_bug_keep_findings_with_accept_risk_ships_kept(state, _no_machine_secrets, tmp_path):
     from raven.trajectory import bugreport as breport
 
     _simple_log(state, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
-    r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "it broke", "--yes", "--accept-risk"])
+    r = runner.invoke(
+        trajectory_app,
+        ["report-bug", "trace-1", "-d", "it broke", "--yes", "--keep-findings", "--accept-risk"],
+    )
 
     assert r.exit_code == 0, r.output
     ((_dir, record),) = breport.list_reports(state)
     assert record["redaction"]["classification"] == "needs_review"
     assert record["status"] == "local_ready"
+    assert [entry["action"] for entry in record["redaction"]["user_decisions"]] == ["kept"]
+    assert _ENTROPY_TOKEN not in json.dumps(record["redaction"]["user_decisions"])
+    assert _ENTROPY_TOKEN in _inner_spans_text(record, tmp_path)
+
+
+def test_report_bug_redact_findings_with_accept_risk_ships_scrubbed(state, _no_machine_secrets, tmp_path):
+    from raven.trajectory import bugreport as breport
+
+    _simple_log(state, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
+    r = runner.invoke(
+        trajectory_app,
+        ["report-bug", "trace-1", "-d", "it broke", "--yes", "--redact-findings", "--accept-risk"],
+    )
+
+    assert r.exit_code == 0, r.output
+    ((_dir, record),) = breport.list_reports(state)
+    assert record["status"] == "local_ready"
+    assert [entry["action"] for entry in record["redaction"]["user_decisions"]] == ["redacted"]
+    assert _ENTROPY_TOKEN not in json.dumps(record)
+    spans = _inner_spans_text(record, tmp_path)
+    assert _ENTROPY_TOKEN not in spans
+    assert "[REDACTED:user-confirmed]" in spans
+
+
+def test_report_bug_flags_are_mutually_exclusive(state, _no_machine_secrets):
+    from raven.trajectory import bugreport as breport
+    from raven.trajectory import store as tstore_module
+
+    _simple_log(state)
+    r = runner.invoke(
+        trajectory_app,
+        ["report-bug", "trace-1", "-d", "x", "--yes", "--keep-findings", "--redact-findings"],
+    )
+
+    assert r.exit_code == 1
+    assert "mutually exclusive" in r.output
+    assert breport.list_reports(state) == []
+    assert not (breport.bugreports_root(state) / breport.STAGING_DIR).exists()
+    assert tstore_module.pins(state) == {}
+
+
+@pytest.mark.parametrize("flag", ["--keep-findings", "--redact-findings"])
+def test_report_bug_flag_without_accept_risk_fails_before_application(state, _no_machine_secrets, flag):
+    """The missing-flag failure must precede any decision application: the
+    original context is listed intact and nothing was replaced or frozen."""
+    from raven.trajectory import bugreport as breport
+
+    _simple_log(state, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
+    r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x", "--yes", flag])
+
+    assert r.exit_code == 1
+    assert "Suspected: high-entropy token" in r.output
+    assert _ENTROPY_TOKEN in r.output
+    assert "--accept-risk" in r.output
+    assert "--keep-findings or --redact-findings" not in r.output
+    assert "[REDACTED:user-confirmed]" not in r.output
+    assert breport.list_reports(state) == []
+    assert _staging_entries(state) == []
+
+
+def test_report_bug_accept_risk_without_keep_or_redact_lists_that_flag(state, _no_machine_secrets):
+    from raven.trajectory import bugreport as breport
+
+    _simple_log(state, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
+    r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x", "--yes", "--accept-risk"])
+
+    assert r.exit_code == 1
+    assert "--keep-findings or --redact-findings" in r.output
+    assert "Pass: --keep-findings or --redact-findings (--yes does not imply them)." in r.output
+    assert breport.list_reports(state) == []
+
+
+def test_report_bug_both_kinds_ship_with_full_flags(state, _no_machine_secrets):
+    from raven.trajectory import bugreport as breport
+
+    _simple_log(state, attrs={"llm.output": f"token {_ENTROPY_TOKEN} and {_PEM}"})
+    r = runner.invoke(
+        trajectory_app,
+        ["report-bug", "trace-1", "-d", "x", "--yes", "--redact-findings", "--accept-risk"],
+    )
+
+    assert r.exit_code == 0, r.output
+    ((_dir, record),) = breport.list_reports(state)
+    actions = sorted(entry["action"] for entry in record["redaction"]["user_decisions"])
+    assert actions == ["acknowledged", "redacted"]
+    assert record["redaction"]["security_notices"] != []
+
+
+def test_report_bug_policy_only_review_needs_accept_risk(state, _no_machine_secrets, monkeypatch):
+    from raven.trajectory import bugreport as breport
+
+    monkeypatch.setenv("RAVEN_BUGREPORT_REQUIRE_REVIEW", "1")
+    _simple_log(state)
+    r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x", "--yes"])
+    assert r.exit_code == 1
+    assert "organization policy requires manual review" in r.output
+    assert breport.list_reports(state) == []
+
+    r2 = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x", "--yes", "--accept-risk"])
+    assert r2.exit_code == 0, r2.output
+    ((_dir, record),) = breport.list_reports(state)
+    assert record["redaction"]["classification"] == "needs_review"
+    assert record["redaction"]["user_decisions"] == []
+
+
+def test_report_bug_tty_full_flags_skip_all_prompts(state, _no_machine_secrets, monkeypatch):
+    """On a TTY, flags pre-decide their kinds: with everything covered plus
+    --yes, no questionary prompt may appear at all."""
+    import raven.cli.trajectory_browse as tbrowse
+    from raven.cli import trajectory_commands as tcmd
+    from raven.trajectory import bugreport as breport
+
+    def _no_prompts():
+        raise AssertionError("questionary must not be used when flags cover every item")
+
+    _simple_log(state, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
+    monkeypatch.setattr(tcmd, "_stdin_is_tty", lambda: True)
+    monkeypatch.setattr(tbrowse, "_require_questionary", _no_prompts)
+
+    r = runner.invoke(
+        trajectory_app,
+        ["report-bug", "trace-1", "-d", "x", "--yes", "--keep-findings", "--accept-risk"],
+    )
+
+    assert r.exit_code == 0, r.output
+    ((_dir, record),) = breport.list_reports(state)
+    assert [entry["action"] for entry in record["redaction"]["user_decisions"]] == ["kept"]
+
+
+def test_report_bug_tty_flags_without_accept_risk_still_confirm_risk(state, _no_machine_secrets, monkeypatch):
+    """--keep-findings covers the items, but the risk consent still gates the
+    ship on a TTY when --accept-risk was not given; declining keeps nothing."""
+    import raven.cli.trajectory_browse as tbrowse
+    from raven.cli import trajectory_commands as tcmd
+    from raven.trajectory import bugreport as breport
+
+    def _no_prompts():
+        raise AssertionError("no per-item prompt is expected: the flag covers every item")
+
+    _simple_log(state, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
+    monkeypatch.setattr(tcmd, "_stdin_is_tty", lambda: True)
+    monkeypatch.setattr(tbrowse, "_require_questionary", _no_prompts)
+    confirms: list[str] = []
+
+    def _reject(message, *_a, **_k):
+        confirms.append(message)
+        return False
+
+    monkeypatch.setattr(tcmd.typer, "confirm", _reject)
+
+    r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x", "--yes", "--keep-findings"])
+
+    assert r.exit_code == 1
+    assert confirms == ["Ship the package with the risks listed above?"]
+    assert "Cancelled — no bug report was created." in r.output
+    assert breport.list_reports(state) == []
+    assert _staging_entries(state) == []
 
 
 def test_report_bug_private_key_ships_with_accept_risk(state, _no_machine_secrets):
@@ -1236,8 +1413,8 @@ def test_report_bug_private_key_in_description_requires_accept_risk(state, _no_m
     r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", f"look: {_PEM}", "--yes"])
 
     assert r.exit_code == 1
-    assert "--accept-risk" in r.output
-    assert "private key block(s)" in r.output
+    assert "Confirmed sensitive: private key block (already replaced)" in r.output
+    assert "Pass: --accept-risk (--yes does not imply them)." in r.output
     assert breport.list_reports(state) == []
     assert _staging_entries(state) == []
 
@@ -1249,8 +1426,8 @@ def test_report_bug_private_key_in_trajectory_requires_accept_risk(state, _no_ma
     r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x", "--yes"])
 
     assert r.exit_code == 1
-    assert "--accept-risk" in r.output
-    assert "private key block(s)" in r.output
+    assert "Confirmed sensitive: private key block (already replaced)" in r.output
+    assert "Pass: --accept-risk (--yes does not imply them)." in r.output
     assert breport.list_reports(state) == []
     assert _staging_entries(state) == []
 
@@ -1407,7 +1584,7 @@ def test_report_bug_summary_shows_semantic_decisions(state, _no_machine_secrets,
 
     _simple_log(state, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
 
-    r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x", "--yes", "--accept-risk"])
+    r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x", "--yes", "--keep-findings", "--accept-risk"])
     assert r.exit_code == 0, r.output
     assert "residual scan flagged" in r.output
     assert "review decision(s)" in r.output

--- a/tests/test_cli_trajectory_commands.py
+++ b/tests/test_cli_trajectory_commands.py
@@ -1134,9 +1134,11 @@ def test_report_bug_suspected_without_flags_lists_items_and_both_flags(state, _n
 
     assert r.exit_code == 1
     assert "1 item(s) require your decision" in r.output
+    assert "Paths are relative to the trajectory snapshot inside the package." in r.output
     assert "Suspected: high-entropy token" in r.output
-    assert "the span log" in r.output
-    assert _ENTROPY_TOKEN in r.output  # the highlighted context (terminal is local)
+    assert f"Token: {_ENTROPY_TOKEN}" in r.output
+    assert "Seen at:" in r.output
+    assert "the span log — spans.jsonl:1" in r.output
     assert "--keep-findings or --redact-findings" in r.output
     assert "--accept-risk" in r.output
     assert breport.list_reports(state) == []
@@ -1516,6 +1518,10 @@ class _FakeReviewQuestionary:
         factory = self._factory
         return type("_Ask", (), {"unsafe_ask": staticmethod(factory)})()
 
+    def text(self, *_a, **_k):
+        factory = self._factory
+        return type("_Ask", (), {"unsafe_ask": staticmethod(factory)})()
+
 
 def _tty_review_setup(state, monkeypatch, attrs):
     from raven.cli import trajectory_commands as tcmd
@@ -1560,12 +1566,11 @@ def test_report_bug_tty_ctrl_c_during_review_cancels(state, _no_machine_secrets,
 def test_report_bug_tty_conflict_then_cancel(state, _no_machine_secrets, monkeypatch):
     import raven.cli.trajectory_browse as tbrowse
     from raven.trajectory import bugreport as breport
-    from raven.trajectory import review as treview
 
     inner = "Hj5tR8uE3iO7pA1sD4fGk9lZ"
     outer = inner + "W6xC2v"
     _tty_review_setup(state, monkeypatch, {"llm.output": f"a {inner} b {outer}"})
-    answers = iter([treview.ACTION_KEPT, treview.ACTION_REDACTED, tbrowse._REVIEW_CANCEL])
+    answers = iter(["k", "r", "c"])
     monkeypatch.setattr(tbrowse, "_require_questionary", lambda: _FakeReviewQuestionary(lambda: next(answers)))
 
     r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x"])
@@ -1587,7 +1592,7 @@ def test_report_bug_summary_shows_semantic_decisions(state, _no_machine_secrets,
     r = runner.invoke(trajectory_app, ["report-bug", "trace-1", "-d", "x", "--yes", "--keep-findings", "--accept-risk"])
     assert r.exit_code == 0, r.output
     assert "residual scan flagged" in r.output
-    assert "review decision(s)" in r.output
+    assert "decision(s) complete" in r.output
     assert "the span log" in r.output
     assert _ENTROPY_TOKEN not in r.output
 

--- a/tests/test_trajectory_bugreport.py
+++ b/tests/test_trajectory_bugreport.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from raven.trajectory import bugreport as breport
+from raven.trajectory import review as treview
 from raven.trajectory import sanitize as tsan
 from raven.trajectory import store as tstore
 from raven.trajectory.redact import KnownSecret, RedactionReport, ResidualFinding
@@ -76,8 +77,26 @@ def _prepared(state, workspace, attrs=None, **prepare_kw):
 
 def _full_flow(state, workspace, description="the agent replied wrongly", attrs=None, **fields):
     prep = _prepared(state, workspace, attrs)
+    # keep-all by default: incidental findings (e.g. a long pytest tmp-dir
+    # segment) must not force every flow test to script the review screen.
+    fields.setdefault("decide", _decide_all())
     prep = breport.freeze_export(prep, description=description, **fields)
     return breport.confirm_and_package(prep, state_dir=state)
+
+
+def _decide_all(suspected_action=treview.ACTION_KEPT):
+    """A scripted decide callback: acknowledge confirmed items, one action for the rest."""
+
+    def _decide(items, _reasons):
+        return [
+            treview.ReviewDecision(
+                item.id,
+                treview.ACTION_ACKNOWLEDGED if item.kind == treview.KIND_CONFIRMED else suspected_action,
+            )
+            for item in items
+        ]
+
+    return _decide
 
 
 # ── path parser / sanitizer ────────────────────────────────────────────
@@ -202,12 +221,13 @@ def _report(**kw):
     return RedactionReport(**defaults)
 
 
-def test_classify_blocked_on_original_private_key_hit():
+def test_classify_private_key_hit_is_a_review_reason():
     classification, reasons = breport.classify_redaction(_report(patterns={"private-key-block": 1}))
-    assert classification == "blocked"
-    assert reasons == ["the original trajectory contains a private key block"]
-    classification, _ = breport.classify_redaction(_report(), _report(patterns={"private-key-block": 2}))
-    assert classification == "blocked"
+    assert classification == "needs_review"
+    assert reasons == ["the original trajectory contained 1 private key block(s), replaced before export"]
+    classification, reasons = breport.classify_redaction(_report(), _report(patterns={"private-key-block": 2}))
+    assert classification == "needs_review"
+    assert reasons == ["the original trajectory contained 2 private key block(s), replaced before export"]
 
 
 def test_classify_needs_review_reasons_merge_both_sides():
@@ -333,6 +353,26 @@ def _damage(payload, spec):
         payload["redaction"]["classification"] = "blocked"
     elif spec == "unreviewed":
         payload["redaction"]["reviewed_by_user"] = False
+    elif spec == "bad-security-notices":
+        payload["redaction"]["security_notices"] = ["ok", 3]
+    elif spec == "decision-bad-action":
+        payload["redaction"]["user_decisions"] = [
+            {"id": "abc123abc123", "category": "high-entropy", "masked_sample": "x", "action": "shipped", "sources": []}
+        ]
+    elif spec == "decision-missing-id":
+        payload["redaction"]["user_decisions"] = [
+            {"category": "high-entropy", "masked_sample": "x", "action": "kept", "sources": []}
+        ]
+    elif spec == "decision-bad-source-count":
+        payload["redaction"]["user_decisions"] = [
+            {
+                "id": "abc123abc123",
+                "category": "high-entropy",
+                "masked_sample": "x",
+                "action": "kept",
+                "sources": [{"source": "the span log", "count": -1}],
+            }
+        ]
     return payload
 
 
@@ -363,6 +403,10 @@ _DAMAGE_SPECS = [
     "traces-unsorted",
     "blocked-classification",
     "unreviewed",
+    "bad-security-notices",
+    "decision-bad-action",
+    "decision-missing-id",
+    "decision-bad-source-count",
 ]
 
 
@@ -457,24 +501,34 @@ def test_problem_token_redacted_but_clean(state, workspace):
 
 def test_problem_entropy_needs_review_with_problem_file(state, workspace):
     prep = _prepared(state, workspace)
-    prep = breport.freeze_export(prep, description=f"weird token {_ENTROPY_TOKEN} appeared")
+    prep = breport.freeze_export(prep, description=f"weird token {_ENTROPY_TOKEN} appeared", decide=_decide_all())
     assert prep.classification == "needs_review"
     findings = prep.package_metadata["redaction"]["residual_findings"]
     assert any(f["file"] == "problem.description" for f in findings)
     prep.cleanup()
 
 
-def test_problem_private_key_blocks_before_export(state, workspace):
+def test_problem_private_key_becomes_a_review_item(state, workspace):
     prep = _prepared(state, workspace)
-    prep = breport.freeze_export(prep, description=f"look: {_PEM}")
-    assert prep.classification == "blocked"
-    assert not prep.export_dir.exists()
+    seen: list = []
+
+    def _decide(items, reasons):
+        seen.extend(items)
+        return _decide_all()(items, reasons)
+
+    prep = breport.freeze_export(prep, description=f"look: {_PEM}", decide=_decide)
+    assert prep.classification == "needs_review"
+    assert prep.export_dir.exists()
+    assert [item.kind for item in seen] == ["confirmed"]
+    assert prep.security_notices == ["the original trajectory contained 1 private key block(s), replaced before export"]
+    assert _PEM not in json.dumps(prep.package_metadata)
     prep.cleanup()
 
 
-def test_trajectory_private_key_blocks_before_input(state, workspace):
+def test_trajectory_private_key_preclassifies_as_review(state, workspace):
     prep = _prepared(state, workspace, attrs={"llm.output": _PEM})
-    assert prep.classification == "blocked"
+    assert prep.classification == "needs_review"
+    assert prep.reasons == ["the original trajectory contained 1 private key block(s), replaced before export"]
     prep.cleanup()
 
 
@@ -493,7 +547,7 @@ def test_description_paths_are_sanitized(state, workspace):
 
 def test_residual_sample_paths_are_sanitized(state, workspace):
     prep = _prepared(state, workspace, attrs={"llm.output": f"token {_ENTROPY_TOKEN} at /tmp/leak/x.json"})
-    prep = breport.freeze_export(prep, description="it broke")
+    prep = breport.freeze_export(prep, description="it broke", decide=_decide_all())
     findings = prep.package_metadata["redaction"]["residual_findings"]
     assert findings, "the injected token must flag"
     assert all("/tmp/leak" not in f["sample"] for f in findings)
@@ -906,17 +960,20 @@ def test_policy_hook_upgrades_clean_to_needs_review(state, workspace, monkeypatc
 def test_policy_hook_reason_coexists_with_other_review_reasons(state, workspace, monkeypatch):
     monkeypatch.setenv("RAVEN_BUGREPORT_REQUIRE_REVIEW", "true")
     prep = _prepared(state, workspace, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
-    prep = breport.freeze_export(prep, description="it broke")
+    prep = breport.freeze_export(prep, description="it broke", decide=_decide_all())
     assert prep.classification == "needs_review"
     assert any(r.startswith("residual scan flagged") for r in prep.reasons)
     assert "organization policy requires manual review" in prep.reasons
     prep.cleanup()
 
 
-def test_policy_hook_never_outranks_blocked(state, workspace, monkeypatch):
+def test_policy_hook_reason_coexists_with_private_key_reason(state, workspace, monkeypatch):
     monkeypatch.setenv("RAVEN_BUGREPORT_REQUIRE_REVIEW", "1")
     prep = _prepared(state, workspace, attrs={"llm.output": _PEM})
-    assert prep.classification == "blocked"
+    prep = breport.freeze_export(prep, description="it broke", decide=_decide_all())
+    assert prep.classification == "needs_review"
+    assert any(r.startswith("the original trajectory contained") for r in prep.reasons)
+    assert "organization policy requires manual review" in prep.reasons
     prep.cleanup()
 
 
@@ -926,6 +983,149 @@ def test_policy_hook_off_keeps_clean(state, workspace, monkeypatch):
     prep = breport.freeze_export(prep, description="it broke")
     assert prep.classification == "clean"
     prep.cleanup()
+
+
+# ── review flow through the pipeline ───────────────────────────────────
+
+
+def test_freeze_without_decide_fails_when_items_exist(state, workspace):
+    prep = _prepared(state, workspace, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
+    with pytest.raises(breport.BugReportError, match="decide"):
+        breport.freeze_export(prep, description="it broke")
+    assert not prep.export_dir.exists()
+    prep.cleanup()
+
+
+def test_review_cancel_leaves_nothing(state, workspace):
+    prep = _prepared(state, workspace, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
+
+    def _cancel(_items, _reasons):
+        raise treview.ReviewCancelledError("cancelled from the review screen")
+
+    with pytest.raises(treview.ReviewCancelledError):
+        breport.freeze_export(prep, description="it broke", decide=_cancel)
+    prep.cleanup()
+    assert not prep.staging_dir.exists()
+    root = breport.bugreports_root(state)
+    assert [p.name for p in root.iterdir() if p.name != breport.STAGING_DIR] == []
+
+
+def test_private_key_flow_packages_with_notices(state, workspace):
+    record_dir, record = _full_flow(state, workspace, attrs={"llm.output": f"before {_PEM} after"})
+    assert record["status"] == "local_ready"
+    assert record["redaction"]["classification"] == "needs_review"
+    notices = ["the original trajectory contained 1 private key block(s), replaced before export"]
+    assert record["redaction"]["security_notices"] == notices
+    decisions = record["redaction"]["user_decisions"]
+    assert [entry["action"] for entry in decisions] == ["acknowledged"]
+    assert decisions[0]["category"] == "private-key-block"
+    with tarfile.open(record["package"]["path"]) as tar:
+        meta = json.loads(tar.extractfile(f"{record['report_id']}/bugreport.json").read().decode("utf-8"))
+    assert meta["redaction"]["security_notices"] == notices
+    assert meta["redaction"]["user_decisions"] == decisions
+    assert meta["redaction"]["risk_accepted"] is True
+    assert record_dir.name == record["report_id"]
+
+
+def test_mixed_decisions_recorded_and_replaced_token_scrubbed(state, workspace, tmp_path):
+    """Adjacent kept/redacted tokens: the kept finding's summary window covers
+    the redacted neighbor, so the package metadata must carry the filtered
+    spelling everywhere (the review-verified reintroduction trap)."""
+    keep = "qW3eR5tY7uI9oP1aS2dF4gH6"
+    drop = "zX8cV6bN4mL2kJ9hG7fD5sQ3"
+
+    def _decide(items, _reasons):
+        return [
+            treview.ReviewDecision(item.id, treview.ACTION_REDACTED if item.token == drop else treview.ACTION_KEPT)
+            for item in items
+        ]
+
+    _record_dir, record = _full_flow(state, workspace, attrs={"llm.output": f"keep {keep} drop {drop}"}, decide=_decide)
+    assert record["status"] == "local_ready"
+    actions = sorted(entry["action"] for entry in record["redaction"]["user_decisions"])
+    assert actions == ["kept", "redacted"]
+    assert drop not in json.dumps(record)
+    rid = record["report_id"]
+    with tarfile.open(record["package"]["path"]) as tar:
+        meta_text = tar.extractfile(f"{rid}/bugreport.json").read().decode("utf-8")
+        inner = tar.extractfile(f"{rid}/trajectory/trace-1.tar.gz").read()
+    assert drop not in meta_text
+    assert "[REDACTED:user-confirmed]" in meta_text
+    inner_tar = tmp_path / "inner.tar.gz"
+    inner_tar.write_bytes(inner)
+    extract_dir = tmp_path / "inner"
+    with tarfile.open(inner_tar) as tar:
+        tar.extractall(extract_dir, filter="data")
+    for path in extract_dir.rglob("*"):
+        if path.is_file():
+            text = path.read_text(encoding="utf-8", errors="replace")
+            assert drop not in text, path
+    spans = (extract_dir / "trace-1" / "spans.jsonl").read_text(encoding="utf-8")
+    assert keep in spans and "[REDACTED:user-confirmed]" in spans
+
+
+def test_all_findings_replaced_still_needs_review(state, workspace):
+    prep = _prepared(state, workspace, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
+    prep = breport.freeze_export(prep, description="it broke", decide=_decide_all(treview.ACTION_REDACTED))
+    assert prep.classification == "needs_review"
+    assert any("replaced at your direction" in reason for reason in prep.reasons)
+    assert prep.package_metadata["redaction"]["risk_accepted"] is True
+    assert prep.package_metadata["redaction"]["residual_findings"] == []
+    prep.cleanup()
+
+
+def test_zero_item_policy_report_skips_decide_but_stays_review(state, workspace, monkeypatch):
+    monkeypatch.setenv("RAVEN_BUGREPORT_REQUIRE_REVIEW", "1")
+    calls: list = []
+
+    def _decide(items, _reasons):
+        calls.append(items)
+        return []
+
+    prep = _prepared(state, workspace)
+    prep = breport.freeze_export(prep, description="it broke", decide=_decide)
+    assert calls == []
+    assert prep.classification == "needs_review"
+    assert prep.package_metadata["redaction"]["risk_accepted"] is True
+    assert prep.package_metadata["redaction"]["user_decisions"] == []
+    prep.cleanup()
+
+
+def test_completeness_probe_runs_on_the_post_decision_tree(state, workspace, monkeypatch):
+    seen: dict = {}
+
+    def _probe(redacted_dir, _report):
+        seen["spans"] = (redacted_dir / "spans.jsonl").read_text(encoding="utf-8")
+        return "complete", []
+
+    monkeypatch.setattr("raven.trajectory.completeness.evaluate_completeness", _probe)
+    prep = _prepared(state, workspace, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
+    prep = breport.freeze_export(prep, description="it broke", decide=_decide_all(treview.ACTION_REDACTED))
+    assert _ENTROPY_TOKEN not in seen["spans"]
+    assert "[REDACTED:user-confirmed]" in seen["spans"]
+    prep.cleanup()
+
+
+def test_completeness_reasons_inherit_user_redactions(state, workspace, monkeypatch):
+    def _probe(_redacted_dir, _report):
+        return "degraded", [f"probe saw {_ENTROPY_TOKEN}"]
+
+    monkeypatch.setattr("raven.trajectory.completeness.evaluate_completeness", _probe)
+    prep = _prepared(state, workspace, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
+    prep = breport.freeze_export(prep, description="it broke", decide=_decide_all(treview.ACTION_REDACTED))
+    assert prep.completeness == ("degraded", ["probe saw [REDACTED:user-confirmed]"])
+    prep.cleanup()
+
+
+def test_new_record_without_review_fields_still_validates(state, workspace):
+    """The review fields are additive: a record stripped back to the old shape
+    (what pre-review writers produced) must still pass validation."""
+    record_dir, record = _full_flow(state, workspace, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
+    payload = json.loads((record_dir / breport.RECORD_FILE).read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    payload["redaction"].pop("security_notices")
+    payload["redaction"].pop("user_decisions")
+    breport._validate_record(payload, record_dir.name)
 
 
 def test_completeness_evaluation_failure_degrades_to_unknown(state, workspace, monkeypatch):
@@ -967,7 +1167,7 @@ def test_deliverable_probe_missing_llm_input_end_to_end(state, workspace, tmp_pa
         ],
     )
     prep = breport.prepare_trajectory("trace-1", workspace=workspace, state_dir=state)
-    prep = breport.freeze_export(prep, description="it broke")
+    prep = breport.freeze_export(prep, description="it broke", decide=_decide_all())
     record_dir, record = breport.confirm_and_package(prep, state_dir=state)
 
     assert record["completeness"]["status"] == "degraded"
@@ -1027,7 +1227,7 @@ def test_deliverable_probe_missing_tool_input_end_to_end(state, workspace, tmp_p
         ],
     )
     prep = breport.prepare_trajectory("trace-1", workspace=workspace, state_dir=state)
-    prep = breport.freeze_export(prep, description="it broke")
+    prep = breport.freeze_export(prep, description="it broke", decide=_decide_all())
     _record_dir, record = breport.confirm_and_package(prep, state_dir=state)
 
     assert record["completeness"]["status"] == "degraded"

--- a/tests/test_trajectory_bugreport.py
+++ b/tests/test_trajectory_bugreport.py
@@ -1064,6 +1064,38 @@ def test_mixed_decisions_recorded_and_replaced_token_scrubbed(state, workspace, 
     assert keep in spans and "[REDACTED:user-confirmed]" in spans
 
 
+def test_redacted_value_in_artifact_filename_never_reaches_the_package(state, workspace, tmp_path):
+    """The reviewed-verified leak: replacing a token rewrites its references,
+    but the artifact file itself would keep the name and ship as a tar member.
+    Member names and contents must both be clean after the rename."""
+    artifact = tmp_path / f"{_ENTROPY_TOKEN}.json"
+    artifact.write_text(json.dumps({"result": "clean"}), encoding="utf-8")
+
+    _record_dir, record = _full_flow(
+        state,
+        workspace,
+        attrs={"tool.output.artifact_path": str(artifact)},
+        decide=_decide_all(treview.ACTION_REDACTED),
+    )
+
+    assert record["status"] == "local_ready"
+    rid = record["report_id"]
+    with tarfile.open(record["package"]["path"]) as tar:
+        assert not any(_ENTROPY_TOKEN in name for name in tar.getnames())
+        inner = tar.extractfile(f"{rid}/trajectory/trace-1.tar.gz").read()
+    inner_tar = tmp_path / "inner.tar.gz"
+    inner_tar.write_bytes(inner)
+    with tarfile.open(inner_tar) as tar:
+        names = tar.getnames()
+        assert not any(_ENTROPY_TOKEN in name for name in names)
+        assert any(name.endswith("artifacts/[REDACTED:user-confirmed].json") for name in names)
+        extract_dir = tmp_path / "inner"
+        tar.extractall(extract_dir, filter="data")
+    spans = (extract_dir / "trace-1" / "spans.jsonl").read_text(encoding="utf-8")
+    assert _ENTROPY_TOKEN not in spans
+    assert "artifacts/[REDACTED:user-confirmed].json" in spans
+
+
 def test_all_findings_replaced_still_needs_review(state, workspace):
     prep = _prepared(state, workspace, attrs={"llm.output": f"token {_ENTROPY_TOKEN}"})
     prep = breport.freeze_export(prep, description="it broke", decide=_decide_all(treview.ACTION_REDACTED))

--- a/tests/test_trajectory_bugreport.py
+++ b/tests/test_trajectory_bugreport.py
@@ -1043,7 +1043,7 @@ def test_private_key_flow_packages_with_notices(state, workspace):
 def test_mixed_decisions_recorded_and_replaced_token_scrubbed(state, workspace, tmp_path):
     """Adjacent kept/redacted tokens: the kept finding's summary window covers
     the redacted neighbor, so the package metadata must carry the filtered
-    spelling everywhere (the review-verified reintroduction trap)."""
+    spelling everywhere."""
     keep = "qW3eR5tY7uI9oP1aS2dF4gH6"
     drop = "zX8cV6bN4mL2kJ9hG7fD5sQ3"
 
@@ -1078,7 +1078,7 @@ def test_mixed_decisions_recorded_and_replaced_token_scrubbed(state, workspace, 
 
 
 def test_redacted_value_in_artifact_filename_never_reaches_the_package(state, workspace, tmp_path):
-    """The reviewed-verified leak: replacing a token rewrites its references,
+    """Replacing a token rewrites its references,
     but the artifact file itself would keep the name and ship as a tar member.
     Member names and contents must both be clean after the rename."""
     artifact = tmp_path / f"{_ENTROPY_TOKEN}.json"

--- a/tests/test_trajectory_bugreport.py
+++ b/tests/test_trajectory_bugreport.py
@@ -363,6 +363,17 @@ def _damage(payload, spec):
         payload["redaction"]["user_decisions"] = [
             {"category": "high-entropy", "masked_sample": "x", "action": "kept", "sources": []}
         ]
+    elif spec == "decision-bad-masked-token":
+        payload["redaction"]["user_decisions"] = [
+            {
+                "id": "abc123abc123",
+                "category": "high-entropy",
+                "masked_sample": "x",
+                "masked_token": "",
+                "action": "kept",
+                "sources": [],
+            }
+        ]
     elif spec == "decision-bad-source-count":
         payload["redaction"]["user_decisions"] = [
             {
@@ -406,6 +417,7 @@ _DAMAGE_SPECS = [
     "bad-security-notices",
     "decision-bad-action",
     "decision-missing-id",
+    "decision-bad-masked-token",
     "decision-bad-source-count",
 ]
 
@@ -1019,6 +1031,7 @@ def test_private_key_flow_packages_with_notices(state, workspace):
     decisions = record["redaction"]["user_decisions"]
     assert [entry["action"] for entry in decisions] == ["acknowledged"]
     assert decisions[0]["category"] == "private-key-block"
+    assert decisions[0]["masked_token"] == "[REDACTED:pattern.private-key-block]"
     with tarfile.open(record["package"]["path"]) as tar:
         meta = json.loads(tar.extractfile(f"{record['report_id']}/bugreport.json").read().decode("utf-8"))
     assert meta["redaction"]["security_notices"] == notices

--- a/tests/test_trajectory_redact.py
+++ b/tests/test_trajectory_redact.py
@@ -204,6 +204,55 @@ def test_residual_scan_reports_never_rewrites(tmp_path):
     assert (report.redacted_dir / "spans.jsonl").read_text(encoding="utf-8") == leftover
 
 
+def test_residual_finding_carries_token_and_occurrences(tmp_path):
+    leftover = "qT7zXp2LmV9wRb4KsD8fGh3J"
+    spans = f"first {leftover} here\nplain line\nagain {leftover}"
+    bundle = _make_bundle(tmp_path, spans_text=spans, artifact_text=f"also {leftover}")
+
+    report = tredact.redact_bundle(bundle, tmp_path / "red", secrets=[])
+
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.token == leftover
+    assert finding.count == 3
+    assert [(o["file"], o["line_no"]) for o in finding.occurrences] == [
+        ("artifacts/tool.output.json", 1),
+        ("spans.jsonl", 1),
+        ("spans.jsonl", 3),
+    ]
+    occurrence = finding.occurrences[1]
+    assert occurrence["line"] == f"first {leftover} here"
+    assert occurrence["line"][occurrence["start"] : occurrence["end"]] == leftover
+
+
+def test_metadata_serializes_no_token_or_occurrences(tmp_path):
+    leftover = "qT7zXp2LmV9wRb4KsD8fGh3J"
+    bundle = _make_bundle(tmp_path, spans_text=f"prefix {leftover} suffix", artifact_text="clean")
+
+    report = tredact.redact_bundle(bundle, tmp_path / "red", secrets=[])
+
+    meta = json.loads((report.redacted_dir / tredact.REDACTION_METADATA_FILE).read_text(encoding="utf-8"))
+    (entry,) = meta["residual_findings"]
+    assert set(entry) == {"category", "sample", "file", "count"}
+    assert leftover not in json.dumps(meta)
+
+
+def test_residual_scan_exempts_provider_call_ids(tmp_path):
+    call_id = "call_9Q7zXp2LmV4wRb8KsD3fT6yH"
+    hyphenated = "call-9Q7zXp2LmV4wRb8KsD3fT6yH"
+    prefixed = "Xcall_9Q7zXp2LmV4wRb8KsD3fT6yH"
+    bundle = _make_bundle(
+        tmp_path, spans_text=f"{call_id}\n{hyphenated}\n{prefixed}", artifact_text="clean"
+    )
+
+    report = tredact.redact_bundle(bundle, tmp_path / "red", secrets=[])
+
+    tokens = {f.token for f in report.findings}
+    assert call_id not in tokens
+    assert hyphenated in tokens
+    assert prefixed in tokens
+
+
 # ── binary policy ─────────────────────────────────────────────────────
 
 

--- a/tests/test_trajectory_redact.py
+++ b/tests/test_trajectory_redact.py
@@ -241,9 +241,7 @@ def test_residual_scan_exempts_provider_call_ids(tmp_path):
     call_id = "call_9Q7zXp2LmV4wRb8KsD3fT6yH"
     hyphenated = "call-9Q7zXp2LmV4wRb8KsD3fT6yH"
     prefixed = "Xcall_9Q7zXp2LmV4wRb8KsD3fT6yH"
-    bundle = _make_bundle(
-        tmp_path, spans_text=f"{call_id}\n{hyphenated}\n{prefixed}", artifact_text="clean"
-    )
+    bundle = _make_bundle(tmp_path, spans_text=f"{call_id}\n{hyphenated}\n{prefixed}", artifact_text="clean")
 
     report = tredact.redact_bundle(bundle, tmp_path / "red", secrets=[])
 

--- a/tests/test_trajectory_redact.py
+++ b/tests/test_trajectory_redact.py
@@ -237,6 +237,25 @@ def test_metadata_serializes_no_token_or_occurrences(tmp_path):
     assert leftover not in json.dumps(meta)
 
 
+def test_residual_scan_exempts_known_benign_literals(tmp_path):
+    """Provider usage field names are fixed literals; only exact matches skip."""
+    lines = [
+        "completion_tokens_details",
+        "prompt_tokens_details",
+        "Xcompletion_tokens_details",
+        "prompt_tokens_details2",
+    ]
+    bundle = _make_bundle(tmp_path, spans_text="\n".join(lines), artifact_text="clean")
+
+    report = tredact.redact_bundle(bundle, tmp_path / "red", secrets=[])
+
+    tokens = {f.token for f in report.findings}
+    assert "completion_tokens_details" not in tokens
+    assert "prompt_tokens_details" not in tokens
+    assert "Xcompletion_tokens_details" in tokens
+    assert "prompt_tokens_details2" in tokens
+
+
 def test_residual_scan_exempts_provider_call_ids(tmp_path):
     call_id = "call_9Q7zXp2LmV4wRb8KsD3fT6yH"
     hyphenated = "call-9Q7zXp2LmV4wRb8KsD3fT6yH"

--- a/tests/test_trajectory_replay.py
+++ b/tests/test_trajectory_replay.py
@@ -577,6 +577,25 @@ async def test_run_replay_drives_the_loop_and_executes_nothing(tmp_path, monkeyp
     assert trace.enabled(), "suppression must not outlive the replay"
 
 
+async def test_run_replay_leaves_no_skill_watcher_threads(tmp_path) -> None:
+    """The loop's ContextBuilder starts a skill file watcher; a replay must
+    stop it, or repeated probes leak daemon threads that crash the process at
+    interpreter shutdown (found by PR review on the completeness probe)."""
+    import threading
+
+    bundle = _make_bundle(
+        tmp_path,
+        llm_calls=[(None, _llm_output(content="done"))],
+        turns=[{"content": "go", "channel": "cli", "chat_id": "direct"}],
+    )
+
+    report = await run_replay(bundle, mode="warn")
+
+    assert report.complete
+    watchers = [t for t in threading.enumerate() if t.name == "SkillFileWatcher" and t.is_alive()]
+    assert watchers == [], "a replay must not leave skill watcher threads running"
+
+
 async def test_run_replay_flags_unconsumed_recording(tmp_path) -> None:
     """A harness that never asks for the rest of the recording diverged too:
     strict halts (exit path), warn records a non-fatal divergence."""
@@ -813,6 +832,7 @@ async def test_end_to_end_record_save_replay_with_real_tracer(tmp_path, monkeypa
             max_iterations=5,
             restrict_to_workspace=True,
         )
+        loop.context.skills.stop_file_watcher()
         loop.tools.register(_MarkerTool(marker))
         # Source identity and session key agree, as they do in every real
         # channel turn (the session key defaults to "<channel>:<chat_id>").
@@ -870,6 +890,7 @@ async def test_end_to_end_replay_after_harness_change_diverges(tmp_path, monkeyp
             max_iterations=5,
             restrict_to_workspace=True,
         )
+        loop.context.skills.stop_file_watcher()
         loop.tools.register(_MarkerTool(tmp_path / "marker"))
         await loop._process_message(
             TurnRequest(
@@ -924,6 +945,7 @@ async def test_end_to_end_streamed_recording_replays_through_the_stream_path(tmp
             max_iterations=5,
             restrict_to_workspace=True,
         )
+        loop.context.skills.stop_file_watcher()
         loop.tools.register(_MarkerTool(marker))
         streamed_tokens: list[str] = []
 
@@ -1011,6 +1033,7 @@ async def test_end_to_end_replay_restores_pre_attempt_history(tmp_path, monkeypa
             max_iterations=5,
             restrict_to_workspace=True,
         )
+        loop.context.skills.stop_file_watcher()
         loop.tools.register(_MarkerTool(marker))
 
         def req(text: str) -> TurnRequest:
@@ -1075,6 +1098,7 @@ async def test_end_to_end_replay_restores_history_when_first_input_repeats(tmp_p
             max_iterations=5,
             restrict_to_workspace=True,
         )
+        loop.context.skills.stop_file_watcher()
         loop.tools.register(_MarkerTool(marker))
 
         def req() -> TurnRequest:

--- a/tests/test_trajectory_replay.py
+++ b/tests/test_trajectory_replay.py
@@ -580,7 +580,8 @@ async def test_run_replay_drives_the_loop_and_executes_nothing(tmp_path, monkeyp
 async def test_run_replay_leaves_no_skill_watcher_threads(tmp_path) -> None:
     """The loop's ContextBuilder starts a skill file watcher; a replay must
     stop it, or repeated probes leak daemon threads that crash the process at
-    interpreter shutdown (found by PR review on the completeness probe)."""
+    interpreter shutdown. Measured as a delta: other suites in the same
+    process may hold their own watcher threads."""
     import threading
 
     bundle = _make_bundle(
@@ -588,12 +589,15 @@ async def test_run_replay_leaves_no_skill_watcher_threads(tmp_path) -> None:
         llm_calls=[(None, _llm_output(content="done"))],
         turns=[{"content": "go", "channel": "cli", "chat_id": "direct"}],
     )
+    before = {t.ident for t in threading.enumerate() if t.name == "SkillFileWatcher"}
 
     report = await run_replay(bundle, mode="warn")
 
     assert report.complete
-    watchers = [t for t in threading.enumerate() if t.name == "SkillFileWatcher" and t.is_alive()]
-    assert watchers == [], "a replay must not leave skill watcher threads running"
+    leaked = [
+        t for t in threading.enumerate() if t.name == "SkillFileWatcher" and t.is_alive() and t.ident not in before
+    ]
+    assert leaked == [], "a replay must not leave new skill watcher threads running"
 
 
 async def test_run_replay_flags_unconsumed_recording(tmp_path) -> None:

--- a/tests/test_trajectory_review.py
+++ b/tests/test_trajectory_review.py
@@ -342,6 +342,61 @@ def test_apply_acknowledges_private_key_and_emits_notice(tmp_path):
     assert decision["category"] == "private-key-block"
 
 
+def test_apply_renames_paths_carrying_redacted_tokens(tmp_path):
+    """Tar member names come from the tree, so a redacted value in a file name
+    must be renamed with the same replacement its references got."""
+    tree = tmp_path / "trajectory"
+    (tree / "artifacts").mkdir(parents=True)
+    _write(tree / "artifacts", f"{TOKEN_A}.json", "clean content")
+    _write(tree, "spans.jsonl", f'{{"tool.output.artifact_path": "artifacts/{TOKEN_A}.json"}}')
+    report = _report(tree)
+    items = treview.build_review_items([report])
+
+    treview.apply_review_decisions(items, _decisions(items, **{TOKEN_A: treview.ACTION_REDACTED}), reports=[report])
+
+    assert not (tree / "artifacts" / f"{TOKEN_A}.json").exists()
+    renamed = tree / "artifacts" / "[REDACTED:user-confirmed].json"
+    assert renamed.exists() and renamed.read_text(encoding="utf-8") == "clean content"
+    spans = (tree / "spans.jsonl").read_text(encoding="utf-8")
+    assert '"artifacts/[REDACTED:user-confirmed].json"' in spans
+    rels = [str(p.relative_to(tree)) for p in tree.rglob("*") if p.is_file()]
+    assert not any(TOKEN_A in rel for rel in rels)
+
+
+def test_apply_rename_collision_aborts(tmp_path):
+    tree = tmp_path / "trajectory"
+    (tree / "artifacts").mkdir(parents=True)
+    _write(tree / "artifacts", f"{TOKEN_A}.json", "clean content")
+    _write(tree / "artifacts", "[REDACTED:user-confirmed].json", "already here")
+    _write(tree, "spans.jsonl", f'{{"tool.output.artifact_path": "artifacts/{TOKEN_A}.json"}}')
+    report = _report(tree)
+    items = treview.build_review_items([report])
+
+    with pytest.raises(breport.PreparationError, match="collides"):
+        treview.apply_review_decisions(items, _decisions(items, **{TOKEN_A: treview.ACTION_REDACTED}), reports=[report])
+
+
+def test_apply_renamed_file_updates_kept_finding_source(tmp_path):
+    tree = tmp_path / "trajectory"
+    (tree / "artifacts").mkdir(parents=True)
+    _write(tree / "artifacts", f"{TOKEN_B}.json", f"keep {TOKEN_A}")
+    _write(tree, "spans.jsonl", f'{{"tool.output.artifact_path": "artifacts/{TOKEN_B}.json"}}')
+    report = _report(tree)
+    items = treview.build_review_items([report])
+
+    treview.apply_review_decisions(
+        items,
+        _decisions(items, **{TOKEN_A: treview.ACTION_KEPT, TOKEN_B: treview.ACTION_REDACTED}),
+        reports=[report],
+    )
+
+    renamed = tree / "artifacts" / "[REDACTED:user-confirmed].json"
+    assert renamed.read_text(encoding="utf-8") == f"keep {TOKEN_A}"
+    (entry,) = json.loads((tree / tredact.REDACTION_METADATA_FILE).read_text(encoding="utf-8"))["residual_findings"]
+    assert entry["file"] == "artifacts/[REDACTED:user-confirmed].json"
+    assert TOKEN_B not in json.dumps(entry)
+
+
 def test_apply_conflicting_decisions_touch_nothing(tmp_path):
     tree = tmp_path / "trajectory"
     _write(tree, "spans.jsonl", f"{TOKEN_INNER} {TOKEN_OUTER}")

--- a/tests/test_trajectory_review.py
+++ b/tests/test_trajectory_review.py
@@ -1,0 +1,362 @@
+"""Data-layer tests for the redaction review flow (build / validate / apply)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from raven.trajectory import bugreport as breport
+from raven.trajectory import redact as tredact
+from raven.trajectory import review as treview
+
+TOKEN_A = "qT7zK9mP4vX2sW8dQ5nRfJ3y"
+TOKEN_B = "Zx4cV7bN1mQ9kL6pT2wYhG8s"
+TOKEN_INNER = "Hj5tR8uE3iO7pA1sD4fGk9lZ"
+TOKEN_OUTER = TOKEN_INNER + "W6xC2v"
+
+
+def _report(tree, *, patterns=None):
+    """A RedactionReport over a hand-rolled redacted tree, scanned for real."""
+    report = tredact.RedactionReport(bundle_dir=tree, redacted_dir=tree.resolve())
+    if patterns:
+        report.patterns.update(patterns)
+    report.findings = tredact.scan_residuals(tree)
+    return report
+
+
+def _write(tree, name, text):
+    tree.mkdir(parents=True, exist_ok=True)
+    (tree / name).write_text(text, encoding="utf-8")
+
+
+def _decisions(items, **actions_by_kind):
+    """One decision per item: confirmed acknowledged, suspected per mapping."""
+    decisions = []
+    for item in items:
+        if item.kind == treview.KIND_CONFIRMED:
+            decisions.append(treview.ReviewDecision(item.id, treview.ACTION_ACKNOWLEDGED))
+        else:
+            decisions.append(treview.ReviewDecision(item.id, actions_by_kind[item.token]))
+    return decisions
+
+
+# ── build_review_items ────────────────────────────────────────────────
+
+
+def test_build_merges_same_token_across_reports(tmp_path):
+    tree_a = tmp_path / "trajectory"
+    tree_b = tmp_path / "problem"
+    _write(tree_a, "spans.jsonl", f"one {TOKEN_A} here")
+    _write(tree_b, "problem.description", f"two {TOKEN_A} there")
+
+    items = treview.build_review_items([_report(tree_a), _report(tree_b)])
+
+    assert len(items) == 1
+    item = items[0]
+    assert item.kind == treview.KIND_SUSPECTED
+    assert item.token == TOKEN_A
+    assert item.id == treview._item_id(TOKEN_A)
+    assert [(s["label"], s["count"]) for s in item.sources] == [
+        ("the span log", 1),
+        ("your problem description", 1),
+    ]
+    assert len(item.occurrences) == 2
+
+
+def test_build_same_mask_different_values_stay_separate(tmp_path):
+    twin = TOKEN_A[:4] + "H6cV1bN8mQ3kL5pT" + TOKEN_A[-4:]
+    tree = tmp_path / "trajectory"
+    _write(tree, "spans.jsonl", f"{TOKEN_A}\n{twin}")
+
+    items = treview.build_review_items([_report(tree)])
+
+    assert len(items) == 2
+    assert {i.token for i in items} == {TOKEN_A, twin}
+    assert len({i.id for i in items}) == 2
+    masks = {i.masked_sample.split()[0][:4] for i in items}
+    assert masks == {TOKEN_A[:4]}
+
+
+def test_build_multiple_findings_in_one_file(tmp_path):
+    tree = tmp_path / "trajectory"
+    _write(tree, "spans.jsonl", f"{TOKEN_A}\n{TOKEN_B}")
+
+    items = treview.build_review_items([_report(tree)])
+
+    assert [i.token for i in items] == [TOKEN_A, TOKEN_B]
+    assert all(i.sources[0]["file"] == "spans.jsonl" for i in items)
+
+
+def test_build_semantic_labels_from_spans(tmp_path):
+    tree = tmp_path / "trajectory"
+    spans = [
+        {
+            "name": "llm.call",
+            "startTime": "2026-01-01T00:00:01Z",
+            "attributes": {"llm.input.artifact_path": "artifacts/a1.json"},
+        },
+        {
+            "name": "llm.call",
+            "startTime": "2026-01-01T00:00:02Z",
+            "attributes": {
+                "llm.input.artifact_path": "artifacts/a2.json",
+                "llm.output.artifact_path": "artifacts/a3.json",
+            },
+        },
+        {
+            "name": "tool.call",
+            "startTime": "2026-01-01T00:00:03Z",
+            "attributes": {"tool.name": "search", "tool.output.artifact_path": "artifacts/t1.json"},
+        },
+        {
+            "name": "agent.turn",
+            "startTime": "2026-01-01T00:00:04Z",
+            "attributes": {"turn.output.artifact_path": "artifacts/u1.json"},
+        },
+    ]
+    _write(tree, "spans.jsonl", "".join(json.dumps(s) + "\n" for s in spans))
+    (tree / "artifacts").mkdir()
+    _write(tree / "artifacts", "a2.json", TOKEN_A)
+    _write(tree / "artifacts", "a3.json", TOKEN_B)
+    _write(tree / "artifacts", "t1.json", TOKEN_INNER)
+    _write(tree / "artifacts", "u1.json", TOKEN_OUTER.replace(TOKEN_INNER, "Vb2nM7cX4zQ8wE1rT5yK"))
+
+    items = treview.build_review_items([_report(tree)])
+
+    labels = {i.token: i.sources[0]["label"] for i in items}
+    assert labels[TOKEN_A] == "model call #2 input"
+    assert labels[TOKEN_B] == "model call #2 output"
+    assert labels[TOKEN_INNER] == "tool call #1 (search) output"
+    assert list(labels.values())[3] == "agent.turn turn.output"
+
+
+def test_build_confirmed_item_from_placeholders(tmp_path):
+    tree = tmp_path / "trajectory"
+    _write(tree, "spans.jsonl", f"before {treview.PRIVATE_KEY_PLACEHOLDER} after")
+
+    items = treview.build_review_items([_report(tree, patterns={"private-key-block": 1})])
+
+    assert len(items) == 1
+    item = items[0]
+    assert item.kind == treview.KIND_CONFIRMED
+    assert item.token == ""
+    assert item.masked_sample == treview.PRIVATE_KEY_PLACEHOLDER
+    assert item.sources == [{"label": "the span log", "file": "spans.jsonl", "count": 1}]
+    occurrence = item.occurrences[0]
+    assert occurrence["line"][occurrence["start"] : occurrence["end"]] == treview.PRIVATE_KEY_PLACEHOLDER
+
+
+def test_build_marks_value_containment_as_linked(tmp_path):
+    tree = tmp_path / "trajectory"
+    _write(tree, "spans.jsonl", f"{TOKEN_INNER} and {TOKEN_OUTER} and {TOKEN_A}")
+
+    items = treview.build_review_items([_report(tree)])
+
+    by_token = {i.token: i for i in items}
+    assert by_token[TOKEN_INNER].linked == [by_token[TOKEN_OUTER].id]
+    assert by_token[TOKEN_OUTER].linked == [by_token[TOKEN_INNER].id]
+    assert by_token[TOKEN_A].linked == []
+
+
+# ── validate_review_decisions ─────────────────────────────────────────
+
+
+def _one_item_tree(tmp_path):
+    tree = tmp_path / "trajectory"
+    _write(tree, "spans.jsonl", TOKEN_A)
+    return treview.build_review_items([_report(tree)])
+
+
+def test_validate_rejects_missing_duplicate_unknown_and_invalid(tmp_path):
+    (item,) = _one_item_tree(tmp_path)
+
+    with pytest.raises(breport.BugReportError, match="missing decision"):
+        treview.validate_review_decisions([item], [])
+    with pytest.raises(breport.BugReportError, match="duplicate"):
+        treview.validate_review_decisions(
+            [item],
+            [
+                treview.ReviewDecision(item.id, treview.ACTION_KEPT),
+                treview.ReviewDecision(item.id, treview.ACTION_KEPT),
+            ],
+        )
+    with pytest.raises(breport.BugReportError, match="unknown"):
+        treview.validate_review_decisions([item], [treview.ReviewDecision("nope", treview.ACTION_KEPT)])
+    with pytest.raises(breport.BugReportError, match="invalid action"):
+        treview.validate_review_decisions([item], [treview.ReviewDecision(item.id, "acknowledged")])
+
+
+def test_validate_conflicting_linked_decisions(tmp_path):
+    tree = tmp_path / "trajectory"
+    _write(tree, "spans.jsonl", f"{TOKEN_INNER} {TOKEN_OUTER}")
+    items = treview.build_review_items([_report(tree)])
+
+    with pytest.raises(treview.ReviewConflictError):
+        treview.validate_review_decisions(
+            items,
+            _decisions(items, **{TOKEN_INNER: treview.ACTION_KEPT, TOKEN_OUTER: treview.ACTION_REDACTED}),
+        )
+
+
+# ── apply_review_decisions ────────────────────────────────────────────
+
+
+def test_apply_mixed_decisions_replace_and_keep(tmp_path):
+    tree = tmp_path / "trajectory"
+    escaped_b = json.dumps(TOKEN_B)[1:-1]
+    _write(tree, "spans.jsonl", f"keep {TOKEN_A} drop {TOKEN_B}\nescaped {escaped_b} again")
+    report = _report(tree)
+    items = treview.build_review_items([report])
+
+    outcome = treview.apply_review_decisions(
+        items,
+        _decisions(items, **{TOKEN_A: treview.ACTION_KEPT, TOKEN_B: treview.ACTION_REDACTED}),
+        reports=[report],
+    )
+
+    text = (tree / "spans.jsonl").read_text(encoding="utf-8")
+    assert TOKEN_B not in text and escaped_b not in text
+    assert text.count("[REDACTED:user-confirmed]") == 2
+    assert TOKEN_A in text
+    assert report.exact["user-confirmed"] == 2
+    assert [f.token for f in report.findings] == [TOKEN_A]
+    assert outcome.user_secrets == [tredact.KnownSecret("user-confirmed", TOKEN_B)]
+    actions = {d["id"]: d["action"] for d in outcome.user_decisions}
+    items_by_token = {i.token: i for i in items}
+    assert actions[items_by_token[TOKEN_A].id] == "kept"
+    assert actions[items_by_token[TOKEN_B].id] == "redacted"
+
+
+def test_apply_adjacent_kept_and_redacted_do_not_leak_via_summary(tmp_path):
+    """The review-verified trap: samples copy neighbors verbatim, so the
+    rewritten summary must not carry the redacted neighbor's plaintext."""
+    tree = tmp_path / "trajectory"
+    _write(tree, "spans.jsonl", f"{TOKEN_A} {TOKEN_B}")
+    report = _report(tree)
+    items = treview.build_review_items([report])
+
+    outcome = treview.apply_review_decisions(
+        items,
+        _decisions(items, **{TOKEN_A: treview.ACTION_KEPT, TOKEN_B: treview.ACTION_REDACTED}),
+        reports=[report],
+    )
+
+    summary = (tree / tredact.REDACTION_METADATA_FILE).read_text(encoding="utf-8")
+    assert TOKEN_B not in summary
+    (entry,) = json.loads(summary)["residual_findings"]
+    assert entry["sample"].startswith(TOKEN_A[:4])
+    assert "[REDACTED:user-confirmed]" in entry["sample"]
+    decisions = {d["action"]: d for d in outcome.user_decisions}
+    assert TOKEN_B not in json.dumps(decisions)
+    assert decisions["kept"]["masked_sample"].startswith(TOKEN_A[:4])
+
+
+def test_apply_adjacent_tokens_both_kept_pass_verification(tmp_path):
+    """Full-keep must not be rejected by the count check even though each
+    token's plaintext also appears inside the other's summary window."""
+    tree = tmp_path / "trajectory"
+    _write(tree, "spans.jsonl", f"{TOKEN_A} {TOKEN_B}")
+    report = _report(tree)
+    items = treview.build_review_items([report])
+
+    outcome = treview.apply_review_decisions(
+        items,
+        _decisions(items, **{TOKEN_A: treview.ACTION_KEPT, TOKEN_B: treview.ACTION_KEPT}),
+        reports=[report],
+    )
+
+    assert outcome.user_secrets == []
+    text = (tree / "spans.jsonl").read_text(encoding="utf-8")
+    assert TOKEN_A in text and TOKEN_B in text
+
+
+def test_apply_kept_token_with_checksum_context_occurrence(tmp_path):
+    """finding.count skips checksum contexts; the baseline must not."""
+    tree = tmp_path / "trajectory"
+    checksum_line = f'{{"tool.output.artifact_sha1": "{TOKEN_A}"}}'
+    _write(tree, "spans.jsonl", f"plain {TOKEN_A}\n{checksum_line}")
+    report = _report(tree)
+    items = treview.build_review_items([report])
+    assert items[0].occurrences[0]["line_no"] == 1 and len(items[0].occurrences) == 1
+
+    treview.apply_review_decisions(
+        items, _decisions(items, **{TOKEN_A: treview.ACTION_KEPT}), reports=[report]
+    )
+
+    assert (tree / "spans.jsonl").read_text(encoding="utf-8").count(TOKEN_A) == 2
+
+
+def test_apply_containment_pair_same_decision(tmp_path):
+    tree = tmp_path / "trajectory"
+    _write(tree, "spans.jsonl", f"{TOKEN_INNER} {TOKEN_OUTER}")
+    report = _report(tree)
+    items = treview.build_review_items([report])
+
+    treview.apply_review_decisions(
+        items,
+        _decisions(items, **{TOKEN_INNER: treview.ACTION_REDACTED, TOKEN_OUTER: treview.ACTION_REDACTED}),
+        reports=[report],
+    )
+
+    text = (tree / "spans.jsonl").read_text(encoding="utf-8")
+    assert TOKEN_INNER not in text and TOKEN_OUTER not in text
+    summary = (tree / tredact.REDACTION_METADATA_FILE).read_text(encoding="utf-8")
+    assert TOKEN_INNER not in summary and json.loads(summary)["residual_findings"] == []
+
+
+def test_apply_filters_source_labels(tmp_path):
+    tree = tmp_path / "trajectory"
+    span = {
+        "name": "tool.call",
+        "startTime": "2026-01-01T00:00:01Z",
+        "attributes": {"tool.name": TOKEN_A, "tool.output.artifact_path": "artifacts/t1.json"},
+    }
+    _write(tree, "spans.jsonl", json.dumps(span) + "\n")
+    (tree / "artifacts").mkdir()
+    _write(tree / "artifacts", "t1.json", f"{TOKEN_A} used here")
+    report = _report(tree)
+    items = treview.build_review_items([report])
+    assert TOKEN_A in items[0].sources[0]["label"]
+
+    outcome = treview.apply_review_decisions(
+        items, _decisions(items, **{TOKEN_A: treview.ACTION_REDACTED}), reports=[report]
+    )
+
+    (decision,) = outcome.user_decisions
+    assert TOKEN_A not in json.dumps(decision)
+    assert "[REDACTED:user-confirmed]" in decision["sources"][0]["source"]
+
+
+def test_apply_acknowledges_private_key_and_emits_notice(tmp_path):
+    tree = tmp_path / "trajectory"
+    _write(tree, "spans.jsonl", treview.PRIVATE_KEY_PLACEHOLDER)
+    report = _report(tree, patterns={"private-key-block": 2})
+    items = treview.build_review_items([report])
+
+    outcome = treview.apply_review_decisions(items, _decisions(items), reports=[report])
+
+    assert outcome.security_notices == [
+        "the original trajectory contained 2 private key block(s), replaced before export"
+    ]
+    (decision,) = outcome.user_decisions
+    assert decision["action"] == "acknowledged"
+    assert decision["category"] == "private-key-block"
+
+
+def test_apply_conflicting_decisions_touch_nothing(tmp_path):
+    tree = tmp_path / "trajectory"
+    _write(tree, "spans.jsonl", f"{TOKEN_INNER} {TOKEN_OUTER}")
+    report = _report(tree)
+    items = treview.build_review_items([report])
+    before = (tree / "spans.jsonl").read_text(encoding="utf-8")
+
+    with pytest.raises(treview.ReviewConflictError):
+        treview.apply_review_decisions(
+            items,
+            _decisions(items, **{TOKEN_INNER: treview.ACTION_REDACTED, TOKEN_OUTER: treview.ACTION_KEPT}),
+            reports=[report],
+        )
+
+    assert (tree / "spans.jsonl").read_text(encoding="utf-8") == before
+    assert not (tree / tredact.REDACTION_METADATA_FILE).exists()

--- a/tests/test_trajectory_review.py
+++ b/tests/test_trajectory_review.py
@@ -280,9 +280,7 @@ def test_apply_kept_token_with_checksum_context_occurrence(tmp_path):
     items = treview.build_review_items([report])
     assert items[0].occurrences[0]["line_no"] == 1 and len(items[0].occurrences) == 1
 
-    treview.apply_review_decisions(
-        items, _decisions(items, **{TOKEN_A: treview.ACTION_KEPT}), reports=[report]
-    )
+    treview.apply_review_decisions(items, _decisions(items, **{TOKEN_A: treview.ACTION_KEPT}), reports=[report])
 
     assert (tree / "spans.jsonl").read_text(encoding="utf-8").count(TOKEN_A) == 2
 

--- a/tests/test_trajectory_review.py
+++ b/tests/test_trajectory_review.py
@@ -233,7 +233,7 @@ def test_apply_mixed_decisions_replace_and_keep(tmp_path):
 
 
 def test_apply_adjacent_kept_and_redacted_do_not_leak_via_summary(tmp_path):
-    """The review-verified trap: samples copy neighbors verbatim, so the
+    """Samples copy neighbors verbatim, so the
     rewritten summary must not carry the redacted neighbor's plaintext."""
     tree = tmp_path / "trajectory"
     _write(tree, "spans.jsonl", f"{TOKEN_A} {TOKEN_B}")

--- a/tests/test_trajectory_review.py
+++ b/tests/test_trajectory_review.py
@@ -226,6 +226,10 @@ def test_apply_mixed_decisions_replace_and_keep(tmp_path):
     items_by_token = {i.token: i for i in items}
     assert actions[items_by_token[TOKEN_A].id] == "kept"
     assert actions[items_by_token[TOKEN_B].id] == "redacted"
+    masked = {d["id"]: d["masked_token"] for d in outcome.user_decisions}
+    assert masked[items_by_token[TOKEN_A].id] == f"{TOKEN_A[:4]}***{TOKEN_A[-4:]}"
+    assert masked[items_by_token[TOKEN_B].id] == f"{TOKEN_B[:4]}***{TOKEN_B[-4:]}"
+    assert TOKEN_B not in json.dumps(outcome.user_decisions)
 
 
 def test_apply_adjacent_kept_and_redacted_do_not_leak_via_summary(tmp_path):
@@ -340,6 +344,7 @@ def test_apply_acknowledges_private_key_and_emits_notice(tmp_path):
     (decision,) = outcome.user_decisions
     assert decision["action"] == "acknowledged"
     assert decision["category"] == "private-key-block"
+    assert decision["masked_token"] == treview.PRIVATE_KEY_PLACEHOLDER
 
 
 def test_apply_renames_paths_carrying_redacted_tokens(tmp_path):


### PR DESCRIPTION

## Summary

Bug reports previously classified redaction into clean / needs_review /
blocked, where a private-key hit refused to produce a report and the
needs_review confirmation showed at most 5 masked samples pointing at a
file buried inside the frozen snapshot. This PR folds blocked into a
per-item review flow:

- Residual findings become review items, adjudicated by token value:
  keep as-is, or replace with [REDACTED:user-confirmed] (all four
  spelling variants replaced and verified gone, tar member names
  included - files carrying a redacted value are renamed with the same
  replacement their references got). Each item leads with the token and
  its occurrence count, groups identical context lines (every hit
  highlighted), and lists every location as semantic source plus
  file:line ("model call #2 input - artifacts/...json:57"); decisions
  are single-letter input (k/r/c) with no default. The user never has
  to open a file, and can still locate everything.
- A private-key hit no longer blocks the report: the content is already
  replaced, the reporter acknowledges the risk per item, and the package
  carries an explicit security notice.
- One risk-worded confirmation replaces the old create-then-review
  double prompt; --yes never implies the risk authorization. The
  summary shows a Reviewed tally (kept / redacted / acknowledged) with
  short masked tokens, keeping completed decisions apart from the
  warnings that still need consent.
- Records and packages gain additive redaction fields security_notices
  and user_decisions (with a masked_token short identifier; absent on
  old records, validated when present); the persisted classification
  enum is unchanged, so old and new readers stay compatible both ways.
- CLI: --keep-findings / --redact-findings (mutually exclusive) decide
  suspected items per kind for scripts; a run missing flags fails before
  any content change, listing every item and every missing flag at once.
- Provider-generated call_ tool-call ids and the fixed usage field
  names (completion_tokens_details, prompt_tokens_details; exact
  literals only) join the residual-scan exemptions.
- Untouched: the freeze pipeline (digests, byte-identical retries, crash
  recovery), the completeness probe, path sanitization, tar header
  anonymization, the expert command raven trajectory report, and the
  record state machine.

Note: this branch is stacked on feat/trajectory_bug_report (#380); the
diff includes those commits until #380 merges, after which this branch
will be rebased onto main.

## Type

- [ ] Fix
- [x] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

- `uv run pytest tests/test_trajectory_redact.py tests/test_trajectory_review.py tests/test_trajectory_bugreport.py tests/test_cli_trajectory_browse.py tests/test_cli_trajectory_commands.py -q` -> 380 passed
- `uv run pytest tests/ --ignore=tests/integration` -> 7156 passed (the 11 failures / 19 errors are pre-existing environment issues on this machine - missing tzdata and similar - identical on the base branch)
- `uv run --frozen --extra dev ruff check raven/ tests/` -> passed
- `uv run --frozen --extra dev ruff format --check raven/ tests/` -> 861 files already formatted
- `make check-large-files` -> passed

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

## Risk

User-visible changes: the blocked refusal wall is gone (replaced by an
informed acknowledgment with an in-package notice), the review
confirmation is a single risk-worded prompt instead of two, and
non-interactive review runs now require an explicit --keep-findings or
--redact-findings for suspected items (previously --accept-risk alone
shipped them as kept). Rollback: revert the squash commit; the new
metadata fields are additive, so already-produced packages and records
keep loading either way.

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

## Related Issues

N/A