### PR TITLE
feat(agent): add Serply as a web_search vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Raven are documented here.
 
 ### Added
 
+- Serply joins the `web_search` vendors: `tools.web.search.provider: serply`
+  with the key under `tools.web.providers.serply.apiKey` (or `SERPLY_API_KEY`).
+  Google SERP rows normalised into the shared render path; the research
+  sub-agent's search tool routes through it too and pages with a result
+  offset like SerpApi.
+
 - Two dark templates join the bundled catalogue, cut from user uploads: a
   near-black circuit-board deck for product launches and a green aurora deck
   for trend reports. Hidden vendor pages are gone, vendor marks are stripped,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -425,7 +425,7 @@ _Avoid_: "provider" unqualified — that is the LLM Provider in this vocabulary;
 
 **Web Search Provider** / **Web Fetch Provider** (`agent/tools/web.py`, `SEARCH_PROVIDERS` / `FETCH_PROVIDERS`):
 Which interchangeable backend each web tool calls: `tools.web.search.provider` selects
-`serper` (default), `anysearch`, `serpapi`, `tavily`, `exa`, `brave` or `firecrawl`, and
+`serper` (default), `anysearch`, `serpapi`, `tavily`, `exa`, `brave`, `firecrawl` or `serply`, and
 `tools.web.fetch.provider` selects `jina` (default), `anysearch`, `tavily`, `exa` or
 `firecrawl`. Every endpoint is a literal in the tool, so a selection names a vendor and
 never a URL. `web_search` is registered whatever the config holds and *withheld* from the

--- a/agents/raven-research/.env.example
+++ b/agents/raven-research/.env.example
@@ -10,7 +10,7 @@
 RESEARCH_API_KEY=
 
 # Which vendor each web tool calls - OPTIONAL. Search: serper (default),
-# anysearch, serpapi, tavily, exa, brave, firecrawl. Fetch: jina (default),
+# anysearch, serpapi, tavily, exa, brave, firecrawl, serply. Fetch: jina (default),
 # anysearch, tavily, exa, firecrawl. Empty here falls back to this product's
 # config.json, then the host raven's tools.web.{search,fetch}.provider. A name
 # not on the list refuses to launch. A fetch vendor selected without its key
@@ -39,6 +39,7 @@ RESEARCH_TAVILY_API_KEY=
 RESEARCH_EXA_API_KEY=
 RESEARCH_BRAVE_API_KEY=
 RESEARCH_FIRECRAWL_API_KEY=
+RESEARCH_SERPLY_API_KEY=
 
 # HTTP/SOCKS5 proxy for both web tools, e.g. http://127.0.0.1:7890 - OPTIONAL.
 # Empty here and absent from the host config means a direct connection (httpx

--- a/agents/raven-research/plugins/research-flow/research_flow/tools/web.py
+++ b/agents/raven-research/plugins/research-flow/research_flow/tools/web.py
@@ -213,6 +213,13 @@ SEARCH_PROVIDERS: dict[str, SearchProviderSpec] = {
         # ``/v1/search`` documents no result-offset parameter.
         paginates=False,
     ),
+    "serply": SearchProviderSpec(
+        vendor="serply",
+        label="Serply",
+        env_var="SERPLY_API_KEY",
+        # ``start`` is a result offset like SerpApi's, so page N is start=(N-1)*num.
+        paginates=True,
+    ),
 }
 
 
@@ -1167,6 +1174,17 @@ class WebSearchTool(Tool):
                 },
                 timeout=10.0,
             )
+        if self.provider == "serply":
+            # ``start`` is an offset in results, omitted at page 1 like SerpApi's.
+            params = {"q": query, "num": n}
+            if page > 1:
+                params["start"] = (page - 1) * n
+            return await client.get(
+                "https://api.serply.io/v1/search",
+                params=params,
+                headers={"Accept": "application/json", "X-Api-Key": self.api_key},
+                timeout=10.0,
+            )
         # AnySearch.
         return await client.post(
             "https://api.anysearch.com/v1/search",
@@ -1237,6 +1255,9 @@ class WebSearchTool(Tool):
             if data.get("success") is False:
                 raise ValueError(f"Firecrawl: {data.get('error') or 'search failed'}")
             return {"organic": _rows(data.get("data"), url="url", snippet="description")}
+        if self.provider == "serply":
+            # Google SERP rows under ``results``; the snippet is ``description``.
+            return {"organic": _rows(data.get("results"), url="link", snippet="description")}
         # AnySearch publishes the request shape but not the response. Parse
         # tolerantly: results may sit at the top level or inside the
         # ``{code, message, data}`` envelope its auth endpoint uses, and an item

--- a/raven/agent/tools/web.py
+++ b/raven/agent/tools/web.py
@@ -74,6 +74,7 @@ SEARCH_PROVIDERS: dict[str, SearchProviderSpec] = {
     "firecrawl": SearchProviderSpec(
         "firecrawl", "Firecrawl", WEB_VENDOR_ENV_VARS["firecrawl"], "https://firecrawl.dev"
     ),
+    "serply": SearchProviderSpec("serply", "Serply", WEB_VENDOR_ENV_VARS["serply"], "https://serply.io"),
 }
 
 FETCH_PROVIDERS: dict[str, FetchProviderSpec] = {
@@ -319,6 +320,13 @@ class WebSearchTool(Tool):
                 },
                 timeout=10.0,
             )
+        if self.provider == "serply":
+            return await client.get(
+                "https://api.serply.io/v1/search",
+                params={"q": query, "num": n},
+                headers={"Accept": "application/json", "X-Api-Key": self.api_key},
+                timeout=10.0,
+            )
         return await client.post(
             "https://api.anysearch.com/v1/search",
             json={"query": query, "max_results": n},
@@ -375,6 +383,9 @@ class WebSearchTool(Tool):
             if data.get("success") is False:
                 raise ValueError(f"Firecrawl: {data.get('error') or 'search failed'}")
             return {"organic": _rows(data.get("data"), url="url", snippet="description")}
+        if self.provider == "serply":
+            # Google SERP rows under ``results``; the snippet is ``description``.
+            return {"organic": _rows(data.get("results"), url="link", snippet="description")}
         # AnySearch publishes the request shape but not the response: results may
         # sit at the top level or inside a ``{code, message, data}`` envelope, and
         # an item spells the URL ``url`` or ``link``, the text ``snippet`` or

--- a/raven/cli/onboard_commands.py
+++ b/raven/cli/onboard_commands.py
@@ -2628,7 +2628,7 @@ def register(app: typer.Typer) -> None:
         search_provider: Optional[str] = typer.Option(
             None,
             "--search-provider",
-            help="web_search vendor: serper, anysearch, serpapi, tavily, exa, brave or firecrawl",
+            help="web_search vendor: serper, anysearch, serpapi, tavily, exa, brave, firecrawl or serply",
         ),
         fetch_provider: Optional[str] = typer.Option(
             None,

--- a/raven/config/schema.py
+++ b/raven/config/schema.py
@@ -905,7 +905,7 @@ class GatewayConfig(Base):
     page: GatewayPageConfig = Field(default_factory=GatewayPageConfig)
 
 
-WebSearchProvider = Literal["serper", "anysearch", "serpapi", "tavily", "exa", "brave", "firecrawl"]
+WebSearchProvider = Literal["serper", "anysearch", "serpapi", "tavily", "exa", "brave", "firecrawl", "serply"]
 WebFetchProvider = Literal["jina", "anysearch", "tavily", "exa", "firecrawl"]
 
 #: The bare environment variable each web vendor's tool falls back to when the
@@ -919,6 +919,7 @@ WEB_VENDOR_ENV_VARS: dict[str, str] = {
     "exa": "EXA_API_KEY",
     "brave": "BRAVE_API_KEY",
     "firecrawl": "FIRECRAWL_API_KEY",
+    "serply": "SERPLY_API_KEY",
 }
 
 
@@ -950,6 +951,7 @@ class WebProvidersConfig(Base):
     exa: WebProviderKey = Field(default_factory=WebProviderKey)
     brave: WebProviderKey = Field(default_factory=WebProviderKey)
     firecrawl: WebProviderKey = Field(default_factory=WebProviderKey)
+    serply: WebProviderKey = Field(default_factory=WebProviderKey)
 
     def key_for(self, vendor: str) -> str:
         """One vendor's configured key, or an empty string for an unknown vendor."""

--- a/tests/test_agent_tools_web_providers.py
+++ b/tests/test_agent_tools_web_providers.py
@@ -184,6 +184,12 @@ _SEARCH_REQUESTS: dict[str, tuple[str, str, dict[str, Any], dict[str, str]]] = {
         {"json": {"query": "q1", "limit": 4}},
         {"Authorization": "Bearer k"},
     ),
+    "serply": (
+        "GET",
+        "https://api.serply.io/v1/search",
+        {"params": {"q": "q1", "num": 4}},
+        {"X-Api-Key": "k"},
+    ),
 }
 
 
@@ -291,6 +297,7 @@ _SEARCH_PAYLOADS: dict[str, Any] = {
     "exa": {"results": [{"title": "T1", "url": "https://a.example", "highlights": ["S1\n\nmore"], "text": "x" * 500}]},
     "brave": {"web": {"results": [{"title": "T1", "url": "https://a.example", "description": "S1"}]}},
     "firecrawl": {"success": True, "data": [{"title": "T1", "url": "https://a.example", "description": "S1"}]},
+    "serply": {"results": [{"title": "T1", "link": "https://a.example", "description": "S1"}]},
 }
 
 
@@ -479,7 +486,7 @@ def test_the_settings_page_offers_exactly_the_schemas_vendors() -> None:
     assert search["vendors"] == list(get_args(WebSearchProvider))
     assert fetch["vendors"] == list(get_args(WebFetchProvider))
     # Not vacuous: the parse found real lists, so an empty one cannot pass.
-    assert len(search["vendors"]) == 7 and len(fetch["vendors"]) == 5
+    assert len(search["vendors"]) == 8 and len(fetch["vendors"]) == 5
     assert search["fallback"] == DEFAULT_SEARCH_PROVIDER
     assert fetch["fallback"] == DEFAULT_FETCH_PROVIDER
     assert search["path"] == "tools.web.search.provider"

--- a/tests/test_agents_research_tools.py
+++ b/tests/test_agents_research_tools.py
@@ -528,6 +528,10 @@ _SEARCH_PAYLOADS: dict[str, tuple[dict, dict]] = {
         {"data": {"results": [{"title": "T", "url": "https://e.com/a", "snippet": "S"}]}},
         {"title": "T", "link": "https://e.com/a", "snippet": "S"},
     ),
+    "serply": (
+        {"results": [{"title": "T", "link": "https://e.com/a", "description": "S"}]},
+        {"title": "T", "link": "https://e.com/a", "snippet": "S"},
+    ),
 }
 
 
@@ -647,7 +651,7 @@ async def test_a_paginating_vendor_sends_its_own_offset_parameter(monkeypatch):
     in results, Brave a page index under a third name. One page number, three
     encodings, and sending the wrong one reads as a duplicate first page."""
     seen: dict[str, httpx.Request] = {}
-    for vendor in ("serper", "serpapi", "brave"):
+    for vendor in ("serper", "serpapi", "brave", "serply"):
         transport = _CaptureTransport(_SEARCH_PAYLOADS[vendor][0])
         # One patch per vendor, undone before the next: patching the already
         # patched factory would pass ``transport`` twice and the request would
@@ -665,6 +669,8 @@ async def test_a_paginating_vendor_sends_its_own_offset_parameter(monkeypatch):
     assert seen["serpapi"].url.params["start"] == "3"
     # A page index, unlike SerpApi's result count.
     assert seen["brave"].url.params["offset"] == "1"
+    # A result offset again, under Google's own parameter name.
+    assert seen["serply"].url.params["start"] == "3"
 
 
 @pytest.mark.parametrize("status", [401, 429])

--- a/tests/test_rpc_console.py
+++ b/tests/test_rpc_console.py
@@ -48,7 +48,7 @@ def test_the_settings_whitelist_is_exactly_this_set() -> None:
         "tools.web.fetch.provider",
         *(
             f"tools.web.providers.{vendor}.apiKey"
-            for vendor in ("serper", "anysearch", "serpapi", "jina", "tavily", "exa", "brave", "firecrawl")
+            for vendor in ("serper", "anysearch", "serpapi", "jina", "tavily", "exa", "brave", "firecrawl", "serply")
         ),
         "tools.media.image.apiKey",
         "tools.media.image.model",

--- a/ui-web/src/features/settings/SettingsPage.tsx
+++ b/ui-web/src/features/settings/SettingsPage.tsx
@@ -2201,7 +2201,7 @@ interface WebVendorPick {
 const WEB_VENDOR: Record<string, WebVendorPick> = {
   web_search: {
     path: 'tools.web.search.provider',
-    vendors: ['serper', 'anysearch', 'serpapi', 'tavily', 'exa', 'brave', 'firecrawl'],
+    vendors: ['serper', 'anysearch', 'serpapi', 'tavily', 'exa', 'brave', 'firecrawl', 'serply'],
     fallback: 'serper',
   },
   web_fetch: {
@@ -2219,6 +2219,7 @@ const WEB_VENDOR_LABEL: Record<string, string> = {
   exa: 'Exa',
   brave: 'Brave Search',
   firecrawl: 'Firecrawl',
+  serply: 'Serply',
 }
 function webVendor(id: string, raw: Record<string, unknown>): string {
   const pick = WEB_VENDOR[id]!


### PR DESCRIPTION
## Summary

Reopens #384 on the linearized `main`, as asked in the auto-close notice. The original branch added a two-way provider switch to a Serper-only `web_search`; `main` has since grown a vendor table (`SEARCH_PROVIDERS`, `tools.web.providers.<vendor>.apiKey`, the doctor and onboard rows reading off the spec), so this is a rewrite to that design rather than a rebase: Serply (https://serply.io) becomes the eighth `web_search` vendor, appended after Firecrawl.

What the entry consists of:

- `raven/config/schema.py`: `serply` joins `WebSearchProvider`, `WEB_VENDOR_ENV_VARS` (`SERPLY_API_KEY`) and `WebProvidersConfig`. Everything that enumerates vendors off the schema (the env-file mirror, the RPC console allow-list, the research launcher's `SEARCH_VENDORS` and `SECRET_SLOTS`, the onboard wizard's picker) picks it up from there.
- `raven/agent/tools/web.py`: one spec row, one request branch (`GET https://api.serply.io/v1/search?q=&num=`, key in the `X-Api-Key` header, same 10s timeout and proxy as the others) and one normaliser branch (Serply answers Google SERP rows under `results` with the snippet in `description`, folded into the shared `organic` shape by `_rows`). No answer box or knowledge graph is produced. The Serper branch is untouched.
- the research plugin's `research_flow/tools/web.py`: the same three additions for the research sub-agent, with `paginates=True` because Serply takes `start` as a result offset like SerpApi (probed live: `start=3` returns a disjoint second page). `.env.example` gains `RESEARCH_SERPLY_API_KEY`.
- The settings page's own vendor array and label, the `--search-provider` help text, CONTEXT.md's vendor list and a CHANGELOG line.
- Tests: rows in the kernel request and payload tables (`test_agent_tools_web_providers.py`, vendor floor 7 to 8), the RPC console allow-list pin, the research payload table, and Serply added to the paginating-vendor offset test.

Default stays `serper`; a deployment that never names `serply` sees no change.

Disclosure: I work with Serply. Happy to trim scope (for example drop the research plugin half) if you prefer.

## Type

- [ ] Fix
- [x] Feature
- [ ] Docs
- [ ] CI / tooling
- [ ] Refactor
- [ ] Other

## Verification

```
uv run --frozen --extra dev ruff check <7 edited .py files>          -> All checks passed!
uv run --frozen --extra dev ruff format --check <7 edited .py files> -> 7 files already formatted
uv run --frozen --all-extras pytest -q tests/test_agent_tools_web_providers.py tests/test_rpc_console.py \
  tests/test_agents_research_tools.py tests/test_agents_research_launcher.py tests/test_tool_capabilities.py \
  tests/test_config_live.py tests/test_agent_loop_web_tools.py tests/test_cli_doctor_commands.py \
  tests/test_cli_onboard_commands.py tests/test_config_raven_sections.py tests/test_config_update_tools.py \
  tests/test_cli_log_file.py                                          -> 1 failed, 890 passed
  (test_cli_doctor_commands.py::test_doctor_answers_where_the_memories_are fails identically on the
   untouched tree on this machine: the doctor output truncates the tmp path; unrelated)
uv run --frozen --all-extras pytest -q                                -> 3 failed, 22047 passed, 52 skipped (6m07s)
  (the same three fail on untouched main here: the doctor memories test above plus
   test_sentinel_persistence::test_cron_claim_prevents_concurrent_fire and
   test_subagent_dag_runner::test_a_streaming_acp_node_is_never_announced_as_stalled, both timing-bound)
```

Live, with a real key held in the header only: `WebSearchTool(provider="serply").execute("raven ai agent harness", count=3)` rendered three organic rows through the shared path; `probe()` answered `(True, '1 result(s)')`; a bogus key answered `(False, 'Serply answered HTTP 401')` with no key text in the detail.

- [x] Relevant tests pass locally
- [x] Relevant lint / type checks pass locally
- [x] User-facing docs or screenshots are updated when needed

## Risk

- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Rollback path is clear for risky changes

- Security: the key travels in a request header to `api.serply.io` over HTTPS, never in the URL, so the SerpApi-style URL redaction concern does not apply. The status-error path renders vendor plus status like every other vendor (covered by the parametrised no-echo tests).
- Backward compatibility: additive. `WebProvidersConfig` keeps `extra="forbid"`, so the only new accepted input is the `serply` slot and enum value.
- Rollback: revert the commit. A config that already names `serply` then fails validation loudly, which is the intended failure mode for an unknown vendor.

## Related Issues

#384
